### PR TITLE
Fix maplibre hover, fitting, focus

### DIFF
--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -13,6 +13,7 @@ import { PluginMapMarkers } from './MapPluginMarkers'
 import { useTransportRoutes } from '../../hooks/useTransportRoutes'
 import type { Reservation } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
+import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 
 function categoryIconSvg(iconName: string | null | undefined, size: number): string {
   const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
@@ -435,8 +436,8 @@ export const MapView = memo(function MapView({
   onMarkerClick,
   onMapClick,
   onMapContextMenu = null,
-  center = [48.8566, 2.3522],
-  zoom = 10,
+  center = DEFAULT_MAP_CENTER,
+  zoom = DEFAULT_MAP_ZOOM,
   tileUrl = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
   fitKey = 0,
   dayOrderMap = {},

--- a/client/src/components/Map/MapViewGL.test.tsx
+++ b/client/src/components/Map/MapViewGL.test.tsx
@@ -37,6 +37,23 @@ const glMap = vi.hoisted(() => ({
   easeTo: vi.fn(),
 }))
 
+const glBounds = vi.hoisted(() => {
+  const state = {
+    instances: [] as Array<{ extend: ReturnType<typeof vi.fn> }>,
+  }
+  return {
+    get instances() { return state.instances },
+    clear: () => { state.instances = [] },
+    create: () => {
+      const bounds = {
+        extend: vi.fn(() => bounds),
+      }
+      state.instances.push(bounds)
+      return bounds
+    },
+  }
+})
+
 vi.mock('mapbox-gl', () => ({
   default: {
     accessToken: '',
@@ -52,7 +69,7 @@ vi.mock('mapbox-gl', () => ({
       }
     }),
     LngLatBounds: vi.fn(function () {
-      return { extend: vi.fn().mockReturnThis() }
+      return glBounds.create()
     }),
     NavigationControl: vi.fn(),
     Popup: vi.fn(function () {
@@ -81,7 +98,7 @@ vi.mock('maplibre-gl', () => ({
       }
     }),
     LngLatBounds: vi.fn(function () {
-      return { extend: vi.fn().mockReturnThis() }
+      return glBounds.create()
     }),
     NavigationControl: vi.fn(),
     Popup: vi.fn(function () {
@@ -148,6 +165,7 @@ beforeEach(() => {
   glMap.on.mockImplementation(() => glMap)
   glMap.off.mockImplementation(() => glMap)
   glMap.once.mockImplementation(() => glMap)
+  glMap.loaded.mockReturnValue(true)
   glMap.getSource.mockReturnValue(null)
   glMap.getLayer.mockReturnValue(null)
   glMap.queryRenderedFeatures.mockReturnValue([])
@@ -165,6 +183,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
+  glBounds.clear()
   resetAllStores()
 })
 
@@ -438,5 +457,52 @@ describe('MapViewGL', () => {
     act(() => { moveEnds.forEach(fn => fn()) })
     act(() => { el.dispatchEvent(new MouseEvent('mouseenter', { clientX: 10, clientY: 10 })) })
     expect(queryByTestId('tooltip')).toBeTruthy()
+  })
+
+  it('FE-COMP-MAPVIEWGL-014: fits bounds immediately even when MapLibre loaded() is false', async () => {
+    glMap.loaded.mockReturnValue(false)
+    const places = [
+      buildMapPlace({ id: 1, lat: 35.38, lng: 136.94 }),
+      buildMapPlace({ id: 2, lat: 35.42, lng: 136.76 }),
+    ]
+
+    render(<MapViewGL places={places} dayPlaces={places} fitKey={1} glProvider="maplibre-gl" />)
+    await act(async () => {})
+
+    expect(glMap.fitBounds).toHaveBeenCalled()
+  })
+
+  it('FE-COMP-MAPVIEWGL-015: fits MapLibre bounds to route geometry when it arrives after a day fit', async () => {
+    const dayPlaces = [
+      buildMapPlace({ id: 1, lat: 35.38, lng: 136.94 }),
+      buildMapPlace({ id: 2, lat: 35.42, lng: 136.76 }),
+    ]
+
+    const { rerender } = render(
+      <MapViewGL
+        places={dayPlaces}
+        dayPlaces={dayPlaces}
+        route={null}
+        fitKey={1}
+        glProvider="maplibre-gl"
+      />,
+    )
+    await act(async () => {})
+    const afterDayFit = glMap.fitBounds.mock.calls.length
+
+    rerender(
+      <MapViewGL
+        places={dayPlaces}
+        dayPlaces={dayPlaces}
+        route={[[[35.38, 136.94], [35.72, 137.51], [35.42, 136.76]]]}
+        fitKey={1}
+        glProvider="maplibre-gl"
+      />,
+    )
+    await act(async () => {})
+
+    expect(glMap.fitBounds.mock.calls.length).toBeGreaterThan(afterDayFit)
+    const latestBounds = glBounds.instances[glBounds.instances.length - 1]
+    expect(latestBounds.extend).toHaveBeenCalledWith([137.51, 35.72])
   })
 })

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -18,6 +18,7 @@ import { useGeolocation } from '../../hooks/useGeolocation'
 import type { Place, Reservation } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { buildPoiPopupHtml } from './placePopup'
+import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 
 function categoryIconSvg(iconName: string | null | undefined, size: number): string {
   const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
@@ -195,8 +196,8 @@ export function MapViewGL({
   onMarkerClick,
   onMapClick,
   onMapContextMenu = null,
-  center = [48.8566, 2.3522],
-  zoom = 10,
+  center = DEFAULT_MAP_CENTER,
+  zoom = DEFAULT_MAP_ZOOM,
   fitKey = 0,
   dayOrderMap = {},
   leftWidth = 0,

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -43,6 +43,10 @@ function hasValidCoords(place: Place): place is PlaceWithCoords {
   return place.lat != null && place.lng != null && Number.isFinite(place.lat) && Number.isFinite(place.lng)
 }
 
+function isValidCoordinate(coord: [number, number] | null | undefined): coord is [number, number] {
+  return !!coord && Number.isFinite(coord[0]) && Number.isFinite(coord[1])
+}
+
 function buildPlaceClusterData(places: Place[]) {
   return {
     type: 'FeatureCollection' as const,
@@ -258,8 +262,8 @@ export function MapViewGL({
   onReservationClickRef.current = onReservationClick
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const poiMarkersRef = useRef<any[]>([])
-  // Single reusable hover popup (name/category/address card) shared by planned
-  // places and POI markers — mirrors the Leaflet map's hover tooltip.
+  // Single reusable hover popup for POI markers. Planned places use the
+  // cursor-following React tooltip below so they match the Leaflet map.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const popupRef = useRef<any | null>(null)
   const onPoiClickRef = useRef(onPoiClick)
@@ -275,6 +279,11 @@ export function MapViewGL({
   onClickRefs.current.context = onMapContextMenu
   const hoverDisabledRef = useRef(hoverDisabled)
   hoverDisabledRef.current = hoverDisabled
+  const routeCoords = useMemo<[number, number][]>(() => (route || []).flat().filter(isValidCoordinate), [route])
+  const routeFitKey = useMemo(
+    () => routeCoords.map(([lat, lng]) => `${lat.toFixed(6)},${lng.toFixed(6)}`).join('|'),
+    [routeCoords],
+  )
 
   // Build/rebuild the map on provider/style/token/3d change
   useEffect(() => {
@@ -935,17 +944,29 @@ export function MapViewGL({
     return { top, right: rightWidth + 40, bottom, left: leftWidth + 40 }
   }, [leftWidth, rightWidth, hasInspector, hasDayDetail])
 
-  const prevFitKey = useRef(-1)
+  const prevFitKey = useRef<number | null>(-1)
+  const pendingRouteFitRef = useRef<{ fitKey: number | null; routeKey: string } | null>(null)
   useEffect(() => {
-    if (fitKey === prevFitKey.current) return
-    prevFitKey.current = fitKey
+    const fitKeyChanged = fitKey !== prevFitKey.current
+    const routeArrivedForPendingFit =
+      !fitKeyChanged
+      && pendingRouteFitRef.current?.fitKey === fitKey
+      && !!routeFitKey
+      && routeFitKey !== pendingRouteFitRef.current.routeKey
+    if (!fitKeyChanged && !routeArrivedForPendingFit) return
     const map = mapRef.current
     if (!map) return
+    if (fitKeyChanged) {
+      prevFitKey.current = fitKey
+      pendingRouteFitRef.current = { fitKey, routeKey: routeFitKey }
+    }
     const target = dayPlaces.length > 0 ? dayPlaces : places
-    const valid = target.filter(p => p.lat && p.lng)
-    if (valid.length === 0) return
+    const markerPoints = target.filter(hasValidCoords).map(p => [p.lat, p.lng] as [number, number])
+    const fitPoints = routeCoords.length > 0 ? [...routeCoords, ...markerPoints] : markerPoints
+    if (fitPoints.length === 0) return
     const bounds = new gl.LngLatBounds()
-    valid.forEach(p => bounds.extend([p.lng, p.lat]))
+    fitPoints.forEach(([lat, lng]) => bounds.extend([lng, lat]))
+    let fitted = false
     const run = () => {
       try {
         map.fitBounds(bounds, {
@@ -954,11 +975,13 @@ export function MapViewGL({
           pitch: enableMapbox3d ? 45 : 0,
           duration: 400,
         })
+        fitted = true
       } catch { /* noop */ }
     }
-    if (map.loaded()) run()
-    else map.once('load', run)
-  }, [fitKey]) // eslint-disable-line react-hooks/exhaustive-deps
+    run()
+    if (!fitted && typeof map.once === 'function') map.once('load', run)
+    if (routeArrivedForPendingFit) pendingRouteFitRef.current = null
+  }, [fitKey, routeFitKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // flyTo selected place
   useEffect(() => {

--- a/client/src/components/Settings/MapSettingsTab.test.tsx
+++ b/client/src/components/Settings/MapSettingsTab.test.tsx
@@ -184,4 +184,16 @@ describe('MapSettingsTab', () => {
       expect(screen.getByDisplayValue('40')).toBeInTheDocument();
     });
   });
+
+  it('keeps zero coordinates as the world-view default instead of falling back to Paris', () => {
+    seedStore(useSettingsStore, {
+      settings: buildSettings({ default_lat: 0, default_lng: 0, default_zoom: 2 }),
+    });
+
+    render(<MapSettingsTab />);
+
+    expect(screen.getAllByDisplayValue('0')).toHaveLength(2);
+    expect(screen.queryByDisplayValue('48.8566')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('2.3522')).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/Settings/MapSettingsTab.tsx
+++ b/client/src/components/Settings/MapSettingsTab.tsx
@@ -18,6 +18,7 @@ import {
   normalizeStyleForProvider,
   type GlMapProvider,
 } from '../Map/glProviders'
+import { DEFAULT_MAP_LAT, DEFAULT_MAP_LNG, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 
 interface MapPreset {
   name: string
@@ -143,6 +144,16 @@ function slotStyle(provider: Provider, s: { mapbox_style?: string; maplibre_styl
   return provider === 'maplibre-gl' ? s.maplibre_style : s.mapbox_style
 }
 
+function parseNumberOr(value: number | string, fallback: number): number {
+  const parsed = parseFloat(String(value))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function parseIntegerOr(value: number | string, fallback: number): number {
+  const parsed = parseInt(String(value), 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
 export default function MapSettingsTab(): React.ReactElement {
   const { settings, updateSettings } = useSettingsStore()
   const { t } = useTranslation()
@@ -155,9 +166,9 @@ export default function MapSettingsTab(): React.ReactElement {
   const [mapboxStyle, setMapboxStyle] = useState<string>(styleForProvider(initialProvider, slotStyle(initialProvider, settings)))
   const [mapbox3d, setMapbox3d] = useState<boolean>(settings.mapbox_3d_enabled !== false)
   const [mapboxQuality, setMapboxQuality] = useState<boolean>(settings.mapbox_quality_mode === true)
-  const [defaultLat, setDefaultLat] = useState<number | string>(settings.default_lat || 48.8566)
-  const [defaultLng, setDefaultLng] = useState<number | string>(settings.default_lng || 2.3522)
-  const [defaultZoom, setDefaultZoom] = useState<number | string>(settings.default_zoom || 10)
+  const [defaultLat, setDefaultLat] = useState<number | string>(settings.default_lat ?? DEFAULT_MAP_LAT)
+  const [defaultLng, setDefaultLng] = useState<number | string>(settings.default_lng ?? DEFAULT_MAP_LNG)
+  const [defaultZoom, setDefaultZoom] = useState<number | string>(settings.default_zoom ?? DEFAULT_MAP_ZOOM)
 
   useEffect(() => {
     const nextProvider = normalizeProvider(settings.map_provider)
@@ -167,9 +178,9 @@ export default function MapSettingsTab(): React.ReactElement {
     setMapboxStyle(styleForProvider(nextProvider, slotStyle(nextProvider, settings)))
     setMapbox3d(settings.mapbox_3d_enabled !== false)
     setMapboxQuality(settings.mapbox_quality_mode === true)
-    setDefaultLat(settings.default_lat || 48.8566)
-    setDefaultLng(settings.default_lng || 2.3522)
-    setDefaultZoom(settings.default_zoom || 10)
+    setDefaultLat(settings.default_lat ?? DEFAULT_MAP_LAT)
+    setDefaultLng(settings.default_lng ?? DEFAULT_MAP_LNG)
+    setDefaultZoom(settings.default_zoom ?? DEFAULT_MAP_ZOOM)
   }, [settings])
 
   const handleMapClick = useCallback((mapInfo) => {
@@ -182,8 +193,8 @@ export default function MapSettingsTab(): React.ReactElement {
     trip_id: 1,
     name: 'Default map center',
     description: '',
-    lat: defaultLat as number,
-    lng: defaultLng as number,
+    lat: parseNumberOr(defaultLat, DEFAULT_MAP_LAT),
+    lng: parseNumberOr(defaultLng, DEFAULT_MAP_LNG),
     address: '',
     category_id: 0,
     price: null,
@@ -210,9 +221,9 @@ export default function MapSettingsTab(): React.ReactElement {
         ...stylePatch,
         mapbox_3d_enabled: mapbox3d,
         mapbox_quality_mode: mapboxQuality,
-        default_lat: parseFloat(String(defaultLat)),
-        default_lng: parseFloat(String(defaultLng)),
-        default_zoom: parseInt(String(defaultZoom)),
+        default_lat: parseNumberOr(defaultLat, DEFAULT_MAP_LAT),
+        default_lng: parseNumberOr(defaultLng, DEFAULT_MAP_LNG),
+        default_zoom: parseIntegerOr(defaultZoom, DEFAULT_MAP_ZOOM),
       })
       toast.success(t('settings.toast.mapSaved'))
     } catch (err: unknown) {
@@ -431,11 +442,11 @@ export default function MapSettingsTab(): React.ReactElement {
               provider={provider}
               token={mapboxToken}
               style={mapboxStyle}
-              lat={parseFloat(String(defaultLat)) || 48.8566}
-              lng={parseFloat(String(defaultLng)) || 2.3522}
+              lat={parseNumberOr(defaultLat, DEFAULT_MAP_LAT)}
+              lng={parseNumberOr(defaultLng, DEFAULT_MAP_LNG)}
               // Zoom in close so the style's character (3D buildings,
               // satellite texture, label density) is immediately visible.
-              zoom={Math.max(parseInt(String(defaultZoom)) || 10, 16)}
+              zoom={Math.max(parseIntegerOr(defaultZoom, DEFAULT_MAP_ZOOM), 16)}
               enable3d={provider === 'mapbox-gl' && mapbox3d && supports3d}
               quality={provider === 'mapbox-gl' && mapboxQuality}
               onClick={(ll) => { setDefaultLat(ll.lat); setDefaultLng(ll.lng) }}
@@ -451,7 +462,7 @@ export default function MapSettingsTab(): React.ReactElement {
               onMarkerClick: null,
               onMapClick: handleMapClick,
               onMapContextMenu: null,
-              center: [settings.default_lat, settings.default_lng],
+              center: [parseNumberOr(defaultLat, DEFAULT_MAP_LAT), parseNumberOr(defaultLng, DEFAULT_MAP_LNG)],
               zoom: defaultZoom,
               tileUrl: mapTileUrl,
               fitKey: null,

--- a/client/src/constants/mapDefaults.ts
+++ b/client/src/constants/mapDefaults.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_MAP_LAT = 0
+export const DEFAULT_MAP_LNG = 0
+export const DEFAULT_MAP_ZOOM = 2
+export const DEFAULT_MAP_CENTER: [number, number] = [DEFAULT_MAP_LAT, DEFAULT_MAP_LNG]

--- a/client/src/pages/TripPlannerPage.test.tsx
+++ b/client/src/pages/TripPlannerPage.test.tsx
@@ -12,8 +12,12 @@ import { server } from '../../tests/helpers/msw/server';
 import { http, HttpResponse } from 'msw';
 
 // Mock Leaflet-dependent components
+const capturedMapViewProps: { current: Record<string, any> } = { current: {} };
 vi.mock('../components/Map/MapView', () => ({
-  MapView: () => React.createElement('div', { 'data-testid': 'map-view' }),
+  MapView: (props: Record<string, any>) => {
+    capturedMapViewProps.current = props;
+    return React.createElement('div', { 'data-testid': 'map-view' });
+  },
 }));
 
 vi.mock('react-leaflet', () => ({
@@ -227,6 +231,7 @@ beforeEach(() => {
   mockSelectAssignment.mockReset();
   mockPlaceSelectionState.selectedPlaceId = null;
   mockPlaceSelectionState.selectedAssignmentId = null;
+  capturedMapViewProps.current = {};
   capturedDayPlanSidebarProps.current = {};
   capturedPlacesSidebarProps.current = {};
   capturedReservationsPanelProps.current = {};
@@ -653,6 +658,33 @@ describe('TripPlannerPage', () => {
       // Call onSelectDay via the captured props — covers handleSelectDay body
       await act(async () => {
         capturedDayPlanSidebarProps.current.onSelectDay?.(day.id);
+      });
+    });
+
+    it('bumps map fitKey even when selecting the already selected day', async () => {
+      vi.useFakeTimers();
+
+      const { day } = seedTripStore({ id: 42 });
+      seedStore(useTripStore, { selectedDayId: day.id } as any);
+
+      renderPlannerPage(42);
+
+      act(() => { vi.runAllTimers(); });
+
+      vi.useRealTimers();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('day-plan-sidebar')).toBeInTheDocument();
+      });
+
+      const initialFitKey = capturedMapViewProps.current.fitKey;
+
+      await act(async () => {
+        capturedDayPlanSidebarProps.current.onSelectDay?.(day.id);
+      });
+
+      await waitFor(() => {
+        expect(capturedMapViewProps.current.fitKey).toBe(initialFitKey + 1);
       });
     });
   });

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -351,12 +351,11 @@ export function useTripPlanner() {
   const { route, routeSegments, routeInfo, setRoute, setRouteInfo, updateRouteForDay } = useRouteCalculation({ assignments } as any, selectedDayId, routeShown, routeProfile, tripAccommodations)
 
   const handleSelectDay = useCallback((dayId: number | null, skipFit?: boolean) => {
-    const changed = dayId !== selectedDayId
     tripActions.setSelectedDay(dayId)
-    if (changed && !skipFit) setFitKey(k => k + 1)
+    if (!skipFit) setFitKey(k => k + 1)
     setMobileSidebarOpen(null)
     updateRouteForDay(dayId)
-  }, [updateRouteForDay, selectedDayId])
+  }, [updateRouteForDay])
 
   const handlePlaceClick = useCallback((placeId: number | null, assignmentId?: number | null) => {
     if (assignmentId) {

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -23,6 +23,7 @@ import { usePlannerHistory } from '../../hooks/usePlannerHistory'
 import { useAirtrailConnection } from '../../hooks/useAirtrailConnection'
 import { usePluginStore } from '../../store/pluginStore'
 import type { Accommodation, TripMember, Day, Place, Reservation } from '../../types'
+import { DEFAULT_MAP_LAT, DEFAULT_MAP_LNG, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 import { resolvePoolAssignmentId } from './tripPlannerModel'
 
 /**
@@ -869,8 +870,8 @@ export function useTripPlanner() {
   }, [selectedDayId, assignments])
 
   const mapTileUrl = settings.map_tile_url || 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
-  const defaultCenter = [settings.default_lat || 48.8566, settings.default_lng || 2.3522]
-  const defaultZoom = settings.default_zoom || 10
+  const defaultCenter = [settings.default_lat ?? DEFAULT_MAP_LAT, settings.default_lng ?? DEFAULT_MAP_LNG]
+  const defaultZoom = settings.default_zoom ?? DEFAULT_MAP_ZOOM
 
   const fontStyle = { fontFamily: "var(--font-system)" }
 

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -4,6 +4,7 @@ import type { Settings } from '../types'
 import { DEFAULT_APPEARANCE } from '@trek/shared'
 import { getApiErrorMessage } from '../types'
 import { SUPPORTED_LANGUAGE_CODES } from '../i18n/supportedLanguages'
+import { DEFAULT_MAP_LAT, DEFAULT_MAP_LNG, DEFAULT_MAP_ZOOM } from '../constants/mapDefaults'
 
 interface SettingsState {
   settings: Settings
@@ -24,9 +25,9 @@ export const hasStoredLanguage = (): boolean =>
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   settings: {
     map_tile_url: '',
-    default_lat: 48.8566,
-    default_lng: 2.3522,
-    default_zoom: 10,
+    default_lat: DEFAULT_MAP_LAT,
+    default_lng: DEFAULT_MAP_LNG,
+    default_zoom: DEFAULT_MAP_ZOOM,
     dark_mode: false,
     default_currency: 'USD',
     language: localStorage.getItem('app_language') || 'en',

--- a/client/tests/helpers/factories.ts
+++ b/client/tests/helpers/factories.ts
@@ -21,6 +21,7 @@ import type {
   Settings,
   AppConfig,
 } from '../../src/types';
+import { DEFAULT_MAP_LAT, DEFAULT_MAP_LNG, DEFAULT_MAP_ZOOM } from '../../src/constants/mapDefaults';
 
 // ── Counters ──────────────────────────────────────────────────────────────────
 
@@ -260,9 +261,9 @@ export function buildCategory(overrides: Partial<Category> = {}): Category {
 export function buildSettings(overrides: Partial<Settings> = {}): Settings {
   return {
     map_tile_url: '',
-    default_lat: 48.8566,
-    default_lng: 2.3522,
-    default_zoom: 10,
+    default_lat: DEFAULT_MAP_LAT,
+    default_lng: DEFAULT_MAP_LNG,
+    default_zoom: DEFAULT_MAP_ZOOM,
     dark_mode: false,
     default_currency: 'USD',
     language: 'en',


### PR DESCRIPTION
## Description
1. Fix MapLibre hover (previously showed the icon which is redundant)
2. Fix MapLibre view fitting
3. Show the entire world by default (previously the map will by default zoom into Paris when the page just loaded and nothing is in focus)

<img width="1199" height="651" alt="image" src="https://github.com/user-attachments/assets/aca84702-3939-46b4-96b4-42796917e584" />

## Related Issue or Discussion
None

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
