### PR TITLE
fix(plugins): derive plugin req.user.isAdmin from role, not is_admin

### DIFF
--- a/server/src/nest/plugins/plugins-proxy.controller.ts
+++ b/server/src/nest/plugins/plugins-proxy.controller.ts
@@ -90,7 +90,7 @@ export class PluginsProxyController {
     }
 
     // Per-route auth: default-on; `auth:false` routes are public (OAuth cb/webhook).
-    let user: { id: number; username: string; is_admin?: boolean } | null = null;
+    let user: { id: number; username: string; role?: 'admin' | 'user' } | null = null;
     if (route.auth) {
       const token = extractToken(req);
       const loaded = token ? verifyJwtAndLoadUser(token) : null;
@@ -121,7 +121,7 @@ export class PluginsProxyController {
             // allowlisted, credential-free subset — an authenticated route never
             // needs them and must not see even the safe ones.
             headers: route.auth === false ? pickInboundHeaders(req.headers as Record<string, unknown>) : {},
-            user: user ? { id: user.id, username: user.username, isAdmin: !!user.is_admin } : null,
+            user: user ? { id: user.id, username: user.username, isAdmin: user.role === 'admin' } : null,
           },
         },
         // Bind the authenticated session user as the acting user for any trip

--- a/server/tests/unit/plugins/plugins-proxy.test.ts
+++ b/server/tests/unit/plugins/plugins-proxy.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { pluginsEnabledMock, extractTokenMock, verifyMock } = vi.hoisted(() => ({
   pluginsEnabledMock: vi.fn(() => true),
   extractTokenMock: vi.fn(() => 'tok'),
-  verifyMock: vi.fn(() => ({ id: 5, username: 'ada', is_admin: false })),
+  verifyMock: vi.fn(() => ({ id: 5, username: 'ada', role: 'user' })),
 }));
 vi.mock('../../../src/nest/plugins/kill-switch', () => ({ pluginsEnabled: pluginsEnabledMock }));
 vi.mock('../../../src/middleware/auth', () => ({ extractToken: extractTokenMock, verifyJwtAndLoadUser: verifyMock }));
@@ -44,7 +44,7 @@ function makeRuntime(over: Partial<PluginRuntimeService> = {}): PluginRuntimeSer
 
 beforeEach(() => {
   pluginsEnabledMock.mockClear().mockReturnValue(true);
-  verifyMock.mockClear().mockReturnValue({ id: 5, username: 'ada', is_admin: false });
+  verifyMock.mockClear().mockReturnValue({ id: 5, username: 'ada', role: 'user' });
   extractTokenMock.mockClear().mockReturnValue('tok');
 });
 
@@ -88,6 +88,18 @@ describe('PluginsProxyController', () => {
       routeId: 0,
       req: expect.objectContaining({ user: { id: 5, username: 'ada', isAdmin: false } }),
     }), 5);
+  });
+
+  it('maps role:admin to isAdmin:true in the forwarded user view', async () => {
+    // Regression: the proxy derives isAdmin from the loaded user's `role`, not a
+    // non-existent `is_admin` field — otherwise every user (admins included) is false.
+    verifyMock.mockReturnValue({ id: 7, username: 'root', role: 'admin' } as never);
+    const runtime = makeRuntime();
+    const res = fakeRes();
+    await new PluginsProxyController(runtime).proxy('p', fakeReq('GET', '/status'), res as never);
+    expect(runtime.invoke).toHaveBeenCalledWith('p', 'invoke.route', expect.objectContaining({
+      req: expect.objectContaining({ user: { id: 7, username: 'root', isAdmin: true } }),
+    }), 7);
   });
 
   it('a public (auth:false) route skips the session check', async () => {


### PR DESCRIPTION
## Description

Plugin route handlers always received `req.user.isAdmin === false`, even for
administrators, so a plugin could not gate any admin-only behaviour on it.

The proxy built the plugin-facing request user with `isAdmin: !!user.is_admin`,
but `verifyJwtAndLoadUser()` returns a `User` whose admin status lives in the
`role` column (`role === 'admin'`) — there is no `is_admin` field. `user.is_admin`
was therefore always `undefined`, making `isAdmin` always `false` for every user,
admins included. The local type annotation on the proxy user even declared the
phantom `is_admin?: boolean`, which is why `tsc` never flagged the mismatch.

Fix (two lines in `plugins-proxy.controller.ts`):
- Derive `isAdmin` from `user.role === 'admin'` instead of `!!user.is_admin`.
- Correct the local type to `role?: 'admin' | 'user'` so it reflects the real
  `User` shape and the phantom field can't silently reappear.

This is the only site in the plugin layer that derives `isAdmin` from the loaded
user. The SDK contract (`plugin-sdk.ts`) already correctly declares
`isAdmin: boolean`; only the mapping populating it was wrong.

## Related Issue or Discussion

Closes #1569

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed