### PR TITLE
fix(planner): don't start a check-in day's route at the hotel (#1597)

### DIFF
--- a/client/src/utils/dayOrder.test.ts
+++ b/client/src/utils/dayOrder.test.ts
@@ -178,13 +178,13 @@ describe('shouldDrawMorningLeg', () => {
     expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: '15:00' })).toBe(true)
   })
 
-  it('DRAWS on a check-in day when time info is missing (home-base default, no over-suppression)', () => {
-    // Without a comparable place time or hotel check-in time, the arrival day stays a
-    // home-base loop — only a place provably before check-in suppresses the leg.
+  it('does NOT draw on a check-in day when time info is missing (#1597)', () => {
+    // An un-timed first place on an arrival day ("Home" before driving out) cannot prove
+    // you were at the hotel yet, so no hotel → first-stop leg — mirroring the evening rule.
     const bookends = { morning: into({ check_in: '15:00' }), morningIsSleptHere: false }
-    expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: null })).toBe(true)
+    expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: null })).toBe(false)
     const noCheckIn = { morning: into({ check_in: null }), morningIsSleptHere: false }
-    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: '19:00' })).toBe(true)
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: '19:00' })).toBe(false)
   })
 
   it('does NOT draw on a check-in day for a transport arrival (not a place, #1321)', () => {

--- a/client/src/utils/dayOrder.ts
+++ b/client/src/utils/dayOrder.ts
@@ -58,11 +58,12 @@ export const getAccommodationAnchors = (
 }
 
 // Whether to draw the morning hotel → first-stop leg. It is a real drive when you slept in the
-// morning hotel (a normal home-base day). On that hotel's check-in day the hotel is your base
-// once you arrive, so the leg is still the default for a PLACE first stop — suppressed only when
-// that place is timed BEFORE check-in (an airport you reach before dropping your bags, #1465), or
-// when the first stop is a transport arrival (you flew in, weren't at the hotel yet, #1321).
-// Un-timed places keep the loop, avoiding over-suppression on ordinary arrival days.
+// morning hotel (a normal home-base day). On that hotel's check-in day you were traveling TO the
+// hotel, so the leg is drawn only when the first stop is a PLACE provably timed at/after check-in
+// (you dropped your bags first). A place before check-in (an airport you reach first, #1465), a
+// transport arrival (you flew in, weren't at the hotel yet, #1321), an un-timed place ("Home"
+// before driving out, #1597), or a missing check-in time all mean no leg — mirroring the
+// evening rule below.
 export const shouldDrawMorningLeg = (
   bookends: { morning?: Accommodation; morningIsSleptHere?: boolean },
   day: Day,
@@ -73,7 +74,7 @@ export const shouldDrawMorningLeg = (
   if (!m || m.start_day_id !== day.id || !firstStop?.isPlace) return false
   const checkIn = parseTimeToMinutes(m.check_in)
   const stop = parseTimeToMinutes(firstStop.time)
-  return !(checkIn != null && stop != null && stop < checkIn)
+  return checkIn != null && stop != null && stop >= checkIn
 }
 
 // Mirror of shouldDrawMorningLeg for the last-stop → hotel evening leg. It is a real drive when

--- a/client/tests/integration/hooks/useRouteCalculation.test.ts
+++ b/client/tests/integration/hooks/useRouteCalculation.test.ts
@@ -295,15 +295,16 @@ describe('useRouteCalculation', () => {
     expect(legs).toContainEqual([`${actB.lat},${actB.lng}`, `${hotel.lat},${hotel.lng}`]);
   });
 
-  it('FE-HOOK-ROUTE-015: day-1 with no transport keeps the hotel → first-activity leg', async () => {
-    // Guard against over-suppression: with no arrival transport, the check-in day is a
-    // home-base loop and the hotel → first-stop leg must remain.
-    const actA = buildPlace({ lat: 41.38, lng: 2.17 });
+  it('FE-HOOK-ROUTE-015: day-1 with a first activity timed after check-in keeps the hotel → first-activity leg', async () => {
+    // The check-in day is still a home-base loop when the first activity provably happens
+    // at/after check-in (you dropped your bags first) — the hotel → first-stop leg remains.
+    // Since #1597 the loop needs that time proof; un-timed activities draw no morning leg.
+    const actA = buildPlace({ lat: 41.38, lng: 2.17, place_time: '15:00' });
     const actB = buildPlace({ lat: 41.40, lng: 2.19 });
     const hotel = { lat: 41.39, lng: 2.16 };
     const a1 = buildAssignment({ day_id: 1, order_index: 0, place: actA });
     const a2 = buildAssignment({ day_id: 1, order_index: 1, place: actB });
-    const accommodations = [{ id: 1, start_day_id: 1, end_day_id: 2, place_lat: hotel.lat, place_lng: hotel.lng }];
+    const accommodations = [{ id: 1, start_day_id: 1, end_day_id: 2, check_in: '14:00', place_lat: hotel.lat, place_lng: hotel.lng }];
     const store = { assignments: { '1': [a1, a2] } } as unknown as TripStoreState;
     useTripStore.setState({
       assignments: store.assignments,
@@ -320,6 +321,47 @@ describe('useRouteCalculation', () => {
     const legs = (result.current.route ?? []).map(run => run.map(p => `${p[0]},${p[1]}`));
     expect(legs).toContainEqual([`${hotel.lat},${hotel.lng}`, `${actA.lat},${actA.lng}`]);
     expect(legs).toContainEqual([`${actB.lat},${actB.lng}`, `${hotel.lat},${hotel.lng}`]);
+  });
+
+  it('FE-HOOK-ROUTE-022: #1597 check-in day with an un-timed place and a transport starts at the place, not the hotel', async () => {
+    // Day 1 of a driving holiday: leave "Home" (no time set), cross by tunnel/ferry, and
+    // check into a hotel near the arrival port tonight. The hotel is only reached at the
+    // end of the day, so no hotel → Home leg may be drawn no matter the check-in time —
+    // the route starts at Home and still ends at the hotel.
+    const home = buildPlace({ lat: 52.48, lng: -1.90 });        // un-timed "Home"
+    const dep = { lat: 51.09, lng: 1.12 };                      // Folkestone terminal
+    const arr = { lat: 50.94, lng: 1.81 };                      // Calais terminal
+    const hotel = { lat: 50.95, lng: 1.85 };
+
+    const tunnel = {
+      id: 200, type: 'train', day_id: 1, end_day_id: 1, day_plan_position: 1,
+      endpoints: [
+        { role: 'from', lat: dep.lat, lng: dep.lng },
+        { role: 'to', lat: arr.lat, lng: arr.lng },
+      ],
+    };
+    const a1 = buildAssignment({ day_id: 1, order_index: 0, place: home });
+    const accommodations = [{ id: 1, start_day_id: 1, end_day_id: 2, check_in: '19:00', place_lat: hotel.lat, place_lng: hotel.lng }];
+    const store = { assignments: { '1': [a1] } } as unknown as TripStoreState;
+    useTripStore.setState({
+      assignments: store.assignments,
+      reservations: [tunnel],
+      days: [{ id: 1, day_number: 1 }, { id: 2, day_number: 2 }],
+    } as any);
+
+    const { result } = renderHook(() =>
+      useRouteCalculation(store, 1, true, 'driving', accommodations as any)
+    );
+
+    await act(async () => {});
+
+    const legs = (result.current.route ?? []).map(run => run.map(p => `${p[0]},${p[1]}`));
+    // No phantom morning bookend [hotel → Home].
+    expect(legs).not.toContainEqual([`${hotel.lat},${hotel.lng}`, `${home.lat},${home.lng}`]);
+    // The day starts at Home and drives to the departure terminal.
+    expect(result.current.route?.[0]?.[0]).toEqual([home.lat, home.lng]);
+    // The evening leg [arrival terminal → hotel] is still drawn.
+    expect(legs).toContainEqual([`${arr.lat},${arr.lng}`, `${hotel.lat},${hotel.lng}`]);
   });
 
   it('FE-HOOK-ROUTE-016: #1297 transfer day with no activities draws the hotel → hotel leg', async () => {


### PR DESCRIPTION
Fixes #1597

## Problem

On an accommodation's check-in day, the route always started at that night's hotel — e.g. a phantom 282-mile `hotel → Home` leg on day 1 of a driving holiday. Changing the check-in time had no effect when the first place was un-timed.

## Root cause

`shouldDrawMorningLeg` (`client/src/utils/dayOrder.ts`) defaulted to drawing the hotel → first-stop leg on a check-in day, suppressing it only when the first place was explicitly timed **before** check-in. An un-timed place always drew the leg.

## Fix

Flip the default to mirror `shouldDrawEveningLeg`: on a check-in day the morning leg is drawn only when the first place is **provably timed at/after check-in** (you dropped your bags first). Un-timed places, places before check-in (#1465), and transport arrivals (#1321) all draw no leg. The drawn map route, sidebar hotel connectors, and Google Maps export share this helper, so all three are fixed. The optimizer anchors (#1321 loop) are unchanged.

## Tests

- Flipped the two tests that encoded the old default (`dayOrder.test.ts`, `FE-HOOK-ROUTE-015` now proves the preserved-loop case with times).
- New regression test `FE-HOOK-ROUTE-022` mirroring the issue repro (un-timed Home → tunnel → hotel check-in): route starts at Home, no hotel → Home leg, evening leg intact.
- Full client suite green (3379 passed), typecheck and lint clean.

Note: the issue's "start a trip from home natively" suggestion is a separate feature request, not addressed here.