### PR TITLE
fix(journey): image viewer hidden behind entry modal on mobile

### DIFF
--- a/client/src/components/Journey/PhotoLightbox.tsx
+++ b/client/src/components/Journey/PhotoLightbox.tsx
@@ -66,7 +66,7 @@ export default function PhotoLightbox({ photos, startIndex = 0, onClose }: Props
   return (
     <div
       style={{
-        position: 'fixed', inset: 0, zIndex: 500,
+        position: 'fixed', inset: 0, zIndex: 10000,
         background: 'rgba(0,0,0,0.92)', backdropFilter: 'blur(20px)',
         display: 'flex', flexDirection: 'column',
         paddingBottom: 'var(--bottom-nav-h)',


### PR DESCRIPTION
## Description
`PhotoLightbox` had `zIndex: 500` while `MobileEntryView` uses `z-[9999]`. Clicking any thumbnail (non-first image) would open the lightbox behind the entry modal, making it invisible until the entry was closed.

Fix: raise `PhotoLightbox` z-index to `10000` so it always renders above the entry overlay.

## Related Issue or Discussion
Closes #1096

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed