### PR TITLE
feat(mobile): context-aware bottom-nav + button per trip tab

### DIFF
--- a/client/src/components/Layout/BottomNav.test.tsx
+++ b/client/src/components/Layout/BottomNav.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-BOTTOMNAV-001 to FE-COMP-BOTTOMNAV-006
+// FE-COMP-BOTTOMNAV-001 to FE-COMP-BOTTOMNAV-010
 
 vi.mock('../../api/websocket', () => ({
   connect: vi.fn(),
@@ -30,6 +30,7 @@ const currentUser = buildUser({ id: 1, username: 'testuser', email: 'test@exampl
 beforeEach(() => {
   resetAllStores();
   mockNavigate.mockClear();
+  sessionStorage.clear();
   seedStore(useAuthStore, { user: currentUser, isAuthenticated: true });
 });
 
@@ -78,5 +79,38 @@ describe('BottomNav', () => {
     });
     render(<BottomNav />);
     expect(screen.queryByText('Foo Addon')).not.toBeInTheDocument();
+  });
+
+  // Context-aware "+" inside a trip — #1349
+  it('FE-COMP-BOTTOMNAV-007: in a trip, the "+" adds a place by default (plan tab)', async () => {
+    const user = userEvent.setup();
+    sessionStorage.setItem('trip-tab-42', 'plan');
+    render(<BottomNav />, { initialEntries: ['/trips/42'] });
+    await user.click(screen.getByRole('button', { name: 'Add Place/Activity' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/trips/42?create=place');
+  });
+
+  it('FE-COMP-BOTTOMNAV-008: Bookings tab → "+" creates a reservation', async () => {
+    const user = userEvent.setup();
+    sessionStorage.setItem('trip-tab-42', 'buchungen');
+    render(<BottomNav />, { initialEntries: ['/trips/42'] });
+    await user.click(screen.getByRole('button', { name: 'Manual Booking' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/trips/42?create=reservation');
+  });
+
+  it('FE-COMP-BOTTOMNAV-009: Transports tab → "+" creates a transport', async () => {
+    const user = userEvent.setup();
+    sessionStorage.setItem('trip-tab-42', 'transports');
+    render(<BottomNav />, { initialEntries: ['/trips/42'] });
+    await user.click(screen.getByRole('button', { name: 'Manual Transport' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/trips/42?create=transport');
+  });
+
+  it('FE-COMP-BOTTOMNAV-010: Costs tab → "+" creates an expense', async () => {
+    const user = userEvent.setup();
+    sessionStorage.setItem('trip-tab-42', 'finanzplan');
+    render(<BottomNav />, { initialEntries: ['/trips/42'] });
+    await user.click(screen.getByRole('button', { name: 'Add expense' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/trips/42?create=expense');
   });
 });

--- a/client/src/components/Layout/BottomNav.tsx
+++ b/client/src/components/Layout/BottomNav.tsx
@@ -25,12 +25,15 @@ function useCreateAction(): { label: string; run: () => void } {
   const onJourneyList = useMatch('/journey')
 
   if (inTrip) {
-    // On the Costs tab the "+" adds an expense; otherwise it adds a place.
-    const tripTab = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(`trip-tab-${inTrip.params.id}`) : null
-    if (tripTab === 'finanzplan') {
-      return { label: t('costs.addExpense'), run: () => navigate(`/trips/${inTrip.params.id}?create=expense`) }
-    }
-    return { label: t('places.addPlace'), run: () => navigate(`/trips/${inTrip.params.id}?create=place`) }
+    // The "+" is context-aware per active tab: Bookings → reservation,
+    // Transports → transport, Costs → expense. Tabs without a create modal
+    // (lists / files / collab) fall through to adding a place. #1349
+    const id = inTrip.params.id
+    const tripTab = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(`trip-tab-${id}`) : null
+    if (tripTab === 'finanzplan') return { label: t('costs.addExpense'), run: () => navigate(`/trips/${id}?create=expense`) }
+    if (tripTab === 'buchungen') return { label: t('reservations.addManual'), run: () => navigate(`/trips/${id}?create=reservation`) }
+    if (tripTab === 'transports') return { label: t('transport.addManual'), run: () => navigate(`/trips/${id}?create=transport`) }
+    return { label: t('places.addPlace'), run: () => navigate(`/trips/${id}?create=place`) }
   }
   if (inJourney) {
     return { label: t('journey.detail.addEntry'), run: () => navigate(`/journey/${inJourney.params.id}?create=entry`) }

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -161,6 +161,20 @@ export function useTripPlanner() {
   const [showTransportModal, setShowTransportModal] = useState<boolean>(false)
   const [editingTransport, setEditingTransport] = useState<Reservation | null>(null)
   const [transportModalDayId, setTransportModalDayId] = useState<number | null>(null)
+
+  // The bottom-nav "+" is context-aware per tab: on the Bookings / Transports tabs
+  // it opens the booking / transport modal via ?create=reservation|transport
+  // (place is handled above, expense in CostsPanel). #1349
+  useEffect(() => {
+    const intent = searchParams.get('create')
+    if (intent === 'reservation') {
+      setEditingReservation(null); setBookingForAssignmentId(null); setShowReservationModal(true)
+      setSearchParams(p => { p.delete('create'); return p }, { replace: true })
+    } else if (intent === 'transport') {
+      setEditingTransport(null); setTransportModalDayId(null); setShowTransportModal(true)
+      setSearchParams(p => { p.delete('create'); return p }, { replace: true })
+    }
+  }, [searchParams])
   // Review-before-save import: each parsed item pre-fills the normal edit modal so
   // the user checks/fixes it, then saves. A ref drives the queue (no stale closures).
   const [reservationPrefill, setReservationPrefill] = useState<BookingReviewDraft | null>(null)


### PR DESCRIPTION
## What

Makes the mobile bottom-nav **"+"** context-aware per trip tab, as requested in discussion #1349. Previously it always created a new place (except on Costs → expense).

| Active tab | "+" now creates |
|---|---|
| Plan | Place (unchanged) |
| Transports | **Transport** (new) |
| Bookings | **Reservation** (new) |
| Costs | Expense (unchanged) |
| Lists / Files / Collab | Place (fallback — no create modal exists for these) |

## How

Reuses the existing `?create=<intent>` pattern:

- `BottomNav.useCreateAction` reads the active tab from `sessionStorage['trip-tab-${id}']` and emits the matching intent (`reservation` / `transport`, alongside the existing `place` / `expense`).
- `useTripPlanner` gains a consumer for `create=reservation|transport` that opens the booking / transport modal and strips the param — mirroring the existing `place` consumer. Both modals are already mounted at page level, so there are no mobile mount concerns.

Lists/Files/Collab have no single-item create modal today, so they keep the place fallback (no behaviour change there).

## Tests

4 new `BottomNav` cases asserting plan → `place`, Bookings → `reservation`, Transports → `transport`, Costs → `expense` (correct navigate target). client `tsc` clean, full client suite green (2855).

> Mobile UX change — worth a quick tap-through on a device against dev once deployed.

Implements #1349
