### PR TITLE
fix(settings): make fresh-instance unit defaults internally consistent

### DIFF
--- a/client/src/components/Settings/DisplaySettingsTab.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { Languages, Map, ChevronDown, Check } from 'lucide-react'
 import { SUPPORTED_LANGUAGES, useTranslation } from '../../i18n'
-import { useSettingsStore } from '../../store/settingsStore'
+import { useSettingsStore, DEFAULT_SETTINGS } from '../../store/settingsStore'
 import { useToast } from '../shared/Toast'
 import CustomSelect from '../shared/CustomSelect'
 import { SYMBOLS, currenciesWith } from '../Budget/BudgetPanel.constants'
@@ -12,8 +12,8 @@ export default function DisplaySettingsTab(): React.ReactElement {
   const { settings, updateSetting } = useSettingsStore()
   const { t } = useTranslation()
   const toast = useToast()
-  const [tempUnit, setTempUnit] = useState<string>(settings.temperature_unit || 'celsius')
-  const [distanceUnit, setDistanceUnit] = useState<DistanceUnit>(settings.distance_unit || 'metric')
+  const [tempUnit, setTempUnit] = useState<string>(settings.temperature_unit || DEFAULT_SETTINGS.temperature_unit)
+  const [distanceUnit, setDistanceUnit] = useState<DistanceUnit>(settings.distance_unit || DEFAULT_SETTINGS.distance_unit)
   const [langOpen, setLangOpen] = useState(false)
   const langDropdownRef = useRef<HTMLDivElement | null>(null)
 
@@ -27,11 +27,11 @@ export default function DisplaySettingsTab(): React.ReactElement {
   }, [langOpen])
 
   useEffect(() => {
-    setTempUnit(settings.temperature_unit || 'celsius')
+    setTempUnit(settings.temperature_unit || DEFAULT_SETTINGS.temperature_unit)
   }, [settings.temperature_unit])
 
   useEffect(() => {
-    setDistanceUnit(settings.distance_unit || 'metric')
+    setDistanceUnit(settings.distance_unit || DEFAULT_SETTINGS.distance_unit)
   }, [settings.distance_unit])
 
   return (

--- a/client/src/store/settingsStore.test.ts
+++ b/client/src/store/settingsStore.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_SETTINGS, useSettingsStore } from './settingsStore'
+
+// A fresh instance sends no value for a setting an admin hasn't defaulted, so DEFAULT_SETTINGS
+// is what a brand-new user actually sees. These guard against the two regressions in the
+// original bug: unit defaults that mix measurement systems (°F alongside kilometres), and a
+// store default that silently disagrees with DisplaySettingsTab's fallback.
+describe('settings defaults', () => {
+  it('SETTINGS-DEFAULTS-001: the shipped unit defaults belong to one consistent system', () => {
+    expect(DEFAULT_SETTINGS.temperature_unit).toBe('celsius')
+    expect(DEFAULT_SETTINGS.distance_unit).toBe('metric')
+    expect(DEFAULT_SETTINGS.time_format).toBe('24h')
+  })
+
+  it('SETTINGS-DEFAULTS-002: the store initialises from DEFAULT_SETTINGS, the same constant DisplaySettingsTab falls back to, so the two cannot drift apart', () => {
+    const settings = useSettingsStore.getState().settings
+    expect(settings.temperature_unit).toBe(DEFAULT_SETTINGS.temperature_unit)
+    expect(settings.distance_unit).toBe(DEFAULT_SETTINGS.distance_unit)
+    expect(settings.time_format).toBe(DEFAULT_SETTINGS.time_format)
+  })
+})

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -21,31 +21,39 @@ interface SettingsState {
 export const hasStoredLanguage = (): boolean =>
   typeof localStorage !== 'undefined' && !!localStorage.getItem('app_language')
 
+// The effective client-side defaults for a fresh instance. The server sends no value for
+// a setting an admin hasn't defaulted (see settingsService.getAdminUserDefaults), so these
+// are what a brand-new user actually sees. Keep them internally consistent — one
+// measurement system, not °F alongside kilometres — and note that DisplaySettingsTab
+// imports these same values for its fallbacks, so the store default and the UI fallback
+// can't drift apart again.
+export const DEFAULT_SETTINGS: Settings = {
+  map_tile_url: '',
+  dark_mode: false,
+  // Empty = no personal display currency, so Costs falls back to the trip's own.
+  default_currency: '',
+  language: localStorage.getItem('app_language') || 'en',
+  temperature_unit: 'celsius',
+  distance_unit: 'metric',
+  time_format: '24h',
+  show_place_description: false,
+  optimize_from_accommodation: true,
+  map_provider: 'leaflet',
+  map_poi_pill_enabled: true,
+  mapbox_access_token: '',
+  mapbox_style: 'mapbox://styles/mapbox/standard',
+  maplibre_style: '',
+  mapbox_3d_enabled: true,
+  mapbox_quality_mode: false,
+  dashboard_fx_from: 'EUR',
+  dashboard_fx_to: 'USD',
+  appearance: DEFAULT_APPEARANCE,
+  // dashboard_timezones is intentionally left unset so the widget can tell "never
+  // chosen" (fall back to home + defaults) from an explicitly emptied list.
+}
+
 export const useSettingsStore = create<SettingsState>((set, get) => ({
-  settings: {
-    map_tile_url: '',
-    dark_mode: false,
-    // Empty = no personal display currency, so Costs falls back to the trip's own.
-    default_currency: '',
-    language: localStorage.getItem('app_language') || 'en',
-    temperature_unit: 'fahrenheit',
-    distance_unit: 'metric',
-    time_format: '12h',
-    show_place_description: false,
-    optimize_from_accommodation: true,
-    map_provider: 'leaflet',
-    map_poi_pill_enabled: true,
-    mapbox_access_token: '',
-    mapbox_style: 'mapbox://styles/mapbox/standard',
-    maplibre_style: '',
-    mapbox_3d_enabled: true,
-    mapbox_quality_mode: false,
-    dashboard_fx_from: 'EUR',
-    dashboard_fx_to: 'USD',
-    appearance: DEFAULT_APPEARANCE,
-    // dashboard_timezones is intentionally left unset so the widget can tell "never
-    // chosen" (fall back to home + defaults) from an explicitly emptied list.
-  },
+  settings: { ...DEFAULT_SETTINGS },
   isLoaded: false,
 
   loadSettings: async () => {


### PR DESCRIPTION
## The bug

A brand-new instance — empty database, no admin-set user defaults, no value the user has saved — renders temperatures in **Fahrenheit** and times on the **12-hour** clock, while distances default to **metric**. That mix matches no locale: a metric-country user sees kilometres next to °F, a US user sees °F next to kilometres.

The server has no hard-coded default (`settingsService` only reads admin-set `default_user_setting_*`), so the effective default comes entirely from the client store:

```ts
// client/src/store/settingsStore.ts (before)
temperature_unit: 'fahrenheit',
distance_unit:   'metric',
time_format:     '12h',
```

The two code paths also disagreed about the intended default: the store seeded `'fahrenheit'`, but `DisplaySettingsTab`'s fallback said `'celsius'` (`settings.temperature_unit || 'celsius'`).

## The fix

Default to **one system — `celsius` / `metric` / `24h`** — matching the already-metric `distance_unit` and the self-hosting majority. (Deriving units from the browser locale is a nicer UX but a separate feature, not a bug fix.)

The unit defaults now live in a single exported `DEFAULT_SETTINGS`, which **both** the store's initial state and `DisplaySettingsTab`'s fallbacks read — so the store default and the UI fallback can no longer drift apart. A test guards it.

## Not changed / preserved

- **Admin-set defaults still win** — the server's `getAdminUserDefaults()` and the admin *User Defaults* surface override the code default exactly as before; an admin who set Fahrenheit sees no difference.
- **Existing users are untouched** — the default only applies where nothing is saved; any value a user already stored is loaded over it.
- **No new accepted values** — `celsius`/`metric`/`24h` are already in `settingsService`'s `VALID_VALUES`, so no server-side validation change and no 400s.
- The plugin `temperatureUnit` passthrough (`PluginFrame`) forwards whatever the value is; only the default changed.

## Verification

- New `settingsStore.test.ts` asserts the shipped unit defaults are one consistent system and that the store initialises from the same `DEFAULT_SETTINGS` the UI falls back to.
- `DisplaySettingsTab` tests and client typecheck/lint pass.
