### PR TITLE
fix(map): group MapLibre icons and add toggle

### DIFF
--- a/client/src/components/Map/MapView.test.tsx
+++ b/client/src/components/Map/MapView.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { resetAllStores } from '../../../tests/helpers/store'
 import { buildPlace } from '../../../tests/helpers/factories'
 import * as photoService from '../../services/photoService'
+import { useSettingsStore } from '../../store/settingsStore'
 
 const mapMock = vi.hoisted(() => ({
   panTo: vi.fn(),
@@ -154,6 +155,19 @@ describe('MapView', () => {
     const places = [buildMapPlace({ lat: 48.8584, lng: 2.2945 })]
     render(<MapView places={places} />)
     expect(screen.getByTestId('cluster-group')).toBeTruthy()
+  })
+
+  it('FE-COMP-MAPVIEW-021: does not render MarkerClusterGroup when icon grouping is disabled', () => {
+    useSettingsStore.setState({
+      settings: {
+        ...useSettingsStore.getState().settings,
+        map_icon_grouping_enabled: false,
+      },
+    } as any)
+    const places = [buildMapPlace({ lat: 48.8584, lng: 2.2945 })]
+    render(<MapView places={places} />)
+    expect(screen.queryByTestId('cluster-group')).toBeNull()
+    expect(screen.getByTestId('marker')).toBeTruthy()
   })
 
   it('FE-COMP-MAPVIEW-011: renders the route polyline; travel times are no longer drawn on the map', () => {

--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -303,6 +303,7 @@ function MapContextMenuHandler({ onContextMenu }: { onContextMenu: ((e: L.Leafle
 // Module-level photo cache shared with PlaceAvatar
 import { getCached, isLoading, fetchPhoto, onThumbReady, getAllThumbs } from '../../services/photoService'
 import { useAuthStore } from '../../store/authStore'
+import { useSettingsStore } from '../../store/settingsStore'
 import { useGeolocation } from '../../hooks/useGeolocation'
 import LocationButton from './LocationButton'
 
@@ -432,6 +433,7 @@ export const MapView = memo(function MapView({
   onPoiClick,
   onViewportChange,
 }: any) {
+  const markerGroupingEnabled = useSettingsStore(s => s.settings.map_icon_grouping_enabled !== false)
   const poiMarkers = useMemo(() => (pois as Poi[]).map((poi: Poi) => (
     <Marker
       key={`poi-${poi.osm_id}`}
@@ -629,20 +631,22 @@ export const MapView = memo(function MapView({
       <ViewportController onViewportChange={onViewportChange} />
       <LeafletLocationLayer position={userPosition} mode={trackingMode} />
 
-      <MarkerClusterGroup
-        chunkedLoading
-        chunkInterval={30}
-        chunkDelay={0}
-        maxClusterRadius={30}
-        disableClusteringAtZoom={11}
-        spiderfyOnMaxZoom
-        showCoverageOnHover={false}
-        zoomToBoundsOnClick
-        animate={false}
-        iconCreateFunction={clusterIconCreateFunction}
-      >
-        {markers}
-      </MarkerClusterGroup>
+      {markerGroupingEnabled ? (
+        <MarkerClusterGroup
+          chunkedLoading
+          chunkInterval={30}
+          chunkDelay={0}
+          maxClusterRadius={30}
+          disableClusteringAtZoom={11}
+          spiderfyOnMaxZoom
+          showCoverageOnHover={false}
+          zoomToBoundsOnClick
+          animate={false}
+          iconCreateFunction={clusterIconCreateFunction}
+        >
+          {markers}
+        </MarkerClusterGroup>
+      ) : markers}
 
       {/* Apple-Maps style: darker-blue casing under a bright-blue core, rounded. */}
       {route && route.length > 0 && route.flatMap((seg, i) => seg.length > 1 ? [

--- a/client/src/components/Map/MapViewGL.test.tsx
+++ b/client/src/components/Map/MapViewGL.test.tsx
@@ -26,6 +26,10 @@ const glMap = vi.hoisted(() => ({
   getStyle: vi.fn().mockReturnValue({ layers: [] }),
   isStyleLoaded: vi.fn().mockReturnValue(true),
   getCanvasContainer: vi.fn(() => document.createElement('div')),
+  getLayer: vi.fn().mockReturnValue(null),
+  queryRenderedFeatures: vi.fn().mockReturnValue([]),
+  querySourceFeatures: vi.fn().mockReturnValue([]),
+  easeTo: vi.fn(),
 }))
 
 vi.mock('mapbox-gl', () => ({
@@ -101,7 +105,7 @@ vi.mock('./locationMarkerMapbox', () => ({
 
 vi.mock('./reservationsMapbox', () => ({
   ReservationMapboxOverlay: vi.fn(function () {
-    return { update: vi.fn() }
+    return { update: vi.fn(), destroy: vi.fn() }
   }),
 }))
 
@@ -136,6 +140,13 @@ function buildMapPlace(overrides: Record<string, any> = {}) {
 }
 
 beforeEach(() => {
+  glMap.on.mockImplementation(() => glMap)
+  glMap.off.mockImplementation(() => glMap)
+  glMap.once.mockImplementation(() => glMap)
+  glMap.getSource.mockReturnValue(null)
+  glMap.getLayer.mockReturnValue(null)
+  glMap.queryRenderedFeatures.mockReturnValue([])
+  glMap.querySourceFeatures.mockReturnValue([])
   useSettingsStore.setState({
     settings: {
       ...useSettingsStore.getState().settings,
@@ -143,6 +154,7 @@ beforeEach(() => {
       mapbox_access_token: 'pk.test_token',
       mapbox_style: 'mapbox://styles/mapbox/streets-v12',
       mapbox_3d_enabled: false,
+      map_icon_grouping_enabled: true,
     },
   } as any)
 })
@@ -226,5 +238,33 @@ describe('MapViewGL', () => {
     // The MapLibre engine builds the map even without a token; Mapbox is not used.
     expect(maplibregl.Map).toHaveBeenCalled()
     expect(mapboxgl.Map).not.toHaveBeenCalled()
+  })
+
+  it('FE-COMP-MAPVIEWGL-005: adds clustered place source for MapLibre when icon grouping is enabled', async () => {
+    glMap.on.mockImplementation((event: string, handlerOrLayer: unknown) => {
+      if (event === 'load' && typeof handlerOrLayer === 'function') handlerOrLayer()
+      return glMap
+    })
+    useSettingsStore.setState({
+      settings: {
+        ...useSettingsStore.getState().settings,
+        map_provider: 'maplibre-gl',
+        mapbox_access_token: '',
+        maplibre_style: 'https://tiles.openfreemap.org/styles/liberty',
+        map_icon_grouping_enabled: true,
+      },
+    } as any)
+
+    render(<MapViewGL places={[buildMapPlace({ id: 1, lat: 48.8584, lng: 2.2945 })]} fitKey={1} glProvider="maplibre-gl" />)
+    await act(async () => {})
+
+    expect(glMap.addSource).toHaveBeenCalledWith('trip-place-clusters', expect.objectContaining({
+      type: 'geojson',
+      cluster: true,
+      clusterRadius: 30,
+      clusterMaxZoom: 10,
+    }))
+    expect(glMap.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'trip-place-clusters-circle' }))
+    expect(glMap.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'trip-place-clusters-count' }))
   })
 })

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -25,6 +25,28 @@ function categoryIconSvg(iconName: string | null | undefined, size: number): str
   } catch { return '' }
 }
 
+const PLACE_CLUSTER_SOURCE_ID = 'trip-place-clusters'
+const PLACE_CLUSTER_CIRCLE_LAYER_ID = 'trip-place-clusters-circle'
+const PLACE_CLUSTER_COUNT_LAYER_ID = 'trip-place-clusters-count'
+const PLACE_UNCLUSTERED_LAYER_ID = 'trip-place-unclustered-hit'
+
+type PlaceWithCoords = Place & { lat: number; lng: number }
+
+function hasValidCoords(place: Place): place is PlaceWithCoords {
+  return place.lat != null && place.lng != null && Number.isFinite(place.lat) && Number.isFinite(place.lng)
+}
+
+function buildPlaceClusterData(places: Place[]) {
+  return {
+    type: 'FeatureCollection' as const,
+    features: places.filter(hasValidCoords).map(place => ({
+      type: 'Feature' as const,
+      properties: { placeId: place.id },
+      geometry: { type: 'Point' as const, coordinates: [place.lng, place.lat] },
+    })),
+  }
+}
+
 interface RouteSegment {
   mid: [number, number]
   from: [number, number]
@@ -182,6 +204,7 @@ export function MapViewGL({
   const mapboxToken = useSettingsStore(s => s.settings.mapbox_access_token || '')
   const mapbox3d = useSettingsStore(s => s.settings.mapbox_3d_enabled !== false)
   const mapboxQuality = useSettingsStore(s => s.settings.mapbox_quality_mode === true)
+  const markerGroupingEnabled = useSettingsStore(s => s.settings.map_icon_grouping_enabled !== false)
   const showEndpointLabels = useSettingsStore(s => s.settings.map_booking_labels) !== false
   const mapLang = useSettingsStore(s => s.settings.language)
   const isMapLibre = glProvider === 'maplibre-gl'
@@ -308,6 +331,87 @@ export function MapViewGL({
           layout: { 'line-cap': 'round', 'line-join': 'round' },
         })
       }
+      if (markerGroupingEnabled && !map.getSource(PLACE_CLUSTER_SOURCE_ID)) {
+        map.addSource(PLACE_CLUSTER_SOURCE_ID, {
+          type: 'geojson',
+          data: { type: 'FeatureCollection', features: [] },
+          cluster: true,
+          clusterRadius: 30,
+          clusterMaxZoom: 10,
+        })
+        map.addLayer({
+          id: PLACE_CLUSTER_CIRCLE_LAYER_ID,
+          type: 'circle',
+          source: PLACE_CLUSTER_SOURCE_ID,
+          filter: ['has', 'point_count'],
+          paint: {
+            'circle-color': '#111827',
+            'circle-opacity': 0.97,
+            'circle-radius': ['step', ['get', 'point_count'], 18, 10, 21, 50, 24],
+            'circle-stroke-width': 2.5,
+            'circle-stroke-color': 'rgba(255,255,255,0.9)',
+          },
+        })
+        map.addLayer({
+          id: PLACE_CLUSTER_COUNT_LAYER_ID,
+          type: 'symbol',
+          source: PLACE_CLUSTER_SOURCE_ID,
+          filter: ['has', 'point_count'],
+          layout: {
+            'text-field': ['get', 'point_count_abbreviated'],
+            'text-size': 12,
+            'text-allow-overlap': true,
+          },
+          paint: {
+            'text-color': '#ffffff',
+            'text-halo-color': 'rgba(17,24,39,0.35)',
+            'text-halo-width': 1,
+          },
+        })
+        map.addLayer({
+          id: PLACE_UNCLUSTERED_LAYER_ID,
+          type: 'circle',
+          source: PLACE_CLUSTER_SOURCE_ID,
+          filter: ['!', ['has', 'point_count']],
+          paint: {
+            'circle-radius': 24,
+            'circle-opacity': 0,
+            'circle-stroke-opacity': 0,
+          },
+        })
+        const zoomToCluster = (e: any) => {
+          const features = typeof map.queryRenderedFeatures === 'function'
+            ? map.queryRenderedFeatures(e.point, { layers: [PLACE_CLUSTER_CIRCLE_LAYER_ID, PLACE_CLUSTER_COUNT_LAYER_ID] })
+            : []
+          const feature = features?.[0]
+          const clusterId = feature?.properties?.cluster_id
+          const coordinates = feature?.geometry?.coordinates
+          if (clusterId == null || !Array.isArray(coordinates)) return
+          const source = map.getSource(PLACE_CLUSTER_SOURCE_ID)
+          const easeToZoom = (nextZoom: number) => {
+            try { map.easeTo({ center: coordinates, zoom: nextZoom, duration: 350 }) } catch { /* noop */ }
+          }
+          try {
+            const maybeZoom = source?.getClusterExpansionZoom?.(clusterId, (err: Error | null, nextZoom: number) => {
+              if (!err && typeof nextZoom === 'number') easeToZoom(nextZoom)
+            })
+            if (typeof maybeZoom === 'number') easeToZoom(maybeZoom)
+            else if (maybeZoom && typeof maybeZoom.then === 'function') maybeZoom.then(easeToZoom).catch(() => {})
+          } catch { /* noop */ }
+        }
+        const setClusterCursor = () => {
+          const canvas = typeof map.getCanvas === 'function' ? map.getCanvas() : null
+          if (canvas) canvas.style.cursor = 'pointer'
+        }
+        const clearClusterCursor = () => {
+          const canvas = typeof map.getCanvas === 'function' ? map.getCanvas() : null
+          if (canvas) canvas.style.cursor = ''
+        }
+        map.on('click', PLACE_CLUSTER_CIRCLE_LAYER_ID, zoomToCluster)
+        map.on('click', PLACE_CLUSTER_COUNT_LAYER_ID, zoomToCluster)
+        map.on('mouseenter', PLACE_CLUSTER_CIRCLE_LAYER_ID, setClusterCursor)
+        map.on('mouseleave', PLACE_CLUSTER_CIRCLE_LAYER_ID, clearClusterCursor)
+      }
       // Signal that sources/layers are attached so overlay effects can
       // safely add their own sources. Style rebuilds reset this via the
       // cleanup below.
@@ -317,6 +421,13 @@ export function MapViewGL({
     map.on('click', (e) => {
       const t = e.originalEvent.target as HTMLElement
       if (t.closest('.mapboxgl-marker, .maplibregl-marker')) return // markers handle their own click
+      if (
+        markerGroupingEnabled
+        && typeof map.getLayer === 'function'
+        && map.getLayer(PLACE_CLUSTER_CIRCLE_LAYER_ID)
+        && typeof map.queryRenderedFeatures === 'function'
+        && map.queryRenderedFeatures(e.point, { layers: [PLACE_CLUSTER_CIRCLE_LAYER_ID, PLACE_CLUSTER_COUNT_LAYER_ID] }).length > 0
+      ) return
       onClickRefs.current.map?.({ latlng: { lat: e.lngLat.lat, lng: e.lngLat.lng } })
     })
     // Emit the viewport bbox (pan/zoom + once on first idle) so the POI-explore
@@ -411,7 +522,7 @@ export function MapViewGL({
       mapRef.current = null
       setMapReady(false)
     }
-  }, [glProvider, glStyle, mapboxToken, enableMapbox3d, mapboxQuality]) // rebuild on provider/style changes only
+  }, [glProvider, glStyle, mapboxToken, enableMapbox3d, mapboxQuality, markerGroupingEnabled]) // rebuild on provider/style/cluster changes only
 
   // Pin the basemap label language to the UI language so labels don't fall back to the
   // browser/OS locale and stack multiple scripts per place (e.g. "India/भारत/India", #1299).
@@ -476,57 +587,107 @@ export function MapViewGL({
     }
   }, [placeIds, placesPhotosEnabled]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Reconcile markers with places + photos. Rebuilds the DOM node when any
-  // visual input changes so photos, selection state and order badges stay
-  // in sync.
+  // Reconcile markers with places + photos. When grouping is enabled the GL
+  // cluster source decides which points are currently unclustered, and we render
+  // the existing rich HTML marker DOM only for those visible leaves.
   useEffect(() => {
     const map = mapRef.current
-    if (!map) return
+    if (!map || !mapReady) return
     // Markers are about to be rebuilt; drop any open hover popup first. A marker
     // recreated under the pointer (e.g. when its photo streams in) never fires
     // mouseleave, which would otherwise leave the popup orphaned on the map.
     popupRef.current?.remove()
-    const ids = new Set(places.map(p => p.id))
+    const validPlaces = places.filter(hasValidCoords)
 
-    markersRef.current.forEach((marker, id) => {
-      if (!ids.has(id)) {
-        marker.remove()
-        markersRef.current.delete(id)
-      }
-    })
+    const reconcileMarkers = (visiblePlaces: PlaceWithCoords[]) => {
+      const ids = new Set(visiblePlaces.map(p => p.id))
 
-    places.forEach(place => {
-      if (!place.lat || !place.lng) return
-      const orderNumbers = dayOrderMap[place.id] ?? null
-      const pck = place.google_place_id || place.osm_id || `${place.lat},${place.lng}`
-      const photoUrl = (pck && photoUrls[pck]) || place.image_url || null
-      const selected = place.id === selectedPlaceId
-      const el = createMarkerElement(place as Place & { category_color?: string; category_icon?: string }, photoUrl, orderNumbers, selected)
-      el.addEventListener('click', (ev) => {
-        ev.stopPropagation()
-        onClickRefs.current.marker?.(place.id)
+      markersRef.current.forEach((marker, id) => {
+        if (!ids.has(id)) {
+          marker.remove()
+          markersRef.current.delete(id)
+        }
       })
-      el.addEventListener('mouseenter', () => {
-        popupRef.current?.setLngLat([place.lng, place.lat])
-          .setHTML(buildPlacePopupHtml(place as Place & { category_color?: string; category_icon?: string; category_name?: string }, photoUrl))
+
+      visiblePlaces.forEach(place => {
+        const orderNumbers = dayOrderMap[place.id] ?? null
+        const pck = place.google_place_id || place.osm_id || `${place.lat},${place.lng}`
+        const photoUrl = (pck && photoUrls[pck]) || place.image_url || null
+        const selected = place.id === selectedPlaceId
+        const el = createMarkerElement(place as Place & { category_color?: string; category_icon?: string }, photoUrl, orderNumbers, selected)
+        el.addEventListener('click', (ev) => {
+          ev.stopPropagation()
+          onClickRefs.current.marker?.(place.id)
+        })
+        el.addEventListener('mouseenter', () => {
+          popupRef.current?.setLngLat([place.lng, place.lat])
+            .setHTML(buildPlacePopupHtml(place as Place & { category_color?: string; category_icon?: string; category_name?: string }, photoUrl))
+            .addTo(map)
+        })
+        el.addEventListener('mouseleave', () => { popupRef.current?.remove() })
+        // Recreate marker each time rather than patching internal state —
+        // mapbox-gl's internal _element bookkeeping breaks under DOM swaps.
+        const existing = markersRef.current.get(place.id)
+        if (existing) existing.remove()
+        // Default (viewport-aligned) anchors keep the marker parallel to the
+        // screen so its pixel centre lines up with the route line at any
+        // pitch. Tried `pitchAlignment: 'map'` to snap markers onto terrain,
+        // but it rotates the element by the pitch angle and visually offsets
+        // the anchor by ~100px at 45° tilt, which caused the observed drift.
+        const m = new gl.Marker({ element: el, anchor: 'center' })
+          .setLngLat([place.lng, place.lat])
           .addTo(map)
+        markersRef.current.set(place.id, m)
       })
-      el.addEventListener('mouseleave', () => { popupRef.current?.remove() })
-      // Recreate marker each time rather than patching internal state —
-      // mapbox-gl's internal _element bookkeeping breaks under DOM swaps.
-      const existing = markersRef.current.get(place.id)
-      if (existing) existing.remove()
-      // Default (viewport-aligned) anchors keep the marker parallel to the
-      // screen so its pixel centre lines up with the route line at any
-      // pitch. Tried `pitchAlignment: 'map'` to snap markers onto terrain,
-      // but it rotates the element by the pitch angle and visually offsets
-      // the anchor by ~100px at 45° tilt, which caused the observed drift.
-      const m = new gl.Marker({ element: el, anchor: 'center' })
-        .setLngLat([place.lng, place.lat])
-        .addTo(map)
-      markersRef.current.set(place.id, m)
-    })
-  }, [places, selectedPlaceId, dayOrderMap, photoUrls, mapReady, glProvider])
+    }
+
+    if (!markerGroupingEnabled) {
+      reconcileMarkers(validPlaces)
+      return
+    }
+
+    const source = map.getSource(PLACE_CLUSTER_SOURCE_ID) as mapboxgl.GeoJSONSource | undefined
+    if (!source || typeof map.querySourceFeatures !== 'function') {
+      reconcileMarkers(validPlaces)
+      return
+    }
+
+    source.setData(buildPlaceClusterData(places) as any)
+    const placesById = new Map<number, PlaceWithCoords>(validPlaces.map(place => [place.id, place]))
+    let raf: number | null = null
+    const runReconcile = () => {
+      raf = null
+      const features = map.querySourceFeatures(PLACE_CLUSTER_SOURCE_ID, { filter: ['!', ['has', 'point_count']] }) || []
+      const seen = new Set<number>()
+      const visiblePlaces: PlaceWithCoords[] = []
+      for (const feature of features) {
+        const rawId = feature?.properties?.placeId
+        const id = typeof rawId === 'string' ? Number(rawId) : rawId
+        if (typeof id !== 'number' || Number.isNaN(id) || seen.has(id)) continue
+        const place = placesById.get(id)
+        if (!place) continue
+        seen.add(id)
+        visiblePlaces.push(place)
+      }
+      reconcileMarkers(visiblePlaces)
+    }
+    const scheduleReconcile = () => {
+      if (raf !== null) return
+      raf = requestAnimationFrame(runReconcile)
+    }
+
+    scheduleReconcile()
+    map.once('idle', scheduleReconcile)
+    map.on('moveend', scheduleReconcile)
+    map.on('zoomend', scheduleReconcile)
+
+    return () => {
+      if (raf !== null) cancelAnimationFrame(raf)
+      map.off('moveend', scheduleReconcile)
+      map.off('zoomend', scheduleReconcile)
+      map.off('idle', scheduleReconcile)
+    }
+  }, [places, selectedPlaceId, dayOrderMap, photoUrls, mapReady, glProvider, markerGroupingEnabled])
 
   // Reconcile OSM "explore" POI markers (imperative, kept separate from the
   // planned-place markers so they don't cluster or get confused with them).

--- a/client/src/components/Settings/DisplaySettingsTab.test.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.test.tsx
@@ -1,5 +1,5 @@
-// FE-COMP-DISPLAY-001 to FE-COMP-DISPLAY-027
-import { render, screen } from '../../../tests/helpers/render';
+// FE-COMP-DISPLAY-001 to FE-COMP-DISPLAY-030
+import { render, screen, within } from '../../../tests/helpers/render';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../../tests/helpers/msw/server';
@@ -127,9 +127,19 @@ describe('DisplaySettingsTab', () => {
   it('FE-COMP-DISPLAY-025: blur booking codes On button is active when blur_booking_codes is true', () => {
     seedStore(useSettingsStore, { settings: buildSettings({ blur_booking_codes: true }) });
     render(<DisplaySettingsTab />);
-    const onButtons = screen.getAllByText(/^On$/i);
-    const blurOnBtn = onButtons[1].closest('button')!;
+    const blurSection = screen.getByText(/blur booking codes/i).parentElement!;
+    const blurOnBtn = within(blurSection).getByText(/^On$/i).closest('button')!;
     expect(blurOnBtn.style.border).toContain('var(--text-primary)');
+  });
+
+  it('FE-COMP-DISPLAY-030: clicking map icon grouping Off calls updateSetting', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, { settings: buildSettings({ map_icon_grouping_enabled: true }), updateSetting });
+    render(<DisplaySettingsTab />);
+    const groupingSection = screen.getByText('Group map icons').parentElement!;
+    await user.click(within(groupingSection).getByText(/^Off$/i));
+    expect(updateSetting).toHaveBeenCalledWith('map_icon_grouping_enabled', false);
   });
 
   it('FE-COMP-DISPLAY-026: updateSetting failure shows toast error', async () => {

--- a/client/src/components/Settings/DisplaySettingsTab.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.tsx
@@ -260,6 +260,37 @@ export default function DisplaySettingsTab(): React.ReactElement {
         <p className="text-xs mt-1 text-content-faint">{t('settings.bookingLabelsHint')}</p>
       </div>
 
+      {/* Map icon grouping */}
+      <div>
+        <label className="block text-sm font-medium mb-2 text-content-secondary">{t('settings.mapIconGrouping')}</label>
+        <div className="flex gap-3">
+          {[
+            { value: true, label: t('settings.on') || 'On' },
+            { value: false, label: t('settings.off') || 'Off' },
+          ].map(opt => (
+            <button
+              key={String(opt.value)}
+              onClick={async () => {
+                try { await updateSetting('map_icon_grouping_enabled', opt.value) }
+                catch (e: unknown) { toast.error(e instanceof Error ? e.message : t('common.error')) }
+              }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '10px 20px', borderRadius: 10, cursor: 'pointer',
+                fontFamily: 'inherit', fontSize: 'calc(14px * var(--fs-scale-body, 1))', fontWeight: 500,
+                border: (settings.map_icon_grouping_enabled !== false) === opt.value ? '2px solid var(--text-primary)' : '2px solid var(--border-primary)',
+                background: (settings.map_icon_grouping_enabled !== false) === opt.value ? 'var(--bg-hover)' : 'var(--bg-card)',
+                color: 'var(--text-primary)',
+                transition: 'all 0.15s',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs mt-1 text-content-faint">{t('settings.mapIconGroupingHint')}</p>
+      </div>
+
       {/* Explore places on the map (POI category pill) */}
       <div>
         <label className="block text-sm font-medium mb-2 text-content-secondary">{t('settings.mapPoiPill')}</label>

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -37,6 +37,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     optimize_from_accommodation: true,
     map_provider: 'leaflet',
     map_poi_pill_enabled: true,
+    map_icon_grouping_enabled: true,
     mapbox_access_token: '',
     mapbox_style: 'mapbox://styles/mapbox/standard',
     maplibre_style: '',

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -119,6 +119,7 @@ export interface Settings {
   blur_booking_codes?: boolean
   map_booking_labels?: boolean
   map_poi_pill_enabled?: boolean
+  map_icon_grouping_enabled?: boolean
   optimize_from_accommodation?: boolean
   map_provider?: 'leaflet' | 'mapbox-gl' | 'maplibre-gl'
   mapbox_access_token?: string

--- a/client/tests/helpers/factories.ts
+++ b/client/tests/helpers/factories.ts
@@ -270,6 +270,7 @@ export function buildSettings(overrides: Partial<Settings> = {}): Settings {
     time_format: '12h',
     show_place_description: false,
     blur_booking_codes: false,
+    map_icon_grouping_enabled: true,
     ...overrides,
   };
 }

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -298,6 +298,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'استكشاف الأماكن على الخريطة',
   'settings.mapPoiPillHint':
     'أظهر شريط فئات على خريطة الرحلة للعثور على المطاعم والفنادق والمزيد القريبة من OpenStreetMap.',
+  'settings.mapIconGrouping': 'تجميع أيقونات الخريطة',
+  'settings.mapIconGroupingHint': 'ادمج أيقونات الأماكن القريبة في مجموعات عند تصغير الخريطة.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'اربط نسخة AirTrail المُستضافة ذاتيًا لاستيراد الرحلات ومزامنتها. أنشئ مفتاح API في AirTrail ضمن الإعدادات ← الأمان.',

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -308,6 +308,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Explorar lugares no mapa',
   'settings.mapPoiPillHint':
     'Mostrar uma etiqueta de categoria no mapa da viagem para encontrar restaurantes, hotéis e mais por perto a partir do OpenStreetMap.',
+  'settings.mapIconGrouping': 'Agrupar ícones do mapa',
+  'settings.mapIconGroupingHint': 'Combine ícones de lugares próximos em grupos quando o mapa estiver afastado.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Conecte seu AirTrail auto-hospedado para importar e sincronizar voos. Crie uma chave de API no AirTrail em Configurações → Segurança.',

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -305,6 +305,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Objevovat místa na mapě',
   'settings.mapPoiPillHint':
     'Zobrazit na mapě výletu kategorie pro hledání restaurací, hotelů a dalšího v okolí z OpenStreetMap.',
+  'settings.mapIconGrouping': 'Seskupovat ikony mapy',
+  'settings.mapIconGroupingHint': 'Sloučit blízké ikony míst do shluků, když je mapa oddálená.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Připojte svou vlastní instanci AirTrail pro import a synchronizaci letů. Vytvořte API klíč v AirTrail v Nastavení → Zabezpečení.',

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -310,6 +310,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Orte auf der Karte entdecken',
   'settings.mapPoiPillHint':
     'Zeigt auf der Reisekarte eine Kategorie-Pille an, um Restaurants, Hotels und mehr aus OpenStreetMap in der Nähe zu finden.',
+  'settings.mapIconGrouping': 'Kartensymbole gruppieren',
+  'settings.mapIconGroupingHint': 'Fasst nahegelegene Ortssymbole zu Clustern zusammen, wenn die Karte herausgezoomt ist.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Verbinden Sie Ihr selbst gehostetes AirTrail, um Flüge zu importieren und zu synchronisieren. Erstellen Sie in AirTrail unter Einstellungen → Sicherheit einen API-Schlüssel.',

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -63,6 +63,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Explore places on the map',
   'settings.mapPoiPillHint':
     'Show a category pill on the trip map to find nearby restaurants, hotels and more from OpenStreetMap.',
+  'settings.mapIconGrouping': 'Group map icons',
+  'settings.mapIconGroupingHint': 'Combine nearby place icons into clusters when the map is zoomed out.',
   'settings.blurBookingCodes': 'Blur Booking Codes',
   'settings.aiAlwaysRetry': 'Always retry booking imports with AI',
   'settings.aiAlwaysRetryHint': 'When a file cannot be read by the standard parser, automatically retry it with AI.',

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -311,6 +311,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Explorar lugares en el mapa',
   'settings.mapPoiPillHint':
     'Muestra una píldora de categorías en el mapa del viaje para encontrar restaurantes, alojamientos y más cerca, desde OpenStreetMap.',
+  'settings.mapIconGrouping': 'Agrupar iconos del mapa',
+  'settings.mapIconGroupingHint': 'Combina iconos de lugares cercanos en grupos cuando el mapa está alejado.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Conecta tu AirTrail autoalojado para importar y sincronizar vuelos. Crea una clave de API en AirTrail en Ajustes → Seguridad.',

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -315,6 +315,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Explorer les lieux sur la carte',
   'settings.mapPoiPillHint':
     'Afficher une pastille de catégorie sur la carte du voyage pour trouver à proximité des restaurants, hébergements et plus encore depuis OpenStreetMap.',
+  'settings.mapIconGrouping': 'Regrouper les icônes de carte',
+  'settings.mapIconGroupingHint': 'Combine les icônes de lieux proches en groupes lorsque la carte est dézoomée.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Connectez votre instance AirTrail auto-hébergée pour importer et synchroniser vos vols. Créez une clé API dans AirTrail sous Paramètres → Sécurité.',

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -317,6 +317,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Εξερεύνηση μερών στον χάρτη',
   'settings.mapPoiPillHint':
     'Εμφάνιση ετικέτας κατηγορίας στον χάρτη του ταξιδιού για εύρεση κοντινών εστιατορίων, ξενοδοχείων και άλλων από το OpenStreetMap.',
+  'settings.mapIconGrouping': 'Ομαδοποίηση εικονιδίων χάρτη',
+  'settings.mapIconGroupingHint': 'Συνδυάζει κοντινά εικονίδια μερών σε ομάδες όταν ο χάρτης είναι σε σμίκρυνση.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Συνδέστε το αυτο-φιλοξενούμενο AirTrail σας για εισαγωγή και συγχρονισμό πτήσεων. Δημιουργήστε ένα κλειδί API στο AirTrail από Ρυθμίσεις → Ασφάλεια.',

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -310,6 +310,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Helyek felfedezése a térképen',
   'settings.mapPoiPillHint':
     'Megjelenít egy kategóriasávot az utazási térképen, hogy az OpenStreetMap segítségével közeli éttermeket, szállásokat és továbbiakat találj.',
+  'settings.mapIconGrouping': 'Térképikonok csoportosítása',
+  'settings.mapIconGroupingHint': 'A közeli helyikonokat csoportokba vonja össze, amikor a térkép ki van nagyítva.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Csatlakoztasd a saját üzemeltetésű AirTrail-példányodat járatok importálásához és szinkronizálásához. Hozz létre egy API-kulcsot az AirTrailben a Beállítások → Biztonság menüpontban.',

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -309,6 +309,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Jelajahi tempat di peta',
   'settings.mapPoiPillHint':
     'Tampilkan pil kategori di peta perjalanan untuk menemukan restoran, hotel, dan lainnya di sekitar dari OpenStreetMap.',
+  'settings.mapIconGrouping': 'Kelompokkan ikon peta',
+  'settings.mapIconGroupingHint': 'Gabungkan ikon tempat yang berdekatan menjadi klaster saat peta diperkecil.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Hubungkan AirTrail yang kamu host sendiri untuk mengimpor dan menyinkronkan penerbangan. Buat kunci API di AirTrail pada Pengaturan → Keamanan.',

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -309,6 +309,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Esplora luoghi sulla mappa',
   'settings.mapPoiPillHint':
     'Mostra un selettore di categorie sulla mappa del viaggio per trovare ristoranti, hotel e altro nelle vicinanze da OpenStreetMap.',
+  'settings.mapIconGrouping': 'Raggruppa icone della mappa',
+  'settings.mapIconGroupingHint': 'Combina le icone dei luoghi vicini in gruppi quando la mappa è ridotta.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Collega il tuo AirTrail self-hosted per importare e sincronizzare i voli. Crea una chiave API in AirTrail in Impostazioni → Sicurezza.',

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -285,6 +285,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': '地図でスポットを探す',
   'settings.mapPoiPillHint':
     '旅行の地図にカテゴリピルを表示して、OpenStreetMapから近くのレストランや宿泊施設などを見つけられます。',
+  'settings.mapIconGrouping': '地図アイコンをグループ化',
+  'settings.mapIconGroupingHint': '地図をズームアウトしたときに、近くのスポットアイコンをクラスターにまとめます。',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'セルフホストの AirTrail を接続して、フライトをインポート・同期します。AirTrail の「設定 → セキュリティ」で API キーを作成してください。',

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -301,6 +301,8 @@ const settings: TranslationStrings = {
   'settings.passkey.neverUsed': '사용한 적 없음',
   'settings.mapPoiPill': '지도에서 장소 탐색',
   'settings.mapPoiPillHint': '여행 지도에 카테고리 칩을 표시하여 OpenStreetMap에서 주변 음식점, 숙소 등을 찾아보세요.',
+  'settings.mapIconGrouping': '지도 아이콘 그룹화',
+  'settings.mapIconGroupingHint': '지도를 축소했을 때 가까운 장소 아이콘을 클러스터로 묶습니다.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     '자체 호스팅한 AirTrail을 연결하여 항공편을 가져오고 동기화하세요. AirTrail의 설정 → 보안에서 API 키를 생성하세요.',

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -309,6 +309,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Plaatsen op de kaart ontdekken',
   'settings.mapPoiPillHint':
     'Toon een categorielabel op de reiskaart om restaurants, hotels en meer in de buurt te vinden via OpenStreetMap.',
+  'settings.mapIconGrouping': 'Kaarticonen groeperen',
+  'settings.mapIconGroupingHint': 'Combineert nabijgelegen plaatsiconen in clusters wanneer de kaart is uitgezoomd.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Verbind je zelf-gehoste AirTrail om vluchten te importeren en te synchroniseren. Maak een API-sleutel aan in AirTrail onder Instellingen → Beveiliging.',

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -309,6 +309,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Odkrywaj miejsca na mapie',
   'settings.mapPoiPillHint':
     'Pokaż na mapie wyprawy pasek z kategoriami, aby znaleźć pobliskie restauracje, hotele i więcej z OpenStreetMap.',
+  'settings.mapIconGrouping': 'Grupuj ikony mapy',
+  'settings.mapIconGroupingHint': 'Łączy pobliskie ikony miejsc w klastry, gdy mapa jest oddalona.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Połącz swój własny AirTrail, aby importować i synchronizować loty. Utwórz klucz API w AirTrail w sekcji Ustawienia → Bezpieczeństwo.',

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -310,6 +310,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Поиск мест на карте',
   'settings.mapPoiPillHint':
     'Показывать на карте поездки кнопку категорий, чтобы находить рядом рестораны, отели и другие места из OpenStreetMap.',
+  'settings.mapIconGrouping': 'Группировать значки карты',
+  'settings.mapIconGroupingHint': 'Объединяет значки ближайших мест в кластеры при уменьшении масштаба карты.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Подключите свой self-hosted AirTrail для импорта и синхронизации рейсов. Создайте ключ API в AirTrail в разделе «Настройки → Безопасность».',

--- a/shared/src/i18n/sv/settings.ts
+++ b/shared/src/i18n/sv/settings.ts
@@ -65,6 +65,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Utforska platser på kartan',
   'settings.mapPoiPillHint':
     'Visa en kategoriknapp på resekartan för att hitta restauranger, hotell och annat i närheten från OpenStreetMap.',
+  'settings.mapIconGrouping': 'Gruppera kartikoner',
+  'settings.mapIconGroupingHint': 'Kombinerar närliggande platsikoner i kluster när kartan är utzoomad.',
   'settings.blurBookingCodes': 'Blurra bokningskoder',
   'settings.optimizeFromAccommodation': 'Optimera rutten från boendet',
   'settings.optimizeFromAccommodationHint':

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -306,6 +306,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Haritada yerleri keşfet',
   'settings.mapPoiPillHint':
     "Yakındaki restoranları, otelleri ve daha fazlasını OpenStreetMap'ten bulmak için gezi haritasında bir kategori etiketi göster.",
+  'settings.mapIconGrouping': 'Harita simgelerini grupla',
+  'settings.mapIconGroupingHint': 'Harita uzaklaştırıldığında yakındaki yer simgelerini kümelerde birleştirir.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     "Uçuşları içe aktarmak ve senkronize etmek için kendi barındırdığınız AirTrail'i bağlayın. AirTrail'de Ayarlar → Güvenlik altından bir API anahtarı oluşturun.",

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -309,6 +309,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Досліджуйте місця на карті',
   'settings.mapPoiPillHint':
     'Показувати на карті подорожі плашку категорій, щоб знаходити поблизу ресторани, готелі та інше з OpenStreetMap.',
+  'settings.mapIconGrouping': 'Групувати значки карти',
+  'settings.mapIconGroupingHint': 'Об’єднує значки найближчих місць у кластери, коли карту віддалено.',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint':
     'Підключіть свій самостійно розміщений AirTrail, щоб імпортувати та синхронізувати рейси. Створіть API-ключ в AirTrail у розділі Налаштування → Безпека.',

--- a/shared/src/i18n/vi/settings.ts
+++ b/shared/src/i18n/vi/settings.ts
@@ -63,6 +63,8 @@ const settings: TranslationStrings = {
   'settings.mapPoiPill': 'Khám phá các địa điểm trên bản đồ',
   'settings.mapPoiPillHint':
     'Hiển thị một danh mục trên bản đồ chuyến đi để tìm các nhà hàng, khách sạn lân cận và hơn thế nữa từ OpenStreetMap.',
+  'settings.mapIconGrouping': 'Nhóm biểu tượng bản đồ',
+  'settings.mapIconGroupingHint': 'Gộp các biểu tượng địa điểm gần nhau thành cụm khi bản đồ được thu nhỏ.',
   'settings.blurBookingCodes': 'Mã đặt chỗ mờ',
   'settings.optimizeFromAccommodation': 'Tối ưu hóa tuyến đường từ chỗ ở',
   'settings.optimizeFromAccommodationHint':

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -291,6 +291,8 @@ const settings: TranslationStrings = {
   'settings.passkey.neverUsed': '從未使用',
   'settings.mapPoiPill': '在地圖上探索地點',
   'settings.mapPoiPillHint': '在行程地圖上顯示分類標籤，透過 OpenStreetMap 尋找附近的餐廳、住宿等地點。',
+  'settings.mapIconGrouping': '群組地圖圖示',
+  'settings.mapIconGroupingHint': '地圖縮小時，將附近的地點圖示合併成叢集。',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint': '連接你自架的 AirTrail 以匯入及同步航班。在 AirTrail 的「設定 → 安全性」中建立 API 金鑰。',
   'settings.airtrail.url': '執行個體網址',

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -289,6 +289,8 @@ const settings: TranslationStrings = {
   'settings.passkey.neverUsed': '从未使用',
   'settings.mapPoiPill': '在地图上探索地点',
   'settings.mapPoiPillHint': '在行程地图上显示分类标签，从 OpenStreetMap 查找附近的餐厅、酒店等。',
+  'settings.mapIconGrouping': '分组地图图标',
+  'settings.mapIconGroupingHint': '地图缩小时，将附近的地点图标合并为聚合组。',
   'settings.airtrail.title': 'AirTrail',
   'settings.airtrail.hint': '连接您的自托管 AirTrail 以导入和同步航班。在 AirTrail 的“设置 → 安全”中创建 API 密钥。',
   'settings.airtrail.url': '实例 URL',


### PR DESCRIPTION
## Description
Grouping of MapLibre GL icons were previously broken

<img width="1152" height="868" alt="image" src="https://github.com/user-attachments/assets/1ef12264-24e8-40d2-844b-701cd0b99006" />

<img width="702" height="173" alt="image" src="https://github.com/user-attachments/assets/ed8d5d76-4b67-4acd-af09-226b1a5bc5f5" />

## Related Issue or Discussion
#1385

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
