### PR TITLE
fix(settings): let an empty user value fall back to the admin default

### DIFF
--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -36,6 +36,8 @@ export const DEFAULTABLE_USER_SETTING_KEYS = [
 
 type DefaultableKey = typeof DEFAULTABLE_USER_SETTING_KEYS[number];
 
+const DEFAULTABLE_USER_SETTING_KEY_SET = new Set<string>(DEFAULTABLE_USER_SETTING_KEYS);
+
 const VALID_VALUES: Partial<Record<DefaultableKey, unknown[]>> = {
   temperature_unit: ['fahrenheit', 'celsius'],
   distance_unit: ['metric', 'imperial'],
@@ -132,8 +134,24 @@ export function getUserSettings(userId: number): Record<string, unknown> {
     }
   }
 
-  // Admin defaults fill in only for keys the user hasn't explicitly set
-  return { ...adminDefaults, ...userSettings };
+  // Admin defaults fill in for keys the user hasn't explicitly set. For a
+  // defaultable key an *empty* user value counts as "not set": the client's
+  // Settings save always writes every field (a blank Mapbox token included), so
+  // an empty string would otherwise shadow the admin/system-wide default and the
+  // user could never fall back to it — even after clearing their own value
+  // (#1634). Non-defaultable keys keep their exact stored value.
+  const merged: Record<string, unknown> = { ...adminDefaults };
+  for (const [key, value] of Object.entries(userSettings)) {
+    if (
+      DEFAULTABLE_USER_SETTING_KEY_SET.has(key) &&
+      (value === '' || value === null || value === undefined) &&
+      key in adminDefaults
+    ) {
+      continue; // empty user value → keep the admin default
+    }
+    merged[key] = value;
+  }
+  return merged;
 }
 
 function serializeValue(key: string, value: unknown): string {

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -140,7 +140,17 @@ export function getUserSettings(userId: number): Record<string, unknown> {
   // an empty string would otherwise shadow the admin/system-wide default and the
   // user could never fall back to it — even after clearing their own value
   // (#1634). Non-defaultable keys keep their exact stored value.
-  const merged: Record<string, unknown> = { ...adminDefaults };
+  //
+  // Seed from the admin defaults, but mask any encrypted secret (e.g. a shared
+  // llm_api_key) exactly like the per-user path above: getUserSettings is the
+  // client-facing accessor and must never hand back a secret in cleartext — not
+  // even one inherited from an admin default (the fall-through above widened the
+  // set of users who inherit it). The server reads the real value via
+  // getAdminUserDefaults / getDecryptedUserSetting, which don't mask.
+  const merged: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(adminDefaults)) {
+    merged[key] = MASKED_SETTING_KEYS.has(key) ? (value ? '••••••••' : '') : value;
+  }
   for (const [key, value] of Object.entries(userSettings)) {
     if (
       DEFAULTABLE_USER_SETTING_KEY_SET.has(key) &&

--- a/server/tests/unit/services/settingsService.test.ts
+++ b/server/tests/unit/services/settingsService.test.ts
@@ -152,6 +152,21 @@ describe('getUserSettings', () => {
     testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'theme', '')").run(user.id);
     expect(getUserSettings(user.id).theme).toBe('');
   });
+
+  it('SET-SVC-025 — an inherited admin llm_api_key is masked, never returned in cleartext', () => {
+    const { user } = createUser(testDb);
+    setAdminDefault('llm_api_key', 'sk-admin-secret');
+    // No user row → the value is inherited from the admin default; it is a secret
+    // and must reach the client masked, not in cleartext.
+    expect(getUserSettings(user.id).llm_api_key).toBe('••••••••');
+  });
+
+  it('SET-SVC-026 — an empty user llm_api_key falls back to the admin key, still masked', () => {
+    const { user } = createUser(testDb);
+    setAdminDefault('llm_api_key', 'sk-admin-secret');
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'llm_api_key', '')").run(user.id);
+    expect(getUserSettings(user.id).llm_api_key).toBe('••••••••');
+  });
 });
 
 // ── upsertSetting ─────────────────────────────────────────────────────────────

--- a/server/tests/unit/services/settingsService.test.ts
+++ b/server/tests/unit/services/settingsService.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../../src/config', () => ({
 // Passthrough crypto — value comes back unchanged for most tests
 vi.mock('../../../src/services/apiKeyCrypto', () => ({
   maybe_encrypt_api_key: (v: string) => v,
+  decrypt_api_key: (v: string) => v,
 }));
 
 import { createTables } from '../../../src/db/schema';
@@ -110,6 +111,46 @@ describe('getUserSettings', () => {
     const s = getUserSettings(a.id);
     expect(s).toHaveProperty('key_a');
     expect(s).not.toHaveProperty('key_b');
+  });
+
+  // Admin "user defaults" fall-through (#1634) — a system-wide Mapbox token must
+  // reach a user who left their own token blank.
+  const setAdminDefault = (settingKey: string, value: string) =>
+    testDb.prepare(
+      "INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    ).run(`default_user_setting_${settingKey}`, value);
+
+  it('SET-SVC-020 — new user with no rows inherits the admin default token', () => {
+    const { user } = createUser(testDb);
+    setAdminDefault('mapbox_access_token', 'pk.admin');
+    expect(getUserSettings(user.id).mapbox_access_token).toBe('pk.admin');
+  });
+
+  it('SET-SVC-021 — an empty user token falls through to the admin default', () => {
+    const { user } = createUser(testDb);
+    setAdminDefault('mapbox_access_token', 'pk.admin');
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'mapbox_access_token', '')").run(user.id);
+    expect(getUserSettings(user.id).mapbox_access_token).toBe('pk.admin');
+  });
+
+  it('SET-SVC-022 — a non-empty user token overrides the admin default', () => {
+    const { user } = createUser(testDb);
+    setAdminDefault('mapbox_access_token', 'pk.admin');
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'mapbox_access_token', 'pk.user')").run(user.id);
+    expect(getUserSettings(user.id).mapbox_access_token).toBe('pk.user');
+  });
+
+  it('SET-SVC-023 — an empty value with no admin default stays empty (no regression)', () => {
+    const { user } = createUser(testDb);
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'mapbox_style', '')").run(user.id);
+    expect(getUserSettings(user.id).mapbox_style).toBe('');
+  });
+
+  it('SET-SVC-024 — a non-defaultable empty value is preserved even against a same-named default', () => {
+    const { user } = createUser(testDb);
+    // 'theme' is not a defaultable key: an empty stored value must be returned as-is.
+    testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'theme', '')").run(user.id);
+    expect(getUserSettings(user.id).theme).toBe('');
   });
 });
 


### PR DESCRIPTION
### Problem

Setting a system-wide Mapbox token in the admin console's *user defaults* had no effect for most users. The admin-defaults merge (`{ ...adminDefaults, ...userSettings }`) kept any user value that was merely *present*, and the client's Settings save always writes every field — a blank Mapbox token included. So any user who ever opened Map Settings had an empty-string `mapbox_access_token` row that shadowed the admin default, and clearing their own token could never restore the fallback.

A brand-new user (no settings rows) inherited the default fine; only existing users were affected — which matches the report.

### Fix

In `getUserSettings`, treat an empty/null user value for a **defaultable** key as "not set" when an admin default exists, so it falls through to the admin/system-wide default. Non-defaultable keys, and defaultable keys without an admin default, keep their exact stored value (no regression).

Single server-side fix point — covers desktop + mobile and every defaultable key, not just the Mapbox token.

### Tests

Five new `settingsService` cases: new-user inheritance, empty-value fall-through, non-empty override, empty-with-no-default stays empty, and a non-defaultable empty value is preserved.

Fixes #1634