### PR TITLE
feat: switch currency widget to Frankfurter v2 API

### DIFF
--- a/client/src/components/Dashboard/CurrencyWidget.tsx
+++ b/client/src/components/Dashboard/CurrencyWidget.tsx
@@ -31,7 +31,7 @@ export default function CurrencyWidget() {
     if (from === to) { setRate(1); return }
     setLoading(true)
     try {
-      const resp = await fetch(`https://api.exchangerate-api.com/v4/latest/${from}`)
+      const resp = await fetch(`https://api.frankfurter.dev/v2/rates?base=${from}&quotes=${to}`)
       const data = await resp.json()
       setRate(data.rates?.[to] || null)
     } catch { setRate(null) }

--- a/client/src/pages/DashboardPage.test.tsx
+++ b/client/src/pages/DashboardPage.test.tsx
@@ -20,8 +20,8 @@ beforeEach(() => {
   } as any);
   // Intercept CurrencyWidget's external fetch so it resolves before teardown
   server.use(
-    http.get('https://api.exchangerate-api.com/v4/latest/:currency', () => {
-      return HttpResponse.json({ rates: { USD: 1.08, EUR: 1, CHF: 0.97 } });
+    http.get('https://api.frankfurter.dev/v2/rates', () => {
+      return HttpResponse.json({ base: 'EUR', date: '2026-01-15', rates: { USD: 1.08, EUR: 1, CHF: 0.97 } });
     }),
   );
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -133,7 +133,7 @@ export function createApp(): express.Application {
           "https://en.wikipedia.org", "https://commons.wikimedia.org",
           "https://*.basemaps.cartocdn.com", "https://*.tile.openstreetmap.org",
           "https://unpkg.com", "https://open-meteo.com", "https://api.open-meteo.com",
-          "https://geocoding-api.open-meteo.com", "https://api.exchangerate-api.com",
+          "https://geocoding-api.open-meteo.com", "https://api.frankfurter.dev",
           "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_50m_admin_0_countries.geojson",
           "https://router.project-osrm.org/route/v1/",
           "https://api.mapbox.com", "https://*.tiles.mapbox.com", "https://events.mapbox.com"

--- a/wiki/Dashboard-Widgets.md
+++ b/wiki/Dashboard-Widgets.md
@@ -31,7 +31,7 @@ The currency converter lets you quickly convert an amount between two currencies
 
 You can also click the swap arrow to reverse source and target.
 
-**Exchange rates** are fetched from [exchangerate-api.com](https://www.exchangerate-api.com) using the `https://api.exchangerate-api.com/v4/latest/{from}` endpoint. Rates are refreshed each time you change a currency or click the refresh icon.
+**Exchange rates** are fetched from [Frankfurter](https://frankfurter.dev) using the `https://api.frankfurter.dev/v2/rates?base={from}&quotes={to}` endpoint. Rates are refreshed each time you change a currency or click the refresh icon. Frankfurter is an open-source service that aggregates data from central banks and supports historical lookups, which TREK will use for multi-currency budgets in a follow-up change.
 
 **Supported currencies:** 162 currencies are available in the selector, including all major fiat currencies (USD, EUR, GBP, JPY, etc.) and many minor ones.
 


### PR DESCRIPTION
## Summary
- Replaces `exchangerate-api.com` with [`frankfurter.dev`](https://frankfurter.dev) (v2) as the rate source for the dashboard CurrencyWidget.
- Updates the server CSP `connect-src` allowlist accordingly, plus the MSW intercept in `DashboardPage.test.tsx` and the wiki entry in `Dashboard-Widgets.md`.
- Same `data.rates[to]` field is read, so the widget behavior is unchanged. The new endpoint shape is `GET /v2/rates?base={from}&quotes={to}` returning `{ base, date, rates: { [code]: number } }`.

## Why
Frankfurter is open-source, aggregates data from central banks, and supports historical lookups by date. That historical capability is the reason for the swap — it will be used in a follow-up PR to convert prior-dated expenses for multi-currency budgets. This PR only does the API swap; no UI change.

## Test plan
- [x] `npx vitest run src/pages/DashboardPage.test.tsx` — 32/32 pass with the updated MSW intercept.
- [ ] Manually try the CurrencyWidget on the dashboard: change source/target currency, click refresh — rate should update.
- [ ] Confirm the CSP doesn't block the request in the browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)