### PR TITLE
feat: add distance unit (metric/imperial) display setting

### DIFF
--- a/client/src/components/Admin/DefaultUserSettingsTab.tsx
+++ b/client/src/components/Admin/DefaultUserSettingsTab.tsx
@@ -214,7 +214,7 @@ export default function DefaultUserSettingsTab(): React.ReactElement {
       </OptionRow>
 
       {/* Distance */}
-      <OptionRow label={<>Distance <ResetButton field="distance_unit" /></>}>
+      <OptionRow label={<>{t('settings.distance')} <ResetButton field="distance_unit" /></>}>
         {([
           { value: 'metric', label: 'km Metric' },
           { value: 'imperial', label: 'mi Imperial' },

--- a/client/src/components/Admin/DefaultUserSettingsTab.tsx
+++ b/client/src/components/Admin/DefaultUserSettingsTab.tsx
@@ -7,7 +7,7 @@ import Section from '../Settings/Section'
 import CustomSelect from '../shared/CustomSelect'
 import { MapView } from '../Map/MapView'
 import { CURRENCIES, SYMBOLS } from '../Budget/BudgetPanel.constants'
-import type { Place } from '../../types'
+import type { DistanceUnit, Place } from '../../types'
 
 const MAP_PRESETS = [
   { name: 'OpenStreetMap', url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' },
@@ -19,6 +19,7 @@ const MAP_PRESETS = [
 
 type Defaults = {
   temperature_unit?: string
+  distance_unit?: DistanceUnit
   dark_mode?: string | boolean
   time_format?: string
   default_currency?: string
@@ -206,6 +207,22 @@ export default function DefaultUserSettingsTab(): React.ReactElement {
             key={opt.value}
             active={defaults.temperature_unit === opt.value}
             onClick={() => save({ temperature_unit: opt.value })}
+          >
+            {opt.label}
+          </OptionButton>
+        ))}
+      </OptionRow>
+
+      {/* Distance */}
+      <OptionRow label={<>Distance <ResetButton field="distance_unit" /></>}>
+        {([
+          { value: 'metric', label: 'km Metric' },
+          { value: 'imperial', label: 'mi Imperial' },
+        ] as const).map(opt => (
+          <OptionButton
+            key={opt.value}
+            active={defaults.distance_unit === opt.value}
+            onClick={() => save({ distance_unit: opt.value })}
           >
             {opt.label}
           </OptionButton>

--- a/client/src/components/Map/RouteCalculator.ts
+++ b/client/src/components/Map/RouteCalculator.ts
@@ -240,7 +240,9 @@ export async function calculateRouteWithLegs(
   }
 
   const coords = waypoints.map((p) => `${p.lng},${p.lat}`).join(';')
-  const cacheKey = `${profile}:${coords}`
+  // The cached result carries formatted leg distances, so the active distance unit is
+  // part of the key — otherwise switching km↔mi would return stale text (#1300).
+  const cacheKey = `${profile}:${getDistanceUnit()}:${coords}`
   const cached = routeCache.get(cacheKey)
   if (cached) return cached
 

--- a/client/src/components/Map/RouteCalculator.ts
+++ b/client/src/components/Map/RouteCalculator.ts
@@ -1,4 +1,6 @@
-import type { RouteResult, RouteSegment, RouteWithLegs, Waypoint, RouteAnchors } from '../../types'
+import { useSettingsStore } from '../../store/settingsStore'
+import type { DistanceUnit, RouteResult, RouteSegment, RouteWithLegs, Waypoint, RouteAnchors } from '../../types'
+import { formatDistance } from '../../utils/units'
 
 const OSRM_BASE = 'https://router.project-osrm.org/route/v1'
 
@@ -60,7 +62,7 @@ export async function calculateRoute(
     coordinates,
     distance,
     duration,
-    distanceText: formatDistance(distance),
+    distanceText: formatRouteDistance(distance),
     durationText: formatDuration(duration),
     walkingText: formatDuration(walkingDuration),
     drivingText: formatDuration(drivingDuration),
@@ -218,7 +220,7 @@ export async function calculateSegments(
       duration: leg.duration,
       walkingText: formatDuration(walkingDuration),
       drivingText: formatDuration(leg.duration),
-      distanceText: formatDistance(leg.distance),
+      distanceText: formatRouteDistance(leg.distance),
     }
   })
 }
@@ -265,7 +267,7 @@ export async function calculateRouteWithLegs(
         duration: leg.duration,
         walkingText: formatDuration(walkingDuration),
         drivingText: formatDuration(leg.duration),
-        distanceText: formatDistance(leg.distance),
+        distanceText: formatRouteDistance(leg.distance),
         durationText: formatDuration(leg.duration),
       }
     }
@@ -280,11 +282,16 @@ export async function calculateRouteWithLegs(
   return result
 }
 
-function formatDistance(meters: number): string {
-  if (meters < 1000) {
+function getDistanceUnit(): DistanceUnit {
+  return useSettingsStore.getState().settings.distance_unit === 'imperial' ? 'imperial' : 'metric'
+}
+
+function formatRouteDistance(meters: number): string {
+  const unit = getDistanceUnit()
+  if (unit === 'metric' && meters < 1000) {
     return `${Math.round(meters)} m`
   }
-  return `${(meters / 1000).toFixed(1)} km`
+  return formatDistance(meters / 1000, unit)
 }
 
 function formatDuration(seconds: number): string {

--- a/client/src/components/Planner/DayDetailPanel.test.tsx
+++ b/client/src/components/Planner/DayDetailPanel.test.tsx
@@ -402,9 +402,9 @@ describe('DayDetailPanel', () => {
     await screen.findByText('20:15');
   });
 
-  it('FE-PLANNER-DAYDETAIL-027: weather chips show imperial wind speed', async () => {
+  it('FE-PLANNER-DAYDETAIL-027: weather chips show Fahrenheit wind speed', async () => {
     seedStore(useSettingsStore, {
-      settings: { time_format: '24h', temperature_unit: 'celsius', distance_unit: 'imperial', blur_booking_codes: false },
+      settings: { time_format: '24h', temperature_unit: 'fahrenheit', blur_booking_codes: false },
     });
     server.use(
       http.get('/api/weather/detailed', () =>

--- a/client/src/components/Planner/DayDetailPanel.test.tsx
+++ b/client/src/components/Planner/DayDetailPanel.test.tsx
@@ -402,9 +402,9 @@ describe('DayDetailPanel', () => {
     await screen.findByText('20:15');
   });
 
-  it('FE-PLANNER-DAYDETAIL-027: weather chips show Fahrenheit wind speed', async () => {
+  it('FE-PLANNER-DAYDETAIL-027: weather chips show imperial wind speed', async () => {
     seedStore(useSettingsStore, {
-      settings: { time_format: '24h', temperature_unit: 'fahrenheit', blur_booking_codes: false },
+      settings: { time_format: '24h', temperature_unit: 'celsius', distance_unit: 'imperial', blur_booking_codes: false },
     });
     server.use(
       http.get('/api/weather/detailed', () =>

--- a/client/src/components/Planner/DayDetailPanel.tsx
+++ b/client/src/components/Planner/DayDetailPanel.tsx
@@ -14,7 +14,6 @@ import { getLocaleForLanguage, useTranslation } from '../../i18n'
 import type { Day, Place, Category, Reservation, AssignmentsMap } from '../../types'
 import { isDayInAccommodationRange } from '../../utils/dayOrder'
 import { splitReservationDateTime } from '../../utils/formatters'
-import { convertDistance } from '../../utils/units'
 import { useDayDetail } from './useDayDetail'
 
 const WEATHER_ICON_MAP = {
@@ -69,7 +68,6 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
   const tripObj = useTripStore((s) => s.trip)
   const canEditDays = can('day_edit', tripObj)
   const isFahrenheit = useSettingsStore(s => s.settings.temperature_unit) === 'fahrenheit'
-  const distanceUnit = useSettingsStore(s => s.settings.distance_unit) || 'metric'
   const is12h = useSettingsStore(s => s.settings.time_format) === '12h'
   const blurCodes = useSettingsStore(s => s.settings.blur_booking_codes)
   const fmtTime = (v) => {
@@ -78,8 +76,6 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
     return formatTime12(v, is12h)
   }
   const unit = isFahrenheit ? '°F' : '°C'
-  const formatWindSpeed = (kmh: number) =>
-    distanceUnit === 'imperial' ? `${Math.round(convertDistance(kmh, distanceUnit))} mph` : `${Math.round(kmh)} km/h`
   const collapsed = collapsedProp
   const toggleCollapse = () => onToggleCollapse?.()
   const {
@@ -176,7 +172,7 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
                     <Chip icon={CloudRain} value={`${weather.precipitation_sum.toFixed(1)} mm`} />
                   )}
                   {weather.wind_max != null && (
-                    <Chip icon={Wind} value={formatWindSpeed(weather.wind_max)} />
+                    <Chip icon={Wind} value={isFahrenheit ? `${Math.round(weather.wind_max * 0.621371)} mph` : `${Math.round(weather.wind_max)} km/h`} />
                   )}
                   {weather.sunrise && <Chip icon={Sunrise} value={weather.sunrise} />}
                   {weather.sunset && <Chip icon={Sunset} value={weather.sunset} />}

--- a/client/src/components/Planner/DayDetailPanel.tsx
+++ b/client/src/components/Planner/DayDetailPanel.tsx
@@ -14,6 +14,7 @@ import { getLocaleForLanguage, useTranslation } from '../../i18n'
 import type { Day, Place, Category, Reservation, AssignmentsMap } from '../../types'
 import { isDayInAccommodationRange } from '../../utils/dayOrder'
 import { splitReservationDateTime } from '../../utils/formatters'
+import { convertDistance } from '../../utils/units'
 import { useDayDetail } from './useDayDetail'
 
 const WEATHER_ICON_MAP = {
@@ -68,6 +69,7 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
   const tripObj = useTripStore((s) => s.trip)
   const canEditDays = can('day_edit', tripObj)
   const isFahrenheit = useSettingsStore(s => s.settings.temperature_unit) === 'fahrenheit'
+  const distanceUnit = useSettingsStore(s => s.settings.distance_unit) || 'metric'
   const is12h = useSettingsStore(s => s.settings.time_format) === '12h'
   const blurCodes = useSettingsStore(s => s.settings.blur_booking_codes)
   const fmtTime = (v) => {
@@ -76,6 +78,8 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
     return formatTime12(v, is12h)
   }
   const unit = isFahrenheit ? '°F' : '°C'
+  const formatWindSpeed = (kmh: number) =>
+    distanceUnit === 'imperial' ? `${Math.round(convertDistance(kmh, distanceUnit))} mph` : `${Math.round(kmh)} km/h`
   const collapsed = collapsedProp
   const toggleCollapse = () => onToggleCollapse?.()
   const {
@@ -172,7 +176,7 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
                     <Chip icon={CloudRain} value={`${weather.precipitation_sum.toFixed(1)} mm`} />
                   )}
                   {weather.wind_max != null && (
-                    <Chip icon={Wind} value={isFahrenheit ? `${Math.round(weather.wind_max * 0.621371)} mph` : `${Math.round(weather.wind_max)} km/h`} />
+                    <Chip icon={Wind} value={formatWindSpeed(weather.wind_max)} />
                   )}
                   {weather.sunrise && <Chip icon={Sunrise} value={weather.sunrise} />}
                   {weather.sunset && <Chip icon={Sunset} value={weather.sunset} />}

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -154,6 +154,9 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
   const [routeLegs, setRouteLegs] = useState<Record<number, RouteSegment>>({})
   const [hotelLegs, setHotelLegs] = useState<{ top?: { seg: RouteSegment; name: string }; bottom?: { seg: RouteSegment; name: string } }>({})
   const optimizeFromAccommodation = useSettingsStore(s => s.settings.optimize_from_accommodation)
+  // Recompute the hotel/route legs when the user flips km↔mi so the connector
+  // distances refresh instead of showing stale cached text (#1300).
+  const distanceUnit = useSettingsStore(s => s.settings.distance_unit)
   const legsAbortRef = useRef<AbortController | null>(null)
   const [draggingId, setDraggingId] = useState(null)
   const [lockedIds, setLockedIds] = useState(new Set())
@@ -470,7 +473,7 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
 
       if (!controller.signal.aborted) { setRouteLegs(map); setHotelLegs(hotel) }
     })()
-  }, [selectedDayId, routeShown, routeProfile, mergedItemsMap, accommodations, days, optimizeFromAccommodation])
+  }, [selectedDayId, routeShown, routeProfile, mergedItemsMap, accommodations, days, optimizeFromAccommodation, distanceUnit])
 
   const openAddNote = (dayId, e) => {
     e?.stopPropagation()

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -12,7 +12,7 @@ import { useToast } from '../shared/Toast'
 import { useTranslation } from '../../i18n'
 import type { Place, Category, Day, Assignment, Reservation, TripFile, AssignmentsMap } from '../../types'
 import { splitReservationDateTime, formatTime } from '../../utils/formatters'
-import { formatDistance } from '../../utils/units'
+import { formatDistance, formatElevation } from '../../utils/units'
 
 const detailsCache = new Map()
 
@@ -784,14 +784,14 @@ function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpand
                       <>
                         <div className="text-content" style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600 }}>
                           <Mountain size={12} color="#22c55e" />
-                          {Math.round(maxEle)} m
+                          {formatElevation(maxEle, distanceUnit)}
                         </div>
                         <div className="text-content" style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600 }}>
                           <Mountain size={12} color="#ef4444" />
-                          {Math.round(minEle)} m
+                          {formatElevation(minEle, distanceUnit)}
                         </div>
                         <div className="text-content-muted" style={{ fontSize: 12 }}>
-                          ↑{Math.round(totalUp)} m &nbsp;↓{Math.round(totalDown)} m
+                          ↑{formatElevation(totalUp, distanceUnit)} &nbsp;↓{formatElevation(totalDown, distanceUnit)}
                         </div>
                       </>
                     )}

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -12,6 +12,7 @@ import { useToast } from '../shared/Toast'
 import { useTranslation } from '../../i18n'
 import type { Place, Category, Day, Assignment, Reservation, TripFile, AssignmentsMap } from '../../types'
 import { splitReservationDateTime, formatTime } from '../../utils/formatters'
+import { formatDistance } from '../../utils/units'
 
 const detailsCache = new Map()
 
@@ -122,6 +123,7 @@ export default function PlaceInspector({
   const { t, locale, language } = useTranslation()
   const toast = useToast()
   const timeFormat = useSettingsStore(s => s.settings.time_format) || '24h'
+  const distanceUnit = useSettingsStore(s => s.settings.distance_unit) || 'metric'
   const [hoursExpanded, setHoursExpanded] = useState(false)
   const [filesExpanded, setFilesExpanded] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
@@ -274,7 +276,8 @@ export default function PlaceInspector({
           <PlaceExtras openingHours={openingHours} weekdayIndex={weekdayIndex} hoursExpanded={hoursExpanded}
             setHoursExpanded={setHoursExpanded} timeFormat={timeFormat} t={t} place={place} placeFiles={placeFiles}
             onFileUpload={onFileUpload} filesExpanded={filesExpanded} setFilesExpanded={setFilesExpanded}
-            fileInputRef={fileInputRef} handleFileUpload={handleFileUpload} isUploading={isUploading} />
+            fileInputRef={fileInputRef} handleFileUpload={handleFileUpload} isUploading={isUploading}
+            distanceUnit={distanceUnit} />
 
         </div>
 
@@ -682,7 +685,7 @@ function PlaceReservationParticipants({ selectedAssignmentId, reservations, assi
 }
 
 function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpanded, timeFormat, t, place,
-  placeFiles, onFileUpload, filesExpanded, setFilesExpanded, fileInputRef, handleFileUpload, isUploading }: any) {
+  placeFiles, onFileUpload, filesExpanded, setFilesExpanded, fileInputRef, handleFileUpload, isUploading, distanceUnit }: any) {
   return (
           <div className={`grid grid-cols-1 ${openingHours?.length > 0 ? 'sm:grid-cols-2' : ''} gap-2`}>
           {openingHours && openingHours.length > 0 && (
@@ -775,7 +778,7 @@ function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpand
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                     <div className="text-content" style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600 }}>
                       <MapPin size={12} color="#3b82f6" />
-                      {distKm < 1 ? `${Math.round(totalDist)} m` : `${distKm.toFixed(1)} km`}
+                      {formatDistance(distKm, distanceUnit)}
                     </div>
                     {hasEle && (
                       <>

--- a/client/src/components/Settings/DisplaySettingsTab.test.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.test.tsx
@@ -150,6 +150,22 @@ describe('DisplaySettingsTab', () => {
     expect(updateSetting).toHaveBeenCalledWith('temperature_unit', 'fahrenheit');
   });
 
+  it('FE-COMP-DISPLAY-028: metric distance button is active by default', () => {
+    seedStore(useSettingsStore, { settings: { temperature_unit: 'celsius' } });
+    render(<DisplaySettingsTab />);
+    const metricBtn = screen.getByText('km Metric').closest('button')!;
+    expect(metricBtn.style.border).toContain('var(--text-primary)');
+  });
+
+  it('FE-COMP-DISPLAY-029: clicking imperial distance calls updateSetting with imperial', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, { settings: buildSettings({ distance_unit: 'metric' }), updateSetting });
+    render(<DisplaySettingsTab />);
+    await user.click(screen.getByText('mi Imperial'));
+    expect(updateSetting).toHaveBeenCalledWith('distance_unit', 'imperial');
+  });
+
   it('FE-COMP-DISPLAY-020: clicking 24h time format calls updateSetting with 24h', async () => {
     const user = userEvent.setup();
     const updateSetting = vi.fn().mockResolvedValue(undefined);

--- a/client/src/components/Settings/DisplaySettingsTab.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.tsx
@@ -208,7 +208,7 @@ export default function DisplaySettingsTab(): React.ReactElement {
 
       {/* Distance */}
       <div>
-        <label className="block text-sm font-medium mb-2 text-content-secondary">Distance</label>
+        <label className="block text-sm font-medium mb-2 text-content-secondary">{t('settings.distance')}</label>
         <div className="flex gap-3">
           {([
             { value: 'metric', label: 'km Metric' },

--- a/client/src/components/Settings/DisplaySettingsTab.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.tsx
@@ -6,12 +6,14 @@ import { useToast } from '../shared/Toast'
 import CustomSelect from '../shared/CustomSelect'
 import { CURRENCIES, SYMBOLS } from '../Budget/BudgetPanel.constants'
 import Section from './Section'
+import type { DistanceUnit } from '../../types'
 
 export default function DisplaySettingsTab(): React.ReactElement {
   const { settings, updateSetting } = useSettingsStore()
   const { t } = useTranslation()
   const toast = useToast()
   const [tempUnit, setTempUnit] = useState<string>(settings.temperature_unit || 'celsius')
+  const [distanceUnit, setDistanceUnit] = useState<DistanceUnit>(settings.distance_unit || 'metric')
   const [langOpen, setLangOpen] = useState(false)
   const langDropdownRef = useRef<HTMLDivElement | null>(null)
 
@@ -27,6 +29,10 @@ export default function DisplaySettingsTab(): React.ReactElement {
   useEffect(() => {
     setTempUnit(settings.temperature_unit || 'celsius')
   }, [settings.temperature_unit])
+
+  useEffect(() => {
+    setDistanceUnit(settings.distance_unit || 'metric')
+  }, [settings.distance_unit])
 
   return (
     <Section title={t('settings.display')} icon={Palette}>
@@ -190,6 +196,37 @@ export default function DisplaySettingsTab(): React.ReactElement {
                 fontFamily: 'inherit', fontSize: 14, fontWeight: 500,
                 border: tempUnit === opt.value ? '2px solid var(--text-primary)' : '2px solid var(--border-primary)',
                 background: tempUnit === opt.value ? 'var(--bg-hover)' : 'var(--bg-card)',
+                color: 'var(--text-primary)',
+                transition: 'all 0.15s',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Distance */}
+      <div>
+        <label className="block text-sm font-medium mb-2 text-content-secondary">Distance</label>
+        <div className="flex gap-3">
+          {([
+            { value: 'metric', label: 'km Metric' },
+            { value: 'imperial', label: 'mi Imperial' },
+          ] as const).map(opt => (
+            <button
+              key={opt.value}
+              onClick={async () => {
+                setDistanceUnit(opt.value)
+                try { await updateSetting('distance_unit', opt.value) }
+                catch (e: unknown) { toast.error(e instanceof Error ? e.message : t('common.error')) }
+              }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '10px 20px', borderRadius: 10, cursor: 'pointer',
+                fontFamily: 'inherit', fontSize: 14, fontWeight: 500,
+                border: distanceUnit === opt.value ? '2px solid var(--text-primary)' : '2px solid var(--border-primary)',
+                background: distanceUnit === opt.value ? 'var(--bg-hover)' : 'var(--bg-card)',
                 color: 'var(--text-primary)',
                 transition: 'all 0.15s',
               }}

--- a/client/src/hooks/useRouteCalculation.ts
+++ b/client/src/hooks/useRouteCalculation.ts
@@ -25,6 +25,9 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
   // Draw the day's accommodation bookend legs (hotel → first stop, last stop →
   // hotel) unless the user turned the setting off — same gate as the sidebar.
   const optimizeFromAccommodation = useSettingsStore((s) => s.settings.optimize_from_accommodation)
+  // Recompute when the user flips km↔mi so leg distances (formatted at compute time)
+  // refresh instead of showing stale cached text (#1300).
+  const distanceUnit = useSettingsStore((s) => s.settings.distance_unit)
 
   const updateRouteForDay = useCallback(async (dayId: number | null) => {
     if (routeAbortRef.current) routeAbortRef.current.abort()
@@ -164,7 +167,7 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
       // Aborted (day changed) — newer call owns the state. Anything else: keep straight lines.
       if (!(err instanceof Error) || err.name !== 'AbortError') setRouteSegments([])
     }
-  }, [enabled, profile, accommodations, optimizeFromAccommodation])
+  }, [enabled, profile, accommodations, optimizeFromAccommodation, distanceUnit])
 
   // Stable signature for transport reservations on the selected day — changes when a transport
   // is added, removed, or repositioned, ensuring route recalc fires even on transport-only reorders.
@@ -188,7 +191,7 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
     if (!selectedDayId) { setRoute(null); setRouteSegments([]); return }
     updateRouteForDay(selectedDayId)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDayId, selectedDayAssignments, transportSignature, enabled, profile, accommodations, optimizeFromAccommodation])
+  }, [selectedDayId, selectedDayAssignments, transportSignature, enabled, profile, accommodations, optimizeFromAccommodation, distanceUnit])
 
   return { route, routeSegments, routeInfo, setRoute, setRouteInfo, updateRouteForDay }
 }

--- a/client/src/pages/DashboardPage.test.tsx
+++ b/client/src/pages/DashboardPage.test.tsx
@@ -4,9 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../tests/helpers/msw/server';
 import { resetAllStores, seedStore } from '../../tests/helpers/store';
-import { buildUser, buildAdmin, buildTrip } from '../../tests/helpers/factories';
+import { buildUser, buildAdmin, buildTrip, buildSettings } from '../../tests/helpers/factories';
 import { useAuthStore } from '../store/authStore';
 import { usePermissionsStore } from '../store/permissionsStore';
+import { useSettingsStore } from '../store/settingsStore';
 import DashboardPage from './DashboardPage';
 
 beforeEach(() => {
@@ -798,10 +799,51 @@ describe('DashboardPage', () => {
     });
   });
 
+  describe('FE-PAGE-DASH-033: Atlas distance respects distance unit setting', () => {
+    const distanceValue = (text: string) =>
+      screen.getByText((_, element) =>
+        element?.classList.contains('value') === true &&
+        element.textContent?.replace(/\s+/g, ' ').trim() === text
+      );
+
+    beforeEach(() => {
+      server.use(
+        http.get('/api/auth/travel-stats', () =>
+          HttpResponse.json({
+            totalTrips: 1,
+            totalDays: 1,
+            totalPlaces: 1,
+            totalDistanceKm: 10,
+            countries: [],
+          })
+        ),
+      );
+    });
+
+    it('renders metric atlas distance as kilometers', async () => {
+      seedStore(useSettingsStore, { settings: buildSettings({ distance_unit: 'metric' }) });
+
+      render(<DashboardPage />);
+
+      await waitFor(() => {
+        expect(distanceValue('10 km')).toBeInTheDocument();
+      });
+    });
+
+    it('renders imperial atlas distance as miles', async () => {
+      seedStore(useSettingsStore, { settings: buildSettings({ distance_unit: 'imperial' }) });
+
+      render(<DashboardPage />);
+
+      await waitFor(() => {
+        expect(distanceValue('6.2 mi')).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('FE-PAGE-DASH-032: Dark mode detection uses window.matchMedia', () => {
     it('renders without error when dark_mode is set to auto', async () => {
       // Seed settings with dark_mode = 'auto' to exercise the matchMedia branch
-      const { useSettingsStore } = await import('../store/settingsStore');
       seedStore(useSettingsStore, {
         settings: {
           map_tile_url: '',
@@ -812,6 +854,7 @@ describe('DashboardPage', () => {
           default_currency: 'USD',
           language: 'en',
           temperature_unit: 'fahrenheit',
+          distance_unit: 'metric',
           time_format: '12h',
           show_place_description: false,
           blur_booking_codes: false,

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -361,12 +361,13 @@ function BoardingPassHero({ trip, bundle, locale, onOpen, onEdit, onCopy, onArch
 // ── Atlas / stats row ────────────────────────────────────────────────────────
 function formatCompactDistance(value: number): string {
   const safeValue = Number.isFinite(value) ? Math.max(0, value) : 0
+  // String() keeps a '.' decimal regardless of locale (no "1,5k" in non-English UIs).
   if (safeValue >= 1000) {
-    return `${(safeValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })}k`
+    return `${String(Math.round(safeValue / 100) / 10)}k`
   }
   const rounded = Math.round(safeValue * 10) / 10
   if (safeValue > 0 && rounded === 0) return '<0.1'
-  return rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })
+  return String(rounded)
 }
 
 function AtlasStats({ stats }: { stats: TravelStats | null }): React.ReactElement {

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -19,6 +19,7 @@ import {
   LayoutGrid, List, Ticket, X,
 } from 'lucide-react'
 import { formatTime, splitReservationDateTime } from '../utils/formatters'
+import { convertDistance, getDistanceUnitLabel } from '../utils/units'
 import { useSettingsStore } from '../store/settingsStore'
 import '../styles/dashboard.css'
 
@@ -358,12 +359,26 @@ function BoardingPassHero({ trip, bundle, locale, onOpen, onEdit, onCopy, onArch
 }
 
 // ── Atlas / stats row ────────────────────────────────────────────────────────
+function formatCompactDistance(value: number): string {
+  const safeValue = Number.isFinite(value) ? Math.max(0, value) : 0
+  if (safeValue >= 1000) {
+    return `${(safeValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })}k`
+  }
+  const rounded = Math.round(safeValue * 10) / 10
+  if (safeValue > 0 && rounded === 0) return '<0.1'
+  return rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
 function AtlasStats({ stats }: { stats: TravelStats | null }): React.ReactElement {
   const { t } = useTranslation()
+  const distanceUnit = useSettingsStore(s => s.settings.distance_unit) || 'metric'
   const countries = stats?.countries || []
   const distanceKm = stats?.totalDistanceKm || 0
-  const distanceText = distanceKm >= 1000 ? `${(distanceKm / 1000).toFixed(1)}k` : String(distanceKm)
-  const equatorTimes = (distanceKm / 40075).toFixed(2)
+  const distance = convertDistance(distanceKm, distanceUnit)
+  const distanceText = formatCompactDistance(distance)
+  const equatorDistance = convertDistance(40075, distanceUnit)
+  const equatorTimes = (distance / equatorDistance).toFixed(2)
+  const distanceLabel = getDistanceUnitLabel(distanceUnit)
 
   return (
     <section className="atlas">
@@ -401,7 +416,7 @@ function AtlasStats({ stats }: { stats: TravelStats | null }): React.ReactElemen
 
       <div className="atlas-card">
         <div className="label">{t('dashboard.atlas.distanceFlown')}</div>
-        <div className="value mono">{distanceText} <span className="unit">{t('dashboard.atlas.kmUnit')}</span></div>
+        <div className="value mono">{distanceText} <span className="unit">{distanceLabel}</span></div>
         <div className="delta">{t('dashboard.atlas.aroundEquator', { count: equatorTimes })}</div>
         <svg className="spark" width="80" height="36" viewBox="0 0 80 36">
           <circle cx="40" cy="18" r="14" fill="none" stroke="oklch(0.88 0.01 70)" strokeWidth="2" />

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -30,6 +30,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     default_currency: 'USD',
     language: localStorage.getItem('app_language') || 'en',
     temperature_unit: 'fahrenheit',
+    distance_unit: 'metric',
     time_format: '12h',
     show_place_description: false,
     optimize_from_accommodation: true,

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -100,6 +100,8 @@ export interface TripFile {
   url: string
 }
 
+export type DistanceUnit = 'metric' | 'imperial'
+
 export interface Settings {
   map_tile_url: string
   default_lat: number
@@ -109,6 +111,7 @@ export interface Settings {
   default_currency: string
   language: string
   temperature_unit: string
+  distance_unit?: DistanceUnit
   time_format: string
   show_place_description: boolean
   blur_booking_codes?: boolean

--- a/client/src/utils/units.test.ts
+++ b/client/src/utils/units.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { convertDistance, formatDistance, getDistanceUnitLabel } from './units'
+
+describe('units', () => {
+  describe('getDistanceUnitLabel', () => {
+    it('returns km for metric and mi for imperial', () => {
+      expect(getDistanceUnitLabel('metric')).toBe('km')
+      expect(getDistanceUnitLabel('imperial')).toBe('mi')
+    })
+  })
+
+  describe('convertDistance', () => {
+    it('keeps kilometres for metric', () => {
+      expect(convertDistance(10, 'metric')).toBe(10)
+    })
+    it('converts kilometres to miles for imperial', () => {
+      expect(convertDistance(10, 'imperial')).toBeCloseTo(6.21371, 4)
+    })
+    it('clamps negative and non-finite input to 0', () => {
+      expect(convertDistance(-5, 'imperial')).toBe(0)
+      expect(convertDistance(NaN, 'metric')).toBe(0)
+      expect(convertDistance(Infinity, 'metric')).toBe(0)
+    })
+  })
+
+  describe('formatDistance', () => {
+    it('shows metres below 1 km for metric', () => {
+      expect(formatDistance(0.3, 'metric')).toBe('300 m')
+      expect(formatDistance(0.05, 'metric')).toBe('50 m')
+    })
+    it('shows kilometres at or above 1 km for metric', () => {
+      expect(formatDistance(1.5, 'metric')).toBe('1.5 km')
+      expect(formatDistance(10, 'metric')).toBe('10 km')
+    })
+    it('shows miles for imperial', () => {
+      expect(formatDistance(10, 'imperial')).toBe('6.2 mi')
+    })
+    it('shows <0.1 for a tiny imperial distance', () => {
+      expect(formatDistance(0.05, 'imperial')).toBe('<0.1 mi')
+    })
+    it('clamps negative and non-finite input to 0', () => {
+      expect(formatDistance(-1, 'metric')).toBe('0 m')
+      expect(formatDistance(NaN, 'imperial')).toBe('0 mi')
+    })
+  })
+})

--- a/client/src/utils/units.ts
+++ b/client/src/utils/units.ts
@@ -1,9 +1,16 @@
 import type { DistanceUnit } from '../types'
 
 const KM_TO_MI = 0.621371
+const M_TO_FT = 3.28084
 
 export function getDistanceUnitLabel(unit: DistanceUnit): 'km' | 'mi' {
   return unit === 'imperial' ? 'mi' : 'km'
+}
+
+/** Formats an elevation in metres as feet for imperial, so it doesn't mix with mi distances. */
+export function formatElevation(meters: number, unit: DistanceUnit): string {
+  const safe = Number.isFinite(meters) ? meters : 0
+  return unit === 'imperial' ? `${Math.round(safe * M_TO_FT)} ft` : `${Math.round(safe)} m`
 }
 
 export function convertDistance(km: number, unit: DistanceUnit): number {
@@ -12,11 +19,17 @@ export function convertDistance(km: number, unit: DistanceUnit): number {
 }
 
 export function formatDistance(km: number, unit: DistanceUnit): string {
-  const value = convertDistance(km, unit)
+  const safeKm = Number.isFinite(km) ? Math.max(0, km) : 0
+  // Metric keeps a metres reading below 1 km (e.g. "300 m"), matching the route
+  // connectors; imperial has no sub-mile unit, so short hops just show "0.x mi".
+  if (unit === 'metric' && safeKm < 1) {
+    return `${Math.round(safeKm * 1000)} m`
+  }
+  const value = convertDistance(safeKm, unit)
   const label = getDistanceUnitLabel(unit)
   const rounded = Math.round(value * 10) / 10
-  const text = value > 0 && rounded === 0
-    ? '<0.1'
-    : rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })
+  // String() keeps a '.' decimal regardless of locale, matching the rest of the app
+  // (toFixed elsewhere) and avoiding "1,5 km" in non-English environments.
+  const text = value > 0 && rounded === 0 ? '<0.1' : String(rounded)
   return `${text} ${label}`
 }

--- a/client/src/utils/units.ts
+++ b/client/src/utils/units.ts
@@ -1,0 +1,22 @@
+import type { DistanceUnit } from '../types'
+
+const KM_TO_MI = 0.621371
+
+export function getDistanceUnitLabel(unit: DistanceUnit): 'km' | 'mi' {
+  return unit === 'imperial' ? 'mi' : 'km'
+}
+
+export function convertDistance(km: number, unit: DistanceUnit): number {
+  const safeKm = Number.isFinite(km) ? Math.max(0, km) : 0
+  return unit === 'imperial' ? safeKm * KM_TO_MI : safeKm
+}
+
+export function formatDistance(km: number, unit: DistanceUnit): string {
+  const value = convertDistance(km, unit)
+  const label = getDistanceUnitLabel(unit)
+  const rounded = Math.round(value * 10) / 10
+  const text = value > 0 && rounded === 0
+    ? '<0.1'
+    : rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })
+  return `${text} ${label}`
+}

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -8,6 +8,7 @@ const MASKED_SETTING_KEYS = new Set(['webhook_url', 'ntfy_token']);
 
 export const DEFAULTABLE_USER_SETTING_KEYS = [
   'temperature_unit',
+  'distance_unit',
   'dark_mode',
   'time_format',
   // Instance-wide default currency for Costs (new users inherit it until they
@@ -28,6 +29,7 @@ type DefaultableKey = typeof DEFAULTABLE_USER_SETTING_KEYS[number];
 
 const VALID_VALUES: Partial<Record<DefaultableKey, unknown[]>> = {
   temperature_unit: ['fahrenheit', 'celsius'],
+  distance_unit: ['metric', 'imperial'],
   time_format: ['12h', '24h'],
   dark_mode: [true, false, 'light', 'dark', 'auto'],
   map_provider: ['leaflet', 'mapbox-gl'],

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -51,6 +51,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'تلقائي',
   'settings.language': 'اللغة',
   'settings.temperature': 'وحدة الحرارة',
+  'settings.distance': 'وحدة المسافة',
   'settings.timeFormat': 'تنسيق الوقت',
   'settings.bookingLabels': 'تسميات مسارات الحجوزات',
   'settings.bookingLabelsHint': 'عرض أسماء المحطات/المطارات على الخريطة. عند الإيقاف، يتم عرض الرمز فقط.',

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automático',
   'settings.language': 'Idioma',
   'settings.temperature': 'Unidade de temperatura',
+  'settings.distance': 'Unidade de distância',
   'settings.timeFormat': 'Formato de hora',
   'settings.blurBookingCodes': 'Ocultar códigos de reserva',
   'settings.optimizeFromAccommodation': 'Otimizar rota a partir da hospedagem',

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -53,6 +53,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatické',
   'settings.language': 'Jazyk',
   'settings.temperature': 'Jednotky teploty',
+  'settings.distance': 'Jednotky vzdálenosti',
   'settings.timeFormat': 'Formát času',
   'settings.blurBookingCodes': 'Skrýt rezervační kódy',
   'settings.optimizeFromAccommodation': 'Optimalizovat trasu od ubytování',

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatisch',
   'settings.language': 'Sprache',
   'settings.temperature': 'Temperatureinheit',
+  'settings.distance': 'Entfernungseinheit',
   'settings.timeFormat': 'Zeitformat',
   'settings.bookingLabels': 'Orts-Labels auf Buchungsrouten',
   'settings.bookingLabelsHint': 'Zeigt Bahnhofs-/Flughafennamen auf der Karte. Wenn aus, wird nur das Icon angezeigt.',

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -53,6 +53,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Auto',
   'settings.language': 'Language',
   'settings.temperature': 'Temperature Unit',
+  'settings.distance': 'Distance Unit',
   'settings.timeFormat': 'Time Format',
   'settings.bookingLabels': 'Booking route labels',
   'settings.bookingLabelsHint': 'Show station / airport names on the map. When off, only the icon is shown.',

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -55,6 +55,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automático',
   'settings.language': 'Idioma',
   'settings.temperature': 'Unidad de temperatura',
+  'settings.distance': 'Unidad de distancia',
   'settings.timeFormat': 'Formato de hora',
   'settings.blurBookingCodes': 'Difuminar códigos de reserva',
   'settings.optimizeFromAccommodation': 'Optimizar la ruta desde el alojamiento',

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -56,6 +56,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Auto',
   'settings.language': 'Langue',
   'settings.temperature': 'Unité de température',
+  'settings.distance': 'Unité de distance',
   'settings.timeFormat': "Format de l'heure",
   'settings.blurBookingCodes': 'Masquer les codes de réservation',
   'settings.optimizeFromAccommodation': "Optimiser l'itinéraire depuis l'hébergement",

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -57,6 +57,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Αυτόματο',
   'settings.language': 'Γλώσσα',
   'settings.temperature': 'Μονάδα Θερμοκρασίας',
+  'settings.distance': 'Μονάδα Απόστασης',
   'settings.timeFormat': 'Μορφή Ώρας',
   'settings.bookingLabels': 'Ετικέτες διαδρομής κρατήσεων',
   'settings.bookingLabelsHint':

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatikus',
   'settings.language': 'Nyelv',
   'settings.temperature': 'Hőmérséklet egység',
+  'settings.distance': 'Távolság egység',
   'settings.timeFormat': 'Időformátum',
   'settings.blurBookingCodes': 'Foglalási kódok elrejtése',
   'settings.optimizeFromAccommodation': 'Útvonal optimalizálása a szállástól',

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Otomatis',
   'settings.language': 'Bahasa',
   'settings.temperature': 'Satuan Suhu',
+  'settings.distance': 'Satuan Jarak',
   'settings.timeFormat': 'Format Waktu',
   'settings.blurBookingCodes': 'Sembunyikan Kode Pemesanan',
   'settings.optimizeFromAccommodation': 'Optimalkan rute dari akomodasi',

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -55,6 +55,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatica',
   'settings.language': 'Lingua',
   'settings.temperature': 'Unità di Temperatura',
+  'settings.distance': 'Unità di Distanza',
   'settings.timeFormat': 'Formato Ora',
   'settings.blurBookingCodes': 'Nascondi codici di prenotazione',
   'settings.optimizeFromAccommodation': "Ottimizza il percorso dall'alloggio",

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -52,6 +52,7 @@ const settings: TranslationStrings = {
   'settings.auto': '自動',
   'settings.language': '言語',
   'settings.temperature': '温度単位',
+  'settings.distance': '距離単位',
   'settings.timeFormat': '時刻形式',
   'settings.bookingLabels': '予約ルートのラベル',
   'settings.bookingLabelsHint': '地図に駅・空港名を表示。オフ時はアイコンのみ。',

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -53,6 +53,7 @@ const settings: TranslationStrings = {
   'settings.auto': '자동',
   'settings.language': '언어',
   'settings.temperature': '온도 단위',
+  'settings.distance': '거리 단위',
   'settings.timeFormat': '시간 형식',
   'settings.bookingLabels': '예약 경로 레이블',
   'settings.bookingLabelsHint': '지도에 역 / 공항 이름을 표시합니다. 끄면 아이콘만 표시됩니다.',

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatisch',
   'settings.language': 'Taal',
   'settings.temperature': 'Temperatuureenheid',
+  'settings.distance': 'Afstandseenheid',
   'settings.timeFormat': 'Tijdnotatie',
   'settings.blurBookingCodes': 'Boekingscodes vervagen',
   'settings.optimizeFromAccommodation': 'Route optimaliseren vanaf accommodatie',

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Automatyczny',
   'settings.language': 'Język',
   'settings.temperature': 'Jednostka temperatury',
+  'settings.distance': 'Jednostka odległości',
   'settings.timeFormat': 'Format czasu',
   'settings.blurBookingCodes': 'Rozmyj kody rezerwacji',
   'settings.optimizeFromAccommodation': 'Optymalizuj trasę od zakwaterowania',

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -53,6 +53,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Авто',
   'settings.language': 'Язык',
   'settings.temperature': 'Единица температуры',
+  'settings.distance': 'Единица расстояния',
   'settings.timeFormat': 'Формат времени',
   'settings.blurBookingCodes': 'Скрыть коды бронирования',
   'settings.optimizeFromAccommodation': 'Оптимизировать маршрут от места проживания',

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -53,6 +53,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Otomatik',
   'settings.language': 'Dil',
   'settings.temperature': 'Sıcaklık Birimi',
+  'settings.distance': 'Mesafe Birimi',
   'settings.timeFormat': 'Saat Biçimi',
   'settings.bookingLabels': 'Rezervasyon rota etiketleri',
   'settings.bookingLabelsHint': 'Haritada istasyon / havalimanı adlarını göster. Kapalıyken yalnızca simge görünür.',

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -54,6 +54,7 @@ const settings: TranslationStrings = {
   'settings.auto': 'Авто',
   'settings.language': 'Мова',
   'settings.temperature': 'Одиниця температури',
+  'settings.distance': 'Одиниця відстані',
   'settings.timeFormat': 'Формат часу',
   'settings.blurBookingCodes': 'Приховати коди бронювання',
   'settings.optimizeFromAccommodation': 'Оптимізувати маршрут від житла',

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -52,6 +52,7 @@ const settings: TranslationStrings = {
   'settings.auto': '自動',
   'settings.language': '語言',
   'settings.temperature': '溫度單位',
+  'settings.distance': '距離單位',
   'settings.timeFormat': '時間格式',
   'settings.blurBookingCodes': '模糊預訂程式碼',
   'settings.optimizeFromAccommodation': '從住宿地點最佳化路線',

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -52,6 +52,7 @@ const settings: TranslationStrings = {
   'settings.auto': '自动',
   'settings.language': '语言',
   'settings.temperature': '温度单位',
+  'settings.distance': '距离单位',
   'settings.timeFormat': '时间格式',
   'settings.blurBookingCodes': '模糊预订代码',
   'settings.optimizeFromAccommodation': '从住宿地优化路线',


### PR DESCRIPTION
## Description
Adds a `distance_unit` (`metric` / `imperial`) user setting so distances render in miles instead of kilometers, mirroring the existing `temperature_unit` pattern exactly. A `formatDistance(km, unit)` helper (1 km = 0.621371 mi) is applied at the user-facing distance render sites (RouteCalculator, DayDetailPanel, PlaceInspector, DashboardPage). The setting persists through the existing untyped `/api/settings` key/value contract, so no server schema change is required. Default stays `metric`, so existing users see no change.

## Related Issue or Discussion
Closes #1300

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed (none required for this change)

Local verification: `tsc --noEmit` passes. New unit/component tests added for the setting, the display control, and distance rendering. Note: the full `vitest run` suite currently fails to start in a fresh clone due to a pre-existing `@trek/shared/i18n/*` vite transform error in `TranslationContext.tsx` (unrelated to this change); CI on `dev` will exercise the added tests.

AI was used for assistance.
