### PR TITLE
fix(plugin-sdk): scaffolded plugins can actually require the SDK

### DIFF
--- a/plugin-sdk/package.json
+++ b/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trek-plugin-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SDK for building TREK plugins: types, definePlugin, a mock host, manifest validation, and the create-trek-plugin / trek-plugin CLIs.",
   "type": "module",
   "license": "MIT",
@@ -13,8 +13,14 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-    "./testing": { "types": "./dist/mock-host.d.ts", "import": "./dist/mock-host.js" }
+    ".": {
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "require": { "types": "./dist/cjs/index.d.ts", "default": "./dist/cjs/index.js" }
+    },
+    "./testing": {
+      "import": { "types": "./dist/mock-host.d.ts", "default": "./dist/mock-host.js" },
+      "require": { "types": "./dist/cjs/mock-host.d.ts", "default": "./dist/cjs/mock-host.js" }
+    }
   },
   "bin": {
     "trek-plugin-sdk": "./dist/cli/trek-plugin.js",
@@ -23,7 +29,7 @@
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && node scripts/finish-cjs.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "prepublishOnly": "npm run build && npm test"

--- a/plugin-sdk/scripts/finish-cjs.mjs
+++ b/plugin-sdk/scripts/finish-cjs.mjs
@@ -1,0 +1,9 @@
+// The package root says `"type": "module"`, so the CommonJS second build in
+// dist/cjs needs its own scope marker or Node would parse those files as ESM.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'cjs');
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(path.join(dir, 'package.json'), '{"type":"commonjs"}\n');

--- a/plugin-sdk/src/cli/create.ts
+++ b/plugin-sdk/src/cli/create.ts
@@ -7,6 +7,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
+import { createRequire } from 'node:module';
+
+/** This package's own version, for the scaffold's devDependency range. */
+function sdkVersionRange(): string {
+  try {
+    const pkg = createRequire(import.meta.url)('../../package.json') as { version?: string };
+    return pkg.version ? `^${pkg.version}` : '^1';
+  } catch {
+    return '^1';
+  }
+}
 
 export interface ScaffoldOptions {
   author?: string;
@@ -42,6 +53,17 @@ export function scaffold(name: string, type: string, targetDir: string, opts: Sc
   fs.writeFileSync(path.join(root, 'trek-plugin.json'), JSON.stringify(manifest, null, 2) + '\n');
   fs.writeFileSync(path.join(root, 'server', 'index.js'), SERVER_JS);
   fs.writeFileSync(path.join(root, 'README.md'), readme(name));
+  // `type: commonjs` pins how the entry is parsed everywhere (dev, tests, TREK);
+  // the SDK is a devDependency ONLY (types + mock host) — at runtime both the
+  // dev server and TREK inject it, so it is never vendored into the artifact.
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+    name,
+    version: '1.0.0',
+    private: true,
+    type: 'commonjs',
+    scripts: { dev: 'npx -y trek-plugin-sdk dev', pack: 'npx -y trek-plugin-sdk pack' },
+    devDependencies: { 'trek-plugin-sdk': sdkVersionRange() },
+  }, null, 2) + '\n');
   if (type !== 'integration') {
     fs.mkdirSync(path.join(root, 'client'), { recursive: true });
     fs.writeFileSync(path.join(root, 'client', 'index.html'), CLIENT_HTML);
@@ -162,7 +184,7 @@ if (process.argv[1] && process.argv[1].endsWith('create.js')) {
   }
   try {
     scaffold(name, type, process.cwd());
-    console.log(`Created ${name}/ — fill in the README, build server/index.js, then \`npx trek-plugin validate ${name}\`.`);
+    console.log(`Created ${name}/ — fill in the README, build server/index.js, then \`npx trek-plugin-sdk validate ${name}\`.`);
   } catch (e) {
     console.error(e instanceof Error ? e.message : e);
     process.exit(1);

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -26,8 +26,17 @@ interface PluginLike { onLoad?: (ctx: unknown) => unknown; routes?: PluginRouteL
 
 class PermissionDenied extends Error {}
 
+/**
+ * Accept both bind shapes the real host accepts: spread positional args AND a
+ * single array of them (better-sqlite3 binds an array; node:sqlite does not,
+ * so a plugin using the array form would fail only in dev).
+ */
+function flatBind(args: unknown[]): unknown[] {
+  return args.length === 1 && Array.isArray(args[0]) ? (args[0] as unknown[]) : args;
+}
+
 /** A dev db backed by node:sqlite if available, else an in-memory recorder that returns []. */
-function createDevDb(dbFile: string): { db: PluginContextDb; note: string; close: () => void } {
+export function createDevDb(dbFile: string): { db: PluginContextDb; note: string; close: () => void } {
   try {
     // node:sqlite is available on Node 22.5+ (experimental). Fall back gracefully if not.
     const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as { DatabaseSync: new (p: string) => SqliteDb };
@@ -38,9 +47,9 @@ function createDevDb(dbFile: string): { db: PluginContextDb; note: string; close
       note: `db:own → real SQLite at ${dbFile}`,
       close: () => { try { sq.close(); } catch { /* ignore */ } },
       db: {
-        async query(sql: string, ...args: unknown[]) { return sq.prepare(sql).all(...args) as unknown[]; },
+        async query(sql: string, ...args: unknown[]) { return sq.prepare(sql).all(...flatBind(args)) as unknown[]; },
         async exec(sql: string, ...args: unknown[]) {
-          if (args.length) { const r = sq.prepare(sql).run(...args); return { changes: Number(r.changes ?? 0) }; }
+          if (args.length) { const r = sq.prepare(sql).run(...flatBind(args)); return { changes: Number(r.changes ?? 0) }; }
           sq.exec(sql); return { changes: 0 };
         },
         async migrate(id: string, sql: string) { if (applied.has(id)) return { applied: false }; sq.exec(sql); applied.add(id); return { applied: true }; },
@@ -167,7 +176,12 @@ export async function runDev(dir: string, opts: { port?: number } = {}): Promise
       await plugin.onLoad?.(ctx);
       version++;
       console.log(`  ↻ loaded ${plugin.routes?.length ?? 0} route(s)`);
-    } catch (e) { console.error('  ✗ plugin failed to load:', e instanceof Error ? e.message : e); }
+    } catch (e) {
+      // A plugin whose load/onLoad throws would fail activation in TREK — don't
+      // keep serving its routes here, or dev would hide exactly that failure.
+      plugin = {};
+      console.error('  ✗ plugin failed to load:', e instanceof Error ? e.message : e);
+    }
   };
   await load();
 

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import { createRequire } from 'node:module';
+import * as sdk from '../index.js';
 
 interface Fixtures {
   config?: Record<string, unknown>;
@@ -92,6 +93,34 @@ function createDevContext(id: string, grants: Set<string>, fx: Fixtures, db: Plu
   };
 }
 
+/**
+ * Serve `require('trek-plugin-sdk')` from THIS package, exactly like the TREK
+ * child process does at runtime — so `dev` works on a fresh scaffold with no
+ * npm install, and what loads here is what loads in production. That parity is
+ * the point: the injected surface is the SAME minimal frozen shim the prod
+ * child serves (definePlugin + PLUGIN_API_VERSION), and subpaths fail with the
+ * same pointed error. validateManifest/createMockHost stay available where they
+ * belong — in your tests, which load the installed package without this patch.
+ */
+let sdkInjected = false;
+export function installSdkInjection(): void {
+  if (sdkInjected) return;
+  const nodeModule = createRequire(import.meta.url)('node:module') as {
+    _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+  };
+  const realLoad = nodeModule._load;
+  if (typeof realLoad !== 'function') return;
+  sdkInjected = true;
+  const shim = Object.freeze({ definePlugin: sdk.definePlugin, PLUGIN_API_VERSION: sdk.PLUGIN_API_VERSION });
+  nodeModule._load = function (request: string, parent: unknown, isMain: boolean): unknown {
+    if (request === 'trek-plugin-sdk') return shim;
+    if (request.startsWith('trek-plugin-sdk/')) {
+      throw new Error(`${request} is a build/test-time module — only 'trek-plugin-sdk' itself is injected inside TREK`);
+    }
+    return realLoad.call(this, request, parent, isMain);
+  };
+}
+
 function loadFixtures(dir: string): Fixtures {
   const p = path.join(dir, 'dev-fixtures.json');
   if (fs.existsSync(p)) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { console.warn('warning: dev-fixtures.json is not valid JSON — ignoring'); } }
@@ -120,6 +149,7 @@ export async function runDev(dir: string, opts: { port?: number } = {}): Promise
   const fx = loadFixtures(abs);
   const { db, note: dbNote, close: closeDb } = createDevDb(path.join(abs, '.trek-dev', 'db.sqlite'));
   const broadcasts: unknown[] = [];
+  installSdkInjection();
   const req = createRequire(path.join(abs, 'server', 'index.js'));
 
   let plugin: PluginLike = {};

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import http from 'node:http';
 import { createRequire } from 'node:module';
 import * as sdk from '../index.js';
+import { readJsonFile } from './json.js';
 
 interface Fixtures {
   config?: Record<string, unknown>;
@@ -123,7 +124,7 @@ export function installSdkInjection(): void {
 
 function loadFixtures(dir: string): Fixtures {
   const p = path.join(dir, 'dev-fixtures.json');
-  if (fs.existsSync(p)) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { console.warn('warning: dev-fixtures.json is not valid JSON — ignoring'); } }
+  if (fs.existsSync(p)) { try { return readJsonFile<Fixtures>(p); } catch { console.warn('warning: dev-fixtures.json is not valid JSON — ignoring'); } }
   return {};
 }
 
@@ -143,7 +144,7 @@ export async function runDev(dir: string, opts: { port?: number } = {}): Promise
   const abs = path.resolve(dir);
   const manifestPath = path.join(abs, 'trek-plugin.json');
   if (!fs.existsSync(manifestPath)) throw new Error(`no trek-plugin.json in ${abs}`);
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+  const manifest = readJsonFile<Record<string, unknown>>(manifestPath);
   const id = String(manifest.id);
   const grants = new Set(Array.isArray(manifest.permissions) ? (manifest.permissions as string[]) : []);
   const fx = loadFixtures(abs);

--- a/plugin-sdk/src/cli/entry.ts
+++ b/plugin-sdk/src/cli/entry.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { loadPrivateKey, signArtifact, publicKeyBase64 } from './sign.js';
+import { readJsonFile } from './json.js';
 
 interface Version {
   version: string; gitTag: string; commitSha: string; downloadUrl: string;
@@ -47,7 +48,7 @@ export function buildEntry(opts: {
   /** Optional Ed25519 private-key file — signs the artifact and pins the author key. */
   signKeyPath?: string;
 }): Entry {
-  const manifest = JSON.parse(fs.readFileSync(path.join(opts.dir, 'trek-plugin.json'), 'utf8')) as Record<string, unknown>;
+  const manifest = readJsonFile<Record<string, unknown>>(path.join(opts.dir, 'trek-plugin.json'));
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(opts.repo)) throw new Error(`--repo must be "owner/name", got "${opts.repo}"`);
   const minTrek = minTrekFrom(manifest.trek);
   if (!minTrek) throw new Error('manifest has no "trek" version range to derive minTrekVersion from (e.g. "trek": ">=3.2.0 <4.0.0")');
@@ -77,7 +78,7 @@ export function buildEntry(opts: {
   }
 
   if (opts.mergePath) {
-    const existing = JSON.parse(fs.readFileSync(opts.mergePath, 'utf8')) as Entry;
+    const existing = readJsonFile<Entry>(opts.mergePath);
     if (authorPublicKey && existing.authorPublicKey && existing.authorPublicKey !== authorPublicKey) {
       throw new Error('this signing key differs from the one already published for this plugin — TREK would reject the update. Use the original key.');
     }

--- a/plugin-sdk/src/cli/json.ts
+++ b/plugin-sdk/src/cli/json.ts
@@ -1,0 +1,11 @@
+import fs from 'node:fs';
+
+/**
+ * Read + parse a JSON file, tolerating a UTF-8 BOM (0xFEFF) — Windows editors
+ * love to add one, and a bare JSON.parse then fails with a cryptic
+ * "Unexpected token" that points at an invisible character.
+ */
+export function readJsonFile<T = unknown>(p: string): T {
+  const text = fs.readFileSync(p, 'utf8');
+  return JSON.parse(text.charCodeAt(0) === 0xfeff ? text.slice(1) : text) as T;
+}

--- a/plugin-sdk/src/cli/submit.ts
+++ b/plugin-sdk/src/cli/submit.ts
@@ -10,6 +10,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { readJsonFile } from './json.js';
 
 const DEFAULT_REGISTRY = 'mauriceboe/TREK-Plugins';
 
@@ -69,7 +70,7 @@ export function submitEntry(entry: EntryLike, opts: { registry?: string; branch?
     let toWrite = entry;
     let action = 'add';
     if (fs.existsSync(abs)) {
-      const existing = JSON.parse(fs.readFileSync(abs, 'utf8')) as EntryLike;
+      const existing = readJsonFile<EntryLike>(abs);
       toWrite = mergeOnto(existing, entry);
       action = 'update';
     }

--- a/plugin-sdk/src/cli/trek-plugin.ts
+++ b/plugin-sdk/src/cli/trek-plugin.ts
@@ -67,14 +67,14 @@ async function main(): Promise<void> {
     const name = pos[0];
     if (!name || flags.interactive) {
       const created = await interactiveScaffold(process.cwd(), name);
-      console.log(`\nCreated ${created}/ — build server/index.js, add docs/screenshot.png, then \`trek-plugin dev ${created}\`.`);
+      console.log(`\nCreated ${created}/ — build server/index.js, add docs/screenshot.png, then \`npx trek-plugin-sdk dev ${created}\`.`);
       return;
     }
     scaffold(name, flags.type || 'integration', process.cwd(), {
       author: flags.author, description: flags.description,
       permissions: flags.permissions ? flags.permissions.split(/[\s,]+/).filter(Boolean) : undefined,
     });
-    console.log(`Created ${name}/ — build server/index.js, add docs/screenshot.png, then \`trek-plugin dev ${name}\`.`);
+    console.log(`Created ${name}/ — build server/index.js, add docs/screenshot.png, then \`npx trek-plugin-sdk dev ${name}\`.`);
   } else if (cmd === 'dev') {
     await runDev(pos[0] || '.', { port: flags.port ? Number(flags.port) : undefined });
   } else if (cmd === 'validate') {
@@ -90,17 +90,17 @@ async function main(): Promise<void> {
       console.log(`Packed ${r.files.length} files -> ${path.relative(process.cwd(), r.artifact) || r.artifact}`);
       for (const f of r.files) console.log('  ' + f);
       console.log(`\nsha256: ${r.sha256}\nsize:   ${r.size}`);
-      console.log('\nUpload this plugin.zip to your release, then run `trek-plugin entry` to generate the registry entry.');
+      console.log('\nUpload this plugin.zip to your release, then run `npx trek-plugin-sdk entry` to generate the registry entry.');
     }
   } else if (cmd === 'keygen') {
     const keyPath = flags.key || defaultKeyPath();
     const { publicKey } = generateKeypair(keyPath);
     console.log(`Signing key written to ${keyPath} (keep it safe + BACK IT UP — losing it means you can't ship signed updates).`);
     console.log(`\nauthorPublicKey (goes in your registry entry): ${publicKey}`);
-    console.log('\nSign releases with `trek-plugin release --sign` (or `entry --sign`).');
+    console.log('\nSign releases with `npx trek-plugin-sdk release --sign` (or `entry --sign`).');
   } else if (cmd === 'sign') {
     const zip = pos[0] || 'plugin.zip';
-    if (!fs.existsSync(zip)) fail(`artifact not found: ${zip} — run \`trek-plugin pack\` first`);
+    if (!fs.existsSync(zip)) fail(`artifact not found: ${zip} — run \`npx trek-plugin-sdk pack\` first`);
     const key = loadPrivateKey(flags.key || defaultKeyPath());
     const buf = fs.readFileSync(zip);
     console.log(`signature:        ${signArtifact(buf, key)}`);
@@ -162,7 +162,7 @@ async function main(): Promise<void> {
     console.error(`Creating GitHub release ${flags.tag} on ${flags.repo}…`);
     execFileSync('gh', ['release', 'create', flags.tag, packed.artifact, '--repo', flags.repo, '--title', flags.tag, '--notes', flags.notes || `Release ${flags.tag}`], { stdio: 'inherit' });
     const entry = buildEntry({ dir, repo: flags.repo, tag: flags.tag, zipPath: packed.artifact, commit: flags.commit, mergePath: flags.merge, signKeyPath: signKey(), now: new Date().toISOString() });
-    console.error('\nRegistry entry (add as registry/plugins/' + entry.id + '.json in a TREK-Plugins PR, or run `trek-plugin submit`):\n');
+    console.error('\nRegistry entry (add as registry/plugins/' + entry.id + '.json in a TREK-Plugins PR, or run `npx trek-plugin-sdk submit`):\n');
     process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
   } else {
     console.error('usage: trek-plugin <create|dev|validate|pack|keygen|sign|entry|preflight|submit|release|publish> [...]');

--- a/plugin-sdk/src/cli/trek-plugin.ts
+++ b/plugin-sdk/src/cli/trek-plugin.ts
@@ -33,6 +33,7 @@ import { preflight } from './preflight.js';
 import { submitEntry } from './submit.js';
 import { publishPlugin } from './publish.js';
 import { generateKeypair, loadPrivateKey, signArtifact, publicKeyBase64, defaultKeyPath } from './sign.js';
+import { readJsonFile } from './json.js';
 
 const [cmd, ...args] = process.argv.slice(2);
 
@@ -124,7 +125,7 @@ async function main(): Promise<void> {
     }
   } else if (cmd === 'preflight') {
     const entry = flags.entry
-      ? JSON.parse(fs.readFileSync(flags.entry, 'utf8'))
+      ? readJsonFile<ReturnType<typeof buildEntry>>(flags.entry)
       : (flags.repo && flags.tag
         ? buildEntry({ dir: pos[0] || '.', repo: flags.repo, tag: flags.tag, zipPath: flags.zip || 'plugin.zip', commit: flags.commit, signKeyPath: signKey(), now: new Date().toISOString() })
         : fail('preflight needs --repo <owner/name> --tag <vX>, or --entry <file.json>'));

--- a/plugin-sdk/src/cli/validate.ts
+++ b/plugin-sdk/src/cli/validate.ts
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { validateManifest } from '../manifest.js';
+import { readJsonFile } from './json.js';
 
 export interface ValidateReport {
   ok: boolean;
@@ -24,7 +25,7 @@ export function validatePluginDir(dir: string): ValidateReport {
 
   let manifestId = '';
   try {
-    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const raw = readJsonFile<Record<string, unknown>>(manifestPath);
     const res = validateManifest(raw);
     errors.push(...res.errors);
     manifestId = res.manifest?.id ?? String(raw.id ?? '');

--- a/plugin-sdk/test/sdk.test.ts
+++ b/plugin-sdk/test/sdk.test.ts
@@ -164,6 +164,26 @@ describe('dev-server SDK injection', () => {
   });
 });
 
+describe('dev db bind shapes', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devdb-')); });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('accepts spread args AND a single array of them, like the real host', async () => {
+    const { createDevDb } = await import('../src/cli/dev.js');
+    const { db, close } = createDevDb(path.join(tmp, 'db.sqlite'));
+    try {
+      await db.migrate('001', 'CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)');
+      await db.exec('INSERT INTO kv (k, v) VALUES (?, ?)', ['a', '1']); // array form (better-sqlite3 style)
+      await db.exec('INSERT INTO kv (k, v) VALUES (?, ?)', 'b', '2'); // spread form
+      expect(await db.query('SELECT v FROM kv WHERE k = ?', ['a'])).toEqual([{ v: '1' }]);
+      expect(await db.query('SELECT v FROM kv WHERE k = ?', 'b')).toEqual([{ v: '2' }]);
+    } finally {
+      close();
+    }
+  });
+});
+
 describe('reference plugin (examples/koffi)', () => {
   const dir = path.resolve(import.meta.dirname, '..', 'examples', 'koffi');
 

--- a/plugin-sdk/test/sdk.test.ts
+++ b/plugin-sdk/test/sdk.test.ts
@@ -105,6 +105,15 @@ describe('scaffold + validate CLIs', () => {
     expect(r.warnings.some((w) => /placeholder|screenshot/.test(w))).toBe(true); // README is the unfilled template
   });
 
+  it('scaffolds a CommonJS package.json with the SDK as a devDependency only', () => {
+    scaffold('my-widget', 'widget', tmp);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'my-widget', 'package.json'), 'utf8'));
+    expect(pkg.type).toBe('commonjs');
+    expect(pkg.private).toBe(true);
+    expect(pkg.devDependencies['trek-plugin-sdk']).toMatch(/^\^\d/);
+    expect(pkg.dependencies).toBeUndefined(); // runtime deps are the author's call; the SDK never is one
+  });
+
   it('applies author, description, and permissions from options', () => {
     scaffold('opt-plug', 'integration', tmp, { author: 'Jane', description: 'Does X', permissions: ['db:own', 'db:read:trips'] });
     const m = JSON.parse(fs.readFileSync(path.join(tmp, 'opt-plug', 'trek-plugin.json'), 'utf8'));
@@ -119,6 +128,32 @@ describe('scaffold + validate CLIs', () => {
 
   it('validatePluginDir flags a missing manifest', () => {
     expect(validatePluginDir(tmp).ok).toBe(false);
+  });
+});
+
+describe('dev-server SDK injection', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-')); });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('makes require(trek-plugin-sdk) resolve from the package itself — no npm install', async () => {
+    const { installSdkInjection } = await import('../src/cli/dev.js');
+    const { createRequire } = await import('node:module');
+    installSdkInjection();
+    // A scaffold-shaped CJS entry that requires the SDK without any node_modules.
+    // The injected surface must MATCH the prod child shim: definePlugin +
+    // PLUGIN_API_VERSION only, subpaths throw the same pointed error.
+    fs.writeFileSync(path.join(tmp, 'entry.cjs'),
+      "const sdkShim = require('trek-plugin-sdk');\n" +
+      "let testingError = '';\n" +
+      "try { require('trek-plugin-sdk/testing'); } catch (e) { testingError = e.message; }\n" +
+      'module.exports = { def: sdkShim.definePlugin({ routes: [] }), api: sdkShim.PLUGIN_API_VERSION, keys: Object.keys(sdkShim).sort(), testingError };\n');
+    const req = createRequire(path.join(tmp, 'entry.cjs'));
+    const mod = req(path.join(tmp, 'entry.cjs')) as { def: unknown; api: number; keys: string[]; testingError: string };
+    expect(mod.def).toEqual({ routes: [] });
+    expect(mod.api).toBe(1);
+    expect(mod.keys).toEqual(['PLUGIN_API_VERSION', 'definePlugin']); // prod parity — no dev-only extras
+    expect(mod.testingError).toMatch(/build\/test-time/);
   });
 });
 

--- a/plugin-sdk/test/sdk.test.ts
+++ b/plugin-sdk/test/sdk.test.ts
@@ -126,6 +126,13 @@ describe('scaffold + validate CLIs', () => {
     expect(() => scaffold('Bad Name', 'widget', tmp)).toThrow(/invalid plugin id/);
   });
 
+  it('tolerates a UTF-8 BOM in trek-plugin.json (Windows editors add one)', () => {
+    scaffold('bom-plug', 'integration', tmp);
+    const mp = path.join(tmp, 'bom-plug', 'trek-plugin.json');
+    fs.writeFileSync(mp, '\uFEFF' + fs.readFileSync(mp, 'utf8'));
+    expect(validatePluginDir(path.join(tmp, 'bom-plug')).ok).toBe(true);
+  });
+
   it('validatePluginDir flags a missing manifest', () => {
     expect(validatePluginDir(tmp).ok).toBe(false);
   });

--- a/plugin-sdk/tsconfig.cjs.json
+++ b/plugin-sdk/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs"
+  },
+  "include": ["src/index.ts", "src/manifest.ts", "src/mock-host.ts"]
+}

--- a/server/src/nest/plugins/install/discovery.ts
+++ b/server/src/nest/plugins/install/discovery.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type BetterSqlite3 from 'better-sqlite3';
 import { pluginsCodeRoot, pluginCodeDir } from '../paths';
-import { parseManifest, type PluginManifest } from './manifest';
+import { parseJsonText, parseManifest, type PluginManifest } from './manifest';
 import { scanForNativeBinaries } from './native-scan';
 
 /**
@@ -26,7 +26,7 @@ export function discoverPlugins(db: BetterSqlite3.Database): { discovered: strin
     if (!fs.existsSync(manifestPath)) continue;
 
     try {
-      const manifest = parseManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+      const manifest = parseManifest(parseJsonText(fs.readFileSync(manifestPath, 'utf8')));
       if (manifest.id !== entry.name) throw new Error(`manifest id "${manifest.id}" != directory "${entry.name}"`);
       if (scanForNativeBinaries(dir).length) throw new Error('directory contains native binaries');
       upsert(db, manifest);

--- a/server/src/nest/plugins/install/manifest.ts
+++ b/server/src/nest/plugins/install/manifest.ts
@@ -65,6 +65,11 @@ const TYPES = new Set(['integration', 'page', 'widget']);
 
 export class ManifestError extends Error {}
 
+/** JSON.parse that tolerates a UTF-8 BOM (0xFEFF) — manifests written on Windows often carry one. */
+export function parseJsonText(text: string): unknown {
+  return JSON.parse(text.charCodeAt(0) === 0xfeff ? text.slice(1) : text);
+}
+
 export function parseManifest(raw: unknown): PluginManifest {
   if (!raw || typeof raw !== 'object') throw new ManifestError('manifest is not an object');
   const m = raw as Record<string, unknown>;

--- a/server/src/nest/plugins/registry/registry.service.ts
+++ b/server/src/nest/plugins/registry/registry.service.ts
@@ -7,7 +7,7 @@ import { safeDownload, sha256Matches } from '../install/safe-fetch';
 import { verifyAuthorSignature } from '../install/verify-signature';
 import { extractArchive } from '../install/safe-extract';
 import { scanForNativeBinaries } from '../install/native-scan';
-import { parseManifest } from '../install/manifest';
+import { parseJsonText, parseManifest } from '../install/manifest';
 import { discoverPlugins } from '../install/discovery';
 
 /**
@@ -132,7 +132,7 @@ export class PluginRegistryService {
     if (latest) {
       try {
         const { bytes } = await safeDownload(rawFileUrl(entry.repo, latest.commitSha, 'trek-plugin.json'), MANIFEST_MAX_BYTES);
-        manifest = previewManifest(JSON.parse(bytes.toString('utf8')));
+        manifest = previewManifest(parseJsonText(bytes.toString('utf8')));
       } catch {
         // Soft-fail: the detail view still renders from registry metadata alone.
       }
@@ -178,7 +178,7 @@ export class PluginRegistryService {
       if (!pluginRoot) throw new RegistryError('archive contains no trek-plugin.json');
 
       // 4. re-validate the bundled manifest + 5. native re-scan
-      const manifest = parseManifest(JSON.parse(fs.readFileSync(path.join(pluginRoot, 'trek-plugin.json'), 'utf8')));
+      const manifest = parseManifest(parseJsonText(fs.readFileSync(path.join(pluginRoot, 'trek-plugin.json'), 'utf8')));
       if (manifest.id !== id) throw new RegistryError(`manifest id "${manifest.id}" != "${id}"`);
       if (scanForNativeBinaries(pluginRoot).length) throw new RegistryError('artifact contains native binaries');
 

--- a/server/src/nest/plugins/runtime/plugin-host-entry.ts
+++ b/server/src/nest/plugins/runtime/plugin-host-entry.ts
@@ -15,7 +15,7 @@ import net from 'node:net';
 import dns from 'node:dns';
 import dgram from 'node:dgram';
 import { createRequire } from 'node:module';
-import { createPluginContext, type ChildTransport, type PluginContext, type PluginDefinition } from './plugin-sdk';
+import { createPluginContext, definePlugin, PLUGIN_API_VERSION, type ChildTransport, type PluginContext, type PluginDefinition } from './plugin-sdk';
 import { isBlockedIp, makeHostAllow, classifyConnect, dgramSendTarget, dgramConnectTarget } from './egress-policy';
 import type { Envelope, RpcError } from '../protocol/envelope';
 
@@ -47,12 +47,37 @@ const transport: ChildTransport = {
 let def: PluginDefinition | null = null;
 let ctx: PluginContext | null = null;
 
+/**
+ * Make `require('trek-plugin-sdk')` resolve inside the child WITHOUT the plugin
+ * vendoring the package: the shim below is served from memory for every require
+ * of that name, anywhere in the plugin's module graph. This is what lets `pack`
+ * strip node_modules and still keep the scaffold's
+ * `const { definePlugin } = require('trek-plugin-sdk')` working in production.
+ * Subpaths (`trek-plugin-sdk/testing`) are build/test-time tools and fail with a
+ * pointed message instead of a confusing MODULE_NOT_FOUND.
+ */
+function installSdkInjection(requirePlugin: NodeJS.Require): void {
+  const nodeModule = requirePlugin('node:module') as {
+    _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+  };
+  const realLoad = nodeModule._load;
+  const shim = Object.freeze({ definePlugin, PLUGIN_API_VERSION });
+  nodeModule._load = function (request: string, parent: unknown, isMain: boolean): unknown {
+    if (request === 'trek-plugin-sdk') return shim;
+    if (request.startsWith('trek-plugin-sdk/')) {
+      throw new Error(`${request} is a build/test-time module — only 'trek-plugin-sdk' itself is injected inside TREK`);
+    }
+    return realLoad.call(this, request, parent, isMain);
+  };
+}
+
 async function boot(config: Record<string, unknown>): Promise<void> {
   try {
     // createRequire works whether this bootstrap runs as CJS (prod dist) or ESM
     // (tsx in tests), so `require` being undefined in ESM never bites us.
     const entry = path.join(pluginDir, 'server', 'index.js');
     const requirePlugin = createRequire(entry);
+    installSdkInjection(requirePlugin);
     const mod = requirePlugin(entry);
     def = mod && mod.default ? (mod.default as PluginDefinition) : (mod as PluginDefinition);
     ctx = createPluginContext(pluginId, config, transport);

--- a/server/src/nest/plugins/runtime/plugin-sdk.ts
+++ b/server/src/nest/plugins/runtime/plugin-sdk.ts
@@ -8,6 +8,9 @@
  * child holds no db handle, no secrets, no network by default.
  */
 
+/** Mirrors the published package's constant — bumped on any breaking API change. */
+export const PLUGIN_API_VERSION = 1 as const;
+
 export interface PluginContext {
   readonly id: string;
   readonly config: Readonly<Record<string, unknown>>;

--- a/server/tests/integration/plugins/supervisor.test.ts
+++ b/server/tests/integration/plugins/supervisor.test.ts
@@ -92,6 +92,33 @@ describe('PluginSupervisor — isolated runtime', () => {
     expect(events.some((e) => e.topic === '__log')).toBe(true);
   });
 
+  it('injects require(trek-plugin-sdk) — a scaffold-style plugin loads with no node_modules', async () => {
+    const events: Array<{ topic: string; data: unknown }> = [];
+    sup = makeSupervisor(events);
+
+    writePlugin(
+      'scaffolded',
+      `const { definePlugin, PLUGIN_API_VERSION } = require('trek-plugin-sdk');
+      let testingError = '';
+      try { require('trek-plugin-sdk/testing'); } catch (e) { testingError = e.message; }
+      module.exports = definePlugin({
+        async onLoad() {
+          process.send({ k: 'evt', topic: 'diag', data: { api: PLUGIN_API_VERSION, fn: typeof definePlugin, testingError } });
+        },
+        routes: [{ method: 'GET', path: '/hello', auth: true, async handler() { return { status: 200 }; } }],
+      });`,
+    );
+
+    await sup.activate('scaffolded', new Set(['db:own']), {});
+    expect(sup.isActive('scaffolded')).toBe(true);
+
+    const diag = events.find((e) => e.topic === 'diag')?.data as { api: number; fn: string; testingError: string };
+    expect(diag).toBeTruthy();
+    expect(diag.api).toBe(1); // the injected shim, not a vendored copy
+    expect(diag.fn).toBe('function');
+    expect(diag.testingError).toMatch(/build\/test-time/); // subpaths fail with a pointed message
+  });
+
   it('a plugin that throws in onLoad fails activation and is marked error — the host survives', async () => {
     const events: Array<{ topic: string; data: unknown }> = [];
     sup = makeSupervisor(events);

--- a/server/tests/unit/plugins/discovery.test.ts
+++ b/server/tests/unit/plugins/discovery.test.ts
@@ -72,6 +72,13 @@ describe('discoverPlugins', () => {
     expect(JSON.parse(row.granted_permissions)).toEqual(['db:own']); // grants preserved
   });
 
+  it('tolerates a UTF-8 BOM in trek-plugin.json (Windows-authored plugins)', () => {
+    writePlugin('bom-plug', { type: 'integration' });
+    const mp = path.join(codeRoot, 'bom-plug', 'trek-plugin.json');
+    fs.writeFileSync(mp, '\uFEFF' + fs.readFileSync(mp, 'utf8'));
+    expect(discoverPlugins(db).discovered).toEqual(['bom-plug']);
+  });
+
   it('skips an invalid manifest and logs the reason', () => {
     writePlugin('bad', { type: 'not-a-type' });
     const res = discoverPlugins(db);

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -22,6 +22,7 @@ This emits:
 ```
 my-plugin/
   trek-plugin.json      # manifest
+  package.json          # CommonJS marker + the SDK as a devDependency
   server/index.js       # your plugin code (built, plain JS)
   client/index.html     # page/widget iframe (page/widget only)
   README.md             # fill this in — the registry requires a screenshot
@@ -33,8 +34,11 @@ my-plugin/
 npx trek-plugin-sdk dev        # http://localhost:4317
 ```
 
-`dev` loads your `server/index.js` through the same `definePlugin` contract the
-host uses and gives you a **real request loop without a full TREK**: a dashboard
+`dev` works straight after `create` — no `npm install` needed, because it
+injects `require('trek-plugin-sdk')` from the CLI itself, exactly like TREK
+injects it in production. It loads your `server/index.js` through the same
+`definePlugin` contract the host uses and gives you a **real request loop
+without a full TREK**: a dashboard
 listing your routes, the routes served under `/api/<path>`, your page/widget UI
 at `/ui`, and a reload on every save. The injected `ctx` **enforces exactly the
 permissions your manifest grants** — an ungranted call throws `PERMISSION_DENIED`,

--- a/wiki/Plugin-Publishing.md
+++ b/wiki/Plugin-Publishing.md
@@ -38,6 +38,7 @@ npx trek-plugin-sdk create flight-tracker --type widget   # integration | page |
 A publishable plugin has, at the repo root:
 
 - `trek-plugin.json` — the manifest (see [[Plugin Development|Plugin-Development]])
+- `package.json` — the CommonJS marker (`"type": "commonjs"`), with the SDK as a devDependency at most
 - `server/index.js` — the built server entry (required)
 - `client/` — the built frontend (only for `page`/`widget` plugins)
 - `README.md` — filled in, with a real screenshot (the quality gate is strict — see below)


### PR DESCRIPTION
Fixes the author workflow the SDK release broke: a freshly scaffolded plugin could not actually load anywhere.

**What was broken**

- `trek-plugin-sdk` on npm is ESM-only — its exports map has no `require` condition, so the scaffold's `require('trek-plugin-sdk')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` the moment `trek-plugin dev` loads it.
- The wiki promises the host makes `require('trek-plugin-sdk')` resolve inside the plugin child, but no such injection existed — and `pack` (correctly) strips `node_modules`, so a scaffolded plugin also crashed with `MODULE_NOT_FOUND` after a real install.

**The fix**

- **Plugin child** (`plugin-host-entry.ts`): `require('trek-plugin-sdk')` now resolves to a frozen in-memory shim (`definePlugin` + `PLUGIN_API_VERSION`), anywhere in the plugin's module graph. `trek-plugin-sdk/*` subpaths fail with a pointed build/test-time error instead of a confusing `MODULE_NOT_FOUND`.
- **`trek-plugin dev`** injects the exact same shim — a fresh scaffold runs with zero `npm install`, and what loads in dev is what loads in production (`validateManifest`/`createMockHost` stay where they belong: in your tests, which load the installed package).
- **npm package** now ships a real CommonJS build (`dist/cjs/` + `require` export conditions), so the installed package requires cleanly on Node 18+ too (types + mock host for author tests).
- **`create`** scaffolds a `package.json` (`"type": "commonjs"`, SDK as devDependency, npx scripts), and every CLI hint prints the resolvable `npx trek-plugin-sdk …` form.
- **Wiki**: `package.json` added to the scaffold tree and the publishing checklist; the dev section documents the zero-install flow.

Verified end to end: scaffold → zero-install `dev` (route serves 200) → `pack` (5 files incl. `package.json`) → tarball install → `require()` resolves; a scaffold-style plugin loads in a real forked child in the supervisor test with no `node_modules`.

Needs `trek-plugin-sdk@1.2.1` on npm once merged (tag `plugin-sdk-v1.2.1`).
