### PR TITLE
fix(settings): retry settings load on reconnect so region prefs stop …

### DIFF
--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -52,21 +52,34 @@ export const DEFAULT_SETTINGS: Settings = {
   // chosen" (fall back to home + defaults) from an explicitly emptied list.
 }
 
+// De-dupe concurrent loads: the reconnection triggers (online / visibility /
+// periodic) can all fire a retry at once — collapse them into one in-flight GET.
+let _loadInFlight: Promise<void> | null = null
+
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   settings: { ...DEFAULT_SETTINGS },
   isLoaded: false,
 
   loadSettings: async () => {
-    try {
-      const data = await settingsApi.get()
-      set((state) => ({
-        settings: { ...state.settings, ...data.settings },
-        isLoaded: true,
-      }))
-    } catch (err: unknown) {
-      set({ isLoaded: true })
-      console.error('Failed to load settings:', err)
-    }
+    if (_loadInFlight) return _loadInFlight
+    _loadInFlight = (async () => {
+      try {
+        const data = await settingsApi.get()
+        set((state) => ({
+          settings: { ...state.settings, ...data.settings },
+          isLoaded: true,
+        }))
+      } catch (err: unknown) {
+        // Leave isLoaded false so a transient failure — offline at launch, or a
+        // (docker) server cold-start racing the first request — is retried on
+        // reconnect instead of stranding the user on built-in defaults (wrong
+        // currency/units) for the whole session (#1618).
+        console.error('Failed to load settings:', err)
+      } finally {
+        _loadInFlight = null
+      }
+    })()
+    return _loadInFlight
   },
 
   updateSetting: async (key: keyof Settings, value: Settings[keyof Settings]) => {

--- a/client/src/sync/syncTriggers.ts
+++ b/client/src/sync/syncTriggers.ts
@@ -17,6 +17,8 @@ import { tripSyncManager } from './tripSyncManager'
 import { isEffectivelyOnline, onNetworkModeChange } from './networkMode'
 import { setPreReconnectHook, setRefetchCallback, getActiveTrips } from '../api/websocket'
 import { useTripStore } from '../store/tripStore'
+import { useSettingsStore } from '../store/settingsStore'
+import { useAuthStore } from '../store/authStore'
 
 const PERIODIC_MS = 30_000
 
@@ -24,6 +26,20 @@ let _intervalId: ReturnType<typeof setInterval> | null = null
 let _unsubscribeNetworkMode: (() => void) | null = null
 let _wasEffectivelyOnline = isEffectivelyOnline()
 let _registered = false
+
+/**
+ * User settings are loaded once on the auth transition (App.tsx), with no retry.
+ * If that single GET fails — offline at launch, or a server cold-start racing the
+ * first request — the store stays on built-in DEFAULT_SETTINGS and the user sees
+ * their currency/units/time-format "reset" for the whole session (#1618). Heal it
+ * on the same connectivity triggers that re-hydrate trips: retry until it loads.
+ */
+function ensureSettingsLoaded() {
+  if (!useAuthStore.getState().isAuthenticated) return
+  if (!isEffectivelyOnline()) return
+  if (useSettingsStore.getState().isLoaded) return
+  useSettingsStore.getState().loadSettings().catch(console.error)
+}
 
 /** Pull the latest server state for every open trip into the Zustand store. */
 function rehydrateActiveTrips() {
@@ -44,6 +60,7 @@ function onOnline() {
   // edits from the cache/UI. Stay put until the user lifts the switch (which
   // routes through onNetworkMode → here with the force flag already cleared).
   if (!isEffectivelyOnline()) return
+  ensureSettingsLoaded()
   mutationQueue.flush()
     .catch(console.error)
     .finally(() => {
@@ -55,6 +72,7 @@ function onOnline() {
 /** Tab became visible — flush only; don't trigger a potentially expensive syncAll. */
 function onVisibility() {
   if (!document.hidden && isEffectivelyOnline()) {
+    ensureSettingsLoaded()
     mutationQueue.flush().catch(console.error)
   }
 }
@@ -62,6 +80,7 @@ function onVisibility() {
 /** Periodic heartbeat — drain any lingering pending mutations. */
 function onPeriodic() {
   if (isEffectivelyOnline()) {
+    ensureSettingsLoaded()
     mutationQueue.flush().catch(console.error)
   }
 }

--- a/client/tests/unit/stores/settingsStore.test.ts
+++ b/client/tests/unit/stores/settingsStore.test.ts
@@ -66,7 +66,7 @@ describe('settingsStore', () => {
   });
 
   describe('FE-SETTINGS-005: loadSettings failure', () => {
-    it('sets isLoaded: true even on API failure (graceful)', async () => {
+    it('leaves isLoaded false on API failure so the load is retried (#1618)', async () => {
       server.use(
         http.get('/api/settings', () =>
           HttpResponse.json({ error: 'Server error' }, { status: 500 })
@@ -74,9 +74,31 @@ describe('settingsStore', () => {
       );
 
       await useSettingsStore.getState().loadSettings();
-      const state = useSettingsStore.getState();
 
+      // A transient failure must NOT be treated as "loaded" — otherwise the store
+      // stays on built-in DEFAULT_SETTINGS (wrong currency/units) for the whole
+      // session with no retry. isLoaded stays false so the reconnect triggers retry.
+      expect(useSettingsStore.getState().isLoaded).toBe(false);
+    });
+
+    it('recovers on a later retry after an initial failure (#1618)', async () => {
+      server.use(
+        http.get('/api/settings', () =>
+          HttpResponse.json({ error: 'Server error' }, { status: 500 })
+        )
+      );
+      await useSettingsStore.getState().loadSettings();
+      expect(useSettingsStore.getState().isLoaded).toBe(false);
+
+      const settings = buildSettings({ default_currency: 'EUR' });
+      server.use(
+        http.get('/api/settings', () => HttpResponse.json({ settings }))
+      );
+      await useSettingsStore.getState().loadSettings();
+
+      const state = useSettingsStore.getState();
       expect(state.isLoaded).toBe(true);
+      expect(state.settings.default_currency).toBe('EUR');
     });
   });
 

--- a/client/tests/unit/sync/syncTriggers.test.ts
+++ b/client/tests/unit/sync/syncTriggers.test.ts
@@ -9,9 +9,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const flush = vi.fn(() => Promise.resolve());
 const syncAll = vi.fn(() => Promise.resolve());
 const hydrate = vi.fn(() => Promise.resolve());
+const loadSettings = vi.fn(() => Promise.resolve());
 
 let refetchCb: ((tripId: string) => void) | null = null;
 let preReconnect: (() => Promise<void>) | null = null;
+let settingsLoaded = false;
+let authenticated = true;
 
 vi.mock('../../../src/sync/mutationQueue', () => ({
   mutationQueue: { flush: () => flush() },
@@ -27,6 +30,12 @@ vi.mock('../../../src/api/websocket', () => ({
 vi.mock('../../../src/store/tripStore', () => ({
   useTripStore: { getState: () => ({ hydrateActiveTrip: hydrate }) },
 }));
+vi.mock('../../../src/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ isLoaded: settingsLoaded, loadSettings }) },
+}));
+vi.mock('../../../src/store/authStore', () => ({
+  useAuthStore: { getState: () => ({ isAuthenticated: authenticated }) },
+}));
 
 import { registerSyncTriggers, unregisterSyncTriggers } from '../../../src/sync/syncTriggers';
 
@@ -35,8 +44,9 @@ const flushMicrotasks = async () => {
 };
 
 beforeEach(() => {
-  flush.mockClear(); syncAll.mockClear(); hydrate.mockClear();
+  flush.mockClear(); syncAll.mockClear(); hydrate.mockClear(); loadSettings.mockClear();
   refetchCb = null; preReconnect = null;
+  settingsLoaded = false; authenticated = true;
   Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true });
 });
 
@@ -72,5 +82,31 @@ describe('syncTriggers', () => {
     expect(flush).toHaveBeenCalled();
     expect(syncAll).toHaveBeenCalled();
     expect(hydrate).toHaveBeenCalledWith('7');
+  });
+
+  it('online event retries the settings load when it has not yet succeeded (#1618)', async () => {
+    registerSyncTriggers();
+    window.dispatchEvent(new Event('online'));
+    await flushMicrotasks();
+
+    expect(loadSettings).toHaveBeenCalled();
+  });
+
+  it('does not retry the settings load once it has loaded', async () => {
+    settingsLoaded = true;
+    registerSyncTriggers();
+    window.dispatchEvent(new Event('online'));
+    await flushMicrotasks();
+
+    expect(loadSettings).not.toHaveBeenCalled();
+  });
+
+  it('does not retry the settings load while unauthenticated', async () => {
+    authenticated = false;
+    registerSyncTriggers();
+    window.dispatchEvent(new Event('online'));
+    await flushMicrotasks();
+
+    expect(loadSettings).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

User settings load **exactly once**, on the `isAuthenticated` transition (`client/src/App.tsx:170-176`), with no retry, and the store is seeded with built-in `DEFAULT_SETTINGS` (`client/src/store/settingsStore.ts:30-53` — `default_currency: ''`, `celsius`, `24h`). When that single `GET /settings` failed — the app briefly offline at launch, or (notably for Docker Compose deployments) the server cold-starting and racing the first request — the old catch at `settingsStore.ts:66-69` swallowed the error and set `isLoaded: true`, leaving the store on defaults.

The reconnection triggers in `client/src/sync/syncTriggers.ts` re-flush mutations and re-hydrate **trip** data on `online` / visibility / WS-reconnect, but never re-ran `loadSettings` — so the store stayed on defaults for the entire session. The dashboard then rendered each trip's own currency (`CostsPanel.tsx:130`, USD → `$`) because `default_currency` was empty, and the Settings page showed every Language & region pref at its default. The server value was never lost; re-selecting values just repopulated the in-memory store, which is why it appeared to "reset" intermittently and self-heal on re-entry (#1618).

The fix, at the connectivity layer where trip rehydration already lives:

- **`settingsStore.ts`** — on a failed load, keep `isLoaded: false` (so a transient failure is known, not masked as loaded) and de-dupe concurrent loads with an in-flight guard.
- **`syncTriggers.ts`** — add `ensureSettingsLoaded()` to the `online` / `visibilitychange` / periodic-30s triggers, gated on authenticated + effectively-online + not-yet-loaded. This heals a failed initial load on reconnect. `online` covers offline-at-launch; visibility/periodic cover the Docker cold-start case where the browser never lost connectivity (so no `online` event fires).

## Related Issue or Discussion

Closes #1618

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [ ] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed