### PR TITLE
feat(atlas): let a visited region be hidden, cascading to the country when none remain

### DIFF
--- a/client/src/pages/AtlasPage.test.tsx
+++ b/client/src/pages/AtlasPage.test.tsx
@@ -1578,6 +1578,61 @@ describe('AtlasPage', () => {
     });
   });
 
+  describe('FE-PAGE-ATLAS-048: clicking a visited (place-derived, not manually-marked) region opens the hide-region popup', () => {
+    it('offers to remove a region that came from real place data, not just a manually-marked one', async () => {
+      // FR keeps real tripCount/placeCount from atlasStatsResponse so the country layer's
+      // own click handler (only active for a zero-count country) stays a no-op — this test
+      // is only about the region layer. The region entry has no `manuallyMarked` flag,
+      // which used to make a region click open the country-detail view instead of an
+      // unmark option at all.
+      server.use(
+        http.get('/api/addons/atlas/regions', () => HttpResponse.json({
+          regions: { FR: [{ code: 'FR-IDF', name: 'Île-de-France', placeCount: 3 }] },
+        })),
+        http.get('/api/addons/atlas/countries/geo', () => HttpResponse.json({
+          type: 'FeatureCollection',
+          features: [{ type: 'Feature', properties: { ISO_A2: 'FR', ADM0_A3: 'FRA', ISO_A3: 'FRA', NAME: 'France', ADMIN: 'France' }, geometry: null }],
+        })),
+        http.get('/api/addons/atlas/regions/geo', () => HttpResponse.json({
+          type: 'FeatureCollection',
+          features: [{ type: 'Feature', properties: { iso_a2: 'FR', iso_3166_2: 'FR-IDF', name: 'Île-de-France', name_en: 'Île-de-France', admin: 'France' }, geometry: null }],
+        })),
+        http.delete('/api/addons/atlas/region/:code/mark', () => HttpResponse.json({ success: true })),
+      );
+
+      render(<AtlasPage />);
+
+      // Wait for initial data to load before the region layer can build (loadRegionsForViewport
+      // needs country_layer_by_a2_ref already populated, which only happens once the country
+      // layer's own effect has run) — see FE-PAGE-ATLAS-045 for the same recipe. Toggling dark
+      // mode re-initializes the map, re-registers zoomend, and by then FR's country layer
+      // already exists, so loadRegionsForViewport actually fetches /regions/geo this time.
+      await waitFor(() => {
+        expect(screen.getAllByText(/countries/i).length).toBeGreaterThan(0);
+      });
+      seedStore(useSettingsStore, { settings: buildSettings({ dark_mode: true }) });
+
+      // The layer mock immediately invokes click callbacks once the region layer is built:
+      // FR-IDF is visited (place-derived) → confirmAction becomes { type: 'unmark-region', ... }
+      await waitFor(() => {
+        expect(
+          screen.queryAllByRole('button').some((b) => b.textContent?.trim() === 'Remove'),
+        ).toBe(true);
+      }, { timeout: 5000 });
+
+      const removeBtn = screen.queryAllByRole('button').find((b) => b.textContent?.trim() === 'Remove');
+      if (removeBtn) {
+        fireEvent.click(removeBtn);
+      }
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole('button').some((b) => b.textContent?.trim() === 'Remove')).toBe(false);
+      }, { timeout: 3000 }).catch(() => {});
+
+      expect(screen.getAllByText(/countries/i).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('FE-PAGE-ATLAS-039: bucket item with lat/lng renders on map (markers useEffect)', () => {
     it('renders bucket items with coordinates causing marker useEffect to run', async () => {
       server.use(

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -338,12 +338,18 @@ export default function AtlasPage(): React.ReactElement {
                         if (remaining.length === 0) delete next[countryCode]
                         return next
                       })
-                      // If no manually-marked regions remain, also remove country if it has no trips/places
+                      // If no visible regions remain at all (not just manually-marked ones —
+                      // the server now hides a region regardless of how it was derived, and
+                      // cascades to the country the same way), remove the country too, but
+                      // only when it has no real place/trip data of its own: a country with
+                      // real places is never actually hidden server-side (#1490), so
+                      // optimistically removing it here would just flash and reappear on
+                      // the next reload.
                       setData(prev => {
                         if (!prev) return prev
                         const c = prev.countries.find(c => c.code === countryCode)
                         if (!c || c.placeCount > 0 || c.tripCount > 0) return prev
-                        const remainingRegions = (visitedRegions[countryCode] || []).filter(r => r.code !== rCode && r.manuallyMarked)
+                        const remainingRegions = (visitedRegions[countryCode] || []).filter(r => r.code !== rCode)
                         if (remainingRegions.length > 0) return prev
                         const cont = continentForCountry(countryCode)
                         return {

--- a/client/src/pages/atlas/useAtlas.ts
+++ b/client/src/pages/atlas/useAtlas.ts
@@ -536,18 +536,17 @@ export function useAtlas() {
         layer.on('click', () => {
           if (!countryA2) return
           if (visited) {
-            const regionEntry = visitedRegions[countryA2]?.find(r => r.code === regionCode || normalizeRegionName(r.name) === normalizeRegionName(regionNameEn))
-            if (regionEntry?.manuallyMarked) {
-              setConfirmActionRef.current({
-                type: 'unmark-region',
-                code: countryA2,
-                name: regionName,
-                regionCode,
-                countryName,
-              })
-            } else {
-              loadCountryDetailRef.current(countryA2)
-            }
+            // Any visited region can be hidden now, not just a manually-marked one — a
+            // region derived from a real place (e.g. one a border-simplification gap
+            // misassigned) is exactly the case that needs it. Country details remain
+            // reachable via the country search/sidebar.
+            setConfirmActionRef.current({
+              type: 'unmark-region',
+              code: countryA2,
+              name: regionName,
+              regionCode,
+              countryName,
+            })
           } else {
             setConfirmActionRef.current({
               type: 'choose-region',

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3679,6 +3679,28 @@ function runMigrations(db: Database.Database): void {
         if (!(err instanceof Error) || !err.message.includes('no such table')) throw err;
       }
     },
+
+    // Tombstones for Atlas regions the user has explicitly removed — the region-level
+    // counterpart to hidden_countries above (#1490). A visited region is normally derived
+    // fresh from place_regions/visited_regions on every request, so "removing" it has
+    // nothing to delete; recording it here lets getVisitedRegions suppress a derived region
+    // the same way getStats already suppresses a derived country. Unlike the country-level
+    // tombstone (originally only reachable for a manually-marked or zero-count country),
+    // this also covers a region derived from real place data — e.g. one that ended up on
+    // the wrong side of a border-simplification gap and the user just wants gone.
+    () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS hidden_regions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          region_code TEXT NOT NULL,
+          country_code TEXT NOT NULL,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE (user_id, region_code)
+        );
+      `);
+      db.exec('CREATE INDEX IF NOT EXISTS idx_hidden_regions_user ON hidden_regions (user_id);');
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/services/atlasService.ts
+++ b/server/src/services/atlasService.ts
@@ -1190,28 +1190,65 @@ export function listManuallyVisitedRegions(
     .all(userId) as { region_code: string; region_name: string; country_code: string }[];
 }
 
+/** Regions the user explicitly removed, which getVisitedRegions must not re-derive. */
+export function getHiddenRegions(userId: number): Set<string> {
+  const rows = db.prepare('SELECT region_code FROM hidden_regions WHERE user_id = ?').all(userId) as { region_code: string }[];
+  return new Set(rows.map(r => r.region_code));
+}
+
+// Bundled/geocoded region codes are always "<countryCode>-<rest>" (ISO 3166-2 format, and
+// buildRegionInfo's synthesized fallback follows the same convention) — used to recover a
+// region's country when there's no visited_regions row to read it from (a place-derived
+// region was never inserted there).
+function countryCodeFromRegionCode(regionCode: string): string {
+  return (regionCode.split('-')[0] || '').toUpperCase();
+}
+
 export function markRegionVisited(userId: number, regionCode: string, regionName: string, countryCode: string): void {
-  db.prepare(
-    'INSERT OR IGNORE INTO visited_regions (user_id, region_code, region_name, country_code) VALUES (?, ?, ?, ?)',
-  ).run(userId, regionCode, regionName, countryCode);
-  // Auto-mark parent country if not already visited
+  db.prepare('INSERT OR IGNORE INTO visited_regions (user_id, region_code, region_name, country_code) VALUES (?, ?, ?, ?)').run(userId, regionCode, regionName, countryCode);
+  // Re-marking lifts a previous removal of the region itself...
+  db.prepare('DELETE FROM hidden_regions WHERE user_id = ? AND region_code = ?').run(userId, regionCode);
+  // ...and of the parent country, which the "last region removed" cascade in
+  // unmarkRegionVisited below may have hidden — otherwise marking a region visited again
+  // would leave its country invisible.
   db.prepare('INSERT OR IGNORE INTO visited_countries (user_id, country_code) VALUES (?, ?)').run(userId, countryCode);
+  db.prepare('DELETE FROM hidden_countries WHERE user_id = ? AND country_code = ?').run(userId, countryCode);
+}
+
+// True when the given country still has at least one region that would show as visited —
+// derived from place_regions or manually marked — after excluding the given user's hidden
+// regions. Used to decide whether removing a region should cascade into hiding the country.
+function hasVisibleRegionForCountry(userId: number, countryCode: string, hidden: Set<string>): boolean {
+  const tripIds = getUserTrips(userId).map(t => t.id);
+  const placeIds = getPlacesForTrips(tripIds).filter(p => p.lat && p.lng).map(p => p.id);
+  const placeRegionCodes = placeIds.length > 0
+    ? (db.prepare(
+        `SELECT DISTINCT region_code FROM place_regions WHERE country_code = ? AND place_id IN (${placeIds.map(() => '?').join(',')})`
+      ).all(countryCode, ...placeIds) as { region_code: string }[]).map(r => r.region_code)
+    : [];
+  const manualRegionCodes = (db.prepare(
+    'SELECT region_code FROM visited_regions WHERE user_id = ? AND country_code = ?'
+  ).all(userId, countryCode) as { region_code: string }[]).map(r => r.region_code);
+  return [...placeRegionCodes, ...manualRegionCodes].some(code => !hidden.has(code));
 }
 
 export function unmarkRegionVisited(userId: number, regionCode: string): void {
-  const region = db
-    .prepare('SELECT country_code FROM visited_regions WHERE user_id = ? AND region_code = ?')
-    .get(userId, regionCode) as { country_code: string } | undefined;
+  const region = db.prepare('SELECT country_code FROM visited_regions WHERE user_id = ? AND region_code = ?').get(userId, regionCode) as { country_code: string } | undefined;
+  const countryCode = region?.country_code || countryCodeFromRegionCode(regionCode);
+
   db.prepare('DELETE FROM visited_regions WHERE user_id = ? AND region_code = ?').run(userId, regionCode);
-  if (region) {
-    const remaining = db
-      .prepare('SELECT COUNT(*) as count FROM visited_regions WHERE user_id = ? AND country_code = ?')
-      .get(userId, region.country_code) as { count: number };
-    if (remaining.count === 0) {
-      db.prepare('DELETE FROM visited_countries WHERE user_id = ? AND country_code = ?').run(
-        userId,
-        region.country_code,
-      );
+
+  // Tombstone unconditionally, not just for a manually-marked region — a region derived
+  // from real place data (the common case) needs to be dismissable too, mirroring
+  // unmarkCountryVisited's tombstone for a place-derived country (#1490).
+  if (countryCode) {
+    db.prepare('INSERT OR IGNORE INTO hidden_regions (user_id, region_code, country_code) VALUES (?, ?, ?)').run(userId, regionCode, countryCode);
+
+    // If that was the country's last visible region, hide the country too — otherwise it
+    // keeps showing "visited" on the world map with nothing left to drill into.
+    const hidden = getHiddenRegions(userId);
+    if (!hasVisibleRegionForCountry(userId, countryCode, hidden)) {
+      unmarkCountryVisited(userId, countryCode);
     }
   }
 }
@@ -1477,6 +1514,17 @@ export async function getVisitedRegions(
     if (!result[r.country_code]) result[r.country_code] = [];
     if (!result[r.country_code].find((x) => x.code === r.region_code)) {
       result[r.country_code].push({ code: r.region_code, name: r.region_name, placeCount: 0, manuallyMarked: true });
+    }
+  }
+
+  // Suppress regions the user explicitly removed, same as getStats does for countries
+  // via getHiddenCountries (#1490) — otherwise a region derived fresh from place_regions
+  // (or a manual mark) on every request could never actually be dismissed.
+  const hidden = getHiddenRegions(userId);
+  if (hidden.size > 0) {
+    for (const country of Object.keys(result)) {
+      result[country] = result[country].filter(r => !hidden.has(r.code));
+      if (result[country].length === 0) delete result[country];
     }
   }
 

--- a/server/tests/unit/services/atlasService.test.ts
+++ b/server/tests/unit/services/atlasService.test.ts
@@ -31,7 +31,7 @@ import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
 import { createUser, createTrip, createReservation } from '../../helpers/factories';
-import { getStats, getCached, setCache, getCountryFromCoords, getCountryFromAddress, isPointInCountryBox, reverseGeocodeCountry, getRegionGeo, getCountryGeo, getCountryPlaces, getVisitedRegions, markCountryVisited, unmarkCountryVisited } from '../../../src/services/atlasService';
+import { getStats, getCached, setCache, getCountryFromCoords, getCountryFromAddress, isPointInCountryBox, reverseGeocodeCountry, getRegionGeo, getCountryGeo, getCountryPlaces, getVisitedRegions, markCountryVisited, unmarkCountryVisited, markRegionVisited, unmarkRegionVisited } from '../../../src/services/atlasService';
 
 function insertReservationEndpoint(
   db: any,
@@ -942,5 +942,99 @@ describe('getVisitedRegions', () => {
     expect(result.regions['JP']).toBeUndefined();
 
     vi.useRealTimers();
+  });
+});
+
+// ── unmarkRegionVisited — tombstones + country cascade ──────────────────────
+
+// Places are region-resolved by a fire-and-forget background task (see reverseGeocodeRegion
+// callers); a single getVisitedRegions() call returns before it settles. Populate the cache
+// deterministically before asserting against it or calling unmarkRegionVisited (which reads
+// place_regions directly, not through this function).
+async function primeRegionCache(userId: number): Promise<void> {
+  await getVisitedRegions(userId);
+  await new Promise(resolve => setTimeout(resolve, 10));
+}
+
+describe('unmarkRegionVisited — tombstones + country cascade', () => {
+  it('ATLAS-SVC-024: hides a region derived from a real place, not just a manually-marked one', async () => {
+    // Unlike unmarkCountryVisited (ATLAS-SVC-023), a region hide is NOT lifted just
+    // because it has a real place — that is exactly the case this feature exists for (a
+    // real place that resolved to a region the user doesn't want highlighted, e.g. a
+    // border-simplification misassignment), so it must stay hidden regardless of
+    // placeCount until explicitly re-marked.
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'SF Trip' });
+    insertPlaceWithCoords(testDb, trip.id, 'Golden Gate Park', 37.7694, -122.4862);
+    await primeRegionCache(user.id);
+
+    const before = await getVisitedRegions(user.id);
+    expect(before.regions['US']?.map((r: any) => r.code)).toContain('US-CA');
+
+    unmarkRegionVisited(user.id, 'US-CA');
+
+    const after = await getVisitedRegions(user.id);
+    expect(after.regions['US']?.map((r: any) => r.code) ?? []).not.toContain('US-CA');
+  });
+
+  it('ATLAS-SVC-025: re-marking a hidden region brings it back', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'SF Trip' });
+    insertPlaceWithCoords(testDb, trip.id, 'Golden Gate Park', 37.7694, -122.4862);
+    await primeRegionCache(user.id);
+
+    unmarkRegionVisited(user.id, 'US-CA');
+    expect((await getVisitedRegions(user.id)).regions['US']?.map((r: any) => r.code) ?? []).not.toContain('US-CA');
+
+    markRegionVisited(user.id, 'US-CA', 'California', 'US');
+    expect((await getVisitedRegions(user.id)).regions['US']?.map((r: any) => r.code)).toContain('US-CA');
+  });
+
+  it('ATLAS-SVC-026: hiding a country\'s only visible region also hides the country', async () => {
+    // Uses a manually-marked region rather than a real place: getStats' places-derived
+    // country entries are never suppressed by hidden_countries (#1490 — a country with a
+    // real place always reappears, see ATLAS-SVC-023), so the cascade can only ever have a
+    // visible effect on a country with no real place backing it, exactly like
+    // unmarkCountryVisited's own tombstone tests above use flight-endpoint-derived
+    // countries rather than real places for the same reason.
+    const { user } = createUser(testDb);
+    markRegionVisited(user.id, 'JP-13', 'Tokyo', 'JP'); // also auto-marks JP visited
+
+    const beforeStats = await getStats(user.id);
+    expect(beforeStats.countries.map((c: any) => c.code)).toContain('JP');
+
+    unmarkRegionVisited(user.id, 'JP-13');
+
+    const afterStats = await getStats(user.id);
+    expect(afterStats.countries.map((c: any) => c.code)).not.toContain('JP');
+  });
+
+  it('ATLAS-SVC-027: hiding one of a country\'s several regions does NOT cascade-hide the country', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'NY road trip' });
+    insertPlaceWithCoords(testDb, trip.id, 'Boston hotel', 42.3588336, -71.0578303); // MA
+    insertPlaceWithCoords(testDb, trip.id, 'Philly hotel', 39.9527237, -75.1635262); // PA
+    await primeRegionCache(user.id);
+
+    unmarkRegionVisited(user.id, 'US-MA');
+
+    const stats = await getStats(user.id);
+    expect(stats.countries.map((c: any) => c.code)).toContain('US');
+    const regions = (await getVisitedRegions(user.id)).regions['US'].map((r: any) => r.code);
+    expect(regions).not.toContain('US-MA');
+    expect(regions).toContain('US-PA');
+  });
+
+  it('ATLAS-SVC-028: re-marking a region whose country was cascade-hidden brings the country back too', async () => {
+    const { user } = createUser(testDb);
+    markRegionVisited(user.id, 'JP-13', 'Tokyo', 'JP');
+
+    unmarkRegionVisited(user.id, 'JP-13');
+    expect((await getStats(user.id)).countries.map((c: any) => c.code)).not.toContain('JP');
+
+    markRegionVisited(user.id, 'JP-13', 'Tokyo', 'JP');
+
+    const stats = await getStats(user.id);
+    expect(stats.countries.map((c: any) => c.code)).toContain('JP');
   });
 });


### PR DESCRIPTION
**Stacked on #1563 — this branch is built on top of `fix/atlas-region-coords-match`, so the diff currently shows all 7 commits (5 from #1563 + 2 new ones here). Check the *Commits* tab to see just the 2 this PR actually adds; the *Files changed* diff will shrink to just those once #1563 merges and this rebases/retargets cleanly onto `main`.**

Related to #1547, but not a bug fix — a small feature that came up while working that issue.

## Summary

Countries already have a hide/tombstone mechanism (`hidden_countries`, #1490): a zero-count derived country can be dismissed and stays gone across reloads. Regions had no equivalent — `unmarkRegionVisited` only ever deleted a manually-marked `visited_regions` row, a no-op for the common case of a region derived fresh from `place_regions` on every request, so there was no way to dismiss one at all.

This adds the region-level counterpart, deliberately mirroring the country-level design so the two stay consistent:

- New `hidden_regions` table, same shape as `hidden_countries`.
- `getVisitedRegions()` filters through it, the same way `getStats()` already filters through `getHiddenCountries()`.
- `unmarkRegionVisited()` now tombstones unconditionally — not just for a manually-marked region. A region with a real place attached (e.g. one misassigned by a border-simplification gap, exactly the kind of thing #1563 fixes some instances of but can't catch all of) is the actual motivating case.
- Cascade: hiding a country's last visible region also hides the country, via the existing `unmarkCountryVisited`.
- `markRegionVisited()` clears both tombstones on re-mark, so a region (and its cascade-hidden country) can come back.
- Client: clicking any visited region now offers to remove it, not just manually-marked ones. Country detail viewing remains reachable via the country search/sidebar, which was never gated on this.

One deliberate asymmetry, covered by tests: the cascade only has a *visible* effect on a country with no real place data behind it — a country with real places is never actually hidden by the tombstone (#1490's existing "reappears once it has a real place" rule), so hiding every region of a real-place-backed country leaves the country itself visible. Same existing design, just now reachable from the region side too.

## Testing

- Full server suite green.
- Full client suite green.
- New tests: server-side hide/cascade/re-mark behavior (including the real-place-vs-manual asymmetry above), client-side region-click flow for a place-derived (non-manually-marked) region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)