### PR TITLE
fix(airtrail): import departure/arrival times for manually-entered flights

### DIFF
--- a/server/src/services/airtrail/airtrailMapper.ts
+++ b/server/src/services/airtrail/airtrailMapper.ts
@@ -64,8 +64,8 @@ export function normalizeFlight(raw: AirtrailFlightRaw): AirtrailFlight {
     toCode: airportCode(raw.to),
     toName: raw.to?.name ?? null,
     date: raw.date ?? null,
-    departure: raw.departureScheduled ?? null,
-    arrival: raw.arrivalScheduled ?? null,
+    departure: raw.departureScheduled ?? raw.departure ?? null,
+    arrival: raw.arrivalScheduled ?? raw.arrival ?? null,
     airline: entityName(raw.airline),
     flightNumber: raw.flightNumber ?? null,
     aircraft: entityCode(raw.aircraft),
@@ -103,11 +103,14 @@ function hasCoords(a: AirtrailAirport | null): a is AirtrailAirport & { lat: num
 
 /** Raw AirTrail flight → the data createReservation() expects (type:'flight'). */
 export function mapFlightToReservation(raw: AirtrailFlightRaw): MappedReservation {
-  // Read the SCHEDULED times only — TREK plans against the scheduled (booked) time,
-  // not the actual/estimated `departure`/`arrival`. When a flight has no scheduled
-  // time, the clock is left blank (date preserved) rather than fabricated.
-  const dep = localParts(raw.departureScheduled, raw.from?.tz ?? null);
-  const arr = localParts(raw.arrivalScheduled, raw.to?.tz ?? null);
+  // Prefer the scheduled (booked) time TREK plans against, but fall back to the
+  // primary departure/arrival instant when AirTrail has no scheduled time. Manually
+  // entered flights only set `departure`/`arrival` (the `*Scheduled` columns stay
+  // null), so reading scheduled alone dropped the clock — and the whole arrival —
+  // for the common case (#1336). Only when neither exists is the clock left blank
+  // (date preserved) rather than fabricated.
+  const dep = localParts(raw.departureScheduled ?? raw.departure, raw.from?.tz ?? null);
+  const arr = localParts(raw.arrivalScheduled ?? raw.arrival, raw.to?.tz ?? null);
 
   const fromCode = airportCode(raw.from);
   const toCode = airportCode(raw.to);
@@ -194,8 +197,11 @@ export function canonicalHash(raw: AirtrailFlightRaw): string {
     to: airportCode(raw.to),
     date: raw.date ?? null,
     datePrecision: raw.datePrecision ?? 'day',
-    departureScheduled: raw.departureScheduled ?? null,
-    arrivalScheduled: raw.arrivalScheduled ?? null,
+    // Hash the same instant the import uses (scheduled, else primary) so a change to
+    // whichever time TREK actually shows triggers a re-sync — and existing flights
+    // imported without a scheduled time re-sync once to pick up their clock (#1336).
+    departureScheduled: raw.departureScheduled ?? raw.departure ?? null,
+    arrivalScheduled: raw.arrivalScheduled ?? raw.arrival ?? null,
     airline: entityCode(raw.airline),
     flightNumber: raw.flightNumber ?? null,
     aircraft: entityCode(raw.aircraft),

--- a/server/tests/unit/services/airtrailMapper.test.ts
+++ b/server/tests/unit/services/airtrailMapper.test.ts
@@ -51,9 +51,15 @@ describe('airtrailMapper.normalizeFlight', () => {
       flightNumber: 'BA178',
       seatClass: 'economy',
     });
-    // The picker preview surfaces the scheduled times, not the actual ones.
+    // The picker preview prefers the scheduled times over the actual ones.
     expect(n.departure).toBe('2021-09-01T23:00:00.000+00:00');
     expect(n.arrival).toBe('2021-09-02T07:00:00.000+00:00');
+  });
+
+  it('#1336 surfaces the primary departure/arrival when there is no scheduled time', () => {
+    const n = normalizeFlight(flight({ departureScheduled: null, arrivalScheduled: null }));
+    expect(n.departure).toBe('2021-09-01T23:42:00.000+00:00');
+    expect(n.arrival).toBe('2021-09-02T07:42:00.000+00:00');
   });
 
   it('falls back to ICAO when IATA is missing and tolerates null airports', () => {
@@ -74,13 +80,24 @@ describe('airtrailMapper.mapFlightToReservation', () => {
     expect(m.reservation_end_time).toBe('2021-09-02T08:00');
   });
 
-  it('leaves the clock blank (date only) when the flight has no scheduled time', () => {
-    const m = mapFlightToReservation(flight({ departureScheduled: null, arrivalScheduled: null }));
+  it('leaves the clock blank (date only) when the flight has no time at all', () => {
+    const m = mapFlightToReservation(flight({ departure: null, arrival: null, departureScheduled: null, arrivalScheduled: null }));
     // Date is preserved from the AirTrail canonical date; no fabricated 00:00.
     expect(m.reservation_time).toBe('2021-09-01');
     expect(m.reservation_end_time).toBeNull();
     expect(m.endpoints.find(e => e.role === 'from')?.local_time).toBeNull();
     expect(m.endpoints.find(e => e.role === 'to')?.local_time).toBeNull();
+  });
+
+  it('#1336 falls back to the primary departure/arrival when AirTrail has no scheduled times', () => {
+    // Manually-entered AirTrail flights set only departure/arrival; *Scheduled stays null.
+    const m = mapFlightToReservation(flight({ departureScheduled: null, arrivalScheduled: null }));
+    // departure 23:42 UTC at JFK (EDT) = 19:42 local; arrival 07:42 UTC at LHR (BST) = 08:42.
+    expect(m.reservation_time).toBe('2021-09-01T19:42');
+    expect(m.reservation_end_time).toBe('2021-09-02T08:42');
+    expect(m.endpoints.find(e => e.role === 'from')?.local_time).toBe('19:42');
+    expect(m.endpoints.find(e => e.role === 'to')?.local_time).toBe('08:42');
+    expect(m.endpoints.find(e => e.role === 'to')?.local_date).toBe('2021-09-02');
   });
 
   it('builds two endpoints with codes, coords and timezones', () => {
@@ -142,8 +159,8 @@ describe('airtrailMapper.mapFlightToReservation', () => {
     expect(m.endpoints.find(e => e.role === 'to')).toBeDefined();
   });
 
-  it('leaves the end time null for a partial flight with no scheduled arrival', () => {
-    const m = mapFlightToReservation(flight({ arrivalScheduled: null }));
+  it('leaves the end time null for a partial flight with no arrival time at all', () => {
+    const m = mapFlightToReservation(flight({ arrival: null, arrivalScheduled: null }));
     expect(m.reservation_end_time).toBeNull();
     expect(m.reservation_time).toBe('2021-09-01T19:00');
   });
@@ -164,9 +181,17 @@ describe('airtrailMapper.canonicalHash', () => {
     expect(canonicalHash(flight())).not.toBe(
       canonicalHash(flight({ departureScheduled: '2021-09-01T22:00:00.000+00:00' })),
     );
-    // ...but a change to the actual time alone must not (TREK never shows it).
+    // ...but a change to the actual time alone must not (TREK shows the scheduled one).
     expect(canonicalHash(flight())).toBe(
       canonicalHash(flight({ departure: '2021-09-01T20:00:00.000+00:00', arrival: '2021-09-02T05:00:00.000+00:00' })),
+    );
+  });
+
+  it('#1336 tracks the primary departure when there is no scheduled time', () => {
+    // With no scheduled time, departure IS what TREK imports, so a change must re-sync.
+    const manual = flight({ departureScheduled: null, arrivalScheduled: null });
+    expect(canonicalHash(manual)).not.toBe(
+      canonicalHash(flight({ departureScheduled: null, arrivalScheduled: null, departure: '2021-09-01T20:00:00.000+00:00' })),
     );
   });
 


### PR DESCRIPTION
## Problem

AirTrail flights imported into TREK were missing their **departure time** (only the date came through) and the **arrival entirely** (no date, no time) — #1336.

## Cause

The mapper read only `departureScheduled` / `arrivalScheduled`. In AirTrail those columns are **optional** and stay `null` for manually-entered flights — there, `departure` / `arrival` are the only times set. Verified against the AirTrail source (`flight` schema + `validateAndSaveFlight`), whose own rule is *"use departure if available, otherwise fall back to departureScheduled"*. TREK had it the other way around, so the common case lost its clock.

## Fix

Mirror AirTrail's precedence — prefer the scheduled instant, fall back to the primary `departure`/`arrival` — in `mapFlightToReservation`, `normalizeFlight`, and the sync `canonicalHash`. Because the hash now covers the resolved instant:

- flights already imported without a scheduled time **re-sync once and pick up their clock automatically**;
- flights that do have scheduled times are unaffected (no spurious re-sync).

The airline-name request in the same issue was already addressed by #1334 (3.1.3) and confirmed fixed by the reporter.

## Tests

3 new mapper cases (fallback mapping, picker preview, hash tracking); two existing cases that asserted the scheduled-only behaviour were updated to the "neither time set" case. Full server suite green (4085).

Fixes #1336
