### PR TITLE
fix(notifications): RFC 2047-encode ntfy header umlauts

### DIFF
--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -513,7 +513,7 @@ export function resolveAdminNtfyUrl(adminCfg: NtfyConfig): string | null {
 
 function encodeHeaderValue(value: string): string {
   for (let i = 0; i < value.length; i++) {
-    if (value.charCodeAt(i) > 0xff) {
+    if (value.charCodeAt(i) > 0x7f) {
       return `=?UTF-8?B?${Buffer.from(value, 'utf8').toString('base64')}?=`;
     }
   }

--- a/server/tests/unit/services/notifications.test.ts
+++ b/server/tests/unit/services/notifications.test.ts
@@ -488,6 +488,19 @@ describe('sendNtfy', () => {
     expect(Buffer.from(b64, 'base64').toString('utf8')).toBe('Buy →€ ticket');
   });
 
+  it('NTFY-009b — title with Latin-1 umlauts is RFC 2047 encoded, not sent as raw bytes', async () => {
+    const mockFetch = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => '' } as never);
+
+    await sendNtfy(ntfyUrl, null, { ...payload, title: 'Frühstück in Zürich' });
+
+    const [, calledOpts] = mockFetch.mock.calls[0];
+    const encoded = calledOpts.headers['Title'] as string;
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+    const b64 = encoded.replace(/^=\?UTF-8\?B\?/, '').replace(/\?=$/, '');
+    expect(Buffer.from(b64, 'base64').toString('utf8')).toBe('Frühstück in Zürich');
+  });
+
   it('NTFY-010 — ASCII-only title is passed through verbatim', async () => {
     const mockFetch = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     mockFetch.mockResolvedValueOnce({ ok: true, text: async () => '' } as never);


### PR DESCRIPTION
## Description

The ntfy `Title` header is passed through `encodeHeaderValue()`
(`server/src/services/notifications.ts:514`), which only RFC 2047-encodes a string
when it contains a character above `0xff`. Umlauts and accented letters — `ä`
(U+00E4=228), `ö` (246), `ü` (252), `í` (237) — live in the Latin-1 supplement
range `0x80`–`0xFF`, so they slipped past the guard and were written into the HTTP
header as raw bytes. ntfy treats header values as ASCII and renders those bytes as
`?`. The notification body was unaffected because it's the UTF-8 POST body, not a
header.

The fix lowers the threshold from `0xff` to `0x7f` so any non-ASCII character
triggers RFC 2047 base64 encoding (`=?UTF-8?B?…?=`), which ntfy decodes correctly.
`encodeHeaderValue` is the single chokepoint for the `Title` and `Click` headers,
so this is the right layer for the change.

## Related Issue or Discussion

Closes #1615

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective 
- [ ] I have updated documentation if needed