### PR TITLE
fix(i18n): correct Vietnamese translation of 'Disabled' (Tàn tật → Tắt)

### DIFF
--- a/shared/src/i18n/vi/admin.ts
+++ b/shared/src/i18n/vi/admin.ts
@@ -3,7 +3,7 @@ import type { TranslationStrings } from '../types';
 const admin: TranslationStrings = {
   'admin.notifications.title': 'Thông báo',
   'admin.notifications.hint': 'Chọn một kênh thông báo. Chỉ có một người có thể hoạt động tại một thời điểm.',
-  'admin.notifications.none': 'Tàn tật',
+  'admin.notifications.none': 'Tắt',
   'admin.notifications.email': 'Email (SMTP)',
   'admin.notifications.webhook': 'Webhook',
   'admin.notifications.ntfy': 'Ntfy',
@@ -357,7 +357,7 @@ const admin: TranslationStrings = {
   'admin.addons.subtitleBefore': 'Bật hoặc tắt các tính năng để tùy chỉnh',
   'admin.addons.subtitleAfter': 'kinh nghiệm.',
   'admin.addons.enabled': 'Đã bật',
-  'admin.addons.disabled': 'Tàn tật',
+  'admin.addons.disabled': 'Tắt',
   'admin.addons.type.trip': 'Chuyến đi',
   'admin.addons.type.global': 'Toàn cầu',
   'admin.addons.type.integration': 'Tích hợp',


### PR DESCRIPTION
## Description

Fixes an incorrect Vietnamese translation of **"Disabled"** in the admin UI.

- Two keys in `shared/src/i18n/vi/admin.ts` render the English string **"Disabled"** as **"Tàn tật"**, which in Vietnamese means *physically handicapped / a disabled person* — not the off/disabled **state** of a setting. To a Vietnamese user this reads as offensive and nonsensical.
- Corrected both to **"Tắt"** ("off"), which is already the established term for this concept in the same file (`admin.plugins.stateOff: 'Tắt'`).
- String-value change only — no keys added/removed, no code/logic touched.

| Key | English | Before | After |
|-----|---------|--------|-------|
| `admin.notifications.none` | Disabled | Tàn tật | Tắt |
| `admin.addons.disabled` | Disabled | Tàn tật | Tắt |

No other `Tàn tật` occurrences remain in the `vi` locale.

## Related Issue or Discussion

<!-- No prior Discord discussion / issue yet — flagging per CONTRIBUTING. Happy to open one in #github-pr if required before review. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works — *this is a translation string-value change with no logic under test; existing i18n key-parity checks are unaffected (no keys changed)*
- [ ] I have updated documentation if needed — *n/a*
