### PR TITLE
test(collections): fix CollectionPlaceDetail suite broken by the labels feature

### DIFF
--- a/client/src/components/Collections/CollectionPlaceDetail.test.tsx
+++ b/client/src/components/Collections/CollectionPlaceDetail.test.tsx
@@ -39,6 +39,7 @@ function renderDetail(overrides: Partial<Omit<DetailProps, 't'>> = {}) {
     canEdit: true,
     canDelete: true,
     categories: [],
+    labels: [],
     anchorRect: null,
     onClose: vi.fn(),
     onSetStatus: vi.fn(),


### PR DESCRIPTION
The per-collection custom-labels feature (`a5522e99`) made `labels` a **required** prop on `CollectionPlaceDetail` and renders `labels.filter(...)`, but `CollectionPlaceDetail.test.tsx` was not updated to pass it. The test's base props are cast to `Omit<DetailProps, 't'>`, which hid the missing prop from the type-checker, so `labels` was `undefined` at runtime and crashed the whole suite (`Cannot read properties of undefined (reading 'filter')`) — the failure you saw on the 3.2.0 release CI.

Fix: pass `labels: []` in the test's base props, exactly like `categories: []`. All 10 tests pass; tsc clean.

This is independent of PR #1425 — it surfaced because the merge-commit CI combined the new component with the un-updated test.