### PR TITLE
fix: back-merge v3.1.4 hotfixes into dev (#1371)

### DIFF
--- a/client/src/components/Files/useFileManager.ts
+++ b/client/src/components/Files/useFileManager.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { useToast } from '../shared/Toast'
-import { useTranslation } from '../../i18n'
+import { useTranslation, translateApiError } from '../../i18n'
 import { filesApi } from '../../api/client'
 import type { Place, Reservation, TripFile, Day, AssignmentsMap } from '../../types'
 import { useCanDo } from '../../store/permissionsStore'
@@ -119,8 +119,8 @@ export function useFileManager({ files = [], onUpload, onDelete, onUpdate, place
       if (lastId && (places.length > 0 || reservations.length > 0)) {
         setAssignFileId(lastId)
       }
-    } catch {
-      toast.error(t('files.uploadError'))
+    } catch (err) {
+      toast.error(translateApiError(t, err, 'files.uploadError'))
     } finally {
       setUploading(false)
     }

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -14,7 +14,7 @@ import { useAddonStore } from '../../store/addonStore'
 import { useSaveToCollectionStore } from '../../store/saveToCollectionStore'
 import { getCategoryIcon } from '../shared/categoryIcons'
 import { useToast } from '../shared/Toast'
-import { useTranslation } from '../../i18n'
+import { useTranslation, translateApiError } from '../../i18n'
 import type { Place, Category, Day, Assignment, Reservation, TripFile, AssignmentsMap } from '../../types'
 import type { CollectionStatus } from '@trek/shared'
 import { splitReservationDateTime, formatTime } from '../../utils/formatters'
@@ -255,7 +255,7 @@ export default function PlaceInspector({
       setFilesExpanded(true)
     } catch (err: unknown) {
       console.error('Upload failed', err)
-      toast.error(t('files.uploadError'))
+      toast.error(translateApiError(t, err, 'files.uploadError'))
     } finally {
       setIsUploading(false)
       if (fileInputRef.current) fileInputRef.current.value = ''

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -8,3 +8,4 @@ export {
   SUPPORTED_LANGUAGES,
 } from './TranslationContext'
 export { TransHtml } from './TransHtml'
+export { translateApiError } from './translateApiError'

--- a/client/src/i18n/translateApiError.test.ts
+++ b/client/src/i18n/translateApiError.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { translateApiError } from './translateApiError'
+
+// Mimics the real t(): returns a translation for known keys, the key itself otherwise.
+const dict: Record<string, string> = {
+  'files.uploadErrorType': "This file type isn't supported",
+  'files.uploadError': 'Upload failed',
+}
+const t = (key: string) => dict[key] ?? key
+
+describe('translateApiError', () => {
+  it('resolves a server message that is a known i18n key', () => {
+    const err = new Error('files.uploadErrorType')
+    expect(translateApiError(t, err, 'files.uploadError')).toBe("This file type isn't supported")
+  })
+
+  it('falls back to the generic key when the message is a plain string', () => {
+    const err = new Error('Some raw server message')
+    expect(translateApiError(t, err, 'files.uploadError')).toBe('Upload failed')
+  })
+
+  it('falls back when the message is an empty string', () => {
+    expect(translateApiError(t, new Error(''), 'files.uploadError')).toBe('Upload failed')
+  })
+
+  it('falls back when the thrown value is not an Error', () => {
+    expect(translateApiError(t, 'nope', 'files.uploadError')).toBe('Upload failed')
+    expect(translateApiError(t, undefined, 'files.uploadError')).toBe('Upload failed')
+  })
+})

--- a/client/src/i18n/translateApiError.ts
+++ b/client/src/i18n/translateApiError.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve a server error whose message may be an i18n key.
+ *
+ * The server can return a translation key as its error message (e.g.
+ * `files.uploadErrorType`). `t()` returns the key unchanged when it isn't a
+ * known translation, so `translated === key` reliably means "not a key" — in
+ * that case we fall back to a generic, always-localized message.
+ */
+export function translateApiError(
+  t: (key: string) => string,
+  err: unknown,
+  fallbackKey: string,
+): string {
+  const key = err instanceof Error ? err.message : ''
+  const translated = t(key)
+  return translated && translated !== key ? translated : t(fallbackKey)
+}

--- a/client/src/pages/SharedTripPage.test.tsx
+++ b/client/src/pages/SharedTripPage.test.tsx
@@ -509,4 +509,67 @@ describe('SharedTripPage', () => {
       await waitFor(() => expect(screen.getByText('Tag 1')).toBeInTheDocument());
     });
   });
+
+  describe('FE-PAGE-SHARED-019: budget renders in the owner\'s baseCurrency, not the EUR trip fallback (#1361)', () => {
+    it('labels totals with the payload baseCurrency even when the trip currency is EUR', async () => {
+      server.use(
+        // No FX needed when the expense is already in the base; stub frankfurter so
+        // the live-rate fetch never hits the network in tests.
+        http.get('https://api.frankfurter.dev/v2/rates', () => HttpResponse.json([])),
+        http.get('/api/shared/:token', ({ params }) => {
+          if (params.token !== 'cad-token') return;
+          return HttpResponse.json({
+            trip: { id: 1, title: 'Shared Paris Trip', start_date: '2026-07-01', end_date: '2026-07-05', currency: 'EUR' },
+            baseCurrency: 'CAD',
+            days: [], assignments: {}, dayNotes: {}, places: [], reservations: [], accommodations: [], packing: [],
+            budget: [{ id: 1, name: 'Hotel', total_price: '200', category: 'Accommodation', currency: 'CAD' }],
+            categories: [],
+            permissions: { share_bookings: false, share_packing: false, share_budget: true, share_collab: false },
+            collab: [],
+          });
+        }),
+      );
+
+      renderSharedTrip('cad-token');
+      await waitFor(() => expect(screen.getByText('Shared Paris Trip')).toBeInTheDocument());
+      fireEvent.click(screen.getByRole('button', { name: /budget/i }));
+
+      await waitFor(() => expect(screen.getByText('Hotel')).toBeInTheDocument());
+      // Total + per-row labelled CAD; never the EUR fallback.
+      expect(screen.getAllByText(/200\.00 CAD/).length).toBeGreaterThan(0);
+      expect(screen.queryByText(/EUR/)).toBeNull();
+    });
+  });
+
+  describe('FE-PAGE-SHARED-020: mixed-currency expenses convert into baseCurrency via live FX (#1361)', () => {
+    it('converts a EUR expense into the base using fetched rates', async () => {
+      // Distinct base (NZD) so this test can't read the cached CAD rates seeded by
+      // FE-PAGE-SHARED-019 (useExchangeRates caches per base in module memory).
+      server.use(
+        // rates[X] = units of X per 1 base(NZD); 0.8 EUR per NZD → 100 EUR = 125.00 NZD
+        // (a clean 2-decimal result, distinct from the unconverted 100).
+        http.get('https://api.frankfurter.dev/v2/rates', () => HttpResponse.json([{ quote: 'EUR', rate: 0.8 }])),
+        http.get('/api/shared/:token', ({ params }) => {
+          if (params.token !== 'mixed-token') return;
+          return HttpResponse.json({
+            trip: { id: 1, title: 'Shared Paris Trip', start_date: '2026-07-01', end_date: '2026-07-05', currency: 'EUR' },
+            baseCurrency: 'NZD',
+            days: [], assignments: {}, dayNotes: {}, places: [], reservations: [], accommodations: [], packing: [],
+            budget: [{ id: 1, name: 'Dinner', total_price: '100', category: 'Food', currency: 'EUR' }],
+            categories: [],
+            permissions: { share_bookings: false, share_packing: false, share_budget: true, share_collab: false },
+            collab: [],
+          });
+        }),
+      );
+
+      renderSharedTrip('mixed-token');
+      await waitFor(() => expect(screen.getByText('Shared Paris Trip')).toBeInTheDocument());
+      fireEvent.click(screen.getByRole('button', { name: /budget/i }));
+
+      await waitFor(() => expect(screen.getByText('Dinner')).toBeInTheDocument());
+      // 100 EUR / 0.8 = 125.00 NZD once the rate resolves.
+      await waitFor(() => expect(screen.getAllByText(/125\.00 NZD/).length).toBeGreaterThan(0));
+    });
+  });
 });

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -42,7 +42,7 @@ function FitBoundsToPlaces({ places }: { places: any[] }) {
 export default function SharedTripPage() {
   const { t, locale } = useTranslation()
   // Page = wiring container: share fetch + view state live in the hook.
-  const { data, error, selectedDay, setSelectedDay, activeTab, setActiveTab, showLangPicker, setShowLangPicker } = useSharedTrip()
+  const { data, error, base, convert, selectedDay, setSelectedDay, activeTab, setActiveTab, showLangPicker, setShowLangPicker } = useSharedTrip()
 
   if (error) return (
     <div className="bg-[#f3f4f6]" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
@@ -328,26 +328,30 @@ export default function SharedTripPage() {
 
         {/* Budget */}
         {activeTab === 'budget' && (budget || []).length > 0 && (() => {
+          // Pre-rework rows store currency = NULL ("the trip's own currency"); convert
+          // each expense into the owner's display base via live FX, mirroring CostsPanel.
+          const curOf = (i: any) => i.currency || trip.currency || base
           const grouped = (budget || []).reduce((g: any, i: any) => { const c = i.category || t('shared.other'); (g[c] = g[c] || []).push(i); return g }, {})
-          const total = (budget || []).reduce((s: number, i: any) => s + (parseFloat(i.total_price) || 0), 0)
+          const sumIn = (items: any[]) => items.reduce((s: number, i: any) => s + convert(parseFloat(i.total_price) || 0, curOf(i)), 0)
+          const total = sumIn(budget || [])
           return (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               {/* Total card */}
               <div className="text-white" style={{ background: 'linear-gradient(135deg, #000 0%, #1a1a2e 100%)', borderRadius: 14, padding: '20px 24px' }}>
                 <div style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, letterSpacing: 1, textTransform: 'uppercase', opacity: 0.5 }}>{t('shared.totalBudget')}</div>
-                <div style={{ fontSize: 'calc(28px * var(--fs-scale-title, 1))', fontWeight: 700, marginTop: 4 }}>{total.toLocaleString(locale, { minimumFractionDigits: 2 })} {trip.currency || 'EUR'}</div>
+                <div style={{ fontSize: 'calc(28px * var(--fs-scale-title, 1))', fontWeight: 700, marginTop: 4 }}>{total.toLocaleString(locale, { minimumFractionDigits: 2 })} {base}</div>
               </div>
               {/* By category */}
               {Object.entries(grouped).map(([cat, items]: [string, any]) => (
                 <div key={cat} className="bg-surface-card border border-edge-faint" style={{ borderRadius: 12, overflow: 'hidden' }}>
                   <div className="bg-[#f9fafb]" style={{ padding: '10px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid #f3f4f6' }}>
                     <span className="text-[#374151]" style={{ fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 700 }}>{cat}</span>
-                    <span className="text-[#6b7280]" style={{ fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 600 }}>{items.reduce((s: number, i: any) => s + (parseFloat(i.total_price) || 0), 0).toLocaleString(locale, { minimumFractionDigits: 2 })} {trip.currency || ''}</span>
+                    <span className="text-[#6b7280]" style={{ fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 600 }}>{sumIn(items).toLocaleString(locale, { minimumFractionDigits: 2 })} {base}</span>
                   </div>
                   {items.map((item: any) => (
                     <div key={item.id} style={{ padding: '8px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid #fafafa' }}>
                       <span className="text-[#111827]" style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))' }}>{item.name}</span>
-                      <span className="text-[#111827]" style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 600 }}>{item.total_price ? Number(item.total_price).toLocaleString(locale, { minimumFractionDigits: 2 }) : '—'}</span>
+                      <span className="text-[#111827]" style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 600 }}>{item.total_price ? `${convert(parseFloat(item.total_price) || 0, curOf(item)).toLocaleString(locale, { minimumFractionDigits: 2 })} ${base}` : '—'}</span>
                     </div>
                   ))}
                 </div>

--- a/client/src/pages/sharedTrip/useSharedTrip.ts
+++ b/client/src/pages/sharedTrip/useSharedTrip.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { shareApi } from '../../api/client'
+import { useExchangeRates } from '../../hooks/useExchangeRates'
 
 /**
  * Shared-trip (public) data hook — owns the token lookup, the read-only share
@@ -24,5 +25,12 @@ export function useSharedTrip() {
     shareApi.getSharedTrip(token).then(setData).catch(() => setError(true))
   }, [token])
 
-  return { data, error, selectedDay, setSelectedDay, activeTab, setActiveTab, showLangPicker, setShowLangPicker }
+  // Budget display currency = what the share owner sees in Costs (embedded in the
+  // payload as baseCurrency), falling back to the trip's own currency, then EUR.
+  // Convert every expense into it via live FX, mirroring CostsPanel — a public
+  // viewer has no settings store, so the base comes from the payload (#1361).
+  const base = String(data?.baseCurrency || data?.trip?.currency || 'EUR').toUpperCase()
+  const { convert } = useExchangeRates(base)
+
+  return { data, error, base, convert, selectedDay, setSelectedDay, activeTab, setActiveTab, showLangPicker, setShowLangPicker }
 }

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -6,7 +6,7 @@ import { useSettingsStore } from '../../store/settingsStore'
 import { getCached, fetchPhoto } from '../../services/photoService'
 import { useToast } from '../../components/shared/Toast'
 import { Map, Ticket, PackageCheck, Wallet, FolderOpen, Users, Train } from 'lucide-react'
-import { useTranslation } from '../../i18n'
+import { useTranslation, translateApiError } from '../../i18n'
 import { addonsApi, accommodationsApi, authApi, tripsApi, assignmentsApi, healthApi, airtrailApi, mapsApi, placesApi } from '../../api/client'
 import { parsedItemToDraft, isTransportItem, type BookingReviewDraft } from '../../components/Planner/parsedItemToDraft'
 import type { BookingImportPreviewItem } from '@trek/shared'
@@ -426,7 +426,7 @@ export function useTripPlanner() {
           const fd = new FormData()
           fd.append('file', file)
           fd.append('place_id', String(editingPlace.id))
-          try { await tripActions.addFile(tripId, fd) } catch { toast.error(t('files.uploadError')) }
+          try { await tripActions.addFile(tripId, fd) } catch (err) { toast.error(translateApiError(t, err, 'files.uploadError')) }
         }
       }
       toast.success(t('trip.toast.placeUpdated'))
@@ -437,7 +437,7 @@ export function useTripPlanner() {
           const fd = new FormData()
           fd.append('file', file)
           fd.append('place_id', String(place.id))
-          try { await tripActions.addFile(tripId, fd) } catch { toast.error(t('files.uploadError')) }
+          try { await tripActions.addFile(tripId, fd) } catch (err) { toast.error(translateApiError(t, err, 'files.uploadError')) }
         }
       }
       toast.success(t('trip.toast.placeAdded'))

--- a/server/src/nest/files/files.controller.ts
+++ b/server/src/nest/files/files.controller.ts
@@ -39,7 +39,8 @@ const UPLOAD = {
   fileFilter: (_req: unknown, file: Express.Multer.File, cb: (err: Error | null, accept: boolean) => void) => {
     const ext = path.extname(file.originalname).toLowerCase();
     const reject = () => {
-      const err: Error & { statusCode?: number } = new Error('File type not allowed');
+      // i18n key — the client resolves it via t() (see translateApiError).
+      const err: Error & { statusCode?: number } = new Error('files.uploadErrorType');
       err.statusCode = 400;
       cb(err, false);
     };

--- a/server/src/services/backupService.ts
+++ b/server/src/services/backupService.ts
@@ -184,9 +184,21 @@ export async function createBackup(): Promise<BackupInfo> {
         // Exclude the place-photo and trek-memory caches: both are re-derivable
         // (re-fetched on demand, keyed on stable ids) and would otherwise dominate
         // backup size. Restores self-heal — the cache dirs are recreated at startup.
+        //
+        // Also exclude backups/ and restore-*/: these live under data/, not uploads/,
+        // but when an install maps data and uploads to the SAME directory (a
+        // misconfiguration, but a catastrophic one) the glob would otherwise sweep
+        // every prior backup zip into the new archive — each run embedding all
+        // previous runs, so size compounds without bound (see issue #1358). Ignoring
+        // them keeps the backup bounded regardless of how the volumes are mounted.
         archive.glob(
           '**/*',
-          { cwd: uploadsDir, ignore: ['photos/google/**', 'photos/trek/**'], nodir: true, dot: true },
+          {
+            cwd: uploadsDir,
+            ignore: ['photos/google/**', 'photos/trek/**', 'backups/**', 'restore-*/**'],
+            nodir: true,
+            dot: true,
+          },
           { prefix: 'uploads' },
         );
       }

--- a/server/src/services/shareService.ts
+++ b/server/src/services/shareService.ts
@@ -2,6 +2,7 @@ import { db, canAccessTrip } from '../db/database';
 import crypto from 'crypto';
 import { loadTagsByPlaceIds } from './queryHelpers';
 import { serveFilePath } from './placePhotoCache';
+import { getUserSettings } from './settingsService';
 
 const PLACE_PHOTO_PROXY_PREFIX = '/api/maps/place-photo/';
 
@@ -219,8 +220,23 @@ export function getSharedTripData(token: string): Record<string, any> | null {
     ? db.prepare('SELECT m.*, u.username, u.avatar FROM collab_messages m JOIN users u ON m.user_id = u.id WHERE m.trip_id = ? AND m.deleted = 0 ORDER BY m.created_at').all(tripId)
     : [];
 
+  // Display currency the share owner sees in their Costs view. A public viewer has
+  // no logged-in user, so the owner's per-user `default_currency` (with the admin
+  // instance default already merged in by getUserSettings) is embedded in the
+  // payload and used by the client to convert every expense — otherwise guests
+  // fall back to the trip's base currency and see the wrong totals (#1361).
+  // getUserSettings merges admin defaults under the user's own settings, so this
+  // honours per-user → admin-default; we then fall back to trip currency → EUR.
+  let baseCurrency = (trip as { currency?: string }).currency || 'EUR';
+  if (shareRow.created_by != null) {
+    const ownerDefault = getUserSettings(shareRow.created_by)['default_currency'];
+    if (typeof ownerDefault === 'string' && ownerDefault.trim()) {
+      baseCurrency = ownerDefault.trim();
+    }
+  }
+
   return {
-    trip, days, assignments, dayNotes, places, categories, permissions,
+    trip, baseCurrency, days, assignments, dayNotes, places, categories, permissions,
     reservations: permissions.share_bookings ? reservations : [],
     accommodations: permissions.share_bookings ? accommodations : [],
     packing: permissions.share_packing ? packing : [],

--- a/server/tests/integration/files.test.ts
+++ b/server/tests/integration/files.test.ts
@@ -126,6 +126,8 @@ describe('Upload file', () => {
         .set('Cookie', authCookie(user.id))
         .attach('file', svgPath);
       expect(res.status).toBe(400);
+      // The error is an i18n key the client resolves via t() (issue #1363).
+      expect(res.body.error).toBe('files.uploadErrorType');
     } finally {
       if (fs.existsSync(svgPath)) fs.unlinkSync(svgPath);
     }

--- a/server/tests/integration/share.test.ts
+++ b/server/tests/integration/share.test.ts
@@ -354,6 +354,56 @@ describe('Shared trip — ordering parity (issue #981)', () => {
   });
 });
 
+describe('Shared trip — display currency (issue #1361)', () => {
+  it('SHARE-021 — baseCurrency resolves from the share owner\'s default_currency setting', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    // Trip keeps the EUR default; the owner's Costs display currency is CAD.
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'default_currency', ?)")
+      .run(user.id, JSON.stringify('CAD'));
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_budget: true });
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.baseCurrency).toBe('CAD');
+  });
+
+  it('SHARE-022 — baseCurrency falls back to the trip currency when the owner has no setting', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    testDb.prepare('UPDATE trips SET currency = ? WHERE id = ?').run('GBP', trip.id);
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_budget: true });
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.baseCurrency).toBe('GBP');
+  });
+
+  it('SHARE-023 — baseCurrency uses the admin instance default when the owner has no per-user setting', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id); // EUR trip default, no user setting
+    testDb.prepare("INSERT INTO app_settings (key, value) VALUES ('default_user_setting_default_currency', ?)")
+      .run(JSON.stringify('USD'));
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_budget: true });
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.baseCurrency).toBe('USD');
+  });
+});
+
 describe('Shared trip — place photos in shared links (issue #1100)', () => {
   const PLACE_ID = 'ChIJsharedPhoto1100';
   const PROXY_URL = `/api/maps/place-photo/${encodeURIComponent(PLACE_ID)}/bytes`;

--- a/server/tests/unit/services/backupService.test.ts
+++ b/server/tests/unit/services/backupService.test.ts
@@ -475,12 +475,44 @@ describe('BACKUP-036 createBackup', () => {
       '**/*',
       expect.objectContaining({
         cwd: expect.stringContaining('uploads'),
-        ignore: ['photos/google/**', 'photos/trek/**'],
+        ignore: ['photos/google/**', 'photos/trek/**', 'backups/**', 'restore-*/**'],
       }),
       { prefix: 'uploads' },
     );
     // The re-derivable caches must not be archived verbatim.
     expect(archiverInstanceMock.directory).not.toHaveBeenCalled();
+  });
+
+  it('BACKUP-036h — never sweeps backups/ or restore-* into the archive (issue #1358)', async () => {
+    // Regression guard: when data and uploads map to the same directory, the
+    // uploads glob would otherwise pick up the backups/ dir and recursively
+    // embed every prior backup zip, compounding size without bound.
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('uploads'));
+    fsMock.mkdirSync.mockReturnValue(undefined);
+
+    const writableEvents: Record<string, Function> = {};
+    const fakeWriteStream = {
+      on: vi.fn((event: string, cb: Function) => {
+        writableEvents[event] = cb;
+      }),
+    };
+    fsMock.createWriteStream.mockReturnValue(fakeWriteStream);
+
+    archiverInstanceMock.on.mockImplementation((_e: string, _cb: Function) => {});
+    archiverInstanceMock.pipe.mockReturnValue(undefined);
+    archiverInstanceMock.finalize.mockImplementation(() => {
+      if (writableEvents['close']) writableEvents['close']();
+    });
+    archiverMock.mockReturnValue(archiverInstanceMock);
+
+    fsMock.statSync.mockReturnValue({ size: 1024, birthtime: new Date('2026-04-06T12:00:00Z') });
+
+    await createBackup();
+
+    const globCall = archiverInstanceMock.glob.mock.calls.at(-1);
+    const ignore: string[] = globCall?.[1]?.ignore ?? [];
+    expect(ignore).toContain('backups/**');
+    expect(ignore).toContain('restore-*/**');
   });
 
   it('BACKUP-036f — bundles .encryption_key when present and ENCRYPTION_KEY env is unset', async () => {

--- a/shared/src/i18n/ar/files.ts
+++ b/shared/src/i18n/ar/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': 'ملف واحد',
   'files.uploaded': 'تم رفع {count}',
   'files.uploadError': 'فشل الرفع',
+  'files.uploadErrorType': 'نوع الملف هذا غير مدعوم',
   'files.dropzone': 'أسقط الملفات هنا',
   'files.dropzoneHint': 'أو انقر للتصفح',
   'files.allowedTypes': 'صور، PDF، DOC، DOCX، XLS، XLSX، TXT، CSV · حد أقصى 50 ميغابايت',

--- a/shared/src/i18n/br/files.ts
+++ b/shared/src/i18n/br/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 arquivo',
   'files.uploaded': '{count} enviado(s)',
   'files.uploadError': 'Falha no envio',
+  'files.uploadErrorType': 'Esse tipo de arquivo não é suportado',
   'files.dropzone': 'Solte os arquivos aqui',
   'files.dropzoneHint': 'ou clique para escolher',
   'files.allowedTypes': 'Imagens, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Máx. 50 MB',

--- a/shared/src/i18n/cs/files.ts
+++ b/shared/src/i18n/cs/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 soubor',
   'files.uploaded': '{count} nahráno',
   'files.uploadError': 'Nahrávání se nezdařilo',
+  'files.uploadErrorType': 'Tento typ souboru není podporován',
   'files.dropzone': 'Přetáhněte soubory sem',
   'files.dropzoneHint': 'nebo klikněte pro výběr',
   'files.allowedTypes': 'Obrázky, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/de/files.ts
+++ b/shared/src/i18n/de/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 Datei',
   'files.uploaded': '{count} hochgeladen',
   'files.uploadError': 'Fehler beim Hochladen',
+  'files.uploadErrorType': 'Dieser Dateityp wird nicht unterstützt',
   'files.dropzone': 'Dateien hier ablegen',
   'files.dropzoneHint': 'oder klicken zum Auswählen',
   'files.allowedTypes': 'Bilder, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/en/files.ts
+++ b/shared/src/i18n/en/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 file',
   'files.uploaded': '{count} uploaded',
   'files.uploadError': 'Upload failed',
+  'files.uploadErrorType': "This file type isn't supported",
   'files.dropzone': 'Drop files here',
   'files.dropzoneHint': 'or click to browse',
   'files.allowedTypes': 'Images, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/es/files.ts
+++ b/shared/src/i18n/es/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 archivo',
   'files.uploaded': '{count} archivos subidos',
   'files.uploadError': 'La subida falló',
+  'files.uploadErrorType': 'Este tipo de archivo no es compatible',
   'files.dropzone': 'Arrastra aquí los archivos',
   'files.dropzoneHint': 'o haz clic para explorar',
   'files.allowedTypes': 'Imágenes, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Máx. 50 MB',

--- a/shared/src/i18n/fr/files.ts
+++ b/shared/src/i18n/fr/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 fichier',
   'files.uploaded': '{count} importés',
   'files.uploadError': "Échec de l'import",
+  'files.uploadErrorType': "Ce type de fichier n'est pas pris en charge",
   'files.dropzone': 'Déposez les fichiers ici',
   'files.dropzoneHint': 'ou cliquez pour parcourir',
   'files.allowedTypes': 'Images, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 Mo',

--- a/shared/src/i18n/gr/files.ts
+++ b/shared/src/i18n/gr/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 αρχείο',
   'files.uploaded': '{count} μεταφορτώθηκαν',
   'files.uploadError': 'Η μεταφόρτωση απέτυχε',
+  'files.uploadErrorType': 'Αυτός ο τύπος αρχείου δεν υποστηρίζεται',
   'files.dropzone': 'Αποθέστε αρχεία εδώ',
   'files.dropzoneHint': 'ή κάντε κλικ για περιήγηση',
   'files.allowedTypes': 'Εικόνες, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Μέγ. 50 MB',

--- a/shared/src/i18n/hu/files.ts
+++ b/shared/src/i18n/hu/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 fájl',
   'files.uploaded': '{count} feltöltve',
   'files.uploadError': 'Feltöltés sikertelen',
+  'files.uploadErrorType': 'Ez a fájltípus nem támogatott',
   'files.dropzone': 'Húzd ide a fájlokat',
   'files.dropzoneHint': 'vagy kattints a böngészéshez',
   'files.allowedTypes': 'Képek, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/id/files.ts
+++ b/shared/src/i18n/id/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 berkas',
   'files.uploaded': '{count} diunggah',
   'files.uploadError': 'Gagal mengunggah',
+  'files.uploadErrorType': 'Tipe file ini tidak didukung',
   'files.dropzone': 'Jatuhkan file di sini',
   'files.dropzoneHint': 'atau klik untuk memilih',
   'files.allowedTypes': 'Gambar, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Maks 50 MB',

--- a/shared/src/i18n/it/files.ts
+++ b/shared/src/i18n/it/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 documento',
   'files.uploaded': '{count} caricati',
   'files.uploadError': 'Caricamento non riuscito',
+  'files.uploadErrorType': 'Questo tipo di file non è supportato',
   'files.dropzone': 'Trascina qui i file',
   'files.dropzoneHint': 'oppure clicca per sfogliare',
   'files.allowedTypes': 'Immagini, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/ja/files.ts
+++ b/shared/src/i18n/ja/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1件のファイル',
   'files.uploaded': '{count}件アップロード',
   'files.uploadError': 'アップロードに失敗しました',
+  'files.uploadErrorType': 'このファイル形式はサポートされていません',
   'files.dropzone': 'ここにファイルをドロップ',
   'files.dropzoneHint': 'またはクリックして参照',
   'files.allowedTypes': '画像、PDF、DOC、DOCX、XLS、XLSX、TXT、CSV · 最大50MB',

--- a/shared/src/i18n/ko/files.ts
+++ b/shared/src/i18n/ko/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '파일 1개',
   'files.uploaded': '{count}개 업로드됨',
   'files.uploadError': '업로드 실패',
+  'files.uploadErrorType': '지원되지 않는 파일 형식입니다',
   'files.dropzone': '여기에 파일을 놓으세요',
   'files.dropzoneHint': '또는 클릭하여 탐색',
   'files.allowedTypes': '이미지, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · 최대 50 MB',

--- a/shared/src/i18n/nl/files.ts
+++ b/shared/src/i18n/nl/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 bestand',
   'files.uploaded': '{count} geüpload',
   'files.uploadError': 'Uploaden mislukt',
+  'files.uploadErrorType': 'Dit bestandstype wordt niet ondersteund',
   'files.dropzone': 'Sleep bestanden hierheen',
   'files.dropzoneHint': 'of klik om te bladeren',
   'files.allowedTypes': 'Afbeeldingen, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Max 50 MB',

--- a/shared/src/i18n/pl/files.ts
+++ b/shared/src/i18n/pl/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 plik',
   'files.uploaded': '{count} przesłanych',
   'files.uploadError': 'Przesyłanie nie powiodło się',
+  'files.uploadErrorType': 'Ten typ pliku nie jest obsługiwany',
   'files.dropzone': 'Przeciągnij pliki tutaj',
   'files.dropzoneHint': 'lub kliknij, aby przeglądać',
   'files.allowedTypes': 'Obrazki, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Maks 50 MB',

--- a/shared/src/i18n/ru/files.ts
+++ b/shared/src/i18n/ru/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 файл',
   'files.uploaded': '{count} загружено',
   'files.uploadError': 'Ошибка загрузки',
+  'files.uploadErrorType': 'Этот тип файла не поддерживается',
   'files.dropzone': 'Перетащите файлы сюда',
   'files.dropzoneHint': 'или нажмите для выбора',
   'files.allowedTypes': 'Изображения, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Макс. 50 МБ',

--- a/shared/src/i18n/sv/files.ts
+++ b/shared/src/i18n/sv/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 fil',
   'files.uploaded': '{count} uppladdade',
   'files.uploadError': 'Uppladdning misslyckades',
+  'files.uploadErrorType': 'Den här filtypen stöds inte',
   'files.dropzone': 'Släpp filer här',
   'files.dropzoneHint': 'eller klicka för att bläddra',
   'files.allowedTypes': 'Foton, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Högst 50 MB',

--- a/shared/src/i18n/tr/files.ts
+++ b/shared/src/i18n/tr/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 dosya',
   'files.uploaded': '{count} yüklendi',
   'files.uploadError': 'Yükleme başarısız oldu',
+  'files.uploadErrorType': 'Bu dosya türü desteklenmiyor',
   'files.dropzone': 'Dosyaları buraya bırakın',
   'files.dropzoneHint': 'veya göz atmak için tıklayın',
   'files.allowedTypes': 'Görsel, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Maks. 50 MB',

--- a/shared/src/i18n/uk/files.ts
+++ b/shared/src/i18n/uk/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 файл',
   'files.uploaded': '{count} завантажено',
   'files.uploadError': 'Помилка завантаження',
+  'files.uploadErrorType': 'Цей тип файлу не підтримується',
   'files.dropzone': 'Перетягніть файли сюди',
   'files.dropzoneHint': 'або натисніть для вибору',
   'files.allowedTypes': 'Зображення, PDF, DOC, DOCX, XLS, XLSX, TXT, CSV · Макс. 50 МБ',

--- a/shared/src/i18n/vi/files.ts
+++ b/shared/src/i18n/vi/files.ts
@@ -1,6 +1,7 @@
 import type { TranslationStrings } from '../types';
 
 const files: TranslationStrings = {
+  'files.uploadErrorType': 'Loại tập tin này không được hỗ trợ',
   'files.title': 'Tập tin',
   'files.pageTitle': 'Tập tin & Tài liệu',
   'files.subtitle': '{count} tệp cho {trip}',

--- a/shared/src/i18n/zh-TW/files.ts
+++ b/shared/src/i18n/zh-TW/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 個檔案',
   'files.uploaded': '已上傳 {count} 個',
   'files.uploadError': '上傳失敗',
+  'files.uploadErrorType': '不支援此檔案類型',
   'files.dropzone': '將檔案拖放到此處',
   'files.dropzoneHint': '或點選瀏覽',
   'files.allowedTypes': '圖片、PDF、DOC、DOCX、XLS、XLSX、TXT、CSV · 最大 50 MB',

--- a/shared/src/i18n/zh/files.ts
+++ b/shared/src/i18n/zh/files.ts
@@ -11,6 +11,7 @@ const files: TranslationStrings = {
   'files.countSingular': '1 个文件',
   'files.uploaded': '已上传 {count} 个',
   'files.uploadError': '上传失败',
+  'files.uploadErrorType': '不支持此文件类型',
   'files.dropzone': '将文件拖放到此处',
   'files.dropzoneHint': '或点击浏览',
   'files.allowedTypes': '图片、PDF、DOC、DOCX、XLS、XLSX、TXT、CSV · 最大 50 MB',


### PR DESCRIPTION
Back-merges the three fixes that shipped on `main` in **v3.1.4 (#1371)** but never made it to `dev`. `dev` has diverged far past 3.1.4 (NestJS rewrite, costs rework, collections), so a straight merge was not possible — the fixes are cherry-picked from `819aa793` and the two conflicts were resolved onto dev's current architecture.

## Fixes

- **fix(backups): prevent recursion when the backup path sits inside the backed-up directory** — a backup target under the data dir no longer recurses into its own output.
- **fix(share): show the viewer's currency on the public share page** — budget items are converted to the share payload's base currency via live FX (mirroring `CostsPanel`) instead of being printed with a flat `EUR`. Picks up dev's per-item multi-currency from the costs rework.
- **fix(files): descriptive error for unsupported upload types (#1363)** — the server emits the `files.uploadErrorType` i18n key and a new `translateApiError()` helper resolves a known key through `t()`, wired into every trip-file upload catch site (planner, file manager, place inspector).

## Conflict resolution

- `SharedTripPage.tsx` — kept dev's font-scaling styles, took the fix's currency conversion (`base` / `convert` / `sumIn` from `useSharedTrip`).
- `useTripPlanner.ts` — kept dev's full import set, added the `translateApiError` import.
- Backfilled the `files.uploadErrorType` key for the `vi` locale (added on dev after 3.1.4) so strict i18n parity holds across all 22 locales.

The version-bump commit (`chore: bump version to 3.1.4`) is intentionally left out — dev is versioned separately at release time.
