### PR TITLE
ci(plugin-sdk): publish workflow on Node 22

### DIFF
--- a/.github/workflows/publish-plugin-sdk.yml
+++ b/.github/workflows/publish-plugin-sdk.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # 22 matches the TREK server runtime and has node:sqlite, which the
+          # dev-server tests exercise.
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish

--- a/plugin-sdk/test/sdk.test.ts
+++ b/plugin-sdk/test/sdk.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import zlib from 'node:zlib';
+import { createRequire } from 'node:module';
 import { definePlugin, PLUGIN_API_VERSION, validateManifest, createMockHost } from '../src/index.js';
 import { scaffold } from '../src/cli/create.js';
 import { validatePluginDir } from '../src/cli/validate.js';
@@ -169,7 +170,13 @@ describe('dev db bind shapes', () => {
   beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devdb-')); });
   afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
 
-  it('accepts spread args AND a single array of them, like the real host', async () => {
+  // Without node:sqlite (Node < 22.5) createDevDb falls back to the [] stub and
+  // there is no bind behaviour to test.
+  const hasNodeSqlite = (() => {
+    try { createRequire(import.meta.url)('node:sqlite'); return true; } catch { return false; }
+  })();
+
+  it.runIf(hasNodeSqlite)('accepts spread args AND a single array of them, like the real host', async () => {
     const { createDevDb } = await import('../src/cli/dev.js');
     const { db, close } = createDevDb(path.join(tmp, 'db.sqlite'));
     try {


### PR DESCRIPTION
The publish workflow ran the SDK's prepublishOnly tests on Node 20, where node:sqlite does not exist — createDevDb falls back to the [] stub and the new dev-db bind test can only fail (that's what sank the plugin-sdk-v1.2.1 publish run). Node 22 matches the TREK server runtime; the test additionally skips itself on runtimes without node:sqlite, since engines allows >=18.