### PR TITLE
fix(map): draw transit routes even without other places on the day

### DIFF
--- a/client/src/components/Map/ReservationOverlay.tsx
+++ b/client/src/components/Map/ReservationOverlay.tsx
@@ -371,6 +371,11 @@ export default function ReservationOverlay({ reservations, showConnections, show
 
   const visibleItems = useMemo(() => {
     return items.filter(item => {
+      // A transit journey draws its real rail/bus alignment, not a straight from->to
+      // line, so the endpoint-proximity declutter (which exists to hide tiny no-op
+      // straight connectors) must not suppress it. Otherwise a zoomed-out day — e.g. one
+      // with no other places to tighten the map onto — hides the whole route (#1570).
+      if (item.transitSegs.length > 0) return true
       const fromPx = map.latLngToContainerPoint([item.from.lat, item.from.lng])
       const toPx = map.latLngToContainerPoint([item.to.lat, item.to.lng])
       const minPx = item.type === 'flight' ? 50 : item.type === 'cruise' ? 150 : item.type === 'car' ? 80 : 200

--- a/client/src/components/Map/reservationsMapbox.test.ts
+++ b/client/src/components/Map/reservationsMapbox.test.ts
@@ -42,6 +42,22 @@ function carBooking(): Reservation {
   } as unknown as Reservation
 }
 
+// A transit journey whose from/to stations project close together (under the 200px
+// declutter threshold) but which carries real per-leg MOTIS geometry. The encoded
+// polyline decodes to [[48,2],[48.02,2.01],[48.05,2]] at precision 6.
+function transitBooking(withGeometry: boolean): Reservation {
+  return {
+    id: 2, type: 'transit', status: 'confirmed',
+    endpoints: [
+      { role: 'from', sequence: 0, name: 'Stop A', code: null, lat: 48.0, lng: 2.0, timezone: null, local_time: null, local_date: null },
+      { role: 'to', sequence: 1, name: 'Stop B', code: null, lat: 48.05, lng: 2.0, timezone: null, local_time: null, local_date: null },
+    ],
+    metadata: withGeometry
+      ? { transit: { legs: [{ geometry: '__upzA_gayB_af@_pR_ry@~oR', mode: 'BUS', line_color: '#7c3aed' }] } }
+      : { transit: { legs: [{ mode: 'BUS' }] } },
+  } as unknown as Reservation
+}
+
 const opts = { showConnections: true, showStats: false, showEndpointLabels: false }
 
 function lastFeatureCoords(map: ReturnType<typeof fakeMap>) {
@@ -71,6 +87,26 @@ describe('ReservationMapboxOverlay road routes (#1425)', () => {
     const map = fakeMap()
     const overlay = new ReservationMapboxOverlay(map as never, opts, FakeMarker as never)
     overlay.update([carBooking()], { ...opts, showConnections: false }, new Map([[1, [[48, 2], [48.2, 2.3]]]]))
+    const calls = map._source.setData.mock.calls
+    const data = calls[calls.length - 1]?.[0] as { features: unknown[] }
+    expect(data.features).toHaveLength(0)
+  })
+})
+
+describe('ReservationMapboxOverlay transit routes (#1570)', () => {
+  it('draws a transit journey with real geometry even when its stations project close together', () => {
+    const map = fakeMap()
+    const overlay = new ReservationMapboxOverlay(map as never, opts, FakeMarker as never)
+    overlay.update([transitBooking(true)], opts)
+    // Stations are ~50px apart — under the 200px declutter — yet the real per-leg
+    // path (GeoJSON [lng, lat]) is drawn because it carries stored geometry.
+    expect(lastFeatureCoords(map)).toEqual([[2, 48], [2.01, 48.02], [2, 48.05]])
+  })
+
+  it('still declutters a geometry-less transit whose stations project close together', () => {
+    const map = fakeMap()
+    const overlay = new ReservationMapboxOverlay(map as never, opts, FakeMarker as never)
+    overlay.update([transitBooking(false)], opts)
     const calls = map._source.setData.mock.calls
     const data = calls[calls.length - 1]?.[0] as { features: unknown[] }
     expect(data.features).toHaveLength(0)

--- a/client/src/components/Map/reservationsMapbox.ts
+++ b/client/src/components/Map/reservationsMapbox.ts
@@ -283,6 +283,10 @@ export class ReservationMapboxOverlay {
     // overlay, so tiny no-op transport lines don't clutter the map.
     const visibleItems = show ? this.items.filter(item => {
       try {
+        // A transit journey draws its real alignment, not a straight from->to line, so
+        // don't let the endpoint-proximity declutter hide it when the map is zoomed out
+        // (#1570). Mirrors the Leaflet overlay.
+        if (item.type === 'transit' && getTransitMapSegments(item.res).length > 0) return true
         const fromPx = map.project([item.from.lng, item.from.lat])
         const toPx = map.project([item.to.lng, item.to.lat])
         const dx = fromPx.x - toPx.x, dy = fromPx.y - toPx.y


### PR DESCRIPTION
The reservation overlays hide any transport booking whose `from`/`to` endpoints project closer than a per-type pixel threshold (200px for transit), so tiny no-op straight connectors don't clutter the map. A transit journey, though, draws its **real** rail/bus alignment from the stored per-leg MOTIS geometry — not a straight endpoint line — so measuring only the straight-line distance between its two stations is the wrong visibility test.

The result is the bug in #1570: on a day the map is zoomed out for — e.g. one with no other places to tighten the frame onto — the two stations project under 200px apart and the **entire** public-transport route disappears, even though its geometry may span kilometres. The `>= 2 other places` correlation in the report is indirect: with more places the day-fit tightens, the stations spread past 200px, and it reappears. (The connecting **drive** legs on such a day do obey the `useRouteCalculation` run gate, which is correct by design — that gate is a different line from the PT route this fixes, and is left untouched.)

Fix: a transit booking that carries real per-leg geometry is exempt from the endpoint-proximity gate in both renderers — `ReservationOverlay` (Leaflet) and `reservationsMapbox` (MapLibre) — so it always draws when the route layer is on, regardless of how many places share the day. A geometry-less/manual transit still falls through to the unchanged 200px straight-arc declutter, and no other booking type is affected. `useRouteCalculation` is not touched, so the #1394/#1321/#1465 run/bookend behaviour cannot regress.

Closes #1570
