### PR TITLE
fix(i18n): Catalan keys for booking-route toggle + language-count test

### DIFF
--- a/client/tests/unit/i18n/index.test.ts
+++ b/client/tests/unit/i18n/index.test.ts
@@ -91,7 +91,7 @@ describe('isRtlLanguage', () => {
 describe('SUPPORTED_LANGUAGES', () => {
   it('FE-COMP-I18N-009: contains expected entries with value/label shape', () => {
     expect(Array.isArray(SUPPORTED_LANGUAGES)).toBe(true)
-    expect(SUPPORTED_LANGUAGES).toHaveLength(22)
+    expect(SUPPORTED_LANGUAGES).toHaveLength(23)
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'en', label: 'English' }))
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'tr', label: 'Türkçe' }))
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'ja', label: '日本語' }))
@@ -100,6 +100,7 @@ describe('SUPPORTED_LANGUAGES', () => {
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'sv', label: 'Svenska' }))
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'ar', label: 'العربية' }))
     expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'vi', label: 'Tiếng Việt' }))
+    expect(SUPPORTED_LANGUAGES).toContainEqual(expect.objectContaining({ value: 'ca', label: 'Català' }))
   })
 })
 

--- a/shared/src/i18n/ca/map.ts
+++ b/shared/src/i18n/ca/map.ts
@@ -13,5 +13,7 @@ const map: TranslationStrings = {
   'poi.cat.museums': 'Museus i cultura',
   'poi.cat.nature': 'Natura i parcs',
   'poi.cat.activities': 'Activitats',
+  'map.showAllConnections': 'Mostra totes les rutes de reserva',
+  'map.hideAllConnections': 'Amaga totes les rutes de reserva',
 };
 export default map;

--- a/shared/src/i18n/ca/settings.ts
+++ b/shared/src/i18n/ca/settings.ts
@@ -495,6 +495,9 @@ const settings: TranslationStrings = {
   'settings.notificationPreferences.pluginConfigured':
     'Configurat. Gestiona les credencials a la configuració del connector.',
   'settings.currencyTrip': 'Divisa del viatge',
+  'settings.alwaysShowRoutes': 'Mostra sempre les rutes de reserva',
+  'settings.alwaysShowRoutesHint':
+    'Dibuixa automàticament al mapa la ruta de cada vol, tren i altra reserva — no cal activar-la una per una.',
 };
 
 export default settings;


### PR DESCRIPTION
Fixes the two red checks on dev after the Catalan (#1418) and booking-route (#1483) merges landed close together:

- **i18n Key Parity** — #1483's new keys (`map.showAllConnections`/`hideAllConnections`, `settings.alwaysShowRoutes`/`Hint`) were added to every locale that existed when it was written; Catalan landed just after and was missing them. Added them, translated.
- **Client Tests** — `FE-COMP-I18N-009` hard-codes `SUPPORTED_LANGUAGES` length (22) and entries; Catalan made it 23. Bumped the length and added the `ca` assertion.

`i18n:parity:strict` clean, the i18n test passes, lint clean.