### PR TITLE
chore(test): make jsdom Storage work under Node's native Web Storage …

### DIFF
--- a/client/tests/environment/jsdom-native-abort.ts
+++ b/client/tests/environment/jsdom-native-abort.ts
@@ -2,15 +2,22 @@
  * Custom Vitest environment that extends jsdom but preserves the native
  * Node.js AbortController and AbortSignal.
  *
- * Problem: jsdom replaces globalThis.AbortController and AbortSignal with its
+ * Problem 1: jsdom replaces globalThis.AbortController and AbortSignal with its
  * own implementations. Node.js's undici-based fetch validates signals via
  * `signal instanceof AbortSignal` against its own native class reference.
  * jsdom's AbortSignal instances fail this check, causing fetch to throw:
  *   TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an
  *   instance of AbortSignal.
- *
  * Fix: after jsdom installs its globals, restore the native AbortController
  * and AbortSignal so fetch works correctly in tests.
+ *
+ * Problem 2 (Node 22+ experimental Web Storage): Node now exposes its own
+ * `localStorage`/`sessionStorage` globals, inert unless `--localstorage-file`
+ * is passed. Vitest's global-populate skips any key already present on the
+ * global that isn't in its own allow-list, and Storage isn't in it — so
+ * jsdom's working Storage never overwrites Node's inert one and every test
+ * throws on `localStorage.clear()`. Fix: delete Node's shadow globals before
+ * jsdom setup runs, so vitest copies jsdom's Storage across.
  */
 
 import { builtinEnvironments } from 'vitest/environments';
@@ -25,6 +32,10 @@ export default {
     // Capture native AbortController/AbortSignal BEFORE jsdom patches them
     const NativeAbortController = global.AbortController;
     const NativeAbortSignal = global.AbortSignal;
+
+    // Clear Node's inert Web Storage globals so jsdom's win, not this shadow.
+    delete (global as { localStorage?: unknown }).localStorage;
+    delete (global as { sessionStorage?: unknown }).sessionStorage;
 
     // Run standard jsdom setup (installs jsdom globals, including its own AbortController)
     const env = await jsdomEnv.setup(global, options as Parameters<typeof jsdomEnv.setup>[1]);


### PR DESCRIPTION
## Description

The client test suite can't run on Node 24+ — every test throws
`TypeError: Cannot read properties of undefined (reading 'clear')` at
`tests/setup.ts:23` (`localStorage.clear()`).

Root cause is an interaction between Node's experimental Web Storage and
Vitest's global setup:

- Node 24+ exposes `localStorage`/`sessionStorage` as native globals, but they
  are inert unless the process is started with `--localstorage-file`, so reading
  `localStorage` returns `undefined`.
- Vitest's jsdom environment only copies a window key onto the global if it
  isn't already present there, unless the key is in its internal allow-list.
  `localStorage`/`sessionStorage` aren't in that list, so once Node's native
  (inert) globals exist, jsdom's working Storage is never copied across.

Result: tests see Node's inert `localStorage` instead of jsdom's. On Node 22
(where Web Storage is still behind `--experimental-webstorage`) the global isn't
present, so this doesn't reproduce — it only bites on Node 24+.

Fix: in the existing custom test environment (`jsdom-native-abort.ts`, which
already restores native AbortController post-setup), delete Node's shadow
Storage globals *before* jsdom setup runs, so Vitest copies jsdom's working
Storage across. On a Node without those globals the `delete` is a harmless
no-op, so CI on Node 22 is unaffected.

## Related Issue or Discussion

No separate issue — test-infrastructure fix surfaced while working on another
change. Happy to open a tracking issue if preferred.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/C
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed