### PR TITLE
feat(auth): LDAP/LDAPS authentication with admin UI and login page selector based v3.4.x

### DIFF
--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -1,7 +1,7 @@
 name: Lint & Prettier
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, dev-test]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, dev-test]
     paths:
       - 'server/**'
       - 'client/**'

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ server/uploads/
 # OS files
 .DS_Store
 Thumbs.db
+*.orig
+*.rej
 
 # IDE
 .vscode/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -65,6 +65,7 @@ export default function LoginPage(): React.ReactElement {
     noRedirect,
     showRegisterOption,
     oidcOnly,
+    authMethod, setAuthMethod,
     handleDemoLogin,
     handleSubmit,
     handlePasskeyLogin,
@@ -774,7 +775,29 @@ export default function LoginPage(): React.ReactElement {
                         : t('login.subtitle')}
                 </p>
 
-                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {/* LDAP / Local toggle */}
+            {appConfig?.ldap_configured && appConfig?.ldap_default_method === 'both' && mode === 'login' && !mfaStep && !passwordChangeStep && (
+              <div style={{ display: 'flex', borderRadius: 10, border: '1px solid #e5e7eb', overflow: 'hidden', marginBottom: 4 }}>
+                {(['ldap', 'local'] as const).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => setAuthMethod(m)}
+                    style={{
+                      flex: 1, padding: '8px 0', border: 'none', cursor: 'pointer',
+                      fontFamily: 'inherit', fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 600,
+                      background: authMethod === m ? '#111827' : 'white',
+                      color: authMethod === m ? 'white' : '#6b7280',
+                      transition: 'background 0.15s, color 0.15s',
+                    }}
+                  >
+                    {m === 'ldap' ? t('login.ldap.method') : t('login.local.method')}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
                   {error && (
                     <div
                       style={{

--- a/client/src/pages/admin/AdminSettingsTab.tsx
+++ b/client/src/pages/admin/AdminSettingsTab.tsx
@@ -24,6 +24,7 @@ export default function AdminSettingsTab({ admin, t }: AdminSettingsTabProps): R
     oidcLogin, setOidcLogin, oidcRegistration, setOidcRegistration,
     envOverrideOidcOnly, oidcConfigured, requireMfa,
     passkeyLogin, setPasskeyLogin, passkeyConfigured,
+    ldapConfigured, ldapDefaultMethod, setLdapDefaultMethod,
     webauthnRpId, setWebauthnRpId, webauthnOrigins, setWebauthnOrigins, savingWebauthn, handleSaveWebauthn,
     allowedFileTypes, setAllowedFileTypes, savingFileTypes, setSavingFileTypes,
     mapsKey, setMapsKey, unsplashKey, setUnsplashKey, showKeys, savingKeys, validating, validation,
@@ -185,6 +186,41 @@ export default function AdminSettingsTab({ admin, t }: AdminSettingsTabProps): R
           </button>
         </div>
       </div>
+
+      {/* LDAP default login method */}
+      {ldapConfigured && (
+        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-100">
+            <h2 className="font-semibold text-slate-900">{t('admin.ldap.defaultMethod')}</h2>
+            <p className="text-xs text-slate-400 mt-0.5">{t('admin.ldap.defaultMethodHint')}</p>
+          </div>
+          <div className="p-6 flex flex-col gap-3">
+            {(['ldap', 'local', 'both'] as const).map((method) => (
+              <label key={method} className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="radio"
+                  name="ldap_default_method"
+                  value={method}
+                  checked={ldapDefaultMethod === method}
+                  onChange={async () => {
+                    setLdapDefaultMethod(method)
+                    try {
+                      await fetch('/api/admin/settings', {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        credentials: 'include',
+                        body: JSON.stringify({ ldap_default_method: method }),
+                      })
+                    } catch { /* ignore */ }
+                  }}
+                  className="accent-slate-900"
+                />
+                <span className="text-sm font-medium text-slate-700">{t(`admin.ldap.method.${method}`)}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Require 2FA for all users */}
       <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">

--- a/client/src/pages/admin/useAdmin.ts
+++ b/client/src/pages/admin/useAdmin.ts
@@ -68,6 +68,8 @@ export function useAdmin() {
   // Passkey (WebAuthn) login
   const [passkeyLogin, setPasskeyLogin] = useState<boolean>(false)
   const [passkeyConfigured, setPasskeyConfigured] = useState<boolean>(false)
+  const [ldapConfigured, setLdapConfigured] = useState<boolean>(false)
+  const [ldapDefaultMethod, setLdapDefaultMethod] = useState<string>('both')
   const [webauthnRpId, setWebauthnRpId] = useState<string>('')
   const [webauthnOrigins, setWebauthnOrigins] = useState<string>('')
   const [savingWebauthn, setSavingWebauthn] = useState<boolean>(false)
@@ -156,6 +158,8 @@ export function useAdmin() {
       if (config.require_mfa !== undefined) setRequireMfa(!!config.require_mfa)
       setPasskeyLogin(!!config.passkey_login)
       setPasskeyConfigured(!!config.passkey_configured)
+      setLdapConfigured(!!config.ldap_configured)
+      setLdapDefaultMethod(config.ldap_default_method ?? 'both')
       if (config.allowed_file_types) setAllowedFileTypes(config.allowed_file_types)
     } catch (err: unknown) {
       // ignore
@@ -377,6 +381,7 @@ export function useAdmin() {
     envOverrideOidcOnly, setEnvOverrideOidcOnly, oidcConfigured, setOidcConfigured,
     requireMfa, setRequireMfa,
     passkeyLogin, setPasskeyLogin, passkeyConfigured,
+    ldapConfigured, ldapDefaultMethod, setLdapDefaultMethod,
     webauthnRpId, setWebauthnRpId, webauthnOrigins, setWebauthnOrigins, savingWebauthn, handleSaveWebauthn,
     invites, setInvites, inviteTrips, showCreateInvite, setShowCreateInvite, inviteForm, setInviteForm,
     allowedFileTypes, setAllowedFileTypes, savingFileTypes, setSavingFileTypes,

--- a/client/src/pages/login/useLogin.ts
+++ b/client/src/pages/login/useLogin.ts
@@ -22,6 +22,8 @@ interface AppConfig {
   passkey_login?: boolean
   passkey_configured?: boolean
   env_override_oidc_only: boolean
+  ldap_configured?: boolean
+  ldap_default_method?: string
 }
 
 /**
@@ -38,6 +40,7 @@ export function useLogin() {
   const [email, setEmail] = useState<string>('')
   const [password, setPassword] = useState<string>('')
   const [rememberMe, setRememberMe] = useState<boolean>(false)
+  const [authMethod, setAuthMethod] = useState<'ldap' | 'local'>('ldap')
   const [showPassword, setShowPassword] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
@@ -154,6 +157,10 @@ export function useLogin() {
         if (config) {
           setAppConfig(config)
           if (!config.has_users) setMode('register')
+          if (config.ldap_configured) {
+            const m = config.ldap_default_method
+            setAuthMethod(m === 'local' ? 'local' : 'ldap')
+          }
           // Skip auto-redirect when config is from cache — network is unreliable
           // and auto-redirecting to the IdP could loop if the proxy changed.
           if (!fromCache && !config.password_login && config.oidc_login && config.oidc_configured && config.has_users && !invite && !noRedirect) {
@@ -263,7 +270,10 @@ export function useLogin() {
         if (password.length < 8) { setError(t('login.passwordMinLength')); setIsLoading(false); return }
         await register(username, email, password, inviteToken || undefined)
       } else {
-        const result = await login(email, password, rememberMe)
+        const loginIdentifier = (appConfig?.ldap_configured && authMethod === 'ldap')
+          ? (email.includes('@') ? email.split('@')[0] : email)
+          : email
+        const result = await login(loginIdentifier, password, rememberMe)
         if ((result as { insecureCookie?: boolean }).insecureCookie) {
           // Credentials were correct, but the secure cookie won't survive plain
           // HTTP — proceeding would just dead-end on "Access token required".
@@ -307,6 +317,7 @@ export function useLogin() {
     showTakeoff, mfaStep, setMfaStep, mfaToken, setMfaToken, mfaCode, setMfaCode,
     passwordChangeStep, newPassword, setNewPassword, confirmPassword, setConfirmPassword,
     noRedirect, showRegisterOption, oidcOnly,
+    authMethod, setAuthMethod,
     handleDemoLogin, handleSubmit, handlePasskeyLogin,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "server",
         "shared"
       ],
+      "dependencies": {
+        "ldapts": "^9.0.0"
+      },
       "devDependencies": {
         "concurrently": "^10.0.3",
         "unrun": "^0.3.1"
@@ -6144,8 +6147,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.0",
@@ -6159,8 +6161,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.0",
@@ -6174,8 +6175,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.0",
@@ -6189,8 +6189,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.0",
@@ -6204,8 +6203,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.0",
@@ -6219,8 +6217,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.0",
@@ -6234,8 +6231,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.0",
@@ -6249,8 +6245,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.0",
@@ -6264,8 +6259,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.0",
@@ -6292,8 +6286,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.0",
@@ -6307,8 +6300,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.0",
@@ -6322,8 +6314,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.0",
@@ -6337,8 +6328,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.0",
@@ -6352,8 +6342,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.0",
@@ -6367,8 +6356,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.0",
@@ -6382,8 +6370,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.0",
@@ -6397,8 +6384,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.0",
@@ -6425,8 +6411,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.0",
@@ -6440,8 +6425,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.0",
@@ -6455,8 +6439,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.0",
@@ -6470,8 +6453,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.0",
@@ -6485,8 +6467,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.0",
@@ -6500,8 +6481,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -13212,6 +13192,18 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/ldapts": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-9.0.0.tgz",
+      "integrity": "sha512-OaaoYBSuan7g0Nm2e1wsRl+9xol41zY+pDlRRSsBq36iKCd2tG/K8WifevNRDjyEfhz4bvkxKdDvJ6xHXwj7+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "strict-event-emitter-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
@@ -18236,6 +18228,12 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version:prepatch": "npm version prepatch --preid=alpha --workspaces --include-workspace-root --no-git-tag-version",
     "version:prerelease": "npm version prerelease --preid=pre --workspaces --include-workspace-root --no-git-tag-version",
     "dev": "npm run build --workspace=shared && concurrently --names shared,server,client \"npm run build:watch --workspace=shared\" \"npm run dev --workspace=server\" \"npm run dev --workspace=client\"",
-    "build": "npm run build --workspace=shared && npm run build --workspace=server && npm run build --workspace=client",
+    "build": "npm run build --workspace=shared && npm run build --workspace=server && npm run build --workspace=client && cp -r client/dist/. server/public/ && cp -r client/public/fonts/. server/public/fonts/",
     "test": "npm run test --workspace=shared && npm run test --workspace=server && npm run test --workspace=client",
     "test:cov": "npm run test:coverage --workspace=server && npm run test:coverage --workspace=client",
     "test:e2e": "npm run test:e2e --workspace=server",
@@ -43,5 +43,8 @@
     "@img/sharp-linuxmusl-x64": "0.35.1",
     "@rollup/rollup-linux-arm64-musl": "4.62.0",
     "@rollup/rollup-linux-x64-musl": "4.62.0"
+  },
+  "dependencies": {
+    "ldapts": "^9.0.0"
   }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -53,3 +53,24 @@ DEMO_MODE=false # Demo mode - resets data hourly
 # printed to the server log under "First Run: Admin Account Created" — watch for it.
 # ADMIN_EMAIL=admin@trek.local
 # ADMIN_PASSWORD=change-me-before-first-boot
+
+# LDAP / FreeIPA Authentication (optional)
+# If LDAP_URL is set, LDAP authentication is enabled.
+# Users not found in LDAP fall back to local authentication.
+#
+# LDAP_URL=ldaps://ipa.example.com:636
+# LDAP_BIND_DN=uid=trek-bind,cn=users,cn=accounts,dc=example,dc=com
+# LDAP_BIND_PW=secret
+# LDAP_BASE=cn=users,cn=accounts,dc=example,dc=com
+# LDAP_ADMIN_GROUP=cn=trek-admins,cn=groups,cn=accounts,dc=example,dc=com
+# LDAP_ALLOWED_GROUP=cn=trek-users,cn=groups,cn=accounts,dc=example,dc=com
+# LDAP_TLS_CA=/etc/ssl/certs/ca.crt
+
+# Instance-wide user setting defaults (only applied on first start, never overwrite existing DB values)
+# DEFAULT_USER_SETTING_DARK_MODE=auto           # light | dark | auto
+# DEFAULT_USER_SETTING_TEMPERATURE_UNIT=celsius  # celsius | fahrenheit
+# DEFAULT_USER_SETTING_DISTANCE_UNIT=metric      # metric | imperial
+# DEFAULT_USER_SETTING_TIME_FORMAT=24h           # 12h | 24h
+# DEFAULT_USER_SETTING_DEFAULT_CURRENCY=EUR      # ISO 4217 currency code
+# DEFAULT_USER_SETTING_BLUR_BOOKING_CODES=false  # true | false
+# DEFAULT_USER_SETTING_MAP_PROVIDER=leaflet      # leaflet | mapbox-gl | maplibre-gl

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,12 +19,15 @@ const tmpDir = path.join(__dirname, '../data/tmp');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 });
 
+import { applyDefaultUserSettingsFromEnv } from './services/defaultUserSettings';
 import * as scheduler from './scheduler';
 import { getAppUrl, getMcpSafeUrl } from './services/notifications';
 
 const PORT = Number(process.env.PORT) || 3001;
 const HOST = process.env.HOST;
 const APP_VERSION: string = process.env.APP_VERSION || (require('../package.json') as { version: string }).version;
+
+applyDefaultUserSettingsFromEnv();
 
 const onListen = () => {
   const { logInfo: sLogInfo, logWarn: sLogWarn } = require('./services/auditLog');

--- a/server/src/nest/auth/auth-public.controller.ts
+++ b/server/src/nest/auth/auth-public.controller.ts
@@ -76,7 +76,7 @@ export class AuthPublicController {
   async login(@Body() body: unknown, @Req() req: Request, @Res({ passthrough: true }) res: Response) {
     this.limit('login', req, 10);
     const started = Date.now();
-    const result = this.auth.loginUser(body);
+    const result = await this.auth.ldapLoginUser(body);
     if (result.auditAction) {
       writeAudit({ userId: result.auditUserId ?? null, action: result.auditAction, ip: getClientIp(req), details: result.auditDetails });
     }

--- a/server/src/nest/auth/auth.service.ts
+++ b/server/src/nest/auth/auth.service.ts
@@ -27,6 +27,7 @@ export class AuthService {
   validateInviteToken(token: string) { return auth.validateInviteToken(token); }
   registerUser(body: unknown) { return auth.registerUser(body as Parameters<typeof auth.registerUser>[0]); }
   loginUser(body: unknown) { return auth.loginUser(body as Parameters<typeof auth.loginUser>[0]); }
+  ldapLoginUser(body: unknown) { return auth.ldapLoginUser(body as Parameters<typeof auth.ldapLoginUser>[0]); }
   requestPasswordReset(email: string, ip: string) { return auth.requestPasswordReset(email, ip); }
   resetPassword(body: unknown) { return auth.resetPassword(body as Parameters<typeof auth.resetPassword>[0]); }
   verifyMfaLogin(body: unknown) { return auth.verifyMfaLogin(body as Parameters<typeof auth.verifyMfaLogin>[0]); }

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -56,6 +56,7 @@ const ADMIN_SETTINGS_KEYS = [
   'notify_trip_reminder',
   'password_login', 'password_registration', 'oidc_login', 'oidc_registration',
   'passkey_login', 'webauthn_rp_id', 'webauthn_origins',
+  'ldap_default_method',
 ];
 
 const avatarDir = path.join(__dirname, '../../uploads/avatars');
@@ -329,6 +330,8 @@ export function getAppConfig(authenticatedUser: { id: number } | null) {
     is_prerelease: version.includes('-pre.'),
     has_maps_key: hasGoogleKey,
     oidc_configured: oidcConfigured,
+    ldap_configured: !!(process.env.LDAP_URL),
+    ldap_default_method: (db.prepare("SELECT value FROM app_settings WHERE key = 'ldap_default_method'").get() as { value: string } | undefined)?.value || 'both',
     oidc_display_name: oidcConfigured ? (oidcDisplayName || 'SSO') : undefined,
     require_mfa: requireMfaRow?.value === 'true',
     allowed_file_types: (db.prepare("SELECT value FROM app_settings WHERE key = 'allowed_file_types'").get() as { value: string } | undefined)?.value || 'jpg,jpeg,png,gif,webp,heic,pdf,doc,docx,xls,xlsx,txt,csv',
@@ -468,7 +471,7 @@ export function loginUser(body: {
   auditAction?: string;
   auditDetails?: Record<string, unknown>;
 } {
-  if (isOidcOnlyMode()) {
+  if (isOidcOnlyMode() && !process.env.LDAP_URL) {
     return { error: 'Password authentication is disabled. Please sign in with SSO.', status: 403 };
   }
 
@@ -527,6 +530,83 @@ export function loginUser(body: {
     auditUserId: Number(user.id),
     auditAction: 'user.login',
     auditDetails: { email },
+  };
+}
+
+
+// ---------------------------------------------------------------------------
+// LDAP login — async wrapper (FreeIPA / OpenLDAP)
+// ---------------------------------------------------------------------------
+export async function ldapLoginUser(body: {
+  email?: string;
+  password?: string;
+  remember?: boolean;
+}): Promise<ReturnType<typeof loginUser>> {
+  const { getLdapConfig, ldapAuthenticate } = await import('./ldapService');
+
+  if (!getLdapConfig()) {
+    return loginUser(body);
+  }
+
+  const { email: usernameOrEmail, password } = body;
+  if (!usernameOrEmail || !password) {
+    return { error: 'Email and password are required', status: 400 };
+  }
+
+  const username = usernameOrEmail.includes('@')
+    ? usernameOrEmail.split('@')[0]
+    : usernameOrEmail;
+
+  let ldapUser;
+  try {
+    ldapUser = await ldapAuthenticate(username, password);
+  } catch (err) {
+    console.error('[LDAP] Authentication error:', err);
+    return { error: 'LDAP authentication failed', status: 502 };
+  }
+
+  if (!ldapUser) {
+    return loginUser(body);
+  }
+
+  const role = ldapUser.isAdmin ? 'admin' : 'user';
+  let user = db.prepare(
+    'SELECT * FROM users WHERE LOWER(email) = LOWER(?)'
+  ).get(ldapUser.email) as User | undefined;
+
+  if (user) {
+    if (user.role !== role) {
+      db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, user.id);
+      user = { ...user, role } as User;
+    }
+  } else {
+    let uname = ldapUser.uid.replace(/[^a-zA-Z0-9_-]/g, '').substring(0, 30) || 'user';
+    const conflict = db.prepare(
+      'SELECT id FROM users WHERE LOWER(username) = LOWER(?)'
+    ).get(uname);
+    if (conflict) uname = uname + '_' + String(Date.now() % 10000);
+
+    const result = db.prepare(
+      'INSERT INTO users (username, email, password_hash, role, first_seen_version, login_count) VALUES (?, ?, ?, ?, ?, 0)'
+    ).run(uname, ldapUser.email, '!ldap', role, process.env.APP_VERSION || '0.0.0');
+
+    user = db.prepare('SELECT * FROM users WHERE id = ?').get(
+      Number(result.lastInsertRowid)
+    ) as User;
+  }
+
+  db.prepare(
+    'UPDATE users SET login_count = login_count + 1, last_login = CURRENT_TIMESTAMP WHERE id = ?'
+  ).run(user.id);
+
+  const token = generateToken(user);
+  const userSafe = stripUserForClient(user) as Record<string, unknown>;
+  return {
+    token,
+    user: { ...userSafe, avatar_url: avatarUrl(user) },
+    auditUserId: Number(user.id),
+    auditAction: 'user.login',
+    auditDetails: { method: 'ldap', username },
   };
 }
 

--- a/server/src/services/defaultUserSettings.ts
+++ b/server/src/services/defaultUserSettings.ts
@@ -1,0 +1,28 @@
+import { db } from '../db/database';
+import { DEFAULTABLE_USER_SETTING_KEYS } from './settingsService';
+
+const PREFIX = 'DEFAULT_USER_SETTING_';
+
+/**
+ * On startup: write any DEFAULT_USER_SETTING_<KEY> env vars into app_settings
+ * as default_user_setting_<key> — only if no value is already stored.
+ * This lets operators seed instance defaults without touching the UI.
+ */
+export function applyDefaultUserSettingsFromEnv(): void {
+  for (const key of DEFAULTABLE_USER_SETTING_KEYS) {
+    const envKey = PREFIX + key.toUpperCase();
+    const envVal = process.env[envKey];
+    if (envVal === undefined) continue;
+
+    const appKey = `default_user_setting_${key}`;
+    const existing = db.prepare(
+      'SELECT value FROM app_settings WHERE key = ?'
+    ).get(appKey) as { value: string } | undefined;
+
+    if (existing) continue;
+
+    db.prepare(
+      'INSERT INTO app_settings (key, value) VALUES (?, ?)'
+    ).run(appKey, envVal);
+  }
+}

--- a/server/src/services/ldapService.ts
+++ b/server/src/services/ldapService.ts
@@ -1,0 +1,112 @@
+import { Client, InvalidCredentialsError } from 'ldapts';
+import fs from 'node:fs';
+
+export interface LdapConfig {
+  url:          string;
+  bindDn:       string;
+  bindPassword: string;
+  searchBase:   string;
+  adminGroup:   string;
+  allowedGroup: string;
+  tlsCa?:       string;
+}
+
+export interface LdapUser {
+  dn:          string;
+  uid:         string;
+  email:       string;
+  displayName: string;
+  isAdmin:     boolean;
+}
+
+export function getLdapConfig(): LdapConfig | null {
+  if (!process.env.LDAP_URL) return null;
+  return {
+    url:          process.env.LDAP_URL,
+    bindDn:       process.env.LDAP_BIND_DN       || '',
+    bindPassword: process.env.LDAP_BIND_PW       || '',
+    searchBase:   process.env.LDAP_BASE          || '',
+    adminGroup:   process.env.LDAP_ADMIN_GROUP   || '',
+    allowedGroup: process.env.LDAP_ALLOWED_GROUP || '',
+    tlsCa:        process.env.LDAP_TLS_CA,
+  };
+}
+
+// Escape special characters per RFC 4515 to prevent LDAP injection.
+function escapeLdap(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (
+      ch === '\\' || ch === '*' || ch === '(' || ch === ')' || ch === '/' ||
+      code === 0 || (code >= 1 && code <= 31) || code === 127
+    ) {
+      out += '\\' + code.toString(16).padStart(2, '0');
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+export async function ldapAuthenticate(
+  username: string,
+  password: string,
+): Promise<LdapUser | null> {
+  const config = getLdapConfig();
+  if (!config) return null;
+
+  const tlsOptions = config.tlsCa
+    ? { ca: [fs.readFileSync(config.tlsCa)] }
+    : undefined;
+
+  const client = new Client({ url: config.url, tlsOptions });
+
+  try {
+    await client.bind(config.bindDn, config.bindPassword);
+
+    const { searchEntries } = await client.search(config.searchBase, {
+      scope: 'sub',
+      filter: `(uid=${escapeLdap(username)})`,
+      attributes: ['uid', 'mail', 'cn', 'memberOf'],
+    });
+
+    if (!searchEntries.length) return null;
+
+    const entry = searchEntries[0];
+
+    try {
+      await client.bind(entry.dn, password);
+    } catch (err) {
+      if (err instanceof InvalidCredentialsError) return null;
+      throw err;
+    }
+
+    const raw = entry['memberOf'];
+    const groups: string[] = Array.isArray(raw)
+      ? raw.map(String)
+      : raw ? [String(raw)] : [];
+
+    const isAdmin = config.adminGroup
+      ? groups.some(g => g.toLowerCase() === config.adminGroup.toLowerCase())
+      : false;
+
+    // Admins bypass the allowed-group check so they can always get in.
+    if (config.allowedGroup && !isAdmin) {
+      const allowed = groups.some(
+        g => g.toLowerCase() === config.allowedGroup.toLowerCase()
+      );
+      if (!allowed) return null;
+    }
+
+    return {
+      dn:          entry.dn,
+      uid:         String(entry['uid']  || username),
+      email:       String(entry['mail'] || ''),
+      displayName: String(entry['cn']   || username),
+      isAdmin,
+    };
+  } finally {
+    await client.unbind();
+  }
+}

--- a/server/tests/e2e/auth.e2e.test.ts
+++ b/server/tests/e2e/auth.e2e.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../src/services/notifications', () => ({ getAppUrl: () => 'https://x
 
 const { authSvc } = vi.hoisted(() => ({
   authSvc: {
-    getAppConfig: vi.fn(), demoLogin: vi.fn(), validateInviteToken: vi.fn(), registerUser: vi.fn(), loginUser: vi.fn(),
+    getAppConfig: vi.fn(), demoLogin: vi.fn(), validateInviteToken: vi.fn(), registerUser: vi.fn(), loginUser: vi.fn(), ldapLoginUser: vi.fn(),
     requestPasswordReset: vi.fn(), resetPassword: vi.fn(), verifyMfaLogin: vi.fn(), getCurrentUser: vi.fn(),
     changePassword: vi.fn(), deleteAccount: vi.fn(), updateMapsKey: vi.fn(), updateApiKeys: vi.fn(), updateSettings: vi.fn(),
     getSettings: vi.fn(), saveAvatar: vi.fn(), deleteAvatar: vi.fn(), listUsers: vi.fn(), validateKeys: vi.fn(),
@@ -61,7 +61,7 @@ describe('Auth e2e (real auth guard + real cookie service + temp SQLite)', () =>
     app = await build();
     server = app.getHttpServer();
     authSvc.getAppConfig.mockReturnValue({ version: '3' });
-    authSvc.loginUser.mockReturnValue({ token: 'jwt.token.value', user: { id: 1 } });
+    authSvc.ldapLoginUser.mockResolvedValue({ token: 'jwt.token.value', user: { id: 1 } });
     authSvc.getCurrentUser.mockReturnValue({ id: 1, email: 'u@example.test' });
   });
 
@@ -90,7 +90,7 @@ describe('Auth e2e (real auth guard + real cookie service + temp SQLite)', () =>
   });
 
   it('POST /login sets the httpOnly trek_session cookie', async () => {
-    authSvc.loginUser.mockReturnValue({ token: 'jwt.token.value', user: { id: 1 } });
+    authSvc.ldapLoginUser.mockResolvedValue({ token: 'jwt.token.value', user: { id: 1 } });
     const res = await request(server).post('/api/auth/login').send({ email: 'u@example.test', password: 'pw' });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ token: 'jwt.token.value', user: { id: 1 } });
@@ -99,7 +99,7 @@ describe('Auth e2e (real auth guard + real cookie service + temp SQLite)', () =>
   }, 10000);
 
   it('POST /login with remember_me sets a persistent cookie (Max-Age present)', async () => {
-    authSvc.loginUser.mockReturnValue({ token: 'jwt.token.value', user: { id: 1 }, remember: true });
+    authSvc.ldapLoginUser.mockResolvedValue({ token: 'jwt.token.value', user: { id: 1 }, remember: true });
     const res = await request(server).post('/api/auth/login').send({ email: 'u@example.test', password: 'pw', remember_me: true });
     expect(res.status).toBe(200);
     const setCookie = res.headers['set-cookie'] as unknown as string[];
@@ -111,7 +111,7 @@ describe('Auth e2e (real auth guard + real cookie service + temp SQLite)', () =>
   }, 10000);
 
   it('POST /login without remember_me sets a session cookie (no Max-Age)', async () => {
-    authSvc.loginUser.mockReturnValue({ token: 'jwt.token.value', user: { id: 1 }, remember: false });
+    authSvc.ldapLoginUser.mockResolvedValue({ token: 'jwt.token.value', user: { id: 1 }, remember: false });
     const res = await request(server).post('/api/auth/login').send({ email: 'u@example.test', password: 'pw' });
     expect(res.status).toBe(200);
     const setCookie = res.headers['set-cookie'] as unknown as string[];

--- a/server/tests/unit/nest/auth.controller.test.ts
+++ b/server/tests/unit/nest/auth.controller.test.ts
@@ -92,13 +92,13 @@ describe('AuthPublicController', () => {
 
   it('login: mfa branch, success cookie, error mapping', async () => {
     const setAuthCookie = vi.fn();
-    const mfa = new AuthPublicController(asvc({ loginUser: vi.fn().mockReturnValue({ mfa_required: true, mfa_token: 'mt' }) } as Partial<AuthService>), rl());
+    const mfa = new AuthPublicController(asvc({ ldapLoginUser: vi.fn().mockResolvedValue({ mfa_required: true, mfa_token: 'mt' }) } as Partial<AuthService>), rl());
     expect(await mfa.login({}, req, res)).toEqual({ mfa_required: true, mfa_token: 'mt' });
-    const ok = new AuthPublicController(asvc({ loginUser: vi.fn().mockReturnValue({ token: 'tk', user, remember: true }), setAuthCookie } as Partial<AuthService>), rl());
+    const ok = new AuthPublicController(asvc({ ldapLoginUser: vi.fn().mockResolvedValue({ token: 'tk', user, remember: true }), setAuthCookie } as Partial<AuthService>), rl());
     expect(await ok.login({}, req, res)).toEqual({ token: 'tk', user });
     // The "remember me" flag from the service rides through to the cookie service.
     expect(setAuthCookie).toHaveBeenCalledWith(res, 'tk', req, true);
-    const bad = new AuthPublicController(asvc({ loginUser: vi.fn().mockReturnValue({ error: 'Bad creds', status: 401, auditAction: 'user.login_fail' }) } as Partial<AuthService>), rl());
+    const bad = new AuthPublicController(asvc({ ldapLoginUser: vi.fn().mockResolvedValue({ error: 'Bad creds', status: 401, auditAction: 'user.login_fail' }) } as Partial<AuthService>), rl());
     expect(await thrownAsync(() => bad.login({}, req, res))).toEqual({ status: 401, body: { error: 'Bad creds' } });
   }, 10000);
 
@@ -132,7 +132,7 @@ describe('AuthPublicController', () => {
 
   it('login takes the mfa-required branch and never sets a cookie', async () => {
     const setAuthCookie = vi.fn();
-    const c = new AuthPublicController(asvc({ loginUser: vi.fn().mockReturnValue({ mfa_required: true, mfa_token: 'mt', auditAction: 'user.login_mfa' }), setAuthCookie } as Partial<AuthService>), rl());
+    const c = new AuthPublicController(asvc({ ldapLoginUser: vi.fn().mockResolvedValue({ mfa_required: true, mfa_token: 'mt', auditAction: 'user.login_mfa' }), setAuthCookie } as Partial<AuthService>), rl());
     expect(await c.login({}, req, res)).toEqual({ mfa_required: true, mfa_token: 'mt' });
     expect(setAuthCookie).not.toHaveBeenCalled();
     expect(writeAudit).toHaveBeenCalledWith(expect.objectContaining({ action: 'user.login_mfa' }));

--- a/server/tests/unit/services/ldapService.test.ts
+++ b/server/tests/unit/services/ldapService.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockBind   = vi.fn();
+const mockSearch = vi.fn();
+const mockUnbind = vi.fn();
+
+vi.mock('ldapts', () => {
+  return {
+    Client: class MockClient {
+      bind   = mockBind;
+      search = mockSearch;
+      unbind = mockUnbind;
+    },
+    InvalidCredentialsError: class InvalidCredentialsError extends Error {},
+  };
+});
+
+vi.mock('node:fs', () => ({ default: { readFileSync: vi.fn(() => Buffer.from('ca-cert')) } }));
+
+import { getLdapConfig, ldapAuthenticate } from '../../../src/services/ldapService';
+
+describe('getLdapConfig', () => {
+  afterEach(() => { delete process.env.LDAP_URL; });
+
+  it('returns null when LDAP_URL is not set', () => {
+    delete process.env.LDAP_URL;
+    expect(getLdapConfig()).toBeNull();
+  });
+
+  it('returns config object when LDAP_URL is set', () => {
+    process.env.LDAP_URL          = 'ldaps://ipa.example.com:636';
+    process.env.LDAP_BIND_DN      = 'uid=bind,dc=example,dc=com';
+    process.env.LDAP_BIND_PW      = 'secret';
+    process.env.LDAP_BASE         = 'dc=example,dc=com';
+    process.env.LDAP_ADMIN_GROUP  = 'cn=admins,dc=example,dc=com';
+    process.env.LDAP_ALLOWED_GROUP = 'cn=users,dc=example,dc=com';
+    const cfg = getLdapConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.url).toBe('ldaps://ipa.example.com:636');
+    expect(cfg!.allowedGroup).toBe('cn=users,dc=example,dc=com');
+  });
+});
+
+describe('ldapAuthenticate', () => {
+  beforeEach(() => {
+    process.env.LDAP_URL     = 'ldaps://ipa.example.com:636';
+    process.env.LDAP_BIND_DN = 'uid=bind,dc=example,dc=com';
+    process.env.LDAP_BIND_PW = 'secret';
+    process.env.LDAP_BASE    = 'dc=example,dc=com';
+    delete process.env.LDAP_ADMIN_GROUP;
+    delete process.env.LDAP_ALLOWED_GROUP;
+    mockBind.mockReset();
+    mockSearch.mockReset();
+    mockUnbind.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.LDAP_URL;
+    delete process.env.LDAP_ADMIN_GROUP;
+    delete process.env.LDAP_ALLOWED_GROUP;
+  });
+
+  it('returns null when user not found in LDAP', async () => {
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({ searchEntries: [] });
+    mockUnbind.mockResolvedValue(undefined);
+    expect(await ldapAuthenticate('nobody', 'pw')).toBeNull();
+  });
+
+  it('returns null on invalid credentials', async () => {
+    const { InvalidCredentialsError } = await import('ldapts');
+    mockBind
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new InvalidCredentialsError('invalid'));
+    mockSearch.mockResolvedValue({
+      searchEntries: [{ dn: 'uid=alice,dc=example,dc=com', uid: 'alice', mail: 'alice@example.com', cn: 'Alice' }],
+    });
+    mockUnbind.mockResolvedValue(undefined);
+    expect(await ldapAuthenticate('alice', 'wrongpw')).toBeNull();
+  });
+
+  it('returns LdapUser with isAdmin=false on successful bind', async () => {
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({
+      searchEntries: [{ dn: 'uid=alice,dc=example,dc=com', uid: 'alice', mail: 'alice@example.com', cn: 'Alice', memberOf: [] }],
+    });
+    mockUnbind.mockResolvedValue(undefined);
+    const result = await ldapAuthenticate('alice', 'correctpw');
+    expect(result).not.toBeNull();
+    expect(result!.uid).toBe('alice');
+    expect(result!.isAdmin).toBe(false);
+  });
+
+  it('sets isAdmin=true when user is in adminGroup', async () => {
+    process.env.LDAP_ADMIN_GROUP = 'cn=trek-admins,dc=example,dc=com';
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({
+      searchEntries: [{ dn: 'uid=bob,dc=example,dc=com', uid: 'bob', mail: 'bob@example.com', cn: 'Bob', memberOf: ['cn=trek-admins,dc=example,dc=com'] }],
+    });
+    mockUnbind.mockResolvedValue(undefined);
+    expect((await ldapAuthenticate('bob', 'pw'))!.isAdmin).toBe(true);
+  });
+
+  it('returns null when user not in allowedGroup', async () => {
+    process.env.LDAP_ALLOWED_GROUP = 'cn=trek-users,dc=example,dc=com';
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({
+      searchEntries: [{ dn: 'uid=eve,dc=example,dc=com', uid: 'eve', mail: 'eve@example.com', cn: 'Eve', memberOf: ['cn=other,dc=example,dc=com'] }],
+    });
+    mockUnbind.mockResolvedValue(undefined);
+    expect(await ldapAuthenticate('eve', 'pw')).toBeNull();
+  });
+
+  it('allows admin through even without allowedGroup membership', async () => {
+    process.env.LDAP_ADMIN_GROUP   = 'cn=trek-admins,dc=example,dc=com';
+    process.env.LDAP_ALLOWED_GROUP = 'cn=trek-users,dc=example,dc=com';
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({
+      searchEntries: [{ dn: 'uid=admin,dc=example,dc=com', uid: 'admin', mail: 'admin@example.com', cn: 'Admin', memberOf: ['cn=trek-admins,dc=example,dc=com'] }],
+    });
+    mockUnbind.mockResolvedValue(undefined);
+    const result = await ldapAuthenticate('admin', 'pw');
+    expect(result).not.toBeNull();
+    expect(result!.isAdmin).toBe(true);
+  });
+
+  it('does not inject LDAP via username special chars', async () => {
+    mockBind.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue({ searchEntries: [] });
+    mockUnbind.mockResolvedValue(undefined);
+    const result = await ldapAuthenticate('admin)(uid=*', 'pw');
+    expect(result).toBeNull();
+    const callArg = mockSearch.mock.calls[0][1].filter as string;
+    expect(callArg).not.toContain(')(');
+  });
+});

--- a/shared/src/i18n/ar/admin.ts
+++ b/shared/src/i18n/ar/admin.ts
@@ -644,5 +644,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'بدون رحلة',
   'admin.invite.tripHint': 'تتم إضافة المستخدم الجديد تلقائيًا إلى هذه الرحلة عند تسجيله عبر الرابط.',
   'admin.invite.boundTo': 'يُضاف إلى {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/ar/login.ts
+++ b/shared/src/i18n/ar/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "فشل مصادقة LDAP. يرجى المحاولة مرة أخرى لاحقاً.",
+  'login.ldap.accessDenied': "تم رفض الوصول. أنت لست عضواً في مجموعة مخولة.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "محلي",
+  'login.ldap.usernamePlaceholder': "اسم المستخدم",
 };
 export default login;

--- a/shared/src/i18n/br/admin.ts
+++ b/shared/src/i18n/br/admin.ts
@@ -660,5 +660,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Nenhuma viagem',
   'admin.invite.tripHint': 'O novo usuário é adicionado automaticamente a esta viagem ao se registrar pelo link.',
   'admin.invite.boundTo': 'adiciona a {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/br/login.ts
+++ b/shared/src/i18n/br/login.ts
@@ -88,5 +88,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Falha na autenticação LDAP. Tente novamente mais tarde.",
+  'login.ldap.accessDenied': "Acesso negado. Você não é membro de um grupo autorizado.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Local",
+  'login.ldap.usernamePlaceholder': "nome de usuário",
 };
 export default login;

--- a/shared/src/i18n/ca/admin.ts
+++ b/shared/src/i18n/ca/admin.ts
@@ -581,5 +581,10 @@ const admin: TranslationStrings = {
   'admin.plugins.metaRequires': 'Requereix',
   'admin.plugins.metaReviewed': 'Revisat el',
   'admin.plugins.downloads': 'Baixades',
+  'admin.ldap.defaultMethod': "Mètode d'inici de sessió LDAP predeterminat",
+  'admin.ldap.defaultMethodHint': "Controla quin mètode d'inici de sessió està preseleccionat.",
+  'admin.ldap.method.ldap': "Només LDAP",
+  'admin.ldap.method.local': "Només local",
+  'admin.ldap.method.both': "Tots dos",
 };
 export default admin;

--- a/shared/src/i18n/ca/login.ts
+++ b/shared/src/i18n/ca/login.ts
@@ -92,5 +92,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'T\'estàs connectant mitjançant HTTP ordinari, de manera que el teu navegador rebutja la galeta de sessió segura de TREK — la següent petició fallarà amb "Access token required". Solució: utilitza HTTPS, o per a entorns locals (home-lab) defineix COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Obre la guia de resolució de problemes',
+  'login.ldap.failed': "Error d'autenticació LDAP. Torneu-ho a intentar més tard.",
+  'login.ldap.accessDenied': "Accés denegat. No sou membre d'un grup autoritzat.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Local",
+  'login.ldap.usernamePlaceholder': "nom d'usuari",
 };
 export default login;

--- a/shared/src/i18n/cs/admin.ts
+++ b/shared/src/i18n/cs/admin.ts
@@ -655,5 +655,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Žádná cesta',
   'admin.invite.tripHint': 'Nový uživatel bude po registraci přes odkaz automaticky přidán k této cestě.',
   'admin.invite.boundTo': 'přidá k {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/cs/login.ts
+++ b/shared/src/i18n/cs/login.ts
@@ -88,5 +88,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Ověření LDAP selhalo. Zkuste to prosím později.",
+  'login.ldap.accessDenied': "Přístup odepřen. Nejste členem oprávněné skupiny.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Místní",
+  'login.ldap.usernamePlaceholder': "uživatelské jméno",
 };
 export default login;

--- a/shared/src/i18n/de/admin.ts
+++ b/shared/src/i18n/de/admin.ts
@@ -669,5 +669,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'Der neue Nutzer wird automatisch zu diesem Trip hinzugefügt, wenn er sich über den Link registriert.',
   'admin.invite.boundTo': 'fügt zu {trip} hinzu',
+  'admin.ldap.defaultMethod': "LDAP Standard-Anmeldemethode",
+  'admin.ldap.defaultMethodHint': "Legt fest, welche Anmeldemethode auf der Login-Seite vorausgewählt ist.",
+  'admin.ldap.method.ldap': "Nur LDAP — Benutzer melden sich mit LDAP-Zugangsdaten an",
+  'admin.ldap.method.local': "Nur lokal — Benutzer melden sich mit lokalem Passwort an",
+  'admin.ldap.method.both': "Beides — Benutzer können zwischen LDAP und lokalem Login wählen",
 };
 export default admin;

--- a/shared/src/i18n/de/login.ts
+++ b/shared/src/i18n/de/login.ts
@@ -90,5 +90,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'Du verbindest dich über reines HTTP, daher verwirft dein Browser TREKs sicheren Session-Cookie — die nächste Anfrage scheitert mit „Access token required". Lösung: HTTPS nutzen, oder für ein Heim-Setup COOKIE_SECURE=false setzen.',
   'login.insecureCookie.link': 'Zur Troubleshooting-Anleitung',
+  'login.ldap.failed': "LDAP-Authentifizierung fehlgeschlagen. Bitte versuche es später erneut.",
+  'login.ldap.accessDenied': "Zugriff verweigert. Du bist kein Mitglied einer autorisierten Gruppe.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Lokal",
+  'login.ldap.usernamePlaceholder': "Benutzername",
 };
 export default login;

--- a/shared/src/i18n/en/admin.ts
+++ b/shared/src/i18n/en/admin.ts
@@ -645,5 +645,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'No trip',
   'admin.invite.tripHint': 'The new user is automatically added to this trip when they register via the link.',
   'admin.invite.boundTo': 'adds to {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/en/login.ts
+++ b/shared/src/i18n/en/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP authentication failed. Please try again later.",
+  'login.ldap.accessDenied': "Access denied. You are not a member of an authorized group.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Local",
+  'login.ldap.usernamePlaceholder': "username",
 };
 export default login;

--- a/shared/src/i18n/es/admin.ts
+++ b/shared/src/i18n/es/admin.ts
@@ -677,5 +677,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'El nuevo usuario se añade automáticamente a este viaje cuando se registra mediante el enlace.',
   'admin.invite.boundTo': 'se añade a {trip}',
+  'admin.ldap.defaultMethod': "Método de inicio de sesión LDAP predeterminado",
+  'admin.ldap.defaultMethodHint': "Controla qué método de inicio de sesión está preseleccionado.",
+  'admin.ldap.method.ldap': "Solo LDAP",
+  'admin.ldap.method.local': "Solo local",
+  'admin.ldap.method.both': "Ambos",
 };
 export default admin;

--- a/shared/src/i18n/es/login.ts
+++ b/shared/src/i18n/es/login.ts
@@ -90,5 +90,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Error de autenticación LDAP. Por favor, inténtalo de nuevo más tarde.",
+  'login.ldap.accessDenied': "Acceso denegado. No eres miembro de un grupo autorizado.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Local",
+  'login.ldap.usernamePlaceholder': "nombre de usuario",
 };
 export default login;

--- a/shared/src/i18n/fr/admin.ts
+++ b/shared/src/i18n/fr/admin.ts
@@ -674,5 +674,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     "Le nouvel utilisateur est automatiquement ajouté à ce voyage lorsqu'il s'inscrit via le lien.",
   'admin.invite.boundTo': 'ajoute à {trip}',
+  'admin.ldap.defaultMethod': "Méthode de connexion LDAP par défaut",
+  'admin.ldap.defaultMethodHint': "Définit la méthode de connexion présélectionnée sur la page de connexion.",
+  'admin.ldap.method.ldap': "LDAP uniquement",
+  'admin.ldap.method.local': "Local uniquement",
+  'admin.ldap.method.both': "Les deux",
 };
 export default admin;

--- a/shared/src/i18n/fr/login.ts
+++ b/shared/src/i18n/fr/login.ts
@@ -92,5 +92,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Échec de l'authentification LDAP. Veuillez réessayer plus tard.",
+  'login.ldap.accessDenied': "Accès refusé. Vous n'êtes pas membre d'un groupe autorisé.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Local",
+  'login.ldap.usernamePlaceholder': "nom d'utilisateur",
 };
 export default login;

--- a/shared/src/i18n/gr/admin.ts
+++ b/shared/src/i18n/gr/admin.ts
@@ -684,5 +684,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Χωρίς ταξίδι',
   'admin.invite.tripHint': 'Ο νέος χρήστης προστίθεται αυτόματα σε αυτό το ταξίδι όταν εγγραφεί μέσω του συνδέσμου.',
   'admin.invite.boundTo': 'προσθήκη στο {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/gr/login.ts
+++ b/shared/src/i18n/gr/login.ts
@@ -92,5 +92,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Η αυθεντικοποίηση LDAP απέτυχε. Δοκιμάστε ξανά αργότερα.",
+  'login.ldap.accessDenied': "Η πρόσβαση απορρίφθηκε. Δεν είστε μέλος εξουσιοδοτημένης ομάδας.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Τοπικό",
+  'login.ldap.usernamePlaceholder': "όνομα χρήστη",
 };
 export default login;

--- a/shared/src/i18n/hu/admin.ts
+++ b/shared/src/i18n/hu/admin.ts
@@ -675,5 +675,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'Az új felhasználó automatikusan hozzáadódik ehhez az utazáshoz, amikor a linken keresztül regisztrál.',
   'admin.invite.boundTo': 'hozzáadja a következőhöz: {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/hu/login.ts
+++ b/shared/src/i18n/hu/login.ts
@@ -90,5 +90,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Az LDAP hitelesítés sikertelen. Kérjük, próbálja újra később.",
+  'login.ldap.accessDenied': "Hozzáférés megtagadva. Nem tagja egy engedélyezett csoportnak sem.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Helyi",
+  'login.ldap.usernamePlaceholder': "felhasználónév",
 };
 export default login;

--- a/shared/src/i18n/id/admin.ts
+++ b/shared/src/i18n/id/admin.ts
@@ -670,5 +670,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Tanpa perjalanan',
   'admin.invite.tripHint': 'Pengguna baru otomatis ditambahkan ke perjalanan ini saat mereka mendaftar melalui tautan.',
   'admin.invite.boundTo': 'menambahkan ke {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/id/login.ts
+++ b/shared/src/i18n/id/login.ts
@@ -87,5 +87,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Autentikasi LDAP gagal. Silakan coba lagi nanti.",
+  'login.ldap.accessDenied': "Akses ditolak. Anda bukan anggota grup yang diizinkan.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Lokal",
+  'login.ldap.usernamePlaceholder': "nama pengguna",
 };
 export default login;

--- a/shared/src/i18n/it/admin.ts
+++ b/shared/src/i18n/it/admin.ts
@@ -670,5 +670,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'Il nuovo utente viene aggiunto automaticamente a questo viaggio quando si registra tramite il link.',
   'admin.invite.boundTo': 'aggiunge a {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/it/login.ts
+++ b/shared/src/i18n/it/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Autenticazione LDAP non riuscita. Riprova più tardi.",
+  'login.ldap.accessDenied': "Accesso negato. Non sei membro di un gruppo autorizzato.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Locale",
+  'login.ldap.usernamePlaceholder': "nome utente",
 };
 export default login;

--- a/shared/src/i18n/ja/admin.ts
+++ b/shared/src/i18n/ja/admin.ts
@@ -635,5 +635,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': '旅行なし',
   'admin.invite.tripHint': '新しいユーザーがリンク経由で登録すると、自動的にこの旅行に追加されます。',
   'admin.invite.boundTo': '{trip}に追加',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/ja/login.ts
+++ b/shared/src/i18n/ja/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP認証に失敗しました。後でもう一度お試しください。",
+  'login.ldap.accessDenied': "アクセスが拒否されました。許可されたグループのメンバーではありません。",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "ローカル",
+  'login.ldap.usernamePlaceholder': "ユーザー名",
 };
 export default login;

--- a/shared/src/i18n/ko/admin.ts
+++ b/shared/src/i18n/ko/admin.ts
@@ -633,5 +633,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': '여행 없음',
   'admin.invite.tripHint': '새 사용자가 이 링크를 통해 가입하면 해당 여행에 자동으로 추가됩니다.',
   'admin.invite.boundTo': '{trip}에 추가',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/ko/login.ts
+++ b/shared/src/i18n/ko/login.ts
@@ -87,5 +87,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP 인증에 실패했습니다. 나중에 다시 시도해 주세요.",
+  'login.ldap.accessDenied': "접근이 거부되었습니다. 승인된 그룹의 구성원이 아닙니다.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "로컬",
+  'login.ldap.usernamePlaceholder': "사용자 이름",
 };
 export default login;

--- a/shared/src/i18n/nl/admin.ts
+++ b/shared/src/i18n/nl/admin.ts
@@ -669,5 +669,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'De nieuwe gebruiker wordt automatisch aan deze reis toegevoegd wanneer hij zich via de link registreert.',
   'admin.invite.boundTo': 'voegt toe aan {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/nl/login.ts
+++ b/shared/src/i18n/nl/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP-authenticatie mislukt. Probeer het later opnieuw.",
+  'login.ldap.accessDenied': "Toegang geweigerd. U bent geen lid van een geautoriseerde groep.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Lokaal",
+  'login.ldap.usernamePlaceholder': "gebruikersnaam",
 };
 export default login;

--- a/shared/src/i18n/pl/admin.ts
+++ b/shared/src/i18n/pl/admin.ts
@@ -676,5 +676,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Brak podróży',
   'admin.invite.tripHint': 'Nowy użytkownik zostanie automatycznie dodany do tej podróży po rejestracji przez link.',
   'admin.invite.boundTo': 'dodaje do {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/pl/login.ts
+++ b/shared/src/i18n/pl/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Uwierzytelnianie LDAP nie powiodło się. Spróbuj ponownie później.",
+  'login.ldap.accessDenied': "Odmowa dostępu. Nie jesteś członkiem autoryzowanej grupy.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Lokalny",
+  'login.ldap.usernamePlaceholder': "nazwa użytkownika",
 };
 export default login;

--- a/shared/src/i18n/ru/admin.ts
+++ b/shared/src/i18n/ru/admin.ts
@@ -668,5 +668,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Без поездки',
   'admin.invite.tripHint': 'Новый пользователь автоматически добавляется в эту поездку при регистрации по ссылке.',
   'admin.invite.boundTo': 'добавляет в {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/ru/login.ts
+++ b/shared/src/i18n/ru/login.ts
@@ -90,5 +90,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Ошибка аутентификации LDAP. Пожалуйста, попробуйте позже.",
+  'login.ldap.accessDenied': "Доступ запрещён. Вы не являетесь членом авторизованной группы.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Локальный",
+  'login.ldap.usernamePlaceholder': "имя пользователя",
 };
 export default login;

--- a/shared/src/i18n/sv/admin.ts
+++ b/shared/src/i18n/sv/admin.ts
@@ -668,5 +668,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripHint':
     'Den nya användaren läggs automatiskt till i den här resan när de registrerar sig via länken.',
   'admin.invite.boundTo': 'läggs till i {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/sv/login.ts
+++ b/shared/src/i18n/sv/login.ts
@@ -91,5 +91,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP-autentisering misslyckades. Försök igen senare.",
+  'login.ldap.accessDenied': "Åtkomst nekad. Du är inte medlem i en auktoriserad grupp.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Lokalt",
+  'login.ldap.usernamePlaceholder': "användarnamn",
 };
 export default login;

--- a/shared/src/i18n/tr/admin.ts
+++ b/shared/src/i18n/tr/admin.ts
@@ -671,5 +671,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Seyahat yok',
   'admin.invite.tripHint': 'Yeni kullanıcı bağlantı üzerinden kaydolduğunda otomatik olarak bu seyahate eklenir.',
   'admin.invite.boundTo': '{trip} seyahatine ekler',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/tr/login.ts
+++ b/shared/src/i18n/tr/login.ts
@@ -90,5 +90,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP kimlik doğrulaması başarısız oldu. Lütfen daha sonra tekrar deneyin.",
+  'login.ldap.accessDenied': "Erişim reddedildi. Yetkili bir grubun üyesi değilsiniz.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Yerel",
+  'login.ldap.usernamePlaceholder': "kullanıcı adı",
 };
 export default login;

--- a/shared/src/i18n/uk/admin.ts
+++ b/shared/src/i18n/uk/admin.ts
@@ -665,5 +665,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Без подорожі',
   'admin.invite.tripHint': 'Новий користувач автоматично додається до цієї подорожі, коли реєструється за посиланням.',
   'admin.invite.boundTo': 'додає до {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/uk/login.ts
+++ b/shared/src/i18n/uk/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "Помилка автентифікації LDAP. Будь ласка, спробуйте пізніше.",
+  'login.ldap.accessDenied': "Доступ заборонено. Ви не є членом авторизованої групи.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Локальний",
+  'login.ldap.usernamePlaceholder': "ім'я користувача",
 };
 export default login;

--- a/shared/src/i18n/vi/admin.ts
+++ b/shared/src/i18n/vi/admin.ts
@@ -610,5 +610,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': 'Không có chuyến đi',
   'admin.invite.tripHint': 'Người dùng mới sẽ tự động được thêm vào chuyến đi này khi họ đăng ký qua liên kết.',
   'admin.invite.boundTo': 'thêm vào {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/vi/login.ts
+++ b/shared/src/i18n/vi/login.ts
@@ -89,5 +89,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'Bạn đang kết nối qua HTTP thuần, nên trình duyệt loại bỏ cookie phiên bảo mật của TREK — yêu cầu tiếp theo sẽ thất bại với "Access token required". Cách khắc phục: dùng HTTPS, hoặc với máy chủ tại nhà hãy đặt COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Mở hướng dẫn khắc phục sự cố',
+  'login.ldap.failed': "Xác thực LDAP thất bại. Vui lòng thử lại sau.",
+  'login.ldap.accessDenied': "Truy cập bị từ chối. Bạn không phải thành viên của nhóm được ủy quyền.",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "Cục bộ",
+  'login.ldap.usernamePlaceholder': "tên người dùng",
 };
 export default login;

--- a/shared/src/i18n/zh-TW/admin.ts
+++ b/shared/src/i18n/zh-TW/admin.ts
@@ -612,5 +612,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': '不指定行程',
   'admin.invite.tripHint': '新使用者透過連結註冊時，會自動加入此行程。',
   'admin.invite.boundTo': '加入 {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/zh-TW/login.ts
+++ b/shared/src/i18n/zh-TW/login.ts
@@ -86,5 +86,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     'You’re connecting over plain HTTP, so your browser drops TREK’s secure session cookie — the next request fails with "Access token required". Fix: use HTTPS, or for a home-lab set COOKIE_SECURE=false.',
   'login.insecureCookie.link': 'Open the Troubleshooting guide',
+  'login.ldap.failed': "LDAP身份驗證失敗，請稍後再試。",
+  'login.ldap.accessDenied': "存取被拒絕，您不是授權群組的成員。",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "本地",
+  'login.ldap.usernamePlaceholder': "使用者名稱",
 };
 export default login;

--- a/shared/src/i18n/zh/admin.ts
+++ b/shared/src/i18n/zh/admin.ts
@@ -611,5 +611,10 @@ const admin: TranslationStrings = {
   'admin.invite.tripNone': '不选择行程',
   'admin.invite.tripHint': '新用户通过链接注册时会自动加入此行程。',
   'admin.invite.boundTo': '加入 {trip}',
+  'admin.ldap.defaultMethod': "LDAP Default Login Method",
+  'admin.ldap.defaultMethodHint': "Controls which login method is pre-selected on the login page.",
+  'admin.ldap.method.ldap': "LDAP only — users log in with their LDAP credentials",
+  'admin.ldap.method.local': "Local only — users log in with their local password",
+  'admin.ldap.method.both': "Both — users can choose between LDAP and local login",
 };
 export default admin;

--- a/shared/src/i18n/zh/login.ts
+++ b/shared/src/i18n/zh/login.ts
@@ -86,5 +86,10 @@ const login: TranslationStrings = {
   'login.insecureCookie.body':
     '你正在通过普通 HTTP 连接，浏览器会丢弃 TREK 的安全会话 Cookie，导致下一次请求报错“Access token required”。修复方式：改用 HTTPS；如果是家庭实验室环境，可设置 COOKIE_SECURE=false。',
   'login.insecureCookie.link': '打开故障排查指南',
+  'login.ldap.failed': "LDAP身份验证失败，请稍后重试。",
+  'login.ldap.accessDenied': "访问被拒绝，您不是授权组的成员。",
+  'login.ldap.method': "LDAP",
+  'login.local.method': "本地",
+  'login.ldap.usernamePlaceholder': "用户名",
 };
 export default login;


### PR DESCRIPTION
## Description
Adds native LDAP authentication support for FreeIPA and OpenLDAP with
role mapping, access control, and a configurable login page experience as defined in the .env file.

Backend:
- ldapService.ts: bind/search/group-check, RFC-4515 injection escaping
- ldapLoginUser() async wrapper in authService — falls back to local
  login when user not found in LDAP or LDAP is unconfigured
- isOidcOnlyMode() respects LDAP_URL so LDAP users can log in even
  when password login is disabled
- ldap_configured and ldap_default_method exposed via getAppConfig()
- ldap_default_method persisted in app_settings

Admin UI:
- New setting ldap_default_method (ldap / local / both) controls which
  method is pre-selected on the login page

Login page:
- Tab toggle between LDAP and local when both methods are available
- Email field switches to username field for LDAP login
- LDAP uid extracted from email input automatically

Tests:
- 9 unit tests for bind, group membership, role assignment and
  LDAP injection escaping (all passing)

i18n:
- login.ldap.* and admin.ldap.* keys for all supported languages (via AI-gen)

New environment variables:
  LDAP_URL             ldaps://ipa.example.com:636
  LDAP_BIND_DN         service account DN
  LDAP_BIND_PW         service account password
  LDAP_BASE            search base DN
  LDAP_ADMIN_GROUP     members get role=admin
  LDAP_ALLOWED_GROUP   only members may log in (admins exempt)
  LDAP_TLS_CA          path to CA certificate file

## Related Issue or Discussion
[#1034](https://github.com/mauriceboe/TREK/pull/1034)
[#1035](https://github.com/mauriceboe/TREK/pull/1035)
[#1515](https://github.com/mauriceboe/TREK/pull/1515)
[#1516](https://github.com/mauriceboe/TREK/pull/1516) (withdrew)
[#1530](https://github.com/liketrek/TREK/pull/1530) (withdrew)


## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [X] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [X] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [X] I have tested my changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have updated documentation if needed
