### PR TITLE
[+] Custom categories, category emojis, import google maps list categ…

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -366,12 +366,30 @@ export const placesApi = {
     if (opts?.paths !== undefined) fd.append('importPaths', String(opts.paths))
     return apiClient.post(`/trips/${tripId}/places/import/map`, fd, { headers: { 'Content-Type': 'multipart/form-data' } }).then(r => r.data)
   },
-  importGoogleList: (tripId: number | string, url: string, enrich?: boolean) =>
-      apiClient.post(`/trips/${tripId}/places/import/google-list`, { url, enrich } satisfies PlaceImportListRequest).then(r => r.data),
-  importNaverList: (tripId: number | string, url: string, enrich?: boolean) =>
-      apiClient.post(`/trips/${tripId}/places/import/naver-list`, { url, enrich } satisfies PlaceImportListRequest).then(r => r.data),
+  importGoogleList: (tripId: number | string, url: string, opts?: boolean | PlaceImportOptions) =>
+      apiClient.post(`/trips/${tripId}/places/import/google-list`, buildPlaceImportListBody(url, opts)).then(r => r.data),
+  importNaverList: (tripId: number | string, url: string, opts?: boolean | PlaceImportOptions) =>
+      apiClient.post(`/trips/${tripId}/places/import/naver-list`, buildPlaceImportListBody(url, opts)).then(r => r.data),
   bulkDelete: (tripId: number | string, ids: number[]) =>
       apiClient.post(`/trips/${tripId}/places/bulk-delete`, { ids } satisfies PlaceBulkDeleteRequest).then(r => r.data),
+}
+
+interface PlaceImportOptions {
+  enrich?: boolean
+  categoryId?: number | string | null
+  createCategoryFromList?: boolean
+  categoryIcon?: string
+}
+
+function buildPlaceImportListBody(url: string, opts?: boolean | PlaceImportOptions): PlaceImportListRequest {
+  const options = typeof opts === 'boolean' ? { enrich: opts } : (opts || {})
+  return {
+    url,
+    enrich: options.enrich,
+    category_id: options.categoryId || undefined,
+    create_category_from_list: options.createCategoryFromList || undefined,
+    category_icon: options.categoryIcon || undefined,
+  }
 }
 
 export const assignmentsApi = {

--- a/client/src/components/Admin/CategoryManager.tsx
+++ b/client/src/components/Admin/CategoryManager.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { categoriesApi } from '../../api/client'
 import { useToast } from '../shared/Toast'
 import { Plus, Edit2, Trash2, Pipette } from 'lucide-react'
-import { CATEGORY_ICON_MAP, ICON_LABELS, getCategoryIcon } from '../shared/categoryIcons'
+import { CATEGORY_ICON_MAP, ICON_LABELS, getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { useTranslation } from '../../i18n'
 import { getApiErrorMessage } from '../../types'
 
@@ -18,7 +18,7 @@ export default function CategoryManager() {
   const [categories, setCategories] = useState([])
   const [showForm, setShowForm] = useState(false)
   const [editingId, setEditingId] = useState(null)
-  const [form, setForm] = useState({ name: '', color: '#6366f1', icon: 'MapPin' })
+  const [form, setForm] = useState({ name: '', color: '#6366f1', icon: '📍' })
   const [isSaving, setIsSaving] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const colorInputRef = useRef(null)
@@ -41,13 +41,13 @@ export default function CategoryManager() {
 
   const handleStartEdit = (cat) => {
     setEditingId(cat.id)
-    setForm({ name: cat.name, color: cat.color || '#6366f1', icon: cat.icon || 'MapPin' })
+    setForm({ name: cat.name, color: cat.color || '#6366f1', icon: cat.icon || '📍' })
     setShowForm(false)
   }
 
   const handleStartCreate = () => {
     setEditingId(null)
-    setForm({ name: '', color: '#6366f1', icon: 'MapPin' })
+    setForm({ name: '', color: '#6366f1', icon: '📍' })
     setShowForm(true)
   }
 
@@ -60,18 +60,19 @@ export default function CategoryManager() {
     if (!form.name.trim()) { toast.error(t('categories.toast.nameRequired')); return }
     setIsSaving(true)
     try {
+      const payload = { ...form, icon: form.icon.trim() || '📍' }
       if (editingId) {
-        const result = await categoriesApi.update(editingId, form)
+        const result = await categoriesApi.update(editingId, payload)
         setCategories(prev => prev.map(c => c.id === editingId ? result.category : c))
         setEditingId(null)
         toast.success(t('categories.toast.updated'))
       } else {
-        const result = await categoriesApi.create(form)
+        const result = await categoriesApi.create(payload)
         setCategories(prev => [...prev, result.category])
         setShowForm(false)
         toast.success(t('categories.toast.created'))
       }
-      setForm({ name: '', color: '#6366f1', icon: 'MapPin' })
+      setForm({ name: '', color: '#6366f1', icon: '📍' })
     } catch (err: unknown) {
       toast.error(getApiErrorMessage(err, t('categories.toast.saveError')))
     } finally {
@@ -92,6 +93,7 @@ export default function CategoryManager() {
 
   const isPresetColor = PRESET_COLORS.includes(form.color)
   const PreviewIcon = getCategoryIcon(form.icon)
+  const previewEmoji = isEmojiCategoryIcon(form.icon) ? form.icon : null
 
   const categoryForm = (
     <div className="bg-gray-50 rounded-xl p-4 space-y-3 border border-gray-200">
@@ -106,6 +108,14 @@ export default function CategoryManager() {
 
       <div>
         <label className="block text-xs font-medium text-gray-600 mb-2">{t('categories.icon')}</label>
+        <input
+          type="text"
+          value={form.icon}
+          onChange={e => setForm(prev => ({ ...prev, icon: e.target.value }))}
+          aria-label={t('categories.icon')}
+          maxLength={8}
+          className="w-16 border border-gray-200 rounded-lg px-2 py-1.5 text-center text-sm focus:outline-none focus:ring-2 focus:ring-slate-400 bg-white mb-2"
+        />
         <div className="max-h-48 overflow-y-auto">
           <div className="flex flex-wrap gap-1.5 px-1.5 py-1.5">
             {ICON_NAMES.map(name => {
@@ -169,7 +179,11 @@ export default function CategoryManager() {
         <span className="text-xs text-gray-500">{t('categories.preview')}:</span>
         <span className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 rounded-full font-medium"
           style={{ backgroundColor: `${form.color}20`, color: form.color }}>
-          <PreviewIcon size={14} strokeWidth={1.8} />
+          {previewEmoji ? (
+            <span style={{ fontSize: 14, lineHeight: 1 }}>{previewEmoji}</span>
+          ) : (
+            <PreviewIcon size={14} strokeWidth={1.8} />
+          )}
           {form.name || t('categories.defaultName')}
         </span>
       </div>
@@ -215,6 +229,7 @@ export default function CategoryManager() {
         <div className="space-y-2">
           {categories.map(cat => {
             const Icon = getCategoryIcon(cat.icon)
+            const emoji = isEmojiCategoryIcon(cat.icon) ? cat.icon : null
             return (
               <div key={cat.id}>
                 {editingId === cat.id ? (
@@ -223,7 +238,11 @@ export default function CategoryManager() {
                   <div className="flex items-center gap-3 p-3 border border-gray-100 rounded-xl hover:border-gray-200 group">
                     <div className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
                       style={{ backgroundColor: `${cat.color}20` }}>
-                      <Icon size={18} strokeWidth={1.8} color={cat.color} />
+                      {emoji ? (
+                        <span style={{ fontSize: 18, lineHeight: 1 }}>{emoji}</span>
+                      ) : (
+                        <Icon size={18} strokeWidth={1.8} color={cat.color} />
+                      )}
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">

--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -7,12 +7,15 @@ import L from 'leaflet'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import { mapsApi } from '../../api/client'
-import { getCategoryIcon, CATEGORY_ICON_MAP } from '../shared/categoryIcons'
+import { getCategoryIcon, CATEGORY_ICON_MAP, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import ReservationOverlay from './ReservationOverlay'
 import type { Reservation } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 
 function categoryIconSvg(iconName: string | null | undefined, size: number): string {
+  if (isEmojiCategoryIcon(iconName)) {
+    return `<span style="font-size:${size}px;line-height:1;display:inline-flex;align-items:center;justify-content:center;">${escAttr(iconName)}</span>`
+  }
   const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
   try {
     return renderToStaticMarkup(createElement(IconComponent, { size, color: 'white', strokeWidth: 2.5 }))
@@ -564,6 +567,7 @@ export const MapView = memo(function MapView({
 
   const TooltipOverlay = hoveredPlace && tooltipPos && !isTouchDevice
   const CatIcon = TooltipOverlay ? getCategoryIcon(hoveredPlace.category_icon) : null
+  const catEmoji = TooltipOverlay && isEmojiCategoryIcon(hoveredPlace.category_icon) ? hoveredPlace.category_icon : null
 
   const { position: userPosition, mode: trackingMode, error: trackingError, cycleMode: cycleTrackingMode } = useGeolocation()
   // Desktop browsers only get IP-based geolocation (city-level accuracy),
@@ -668,7 +672,11 @@ export const MapView = memo(function MapView({
         </div>
         {hoveredPlace.category_name && CatIcon && (
           <div style={{ display: 'flex', alignItems: 'center', gap: 3, marginTop: 1 }}>
-            <CatIcon size={10} style={{ color: hoveredPlace.category_color || '#6b7280', flexShrink: 0 }} />
+            {catEmoji ? (
+              <span style={{ fontSize: 10, lineHeight: 1, flexShrink: 0 }}>{catEmoji}</span>
+            ) : (
+              <CatIcon size={10} style={{ color: hoveredPlace.category_color || '#6b7280', flexShrink: 0 }} />
+            )}
             <span style={{ fontSize: 11, color: '#6b7280' }}>{hoveredPlace.category_name}</span>
           </div>
         )}

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -5,7 +5,7 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useAuthStore } from '../../store/authStore'
 import { getCached, isLoading, fetchPhoto, onThumbReady, getAllThumbs } from '../../services/photoService'
-import { CATEGORY_ICON_MAP } from '../shared/categoryIcons'
+import { CATEGORY_ICON_MAP, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { isStandardFamily, supportsCustom3d, wantsTerrain, addCustom3dBuildings, addTerrainAndSky } from './mapboxSetup'
 import { attachLocationMarker, type LocationMarkerHandle } from './locationMarkerMapbox'
 import { ReservationMapboxOverlay } from './reservationsMapbox'
@@ -16,10 +16,21 @@ import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { buildPlacePopupHtml, buildPoiPopupHtml } from './placePopup'
 
 function categoryIconSvg(iconName: string | null | undefined, size: number): string {
+  if (isEmojiCategoryIcon(iconName)) {
+    return `<span style="font-size:${size}px;line-height:1;display:inline-flex;align-items:center;justify-content:center;">${escapeHtml(iconName)}</span>`
+  }
   const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
   try {
     return renderToStaticMarkup(createElement(IconComponent, { size, color: 'white', strokeWidth: 2.5 }))
   } catch { return '' }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 interface RouteSegment {

--- a/client/src/components/Map/placePopup.ts
+++ b/client/src/components/Map/placePopup.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { CATEGORY_ICON_MAP } from '../shared/categoryIcons'
+import { CATEGORY_ICON_MAP, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import type { Place } from '../../types'
 
@@ -26,6 +26,9 @@ function esc(s: string | null | undefined): string {
 
 // Render a lucide category icon to an inline SVG string in the given colour.
 function iconSvg(iconName: string | null | undefined, size: number, color: string): string {
+  if (isEmojiCategoryIcon(iconName)) {
+    return `<span style="font-size:${size}px;line-height:1;display:inline-flex;align-items:center;justify-content:center;">${esc(iconName)}</span>`
+  }
   const Icon = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
   try {
     return renderToStaticMarkup(createElement(Icon, { size, color, strokeWidth: 2 }))

--- a/client/src/components/PDF/TripPDF.tsx
+++ b/client/src/components/PDF/TripPDF.tsx
@@ -1,6 +1,6 @@
 // Trip PDF via browser print window
 import { createElement } from 'react'
-import { getCategoryIcon } from '../shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { FileText, Info, Clock, MapPin, Navigation, Train, Plane, Bus, Car, Ship, Sailboat, Bike, CarTaxiFront, Route, Coffee, Ticket, Star, Heart, Camera, Flag, Lightbulb, AlertTriangle, ShoppingBag, Bookmark, Hotel, LogIn, LogOut, KeyRound, BedDouble, Utensils, Users, LucideIcon } from 'lucide-react'
 import { accommodationsApi, mapsApi } from '../../api/client'
 import type { Trip, Day, Place, Category, AssignmentsMap, DayNote } from '../../types'
@@ -72,6 +72,9 @@ async function ensureRenderer() {
   }
 }
 function categoryIconSvg(iconName, color = '#6366f1', size = 24) {
+  if (isEmojiCategoryIcon(iconName)) {
+    return `<span style="font-size:${size}px;line-height:1;display:inline-flex;align-items:center;justify-content:center;">${escHtml(iconName)}</span>`
+  }
   if (!_renderToStaticMarkup) return ''
   const Icon = getCategoryIcon(iconName)
   return _renderToStaticMarkup(

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -13,7 +13,7 @@ import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import WeatherWidget from '../Weather/WeatherWidget'
 import { useToast } from '../shared/Toast'
-import { getCategoryIcon } from '../shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { useTripStore } from '../../store/tripStore'
 import { useCanDo } from '../../store/permissionsStore'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -1671,8 +1671,13 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                             <div style={{ flex: 1, minWidth: 0 }}>
                               <div style={{ display: 'flex', alignItems: 'center', gap: 4, overflow: 'hidden' }}>
                                 {cat && (() => {
+                                  if (isEmojiCategoryIcon(cat.icon)) return null
                                   const CatIcon = getCategoryIcon(cat.icon)
-                                  return <span title={cat.name} style={{ display: 'inline-flex', flexShrink: 0 }}><CatIcon size={10} strokeWidth={2} color={cat.color || 'var(--text-muted)'} /></span>
+                                  return (
+                                    <span title={cat.name} style={{ display: 'inline-flex', flexShrink: 0 }}>
+                                      <CatIcon size={10} strokeWidth={2} color={cat.color || 'var(--text-muted)'} />
+                                    </span>
+                                  )
                                 })()}
                                 <span style={{ fontSize: 12.5, fontWeight: 500, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.2 }}>
                                   {place.name}

--- a/client/src/components/Planner/PlaceFormModal.tsx
+++ b/client/src/components/Planner/PlaceFormModal.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '../../store/authStore'
 import { useCanDo } from '../../store/permissionsStore'
 import { useTripStore } from '../../store/tripStore'
 import { useToast } from '../shared/Toast'
-import { Search, Paperclip, X, AlertTriangle, Loader2 } from 'lucide-react'
+import { Search, Paperclip, X, AlertTriangle, Loader2, Plus } from 'lucide-react'
 import { useTranslation } from '../../i18n'
 import CustomTimePicker from '../shared/CustomTimePicker'
 import { DEFAULT_FORM, isGoogleMapsUrl, type PlaceFormData } from './PlaceFormModal.helpers'
@@ -74,6 +74,7 @@ function usePlaceFormModal(props: PlaceFormModalProps) {
   const [mapsResults, setMapsResults] = useState([])
   const [isSearchingMaps, setIsSearchingMaps] = useState(false)
   const [newCategoryName, setNewCategoryName] = useState('')
+  const [newCategoryIcon, setNewCategoryIcon] = useState('📍')
   const [showNewCategory, setShowNewCategory] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [duplicateWarning, setDuplicateWarning] = useState<string | null>(null)
@@ -85,10 +86,11 @@ function usePlaceFormModal(props: PlaceFormModalProps) {
   const acAbortRef = useRef<AbortController | null>(null)
   const toast = useToast()
   const { t, language } = useTranslation()
-  const { hasMapsKey } = useAuthStore()
+  const { hasMapsKey, user } = useAuthStore()
   const can = useCanDo()
   const tripObj = useTripStore((s) => s.trip)
   const canUploadFiles = can('file_upload', tripObj)
+  const canCreateCategory = user?.role === 'admin'
 
   useEffect(() => {
     if (place) {
@@ -321,9 +323,10 @@ function usePlaceFormModal(props: PlaceFormModalProps) {
   const handleCreateCategory = async () => {
     if (!newCategoryName.trim()) return
     try {
-      const cat = await onCategoryCreated?.({ name: newCategoryName, color: '#6366f1', icon: 'MapPin' })
+      const cat = await onCategoryCreated?.({ name: newCategoryName, color: '#6366f1', icon: newCategoryIcon.trim() || '📍' })
       if (cat) setForm(prev => ({ ...prev, category_id: String(cat.id) }))
       setNewCategoryName('')
+      setNewCategoryIcon('📍')
       setShowNewCategory(false)
     } catch (err: unknown) {
       toast.error(t('places.categoryCreateError'))
@@ -412,6 +415,8 @@ function usePlaceFormModal(props: PlaceFormModalProps) {
     setIsSearchingMaps,
     newCategoryName,
     setNewCategoryName,
+    newCategoryIcon,
+    setNewCategoryIcon,
     showNewCategory,
     setShowNewCategory,
     isSaving,
@@ -432,6 +437,7 @@ function usePlaceFormModal(props: PlaceFormModalProps) {
     can,
     tripObj,
     canUploadFiles,
+    canCreateCategory,
     places,
     locationBias,
     fetchSuggestions,
@@ -473,6 +479,8 @@ export default function PlaceFormModal(props: PlaceFormModalProps) {
     setIsSearchingMaps,
     newCategoryName,
     setNewCategoryName,
+    newCategoryIcon,
+    setNewCategoryIcon,
     showNewCategory,
     setShowNewCategory,
     isSaving,
@@ -493,6 +501,7 @@ export default function PlaceFormModal(props: PlaceFormModalProps) {
     can,
     tripObj,
     canUploadFiles,
+    canCreateCategory,
     places,
     locationBias,
     fetchSuggestions,
@@ -716,9 +725,28 @@ export default function PlaceFormModal(props: PlaceFormModalProps) {
                 style={{ flex: 1 }}
                 size="sm"
               />
+              {canCreateCategory && (
+                <button
+                  type="button"
+                  onClick={() => setShowNewCategory(true)}
+                  aria-label={t('categories.new')}
+                  className="border border-slate-200 text-slate-600 rounded-lg px-2 hover:bg-slate-50"
+                >
+                  <Plus className="w-4 h-4" />
+                </button>
+              )}
             </div>
           ) : (
             <div className="flex gap-2">
+              <input
+                type="text"
+                value={newCategoryIcon}
+                onChange={e => setNewCategoryIcon(e.target.value)}
+                aria-label={t('categories.icon')}
+                maxLength={8}
+                className="form-input text-center"
+                style={{ width: 52, flexShrink: 0 }}
+              />
               <input
                 type="text"
                 value={newCategoryName}
@@ -729,7 +757,7 @@ export default function PlaceFormModal(props: PlaceFormModalProps) {
               <button type="button" onClick={handleCreateCategory} className="bg-slate-900 text-white px-3 rounded-lg hover:bg-slate-700 text-sm">
                 OK
               </button>
-              <button type="button" onClick={() => setShowNewCategory(false)} className="text-gray-500 px-2 text-sm">
+              <button type="button" onClick={() => { setShowNewCategory(false); setNewCategoryIcon('📍') }} className="text-gray-500 px-2 text-sm">
                 {t('common.cancel')}
               </button>
             </div>

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -7,7 +7,7 @@ import { X, Clock, MapPin, ExternalLink, Phone, Euro, Edit2, Trash2, Plus, Minus
 import PlaceAvatar from '../shared/PlaceAvatar'
 import { mapsApi } from '../../api/client'
 import { useSettingsStore } from '../../store/settingsStore'
-import { getCategoryIcon } from '../shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import { useToast } from '../shared/Toast'
 import { useTranslation } from '../../i18n'
 import type { Place, Category, Day, Assignment, Reservation, TripFile, AssignmentsMap } from '../../types'
@@ -541,6 +541,7 @@ function PlaceInspectorHeader({ openNow, place, category, t, editingName, nameIn
               )}
               {category && (() => {
                 const CatIcon = getCategoryIcon(category.icon)
+                const emojiIcon = isEmojiCategoryIcon(category.icon) ? category.icon : null
                 return (
                   <span style={{
                     display: 'inline-flex', alignItems: 'center', gap: 4,
@@ -550,7 +551,11 @@ function PlaceInspectorHeader({ openNow, place, category, t, editingName, nameIn
                     border: `1px solid ${category.color ? `${category.color}30` : 'transparent'}`,
                     padding: '2px 8px', borderRadius: 99,
                   }}>
-                    <CatIcon size={10} />
+                    {emojiIcon ? (
+                      <span style={{ fontSize: 10, lineHeight: 1 }}>{emojiIcon}</span>
+                    ) : (
+                      <CatIcon size={10} />
+                    )}
                     <span className="hidden sm:inline">{category.name}</span>
                   </span>
                 )

--- a/client/src/components/Planner/PlacesSidebarHeader.tsx
+++ b/client/src/components/Planner/PlacesSidebarHeader.tsx
@@ -1,5 +1,5 @@
 import { Search, Plus, X, Upload, ChevronDown, Check, MapPin } from 'lucide-react'
-import { getCategoryIcon } from '../shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import Tooltip from '../shared/Tooltip'
 import type { SidebarState } from './usePlacesSidebar'
 
@@ -209,6 +209,7 @@ export function PlacesHeader(S: SidebarState) {
                 {categories.map(c => {
                   const active = categoryFilters.has(String(c.id))
                   const CatIcon = getCategoryIcon(c.icon)
+                  const emojiIcon = isEmojiCategoryIcon(c.icon) ? c.icon : null
                   return (
                     <button key={c.id} onClick={() => toggleCategoryFilter(String(c.id))} className={`text-content ${active ? 'bg-surface-hover' : 'bg-transparent'}`} style={{
                       display: 'flex', alignItems: 'center', gap: 8, width: '100%',
@@ -224,7 +225,11 @@ export function PlacesHeader(S: SidebarState) {
                       }}>
                         {active && <Check size={10} strokeWidth={3} color="white" />}
                       </div>
-                      <CatIcon size={12} strokeWidth={2} color={c.color || 'var(--text-muted)'} />
+                      {emojiIcon ? (
+                        <span style={{ fontSize: 12, lineHeight: 1 }}>{emojiIcon}</span>
+                      ) : (
+                        <CatIcon size={12} strokeWidth={2} color={c.color || 'var(--text-muted)'} />
+                      )}
                       <span style={{ flex: 1 }}>{c.name}</span>
                     </button>
                   )

--- a/client/src/components/Planner/PlacesSidebarListImportModal.tsx
+++ b/client/src/components/Planner/PlacesSidebarListImportModal.tsx
@@ -7,7 +7,10 @@ export function ListImportModal(S: SidebarState) {
     setListImportOpen, setListImportUrl, t, hasMultipleListImportProviders, availableListImportProviders,
     listImportProvider, setListImportProvider, listImportUrl, listImportLoading, handleListImport,
     listImportEnrich, setListImportEnrich, canEnrichImport,
+    categories, listImportCategoryMode, setListImportCategoryMode,
+    listImportCategoryId, setListImportCategoryId,
   } = S
+  const importDisabled = !listImportUrl.trim() || listImportLoading || (listImportCategoryMode === 'existing' && !listImportCategoryId)
   return ReactDOM.createPortal(
     <div
       onClick={() => { setListImportOpen(false); setListImportUrl('') }}
@@ -57,6 +60,42 @@ export function ListImportModal(S: SidebarState) {
             fontFamily: 'inherit', boxSizing: 'border-box',
           }}
         />
+        <div style={{ marginTop: 12 }}>
+          <label className="text-content" style={{ display: 'block', fontSize: 12, fontWeight: 600, marginBottom: 6 }}>
+            {t('places.formCategory')}
+          </label>
+          <select
+            value={listImportCategoryMode}
+            onChange={e => setListImportCategoryMode(e.target.value as 'none' | 'existing' | 'list')}
+            className="bg-surface-tertiary text-content"
+            style={{
+              width: '100%', padding: '9px 12px', borderRadius: 10,
+              border: '1px solid var(--border-primary)', fontSize: 13,
+              outline: 'none', fontFamily: 'inherit', boxSizing: 'border-box',
+            }}
+          >
+            <option value="none">{t('places.noCategory')}</option>
+            {categories.length > 0 && <option value="existing">Specific category</option>}
+            <option value="list">New category from list title</option>
+          </select>
+          {listImportCategoryMode === 'existing' && (
+            <select
+              value={listImportCategoryId}
+              onChange={e => setListImportCategoryId(e.target.value)}
+              className="bg-surface-tertiary text-content"
+              style={{
+                width: '100%', padding: '9px 12px', borderRadius: 10,
+                border: '1px solid var(--border-primary)', fontSize: 13,
+                outline: 'none', fontFamily: 'inherit', boxSizing: 'border-box', marginTop: 8,
+              }}
+            >
+              <option value="">{t('places.formCategory')}</option>
+              {categories.map(category => (
+                <option key={category.id} value={String(category.id)}>{category.name}</option>
+              ))}
+            </select>
+          )}
+        </div>
         {canEnrichImport && (
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginTop: 12 }}>
             <div style={{ flex: 1, minWidth: 0 }}>
@@ -80,11 +119,11 @@ export function ListImportModal(S: SidebarState) {
           </button>
           <button
             onClick={handleListImport}
-            disabled={!listImportUrl.trim() || listImportLoading}
-            className={!listImportUrl.trim() || listImportLoading ? 'bg-surface-tertiary text-content-faint' : 'bg-accent text-accent-text'}
+            disabled={importDisabled}
+            className={importDisabled ? 'bg-surface-tertiary text-content-faint' : 'bg-accent text-accent-text'}
             style={{
               padding: '8px 16px', borderRadius: 10, border: 'none',
-              fontSize: 13, fontWeight: 500, cursor: !listImportUrl.trim() || listImportLoading ? 'default' : 'pointer',
+              fontSize: 13, fontWeight: 500, cursor: importDisabled ? 'default' : 'pointer',
               fontFamily: 'inherit',
             }}
           >

--- a/client/src/components/Planner/PlacesSidebarRow.tsx
+++ b/client/src/components/Planner/PlacesSidebarRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Plus, Check, Route } from 'lucide-react'
 import PlaceAvatar from '../shared/PlaceAvatar'
-import { getCategoryIcon } from '../shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../shared/categoryIcons'
 import type { Place, Category } from '../../types'
 
 interface MemoPlaceRowProps {
@@ -75,8 +75,13 @@ export const MemoPlaceRow = React.memo(function MemoPlaceRow({
         <div style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden' }}>
           {hasGeometry && <span title="Track / Route" style={{ display: 'inline-flex', flexShrink: 0 }}><Route size={11} strokeWidth={2} color="var(--text-faint)" /></span>}
           {cat && (() => {
+            if (isEmojiCategoryIcon(cat.icon)) return null
             const CatIcon = getCategoryIcon(cat.icon)
-            return <span title={cat.name} style={{ display: 'inline-flex', flexShrink: 0 }}><CatIcon size={11} strokeWidth={2} color={cat.color || '#6366f1'} /></span>
+            return (
+              <span title={cat.name} style={{ display: 'inline-flex', flexShrink: 0 }}>
+                <CatIcon size={11} strokeWidth={2} color={cat.color || '#6366f1'} />
+              </span>
+            )
           })()}
           <span className="text-content" style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.2 }}>
             {place.name}

--- a/client/src/components/Planner/usePlacesSidebar.ts
+++ b/client/src/components/Planner/usePlacesSidebar.ts
@@ -98,6 +98,8 @@ export function usePlacesSidebar(props: PlacesSidebarProps) {
   const [listImportLoading, setListImportLoading] = useState(false)
   const [listImportProvider, setListImportProvider] = useState<'google' | 'naver'>('google')
   const [listImportEnrich, setListImportEnrich] = useState(false)
+  const [listImportCategoryMode, setListImportCategoryMode] = useState<'none' | 'existing' | 'list'>('none')
+  const [listImportCategoryId, setListImportCategoryId] = useState('')
   const availableListImportProviders: Array<'google' | 'naver'> = isNaverListImportEnabled ? ['google', 'naver'] : ['google']
   const hasMultipleListImportProviders = availableListImportProviders.length > 1
 
@@ -109,13 +111,19 @@ export function usePlacesSidebar(props: PlacesSidebarProps) {
 
   const handleListImport = async () => {
     if (!listImportUrl.trim()) return
+    if (listImportCategoryMode === 'existing' && !listImportCategoryId) return
     setListImportLoading(true)
     const provider = listImportProvider === 'naver' && isNaverListImportEnabled ? 'naver' : 'google'
     try {
       const enrich = listImportEnrich && canEnrichImport
+      const categoryOptions = listImportCategoryMode === 'existing' && listImportCategoryId
+        ? { categoryId: listImportCategoryId }
+        : listImportCategoryMode === 'list'
+          ? { createCategoryFromList: true }
+          : {}
       const result = provider === 'google'
-        ? await placesApi.importGoogleList(tripId, listImportUrl.trim(), enrich)
-        : await placesApi.importNaverList(tripId, listImportUrl.trim(), enrich)
+        ? await placesApi.importGoogleList(tripId, listImportUrl.trim(), { enrich, ...categoryOptions })
+        : await placesApi.importNaverList(tripId, listImportUrl.trim(), { enrich, ...categoryOptions })
       await loadTrip(tripId)
       if (result.count === 0 && result.skipped > 0) {
         toast.warning(t('places.importAllSkipped'))
@@ -229,6 +237,8 @@ export function usePlacesSidebar(props: PlacesSidebarProps) {
     listImportOpen, setListImportOpen, listImportUrl, setListImportUrl,
     listImportLoading, listImportProvider, setListImportProvider,
     listImportEnrich, setListImportEnrich, canEnrichImport,
+    listImportCategoryMode, setListImportCategoryMode,
+    listImportCategoryId, setListImportCategoryId,
     availableListImportProviders, hasMultipleListImportProviders, handleListImport,
     search, setSearch, filter, setFilter, categoryFilters, setCategoryFiltersLocal,
     selectMode, setSelectMode, selectedIds, setSelectedIds, pendingDeleteIds, setPendingDeleteIds,

--- a/client/src/components/shared/PlaceAvatar.tsx
+++ b/client/src/components/shared/PlaceAvatar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { getCategoryIcon } from './categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from './categoryIcons'
 import { getCached, isLoading, fetchPhoto, onThumbReady } from '../../services/photoService'
 import { useAuthStore } from '../../store/authStore'
 import type { Place } from '../../types'
@@ -68,6 +68,7 @@ export default React.memo(function PlaceAvatar({ place, size = 32, category }: P
 
   const bgColor = category?.color || '#6366f1'
   const IconComp = getCategoryIcon(category?.icon)
+  const emojiIcon = isEmojiCategoryIcon(category?.icon) ? category.icon : null
   const iconSize = Math.round(size * 0.46)
 
   const containerStyle: React.CSSProperties = {
@@ -106,7 +107,11 @@ export default React.memo(function PlaceAvatar({ place, size = 32, category }: P
 
   return (
     <div ref={ref} style={containerStyle}>
-      <IconComp size={iconSize} strokeWidth={1.8} color="rgba(255,255,255,0.92)" />
+      {emojiIcon ? (
+        <span style={{ fontSize: iconSize, lineHeight: 1 }}>{emojiIcon}</span>
+      ) : (
+        <IconComp size={iconSize} strokeWidth={1.8} color="rgba(255,255,255,0.92)" />
+      )}
     </div>
   )
 })

--- a/client/src/components/shared/categoryIcons.ts
+++ b/client/src/components/shared/categoryIcons.ts
@@ -39,6 +39,10 @@ export const ICON_LABELS: Record<string, string> = {
   Luggage: 'Luggage', Backpack: 'Backpack', Zap: 'Adventure',
 }
 
+export function isEmojiCategoryIcon(iconName: string | null | undefined): iconName is string {
+  return !!iconName && !CATEGORY_ICON_MAP[iconName]
+}
+
 export function getCategoryIcon(iconName: string | null | undefined): LucideIcon {
   return (iconName && CATEGORY_ICON_MAP[iconName]) || MapPin
 }

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation, SUPPORTED_LANGUAGES } from '../i18n'
 import { useSettingsStore } from '../store/settingsStore'
 import { getLocaleForLanguage } from '../i18n'
 import { useSharedTrip } from './sharedTrip/useSharedTrip'
-import { getCategoryIcon } from '../components/shared/categoryIcons'
+import { getCategoryIcon, isEmojiCategoryIcon } from '../components/shared/categoryIcons'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Clock, MapPin, FileText, Train, Plane, Bus, Car, Ship, Ticket, Hotel, Map, Luggage, Wallet, MessageCircle } from 'lucide-react'
@@ -20,13 +20,23 @@ function createMarkerIcon(place: any) {
   const cat = place.category
   const color = cat?.color || '#6366f1'
   const CatIcon = getCategoryIcon(cat?.icon)
-  const iconSvg = renderToStaticMarkup(createElement(CatIcon, { size: 14, strokeWidth: 2, color: 'white' }))
+  const iconSvg = isEmojiCategoryIcon(cat?.icon)
+    ? `<span style="font-size:14px;line-height:1;display:inline-flex;align-items:center;justify-content:center;">${escHtml(cat.icon)}</span>`
+    : renderToStaticMarkup(createElement(CatIcon, { size: 14, strokeWidth: 2, color: 'white' }))
   return L.divIcon({
     className: '',
     iconSize: [28, 28],
     iconAnchor: [14, 14],
     html: `<div style="width:28px;height:28px;border-radius:50%;background:${color};display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,0.3);border:2px solid white;">${iconSvg}</div>`,
   })
+}
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 function FitBoundsToPlaces({ places }: { places: any[] }) {

--- a/server/src/nest/places/places.controller.ts
+++ b/server/src/nest/places/places.controller.ts
@@ -163,17 +163,45 @@ export class PlacesController {
   }
 
   @Post('import/google-list')
-  async importGoogle(@CurrentUser() user: User, @Param('tripId') tripId: string, @Body('url') url: unknown, @Body('enrich') enrich: unknown, @Headers('x-socket-id') socketId?: string) {
-    return this.importList('google', user, tripId, url, enrich, socketId);
+  async importGoogle(
+    @CurrentUser() user: User,
+    @Param('tripId') tripId: string,
+    @Body('url') url: unknown,
+    @Body('enrich') enrich: unknown,
+    @Body('category_id') categoryId: unknown,
+    @Body('create_category_from_list') createCategoryFromList: unknown,
+    @Body('category_icon') categoryIcon: unknown,
+    @Headers('x-socket-id') socketId?: string,
+  ) {
+    return this.importList('google', user, tripId, url, enrich, categoryId, createCategoryFromList, categoryIcon, socketId);
   }
 
   @Post('import/naver-list')
-  async importNaver(@CurrentUser() user: User, @Param('tripId') tripId: string, @Body('url') url: unknown, @Body('enrich') enrich: unknown, @Headers('x-socket-id') socketId?: string) {
-    return this.importList('naver', user, tripId, url, enrich, socketId);
+  async importNaver(
+    @CurrentUser() user: User,
+    @Param('tripId') tripId: string,
+    @Body('url') url: unknown,
+    @Body('enrich') enrich: unknown,
+    @Body('category_id') categoryId: unknown,
+    @Body('create_category_from_list') createCategoryFromList: unknown,
+    @Body('category_icon') categoryIcon: unknown,
+    @Headers('x-socket-id') socketId?: string,
+  ) {
+    return this.importList('naver', user, tripId, url, enrich, categoryId, createCategoryFromList, categoryIcon, socketId);
   }
 
   /** Shared google/naver list import — identical flow, different provider + error string. */
-  private async importList(provider: 'google' | 'naver', user: User, tripId: string, url: unknown, enrich: unknown, socketId?: string) {
+  private async importList(
+    provider: 'google' | 'naver',
+    user: User,
+    tripId: string,
+    url: unknown,
+    enrich: unknown,
+    categoryId: unknown,
+    createCategoryFromList: unknown,
+    categoryIcon: unknown,
+    socketId?: string,
+  ) {
     const trip = this.requireTrip(tripId, user);
     this.requireEdit(trip, user);
     if (!url || typeof url !== 'string') {
@@ -181,7 +209,13 @@ export class PlacesController {
     }
     // Opt-in: re-resolve each imported place via the Places API to fill in
     // photo / address / website / phone and persist a google_place_id (#886).
-    const opts = { enrich: parseBool(enrich, false), userId: user.id };
+    const opts = {
+      enrich: parseBool(enrich, false),
+      userId: user.id,
+      categoryId: (typeof categoryId === 'string' || typeof categoryId === 'number') ? categoryId : undefined,
+      createCategoryFromList: parseBool(createCategoryFromList, false),
+      categoryIcon: typeof categoryIcon === 'string' ? categoryIcon : undefined,
+    };
     const label = provider === 'google' ? 'Google' : 'Naver';
     try {
       const result = provider === 'google'

--- a/server/src/services/placeService.ts
+++ b/server/src/services/placeService.ts
@@ -29,11 +29,66 @@ function reclaimPhotoCache(googlePlaceId: string | null, imageUrl: string | null
   }
 }
 
-/** Opt-in Places-API enrichment for list imports (#886). */
+/** Options for list imports: optional enrichment and category assignment. */
 export interface ListImportOptions {
   enrich?: boolean;
   userId?: number;
   lang?: string;
+  categoryId?: number | string | null;
+  createCategoryFromList?: boolean;
+  categoryIcon?: string | null;
+}
+
+type ImportCategoryResult =
+  | { categoryId: number | null }
+  | { error: string; status: number };
+
+const EMOJI_PATTERN = /(?:[\u{1F1E6}-\u{1F1FF}]{2}|\p{Extended_Pictographic}[\uFE0E\uFE0F]?(?:[\u{1F3FB}-\u{1F3FF}])?(?:\u200D\p{Extended_Pictographic}[\uFE0E\uFE0F]?(?:[\u{1F3FB}-\u{1F3FF}])?)*)/u;
+
+function firstEmoji(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return value.match(EMOJI_PATTERN)?.[0] || null;
+}
+
+function extractGoogleListIcon(meta: unknown): string | null {
+  if (!Array.isArray(meta)) return null;
+  const knownIcon = firstEmoji(meta[17]);
+  if (knownIcon) return knownIcon;
+  for (const value of meta) {
+    const icon = firstEmoji(value);
+    if (icon) return icon;
+  }
+  return null;
+}
+
+function resolveListImportCategoryId(listName: string, opts?: ListImportOptions, listIcon?: string | null): ImportCategoryResult {
+  const requestedId = opts?.categoryId;
+  if (requestedId !== undefined && requestedId !== null && String(requestedId).trim() !== '') {
+    const categoryId = Number(requestedId);
+    if (!Number.isInteger(categoryId) || categoryId <= 0) {
+      return { error: 'Category not found', status: 400 };
+    }
+    const existing = db.prepare('SELECT id FROM categories WHERE id = ?').get(categoryId) as { id: number } | undefined;
+    if (!existing) {
+      return { error: 'Category not found', status: 404 };
+    }
+    return { categoryId };
+  }
+
+  if (opts?.createCategoryFromList) {
+    const name = listName.trim() || 'Imported list';
+    const existing = db.prepare('SELECT id FROM categories WHERE lower(name) = lower(?) LIMIT 1').get(name) as { id: number } | undefined;
+    if (existing) {
+      return { categoryId: existing.id };
+    }
+    const icon = listIcon?.trim() || opts.categoryIcon?.trim() || '📍';
+    const result = db.prepare(
+      'INSERT INTO categories (name, color, icon, user_id) VALUES (?, ?, ?, ?)',
+    ).run(name, '#6366f1', icon, opts.userId || null);
+    return { categoryId: Number(result.lastInsertRowid) };
+  }
+
+  return { categoryId: null };
 }
 
 interface PlaceWithCategory extends Place {
@@ -682,6 +737,7 @@ export async function importGoogleList(tripId: string, url: string, opts?: ListI
   }
 
   const listName = meta[4] || 'Google Maps List';
+  const listIcon = extractGoogleListIcon(meta);
   const items = meta[8];
 
   if (!Array.isArray(items) || items.length === 0) {
@@ -706,10 +762,14 @@ export async function importGoogleList(tripId: string, url: string, opts?: ListI
     return { error: 'No places with coordinates found in list', status: 400 };
   }
 
+  const categoryResult = resolveListImportCategoryId(listName, opts, listIcon);
+  if ('error' in categoryResult) return categoryResult;
+  const categoryId = categoryResult.categoryId;
+
   const dedup = buildDedupSet(tripId);
   const insertStmt = db.prepare(`
-    INSERT INTO places (trip_id, name, lat, lng, notes, transport_mode)
-    VALUES (?, ?, ?, ?, ?, 'walking')
+    INSERT INTO places (trip_id, name, lat, lng, notes, category_id, transport_mode)
+    VALUES (?, ?, ?, ?, ?, ?, 'walking')
   `);
   const created: any[] = [];
   let skipped = 0;
@@ -719,7 +779,7 @@ export async function importGoogleList(tripId: string, url: string, opts?: ListI
         skipped++;
         continue;
       }
-      const result = insertStmt.run(tripId, p.name, p.lat, p.lng, p.notes);
+      const result = insertStmt.run(tripId, p.name, p.lat, p.lng, p.notes, categoryId);
       const place = getPlaceWithTags(Number(result.lastInsertRowid));
       created.push(place);
       trackInsertedInDedupSet({ name: p.name, lat: p.lat, lng: p.lng }, dedup);
@@ -840,10 +900,14 @@ export async function importNaverList(
     return { error: 'No places with coordinates found in list', status: 400 };
   }
 
+  const categoryResult = resolveListImportCategoryId(listName, opts);
+  if ('error' in categoryResult) return categoryResult;
+  const categoryId = categoryResult.categoryId;
+
   const dedup = buildDedupSet(tripId);
   const insertStmt = db.prepare(`
-    INSERT INTO places (trip_id, name, lat, lng, address, notes, transport_mode)
-    VALUES (?, ?, ?, ?, ?, ?, 'walking')
+    INSERT INTO places (trip_id, name, lat, lng, address, notes, category_id, transport_mode)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'walking')
   `);
   const created: any[] = [];
   let skipped = 0;
@@ -853,7 +917,7 @@ export async function importNaverList(
         skipped++;
         continue;
       }
-      const result = insertStmt.run(tripId, p.name, p.lat, p.lng, p.address, p.notes);
+      const result = insertStmt.run(tripId, p.name, p.lat, p.lng, p.address, p.notes, categoryId);
       const place = getPlaceWithTags(Number(result.lastInsertRowid));
       created.push(place);
       trackInsertedInDedupSet({ name: p.name, lat: p.lat, lng: p.lng }, dedup);

--- a/shared/src/place/place.schema.ts
+++ b/shared/src/place/place.schema.ts
@@ -116,6 +116,9 @@ export const placeImportListRequestSchema = z.object({
   // Opt-in: enrich imported places via the Places API (#886). Requires a Google
   // Maps key; runs as a background pass after the import returns.
   enrich: z.boolean().optional(),
+  category_id: z.union([z.number(), z.string()]).optional(),
+  create_category_from_list: z.boolean().optional(),
+  category_icon: z.string().optional(),
 });
 export type PlaceImportListRequest = z.infer<typeof placeImportListRequestSchema>;
 


### PR DESCRIPTION
## Description
1. Add the ability to create a custom category, and set an icon (emoji) for it.
2. When importing a list from Google Maps, add the ability to import it to a specific / new category. (Also, for lists with an emoji set, it should import that emoji to the category)
3. Map marker without photos should display the category emoji, instead of the generic icon

I need these features because here is what my Google Maps look like:

<img width="1151" height="1032" alt="image" src="https://github.com/user-attachments/assets/10a78dc2-4b69-449b-b58d-44ba879ad182" />

## Related Issue or Discussion
#1284 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
