### PR TITLE
Prefer the registry's resolved store screenshot

### DIFF
--- a/server/src/nest/plugins/registry/registry.service.ts
+++ b/server/src/nest/plugins/registry/registry.service.ts
@@ -76,6 +76,13 @@ export interface RegistryEntry {
   authorPublicKey?: string;
   /** Release-asset downloads across all versions, aggregated by the registry's stats cron. */
   downloadCount?: number | null;
+  /**
+   * Store cover image, resolved at build time by the registry's aggregate step:
+   * docs/screenshot.png at the latest commit, else the first README image that
+   * resolves there. Absent for entries published before this existed — browse
+   * and detail then construct the docs/screenshot.png URL themselves.
+   */
+  screenshotUrl?: string | null;
   versions: RegistryVersion[];
 }
 interface Registry {
@@ -208,7 +215,7 @@ export class PluginRegistryService {
         minTrekVersion: latest?.minTrekVersion ?? null,
         requiredAddons: latest?.requiredAddons ?? [],
         pluginDependencies: latest?.pluginDependencies ?? [],
-        screenshotUrl: latest ? rawFileUrl(p.repo, latest.commitSha, 'docs/screenshot.png') : null,
+        screenshotUrl: p.screenshotUrl ?? (latest ? rawFileUrl(p.repo, latest.commitSha, 'docs/screenshot.png') : null),
         signed: !!p.authorPublicKey && !!latest?.signature,
         authorPublicKey: p.authorPublicKey ?? null,
         ...this.hostCompat(p),
@@ -283,7 +290,7 @@ export class PluginRegistryService {
       publishedAt: latest?.publishedAt ?? null,
       requiredAddons: latest?.requiredAddons ?? [],
       pluginDependencies: latest?.pluginDependencies ?? [],
-      screenshotUrl: latest ? rawFileUrl(entry.repo, latest.commitSha, 'docs/screenshot.png') : null,
+      screenshotUrl: entry.screenshotUrl ?? (latest ? rawFileUrl(entry.repo, latest.commitSha, 'docs/screenshot.png') : null),
       signed: !!entry.authorPublicKey && !!latest?.signature,
       authorPublicKey: entry.authorPublicKey ?? null,
       ...this.hostCompat(entry),

--- a/server/tests/integration/plugins/registry.test.ts
+++ b/server/tests/integration/plugins/registry.test.ts
@@ -136,6 +136,23 @@ describe('PluginRegistryService', () => {
     expect(list[0].screenshotUrl).toBe(`https://raw.githubusercontent.com/acme/trek-flight/${'a'.repeat(40)}/docs/screenshot.png`);
   });
 
+  // The registry aggregate now resolves the cover at build time (docs/screenshot.png
+  // else the first resolving README image) and injects screenshotUrl. When present it
+  // must win over the docs/screenshot.png guess — that's what gives entries without a
+  // committed docs/screenshot.png a non-blank card.
+  it('browse prefers a build-injected screenshotUrl over the docs/screenshot.png guess', async () => {
+    const injected = 'https://raw.githubusercontent.com/acme/trek-flight/bbbb/docs/img1.png';
+    (REGISTRY.plugins[0] as { screenshotUrl?: string }).screenshotUrl = injected;
+    try {
+      const [entry] = await svc.browse();
+      expect(entry.screenshotUrl).toBe(injected);
+      const d = await svc.detail('flight-tracker');
+      expect(d.screenshotUrl).toBe(injected);
+    } finally {
+      delete (REGISTRY.plugins[0] as { screenshotUrl?: string }).screenshotUrl;
+    }
+  });
+
   it('detail merges registry metadata with a live manifest preview', async () => {
     safeDownload.mockResolvedValue({
       bytes: Buffer.from(JSON.stringify({


### PR DESCRIPTION
Plugin store cards were built purely from `raw.../<commit>/docs/screenshot.png`, so any plugin without that exact file at the pinned commit showed a blank card even when its repo had screenshots.

`browse`/`detail` now prefer the `screenshotUrl` the registry aggregate step resolves (cover at the latest commit, or the first resolving README image), and fall back to the old `docs/screenshot.png` construction when the field is absent — backward-compatible with a registry that doesn't carry it yet.

Pairs with liketrek/TREK-Plugins#40, which injects the field. The client `Screenshot` component already renders a placeholder for a broken/absent image, so no client change is needed.
