### PR TITLE
fix(plugin-sdk): dev /ui frame at /ui/index.html so multi-file builds' relative assets resolve

### DIFF
--- a/plugin-sdk/package.json
+++ b/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trek-plugin-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SDK for building TREK plugins: types, definePlugin, a mock host, manifest validation, and the create-trek-plugin / trek-plugin CLIs.",
   "type": "module",
   "license": "MIT",

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -360,9 +360,15 @@ export async function runDev(dir: string, opts: { port?: number } = {}): Promise
       return send(200, preview(id, String(manifest.type)), 'text/html; charset=utf-8');
     }
 
-    // Static plugin UI at /ui (page/widget client bundle)
+    // Static plugin UI at /ui (page/widget client bundle). The iframe loads
+    // `/ui/index.html` (not bare `/ui`) so relative asset URLs — `./assets/x.js`
+    // from a multi-file Vite/React build with `base: './'` — resolve to
+    // `/ui/assets/x.js`, exactly as the real host resolves them against
+    // `/plugin-frame/<id>/index.html`. A bare `/ui` document would resolve them
+    // against the origin root (`/assets/x.js`) and 404. Bare `/ui` and `/ui/` both
+    // still serve index.html for direct navigation.
     if (url.pathname === '/ui' || url.pathname.startsWith('/ui/')) {
-      const relFile = url.pathname === '/ui' ? 'index.html' : url.pathname.slice('/ui/'.length);
+      const relFile = url.pathname === '/ui' ? 'index.html' : (url.pathname.slice('/ui/'.length) || 'index.html');
       const file = path.join(abs, 'client', relFile);
       if (!file.startsWith(path.join(abs, 'client'))) return send(403, 'forbidden');
       if (!fs.existsSync(file) || !fs.statSync(file).isFile()) return send(404, 'not found — build your client/ bundle');
@@ -510,7 +516,7 @@ iframe{width:100%;border:0;background:transparent;min-height:120px;display:block
   <label><input type="checkbox" id="nt"> no transparency</label>
   <label><input type="checkbox" id="trip" checked> trip context</label>
 </header>
-<div class="stage"><div class="wrap"><iframe id="f" src="/ui" sandbox="allow-scripts allow-forms" referrerpolicy="no-referrer" title="${id}"></iframe></div></div>
+<div class="stage"><div class="wrap"><iframe id="f" src="/ui/index.html" sandbox="allow-scripts allow-forms" referrerpolicy="no-referrer" title="${id}"></iframe></div></div>
 <p class="hint">The frame runs sandboxed at an opaque origin, exactly like TREK — <code>trek.invoke()</code> is proxied to your /api routes as the dev user.</p>
 <div class="toast" id="toast"></div>
 <script>


### PR DESCRIPTION
`trek-plugin dev` embedded the plugin UI as `<iframe src="/ui">` — no trailing slash — so a multi-file build's **relative** asset URLs (`./assets/x.js`, what Vite `base: './'` emits) resolved against the **origin root** → `/assets/x.js` → **404**, even though the files are served at `/ui/assets/*`.

The real host loads the frame at `/plugin-frame/<id>/index.html` (`PluginFrame.tsx`), where those same relative URLs resolve correctly. So `dev` was **unfaithful** for multi-file / Vite-React builds — the exact scenario reported on Discord.

**Fix:** the dev preview iframe now loads `/ui/index.html` (matching the real host), and the `/ui` handler also serves `/ui/` as `index.html`. No behaviour change for single-file plugins.

Ships as **`trek-plugin-sdk@1.4.1`** (version bumped) — publishes independently of the TREK app via the existing `plugin-sdk-v*` tag workflow; **no TREK main/Docker/Helm release needed**.

Build + all 94 SDK tests pass; smoke-verified `/ui/index.html`, `/ui/`, `/ui/assets/*` all serve.