### PR TITLE
fix: recompute vacay calendar when week start changes

### DIFF
--- a/client/src/components/Vacay/VacayMonthCard.test.tsx
+++ b/client/src/components/Vacay/VacayMonthCard.test.tsx
@@ -127,6 +127,23 @@ describe('VacayMonthCard', () => {
     }
   })
 
+  it('FE-COMP-VACAYMONTHCARD-013: Recomputes day positions when week start changes', () => {
+    const { container, rerender } = render(<VacayMonthCard {...baseProps} weekStart={1} />)
+
+    const getFirstWeekLabels = () =>
+      Array.from(container.querySelectorAll('.grid.grid-cols-7')[1].children)
+        .map((cell) => cell.textContent?.trim() || '')
+
+    // January 1, 2025 is Wednesday: two leading blanks for Monday-first weeks.
+    expect(getFirstWeekLabels()).toEqual(['', '', '1', '2', '3', '4', '5'])
+
+    rerender(<VacayMonthCard {...baseProps} weekStart={0} />)
+
+    // Sunday-first weeks need three leading blanks; this must update after the
+    // setting changes so Saturday/Sunday weekends stay under their real headers.
+    expect(getFirstWeekLabels()).toEqual(['', '', '', '1', '2', '3', '4'])
+  })
+
   it('FE-COMP-VACAYMONTHCARD-011: Two vacation entries render gradient overlay', () => {
     const props = {
       ...baseProps,

--- a/client/src/components/Vacay/VacayMonthCard.tsx
+++ b/client/src/components/Vacay/VacayMonthCard.tsx
@@ -50,7 +50,7 @@ export default function VacayMonthCard({
     const w = []
     for (let i = 0; i < cells.length; i += 7) w.push(cells.slice(i, i + 7))
     return w
-  }, [year, month])
+  }, [year, month, weekStart])
 
   const pad = (n) => String(n).padStart(2, '0')
 


### PR DESCRIPTION
## Summary
- Recompute Vacay month cell positions when `week_start` changes
- Add a regression test for switching from Monday-first to Sunday-first calendars

## Testing
- `npm run build --workspace=shared`
- `npx vitest run src/components/Vacay/VacayMonthCard.test.tsx --pool=threads`

Closes #1548