### PR TITLE
feat(helm): Allow to use existing PVC with customised names

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -40,6 +40,7 @@ See `values.yaml` for more options.
 ## Notes
 - Ingress is off by default. Enable and configure hosts for your domain.
 - PVCs use the cluster's default StorageClass. Set `persistence.data.storageClassName` and/or `persistence.uploads.storageClassName` to bind a specific class.
+- If you want to use your own PVCs, set `persistence.data.existingClaim` or `persistence.uploads.existingClaim` to bind it. The other PVCs values ​​will be ignored (size, storageClassName, annotations).
 - `JWT_SECRET` is managed entirely by the server — auto-generated into the data PVC on first start and rotatable via the admin panel (Settings → Danger Zone). No Helm configuration needed.
 - `ENCRYPTION_KEY` encrypts stored secrets (API keys, MFA, SMTP, OIDC) at rest. Recommended: set via `secretEnv.ENCRYPTION_KEY` or `existingSecret`. If left empty, the server falls back automatically: existing installs use `data/.jwt_secret` (no action needed on upgrade); fresh installs auto-generate a key persisted to the data PVC.
 - If using ingress, you must manually keep `env.ALLOWED_ORIGINS` and `ingress.hosts` in sync to ensure CORS works correctly. The chart does not sync these automatically.

--- a/charts/README.md
+++ b/charts/README.md
@@ -40,7 +40,8 @@ See `values.yaml` for more options.
 ## Notes
 - Ingress is off by default. Enable and configure hosts for your domain.
 - PVCs use the cluster's default StorageClass. Set `persistence.data.storageClassName` and/or `persistence.uploads.storageClassName` to bind a specific class.
-- If you want to use your own PVCs, set `persistence.data.existingClaim` or `persistence.uploads.existingClaim` to bind it. The other PVCs values ​​will be ignored (size, storageClassName, annotations).
+- To use your own PVCs, set `persistence.data.existingClaim` and/or `persistence.uploads.existingClaim`. The other values for that volume (size, storageClassName, annotations) are then ignored.
+- With `persistence.enabled: false`, the data and uploads volumes use an `emptyDir` — storage is ephemeral and lost on pod restart. Intended for testing only.
 - `JWT_SECRET` is managed entirely by the server — auto-generated into the data PVC on first start and rotatable via the admin panel (Settings → Danger Zone). No Helm configuration needed.
 - `ENCRYPTION_KEY` encrypts stored secrets (API keys, MFA, SMTP, OIDC) at rest. Recommended: set via `secretEnv.ENCRYPTION_KEY` or `existingSecret`. If left empty, the server falls back automatically: existing installs use `data/.jwt_secret` (no action needed on upgrade); fresh installs auto-generate a key persisted to the data PVC.
 - If using ingress, you must manually keep `env.ALLOWED_ORIGINS` and `ingress.hosts` in sync to ensure CORS works correctly. The chart does not sync these automatically.

--- a/charts/trek/templates/NOTES.txt
+++ b/charts/trek/templates/NOTES.txt
@@ -18,6 +18,7 @@
    - Generate a random key at install: `--set generateEncryptionKey=true`
    - Use an existing secret: `--set existingSecret=my-k8s-secret`
    - Use a custom key name in the existing secret: `--set existingSecret=my-k8s-secret --set existingSecretKey=MY_ENC_KEY`
+   - Use your own PVCs, set `persistence.data.existingClaim` or `persistence.uploads.existingClaim` to bind it. The other PVCs values ​​will be ignored (size, storageClassName, annotations).
 
 4. Only one method should be used at a time. If both `generateEncryptionKey` and `existingSecret` are
    set, `existingSecret` takes precedence. Ensure the referenced secret and key exist in the namespace.

--- a/charts/trek/templates/NOTES.txt
+++ b/charts/trek/templates/NOTES.txt
@@ -18,7 +18,12 @@
    - Generate a random key at install: `--set generateEncryptionKey=true`
    - Use an existing secret: `--set existingSecret=my-k8s-secret`
    - Use a custom key name in the existing secret: `--set existingSecret=my-k8s-secret --set existingSecretKey=MY_ENC_KEY`
-   - Use your own PVCs, set `persistence.data.existingClaim` or `persistence.uploads.existingClaim` to bind it. The other PVCs values ​​will be ignored (size, storageClassName, annotations).
 
 4. Only one method should be used at a time. If both `generateEncryptionKey` and `existingSecret` are
    set, `existingSecret` takes precedence. Ensure the referenced secret and key exist in the namespace.
+
+5. Persistence:
+   - To bind your own PVCs, set `persistence.data.existingClaim` and/or `persistence.uploads.existingClaim`.
+     The other values for that volume (size, storageClassName, annotations) are then ignored.
+   - With `persistence.enabled=false` the volumes use an emptyDir — storage is ephemeral and is lost
+     when the pod restarts. Use only for testing.

--- a/charts/trek/templates/deployment.yaml
+++ b/charts/trek/templates/deployment.yaml
@@ -82,8 +82,16 @@ spec:
             periodSeconds: 10
       volumes:
         - name: data
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-data" (include "trek.fullname" .)) .Values.persistence.data.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: uploads
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-uploads" (include "trek.fullname" .)) .Values.persistence.uploads.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/trek/templates/deployment.yaml
+++ b/charts/trek/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "trek.fullname" . }}-data
+            claimName: {{ default (printf "%s-data" (include "trek.fullname" .)) .Values.persistence.data.existingClaim }}
         - name: uploads
           persistentVolumeClaim:
-            claimName: {{ include "trek.fullname" . }}-uploads
+            claimName: {{ default (printf "%s-uploads" (include "trek.fullname" .)) .Values.persistence.uploads.existingClaim }}

--- a/charts/trek/templates/pvc.yaml
+++ b/charts/trek/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.data.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,7 +18,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.data.size }}
+{{- end }}
 ---
+{{- if and .Values.persistence.enabled (not .Values.persistence.uploads.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/trek/values.yaml
+++ b/charts/trek/values.yaml
@@ -106,10 +106,13 @@ persistence:
     size: 1Gi
     # Leave empty to use the cluster's default StorageClass; set to bind a specific class.
     storageClassName: ""
+    # Specify an existing PVC to use. The other values ​​will be ignored.
+    existingClaim: ""
     annotations: {}
   uploads:
     size: 1Gi
     storageClassName: ""
+    existingClaim: ""
     annotations: {}
 
 resources:

--- a/charts/trek/values.yaml
+++ b/charts/trek/values.yaml
@@ -101,17 +101,19 @@ existingSecret: ""
 existingSecretKey: ENCRYPTION_KEY
 
 persistence:
+  # When disabled, volumes fall back to an ephemeral emptyDir (data lost on pod restart).
   enabled: true
   data:
     size: 1Gi
     # Leave empty to use the cluster's default StorageClass; set to bind a specific class.
     storageClassName: ""
-    # Specify an existing PVC to use. The other values ​​will be ignored.
+    # Bind an existing PVC. The other values (size, storageClassName, annotations) are then ignored.
     existingClaim: ""
     annotations: {}
   uploads:
     size: 1Gi
     storageClassName: ""
+    # Specify an existing PVC to bind. The other values are then ignored.
     existingClaim: ""
     annotations: {}
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why? -->
This PR adds the ability to use existing PVCs via the `existingClaim` variable in the chart.
It also provides a fallback solution if persistence is not enabled and the PVC is replaced by an emptyDir.

## Related Issue or Discussion
<!-- This project requires an issue or an approved feature request before submitting a PR. -->
<!-- For bug fixes: Closes #ISSUE_NUMBER -->
<!-- For features: Addresses discussion #DISCUSSION_NUMBER -->
Feature validated on Discord topic.

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [X] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [X] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [X] I have tested my changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have updated documentation if needed