### PR TITLE
fix(llm-parse): tolerate non-strict JSON from Gemini and similar models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6144,7 +6144,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.0",
@@ -6158,7 +6159,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.0",
@@ -6172,7 +6174,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.0",
@@ -6186,7 +6189,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.0",
@@ -6200,7 +6204,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.0",
@@ -6214,7 +6219,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.0",
@@ -6228,7 +6234,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.0",
@@ -6242,7 +6249,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.0",
@@ -6256,7 +6264,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.0",
@@ -6283,7 +6292,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.0",
@@ -6297,7 +6307,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.0",
@@ -6311,7 +6322,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.0",
@@ -6325,7 +6337,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.0",
@@ -6339,7 +6352,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.0",
@@ -6353,7 +6367,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.0",
@@ -6367,7 +6382,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.0",
@@ -6381,7 +6397,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.0",
@@ -6408,7 +6425,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.0",
@@ -6422,7 +6440,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.0",
@@ -6436,7 +6455,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.0",
@@ -6450,7 +6470,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.0",
@@ -6464,7 +6485,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.0",
@@ -6478,7 +6500,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21232,6 +21232,7 @@
         "fast-xml-parser": "^5.5.10",
         "helmet": "^8.1.0",
         "jimp": "^1.6.1",
+        "json5": "^2.2.3",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^4.2.1",
         "nodemailer": "^9.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "fast-xml-parser": "^5.5.10",
     "helmet": "^8.1.0",
     "jimp": "^1.6.1",
+    "json5": "^2.2.3",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^4.2.1",
     "nodemailer": "^9.0.1",

--- a/server/src/nest/llm-parse/clients/openai-compatible.client.ts
+++ b/server/src/nest/llm-parse/clients/openai-compatible.client.ts
@@ -1,5 +1,6 @@
 import type { LlmExtractionClient, LlmExtractionInput } from '../llm-provider.interface';
 import { isNuExtractModel, buildNuExtractUserText, nuExtractToKiReservations } from './nuextract';
+import { parseLenientJson } from '../lenient-json';
 import { safeFetchLlm } from '../../../utils/ssrfGuard';
 
 // Generous: a local CPU model (Ollama, no GPU) may cold-load several GB and then
@@ -110,27 +111,16 @@ export class OpenAiCompatibleClient implements LlmExtractionClient {
   }
 }
 
-/** Strip code fences and JSON.parse; `null` on failure. */
-function parseJson(content: string | undefined | null): unknown {
-  if (!content) return null;
-  const stripped = content.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
-  try {
-    return JSON.parse(stripped);
-  } catch {
-    return null;
-  }
-}
-
 /** Parse a NuExtract response and map its flat template output to KiReservation nodes. */
 function parseNuExtract(content: string | undefined | null): Record<string, unknown>[] {
-  return nuExtractToKiReservations(parseJson(content));
+  return nuExtractToKiReservations(parseLenientJson(content));
 }
 
 const USER_TEXT = 'Extract every travel reservation from the following document as schema.org JSON-LD.';
 
-/** Tolerant parse: strip code fences, JSON.parse, pull `reservations`. `[]` on failure. */
+/** Tolerant parse: strip code fences, JSON(5).parse, pull `reservations`. `[]` on failure. */
 function parseReservations(content: string | undefined | null): Record<string, unknown>[] {
-  const parsed = parseJson(content);
+  const parsed = parseLenientJson(content);
   if (Array.isArray(parsed)) return parsed as Record<string, unknown>[];
   if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { reservations?: unknown }).reservations)) {
     return (parsed as { reservations: Record<string, unknown>[] }).reservations;

--- a/server/src/nest/llm-parse/lenient-json.ts
+++ b/server/src/nest/llm-parse/lenient-json.ts
@@ -1,0 +1,31 @@
+import JSON5 from 'json5';
+
+/**
+ * Parse LLM output that is *meant* to be JSON but may not be strict JSON.
+ *
+ * Cloud providers reached through the OpenAI-compatible endpoint don't all honour
+ * `response_format` faithfully — Gemini in particular emits JavaScript-object-literal
+ * text: single-quoted strings, unquoted keys, and trailing commas (#1638), e.g.
+ *
+ *   [ { '@type': 'LodgingReservation', checkinTime: '2026-08-28T00:00:00', price: 146.25, } ]
+ *
+ * Strict `JSON.parse` throws on all three, so the reservation list came back empty and
+ * the UI showed nothing. We try strict JSON first (the common, cheapest path) and fall
+ * back to JSON5, which accepts exactly that relaxed superset. Returns `null` on failure.
+ *
+ * The leading/trailing code-fence strip stays here because some models still wrap the
+ * payload in a ```json fence even when asked for raw JSON.
+ */
+export function parseLenientJson(content: string | undefined | null): unknown {
+  if (!content) return null;
+  const stripped = content.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    try {
+      return JSON5.parse(stripped);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/server/src/nest/llm-parse/router/ollama-format.client.ts
+++ b/server/src/nest/llm-parse/router/ollama-format.client.ts
@@ -11,6 +11,7 @@
  * tool/response_format and keep using the existing clients.)
  */
 
+import { parseLenientJson } from '../lenient-json';
 import { safeFetchLlm } from '../../../utils/ssrfGuard';
 
 const TIMEOUT_MS = 300_000;
@@ -32,17 +33,6 @@ export interface EnforcedExtractInput {
 /** Resolve the native API base from a config base URL that may end in `/v1`. */
 export function toNativeBase(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
-}
-
-/** Strip code fences and JSON.parse; returns null on failure. */
-function parseJson(content: string | undefined | null): unknown {
-  if (!content) return null;
-  const stripped = content.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
-  try {
-    return JSON.parse(stripped);
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -94,6 +84,6 @@ export async function extractEnforced(input: EnforcedExtractInput): Promise<Reco
   }
 
   const data = (await res.json()) as { message?: { content?: string } };
-  const parsed = parseJson(data.message?.content);
+  const parsed = parseLenientJson(data.message?.content);
   return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
 }

--- a/server/tests/unit/nest/llm-parse/clients.test.ts
+++ b/server/tests/unit/nest/llm-parse/clients.test.ts
@@ -47,6 +47,23 @@ describe('OpenAiCompatibleClient', () => {
     expect(out).toEqual([{ '@type': 'TrainReservation' }]);
   });
 
+  it('tolerates single-quoted, non-strict JSON output (Gemini, #1638)', async () => {
+    mockFetch(() =>
+      jsonResponse({
+        choices: [
+          {
+            message: {
+              content:
+                "[{ '@type': 'LodgingReservation', checkinTime: '2026-08-28T00:00:00', price: 146.25, }]",
+            },
+          },
+        ],
+      }),
+    );
+    const out = await new OpenAiCompatibleClient().extract(baseInput);
+    expect(out).toEqual([{ '@type': 'LodgingReservation', checkinTime: '2026-08-28T00:00:00', price: 146.25 }]);
+  });
+
   it('returns [] on malformed content', async () => {
     mockFetch(() => jsonResponse({ choices: [{ message: { content: 'not json' } }] }));
     expect(await new OpenAiCompatibleClient().extract(baseInput)).toEqual([]);

--- a/server/tests/unit/nest/llm-parse/lenient-json.test.ts
+++ b/server/tests/unit/nest/llm-parse/lenient-json.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseLenientJson } from '../../../../src/nest/llm-parse/lenient-json';
+
+describe('parseLenientJson', () => {
+  it('parses strict JSON', () => {
+    expect(parseLenientJson('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' });
+  });
+
+  it('strips a ```json code fence', () => {
+    expect(parseLenientJson('```json\n[{"@type":"FlightReservation"}]\n```')).toEqual([
+      { '@type': 'FlightReservation' },
+    ]);
+  });
+
+  it('parses single-quoted, unquoted-key, trailing-comma output (Gemini, #1638)', () => {
+    const gemini = `[
+      {
+        '@type': 'LodgingReservation',
+        checkinTime: '2026-08-28T00:00:00',
+        checkoutTime: '2026-08-30T11:00:00',
+        price: 146.25,
+        priceCurrency: 'EUR',
+      }
+    ]`;
+    expect(parseLenientJson(gemini)).toEqual([
+      {
+        '@type': 'LodgingReservation',
+        checkinTime: '2026-08-28T00:00:00',
+        checkoutTime: '2026-08-30T11:00:00',
+        price: 146.25,
+        priceCurrency: 'EUR',
+      },
+    ]);
+  });
+
+  it('parses a code-fenced non-strict object', () => {
+    expect(parseLenientJson("```\n{ reservations: [{ '@type': 'TrainReservation' }] }\n```")).toEqual({
+      reservations: [{ '@type': 'TrainReservation' }],
+    });
+  });
+
+  it('returns null on empty or truly unparseable input', () => {
+    expect(parseLenientJson('')).toBeNull();
+    expect(parseLenientJson(null)).toBeNull();
+    expect(parseLenientJson(undefined)).toBeNull();
+    expect(parseLenientJson('this is prose, not json')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Problem

Gemini reached through the OpenAI-compatible endpoint returns JavaScript-object-literal output — single-quoted strings, unquoted keys, trailing commas — instead of strict JSON:

```
[ { '@type': 'LodgingReservation', checkinTime: '2026-08-28T00:00:00', price: 146.25, } ]
```

Strict `JSON.parse` throws on all three, the parse path swallows the error and returns `[]`, so the booking-import UI shows nothing.

### Fix

Add a shared `parseLenientJson()` that tries strict `JSON.parse` first (the common, cheapest path) and falls back to JSON5, which accepts exactly that relaxed superset. Both the OpenAI-compatible client and the Ollama-native router client now route through it, replacing the two identical strict parsers.

### Tests

- New `lenient-json.test.ts` covering strict JSON, code fences, and the single-quoted/unquoted-key/trailing-comma case.
- New end-to-end case in `clients.test.ts` proving the Gemini-style payload now reaches the reservations array.

Fixes #1638