### PR TITLE
fix(transport): guard non-finite dates in trip-map duration

### DIFF
--- a/client/src/components/Map/ReservationOverlay.tsx
+++ b/client/src/components/Map/ReservationOverlay.tsx
@@ -83,6 +83,11 @@ function parseInTz(isoLocal: string, tz: string): number {
   const [y, mo, d] = datePart.split('-').map(Number)
   const [h, mi] = (timePart || '00:00').split(':').map(Number)
   const guess = Date.UTC(y, mo - 1, d, h, mi)
+  // A malformed date/time (e.g. an imported booking whose time is missing its
+  // minutes) makes Date.UTC NaN; bail before formatToParts, which throws on a
+  // non-finite date and would blank the whole trip. computeDuration's finiteness
+  // check then drops the duration cleanly.
+  if (!Number.isFinite(guess)) return NaN
   const fmt = new Intl.DateTimeFormat('en-US', {
     timeZone: tz, hour12: false,
     year: 'numeric', month: '2-digit', day: '2-digit',

--- a/client/src/components/Map/reservationsMapbox.test.ts
+++ b/client/src/components/Map/reservationsMapbox.test.ts
@@ -93,6 +93,28 @@ describe('ReservationMapboxOverlay road routes (#1425)', () => {
   })
 })
 
+// A flight whose endpoints carry a malformed local_time (an imported booking
+// missing the minutes) plus timezones, so computeDuration takes the parseInTz
+// path. Pre-fix, Date.UTC → NaN and formatToParts threw mid-render (#1620).
+function malformedTimeFlight(): Reservation {
+  return {
+    id: 3, type: 'flight', status: 'confirmed',
+    reservation_time: '2024-01-15T22', reservation_end_time: '2024-01-16T08',
+    endpoints: [
+      { role: 'from', sequence: 0, name: 'JFK', code: 'JFK', lat: 40.6, lng: -73.8, timezone: 'America/New_York', local_date: '2024-01-15', local_time: '22' },
+      { role: 'to', sequence: 1, name: 'LHR', code: 'LHR', lat: 51.5, lng: -0.5, timezone: 'Europe/London', local_date: '2024-01-16', local_time: '08' },
+    ],
+  } as unknown as Reservation
+}
+
+describe('ReservationMapboxOverlay malformed times (#1620)', () => {
+  it('renders a flight with a malformed time instead of throwing on formatToParts', () => {
+    const map = fakeMap()
+    const overlay = new ReservationMapboxOverlay(map as never, opts, FakeMarker as never)
+    expect(() => overlay.update([malformedTimeFlight()], opts)).not.toThrow()
+  })
+})
+
 describe('ReservationMapboxOverlay transit routes (#1570)', () => {
   it('draws a transit journey with real geometry even when its stations project close together', () => {
     const map = fakeMap()

--- a/client/src/components/Map/reservationsMapbox.ts
+++ b/client/src/components/Map/reservationsMapbox.ts
@@ -51,6 +51,11 @@ function parseInTz(isoLocal: string, tz: string): number {
   const [y, mo, d] = datePart.split('-').map(Number)
   const [h, mi] = (timePart || '00:00').split(':').map(Number)
   const guess = Date.UTC(y, mo - 1, d, h, mi)
+  // A malformed date/time (e.g. an imported booking whose time is missing its
+  // minutes) makes Date.UTC NaN; bail before formatToParts, which throws on a
+  // non-finite date and would blank the whole trip. computeDuration's finiteness
+  // check then drops the duration cleanly.
+  if (!Number.isFinite(guess)) return NaN
   const fmt = new Intl.DateTimeFormat('en-US', {
     timeZone: tz, hour12: false,
     year: 'numeric', month: '2-digit', day: '2-digit',


### PR DESCRIPTION
## Description

Clicking into a trip could blank the whole page with an uncaught
`RangeError: date value is not finite` from an `Intl.DateTimeFormat`
method, unrecoverable on reload.

**Root cause** (`client/src/components/Map/reservationsMapbox.ts:53` and
`client/src/components/Map/ReservationOverlay.tsx:85`): on the default
"plan" tab both map overlays build their transport items inside an
on-load `useMemo`, calling `computeDuration → parseInTz` for every
transport reservation. `parseInTz` does
`formatToParts(new Date(Date.UTC(y, mo-1, d, h, mi)))`. When a
reservation carries a malformed time — e.g. an imported flight whose
`local_time` is missing its minutes (`"22"`) or is empty — `Date.UTC`
returns `NaN`, and `formatToParts(new Date(NaN))` throws mid-render,
blanking the page. `computeDuration`'s existing `Number.isFinite`
guard runs on `parseInTz`'s return value, so the formatter throws
before it can reject the reservation. Because the data is persisted,
every reload re-crashes.

Note: reversed-but-valid times (a legitimate overnight flight arriving
"before" it departs) never caused this — `formatToParts` only throws on
a non-finite date, and `computeDuration` already handles the overnight
case by adding 24h. The trigger is specifically the `NaN` date.

**Fix:** bail out of `parseInTz` with `NaN` when the parsed date is
non-finite, before the formatter runs. `computeDuration`'s finiteness
check then drops the duration cleanly. Applied to both the Leaflet and
Mapbox overlays (the two on-load render paths). This also recovers
trips whose data is already corrupted — which entry-side validation
could not do.

## Related Issue or Discussion

Closes #1620

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed