### PR TITLE
fix(websocket): handle socket 'error' events to prevent crash on malformed frames

### DIFF
--- a/server/src/websocket.ts
+++ b/server/src/websocket.ts
@@ -61,6 +61,13 @@ function setupWebSocket(server: http.Server): void {
 
   wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
     const nws = ws as NomadWebSocket;
+
+    // ws emits protocol violations (malformed frames, reserved close codes such as 1006)
+    // as an 'error' event on the socket; unhandled, Node rethrows it and the process dies.
+    // Must stay above the auth guards below: they close and return early, and a socket that
+    // never gets this listener can still crash the server before it finishes closing.
+    nws.on('error', () => nws.terminate());
+
     // Extract token from query param
     const url = new URL(req.url, 'http://localhost');
     const token = url.searchParams.get('token');

--- a/server/tests/websocket/connection.test.ts
+++ b/server/tests/websocket/connection.test.ts
@@ -6,6 +6,8 @@
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'http';
+import net from 'node:net';
+import crypto from 'node:crypto';
 import request from 'supertest';
 import WebSocket from 'ws';
 import { broadcastToUser, getOnlineUserIds } from '../../src/websocket';
@@ -576,6 +578,54 @@ describe('WS message processing edge cases', () => {
     expect(errors).toHaveLength(0);
 
     rawWs.close();
+  });
+
+  it('WS-015d — a close frame with a reserved status code does not crash the server (#1576)', async () => {
+    // The `ws` client cannot send an invalid close code, so craft the frame over a raw
+    // socket. Reserved code 1006 makes ws emit an 'error' event on the socket; with no
+    // listener attached in setupWebSocket, Node rethrows it as an uncaughtException and the
+    // process dies in production. In-process under vitest that surfaces as an uncaught
+    // WS_ERR_INVALID_CLOSE_CODE, so capture uncaughtException for the duration and assert
+    // none fired — then confirm the server is still serving.
+    const uncaught: Error[] = [];
+    const onUncaught = (err: Error): void => { uncaught.push(err); };
+    process.on('uncaughtException', onUncaught);
+
+    try {
+      const port = (server.address() as { port: number }).port;
+      await new Promise<void>((resolve, reject) => {
+        const key = crypto.randomBytes(16).toString('base64');
+        const sock = net.connect(port, '127.0.0.1');
+        sock.on('error', reject);
+        sock.write(
+          `GET /ws HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nUpgrade: websocket\r\n` +
+          `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`
+        );
+        sock.once('data', (buf) => {
+          if (!buf.toString('latin1').includes('101 Switching Protocols')) return reject(new Error('no upgrade'));
+          const mask = crypto.randomBytes(4);
+          const payload = Buffer.alloc(2);
+          payload.writeUInt16BE(1006, 0); // reserved — MUST NOT appear in a close frame (RFC 6455)
+          const masked = Buffer.from(payload.map((b, i) => b ^ mask[i % 4]));
+          sock.write(Buffer.concat([Buffer.from([0x88, 0x82]), mask, masked])); // FIN|close, MASK|len2
+          setTimeout(() => { sock.destroy(); resolve(); }, 200);
+        });
+      });
+
+      expect(uncaught.map(e => (e as { code?: string }).code)).not.toContain('WS_ERR_INVALID_CLOSE_CODE');
+
+      // And the server is still serving: a fresh connection still gets a welcome.
+      const { user } = createUser(testDb);
+      const token = createEphemeralToken(user.id, 'ws')!;
+      const client = await connectWs(token);
+      try {
+        expect((await client.next()).type).toBe('welcome');
+      } finally {
+        client.close();
+      }
+    } finally {
+      process.off('uncaughtException', onUncaught);
+    }
   });
 
   it('WS-016 — rate-limit window resets: after limit hit, next window accepts messages again', async () => {


### PR DESCRIPTION
## Description
`server/src/websocket.ts` attached `pong`/`message`/`close` listeners to each
socket but never `error`. When the `ws` receiver hits a protocol violation —
e.g. a close frame carrying the reserved code 1006 (`WS_ERR_INVALID_CLOSE_CODE`),
which a flaky mobile/proxy client can send — it emits `'error'` on the socket.
With no listener, Node rethrows it as an uncaughtException and the process exits.
That is the crash in the attached log; the `[Atlas] Loaded admin0 GeoJSON` line
just happened to be the last line before it.

The fix attaches `nws.on('error', () => nws.terminate())`, placed above the auth
guards on purpose: those guards `close()` and `return` early, but the socket
still parses inbound frames, so a socket rejected there could crash the server
before it finished closing — reachable without authentication.

## Related Issue or Discussion
Closes #1576

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed 