### PR TITLE
feat(booking-import): retry a failed import with AI parsing

### DIFF
--- a/client/src/components/BackgroundTasks/BackgroundTasksWidget.test.tsx
+++ b/client/src/components/BackgroundTasks/BackgroundTasksWidget.test.tsx
@@ -1,14 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { render } from '../../../tests/helpers/render'
+import { reservationsApi, healthApi } from '../../api/client'
+import { saveImportFiles } from '../../db/offlineDb'
 import { useBackgroundTasksStore, type BackgroundImportTask } from '../../store/backgroundTasksStore'
 import BackgroundTasksWidget from './BackgroundTasksWidget'
 
 vi.mock('../../api/websocket', () => ({ addListener: vi.fn(), removeListener: vi.fn() }))
 vi.mock('../../api/client', () => ({
   // Keep the rehydrate/poll backstops pending so the seeded state is what renders.
-  reservationsApi: { importJobStatus: vi.fn(() => new Promise(() => {})) },
+  reservationsApi: { importJobStatus: vi.fn(() => new Promise(() => {})), importBookingAsync: vi.fn() },
+  healthApi: { features: vi.fn() },
 }))
+vi.mock('../../db/offlineDb', () => ({ saveImportFiles: vi.fn(() => Promise.resolve()) }))
 
 const task = (overrides: Partial<BackgroundImportTask> = {}): BackgroundImportTask => ({
   id: 'j1',
@@ -22,8 +27,14 @@ const task = (overrides: Partial<BackgroundImportTask> = {}): BackgroundImportTa
   ...overrides,
 })
 
+const pdf = () => new File(['%PDF'], 'voucher.pdf', { type: 'application/pdf' })
+
 beforeEach(() => {
   vi.clearAllMocks()
+  // Like the poll backstop above: leave the feature probe pending so tests that don't care
+  // about the AI retry render the same widget they did before the button existed.
+  vi.mocked(healthApi.features).mockReturnValue(new Promise(() => {}))
+  vi.mocked(saveImportFiles).mockResolvedValue(undefined)
   useBackgroundTasksStore.setState({ tasks: [] })
 })
 
@@ -41,5 +52,85 @@ describe('BackgroundTasksWidget', () => {
     render(<BackgroundTasksWidget />)
     expect(screen.getByText('No reservations could be extracted from the uploaded files.')).toBeInTheDocument()
     expect(screen.queryByText(/AI parsing failed/)).not.toBeInTheDocument()
+  })
+
+  describe('AI retry', () => {
+    it('offers the retry on an empty result once the addon reports AI parsing', async () => {
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: true })
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [pdf()] })] })
+      render(<BackgroundTasksWidget />)
+      expect(await screen.findByRole('button', { name: 'Try AI parsing' })).toBeInTheDocument()
+    })
+
+    it('stays hidden when the addon is off, the files are gone, or the run was already force-ai', async () => {
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: false })
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [pdf()] })] })
+      const { unmount } = render(<BackgroundTasksWidget />)
+      await waitFor(() => expect(healthApi.features).toHaveBeenCalled())
+      expect(screen.queryByRole('button', { name: 'Try AI parsing' })).not.toBeInTheDocument()
+      unmount()
+
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: true })
+      // Rehydrated from storage: sourceFiles can't survive a reload, so there is nothing to resend.
+      useBackgroundTasksStore.setState({ tasks: [task()] })
+      const withoutFiles = render(<BackgroundTasksWidget />)
+      await waitFor(() => expect(healthApi.features).toHaveBeenCalledTimes(2))
+      expect(screen.queryByRole('button', { name: 'Try AI parsing' })).not.toBeInTheDocument()
+      withoutFiles.unmount()
+
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [pdf()], mode: 'force-ai' })] })
+      render(<BackgroundTasksWidget />)
+      await waitFor(() => expect(healthApi.features).toHaveBeenCalledTimes(3))
+      expect(screen.queryByRole('button', { name: 'Try AI parsing' })).not.toBeInTheDocument()
+    })
+
+    it('re-submits the files with force-ai, keeps them for the review and replaces the task', async () => {
+      const file = pdf()
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: true })
+      vi.mocked(reservationsApi.importBookingAsync).mockResolvedValue({ jobId: 'j2' })
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [file] })] })
+      render(<BackgroundTasksWidget />)
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Try AI parsing' }))
+
+      expect(reservationsApi.importBookingAsync).toHaveBeenCalledWith('t1', [file], 'force-ai')
+      // Without this the reviewed bookings lose their source document after a reload.
+      await waitFor(() => expect(saveImportFiles).toHaveBeenCalledWith('j2', [file]))
+      await waitFor(() => {
+        const tasks = useBackgroundTasksStore.getState().tasks
+        expect(tasks).toHaveLength(1)
+        expect(tasks[0]).toMatchObject({ id: 'j2', tripId: 't1', status: 'running', mode: 'force-ai' })
+      })
+    })
+
+    it('keeps the task and surfaces the server error when the retry is rejected', async () => {
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: true })
+      vi.mocked(reservationsApi.importBookingAsync).mockRejectedValue({ response: { data: { error: 'No AI model configured' } } })
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [pdf()] })] })
+      render(<BackgroundTasksWidget />)
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Try AI parsing' }))
+
+      expect(await screen.findByText('No AI model configured')).toBeInTheDocument()
+      const tasks = useBackgroundTasksStore.getState().tasks
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0]).toMatchObject({ id: 'j1', status: 'error' })
+      expect(saveImportFiles).not.toHaveBeenCalled()
+    })
+
+    it('ignores a second click while the first retry is still in flight', async () => {
+      vi.mocked(healthApi.features).mockResolvedValue({ bookingImport: true, aiParsing: true })
+      // Never settles: the retry stays in flight for the whole test.
+      vi.mocked(reservationsApi.importBookingAsync).mockReturnValue(new Promise<{ jobId: string }>(() => {}))
+      useBackgroundTasksStore.setState({ tasks: [task({ sourceFiles: [pdf()] })] })
+      render(<BackgroundTasksWidget />)
+
+      const button = await screen.findByRole('button', { name: 'Try AI parsing' })
+      await userEvent.click(button)
+      await waitFor(() => expect(button).toBeDisabled())
+      await userEvent.click(button)
+
+      expect(reservationsApi.importBookingAsync).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/client/src/components/BackgroundTasks/BackgroundTasksWidget.tsx
+++ b/client/src/components/BackgroundTasks/BackgroundTasksWidget.tsx
@@ -1,10 +1,10 @@
 import ReactDOM from 'react-dom'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Loader2, CheckCircle2, AlertCircle, X } from 'lucide-react'
 import { useTranslation } from '../../i18n'
 import { addListener, removeListener } from '../../api/websocket'
-import { reservationsApi } from '../../api/client'
+import { reservationsApi, healthApi } from '../../api/client'
 import { useBackgroundTasksStore, type BackgroundImportTask } from '../../store/backgroundTasksStore'
 
 /**
@@ -23,6 +23,25 @@ export default function BackgroundTasksWidget() {
   const setError = useBackgroundTasksStore((s) => s.setError)
   const requestReview = useBackgroundTasksStore((s) => s.requestReview)
   const dismiss = useBackgroundTasksStore((s) => s.dismiss)
+  const addTask = useBackgroundTasksStore((s) => s.addTask)
+
+  const [aiParsing, setAiParsing] = useState(false)
+  useEffect(() => {
+    healthApi.features().then((f) => setAiParsing(!!f.aiParsing)).catch(() => setAiParsing(false))
+  }, [])
+
+  // Re-runs the same files with force-ai: the LLM sees every file, kitinerary is skipped.
+  const retryWithAi = (task: BackgroundImportTask) => {
+    if (!task.sourceFiles || task.sourceFiles.length === 0) return
+    reservationsApi
+      .importBookingAsync(task.tripId, task.sourceFiles, 'force-ai')
+      .then(({ jobId }) => {
+        dismiss(task.id)
+        addTask({ id: jobId, tripId: task.tripId, label: task.label, total: task.sourceFiles!.length, files: task.sourceFiles, mode: 'force-ai' })
+      })
+      // 409 when the addon is enabled but this user has no model configured.
+      .catch((err) => setError(task.id, task.tripId, err?.response?.data?.error ?? t('reservations.import.error')))
+  }
 
   // On (re)load, reconcile tasks restored from localStorage with the server: a parse
   // that was still running when the page reloaded must keep its widget, so re-fetch each
@@ -136,12 +155,23 @@ export default function BackgroundTasksWidget() {
                   {t('common.import')}
                 </button>
               ) : (
-                <div style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', color: 'var(--text-faint)', marginTop: 1 }}>
-                  {t('reservations.import.previewEmpty')}
-                  {(task.warnings?.length ?? 0) > 0 && (
-                    <div style={{ color: '#b45309', marginTop: 3, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 96, overflowY: 'auto' }}>
-                      {task.warnings!.join('\n')}
-                    </div>
+                <div>
+                  <div style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', color: 'var(--text-faint)', marginTop: 1 }}>
+                    {t('reservations.import.previewEmpty')}
+                    {(task.warnings?.length ?? 0) > 0 && (
+                      <div style={{ color: '#b45309', marginTop: 3, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 96, overflowY: 'auto' }}>
+                        {task.warnings!.join('\n')}
+                      </div>
+                    )}
+                  </div>
+                  {aiParsing && task.mode !== 'force-ai' && task.sourceFiles && task.sourceFiles.length > 0 && (
+                    <button
+                      onClick={() => retryWithAi(task)}
+                      className="bg-surface-tertiary text-content"
+                      style={{ marginTop: 4, border: 'none', borderRadius: 8, padding: '4px 12px', fontSize: 'calc(11.5px * var(--fs-scale-caption, 1))', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
+                    >
+                      {t('reservations.import.tryAi')}
+                    </button>
                   )}
                 </div>
               )

--- a/client/src/components/BackgroundTasks/BackgroundTasksWidget.tsx
+++ b/client/src/components/BackgroundTasks/BackgroundTasksWidget.tsx
@@ -5,6 +5,7 @@ import { Loader2, CheckCircle2, AlertCircle, X } from 'lucide-react'
 import { useTranslation } from '../../i18n'
 import { addListener, removeListener } from '../../api/websocket'
 import { reservationsApi, healthApi } from '../../api/client'
+import { saveImportFiles } from '../../db/offlineDb'
 import { useBackgroundTasksStore, type BackgroundImportTask } from '../../store/backgroundTasksStore'
 
 /**
@@ -31,16 +32,25 @@ export default function BackgroundTasksWidget() {
   }, [])
 
   // Re-runs the same files with force-ai: the LLM sees every file, kitinerary is skipped.
-  const retryWithAi = (task: BackgroundImportTask) => {
-    if (!task.sourceFiles || task.sourceFiles.length === 0) return
-    reservationsApi
-      .importBookingAsync(task.tripId, task.sourceFiles, 'force-ai')
-      .then(({ jobId }) => {
-        dismiss(task.id)
-        addTask({ id: jobId, tripId: task.tripId, label: task.label, total: task.sourceFiles!.length, files: task.sourceFiles, mode: 'force-ai' })
-      })
+  const [retrying, setRetrying] = useState<string | null>(null)
+  const retryWithAi = async (task: BackgroundImportTask) => {
+    const files = task.sourceFiles
+    if (!files || files.length === 0 || retrying === task.id) return
+    setRetrying(task.id)
+    try {
+      const { jobId } = await reservationsApi.importBookingAsync(task.tripId, files, 'force-ai')
+      // Same as the modal's first submit: the review attaches each source document to the
+      // booking it created, and only IndexedDB survives a reload mid-parse.
+      await saveImportFiles(jobId, files)
+      dismiss(task.id)
+      addTask({ id: jobId, tripId: task.tripId, label: task.label, total: files.length, files, mode: 'force-ai' })
+    } catch (err) {
       // 409 when the addon is enabled but this user has no model configured.
-      .catch((err) => setError(task.id, task.tripId, err?.response?.data?.error ?? t('reservations.import.error')))
+      const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+      setError(task.id, task.tripId, message ?? t('reservations.import.error'))
+    } finally {
+      setRetrying(null)
+    }
   }
 
   // On (re)load, reconcile tasks restored from localStorage with the server: a parse
@@ -167,8 +177,9 @@ export default function BackgroundTasksWidget() {
                   {aiParsing && task.mode !== 'force-ai' && task.sourceFiles && task.sourceFiles.length > 0 && (
                     <button
                       onClick={() => retryWithAi(task)}
+                      disabled={retrying === task.id}
                       className="bg-surface-tertiary text-content"
-                      style={{ marginTop: 4, border: 'none', borderRadius: 8, padding: '4px 12px', fontSize: 'calc(11.5px * var(--fs-scale-caption, 1))', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
+                      style={{ marginTop: 4, border: 'none', borderRadius: 8, padding: '4px 12px', fontSize: 'calc(11.5px * var(--fs-scale-caption, 1))', fontWeight: 600, cursor: retrying === task.id ? 'default' : 'pointer', opacity: retrying === task.id ? 0.6 : 1, fontFamily: 'inherit' }}
                     >
                       {t('reservations.import.tryAi')}
                     </button>

--- a/client/src/components/Planner/BookingImportModal.tsx
+++ b/client/src/components/Planner/BookingImportModal.tsx
@@ -100,7 +100,7 @@ export default function BookingImportModal({ isOpen, onClose, tripId }: BookingI
       // Keep the uploaded files so the review can attach each source document to its booking —
       // in memory for the immediate path, and in IndexedDB so it survives a reload mid-parse.
       await saveImportFiles(jobId, files)
-      addTask({ id: jobId, tripId: String(tripId), label: files.map((f) => f.name).join(', '), total: files.length, files })
+      addTask({ id: jobId, tripId: String(tripId), label: files.map((f) => f.name).join(', '), total: files.length, files, mode })
       handleClose()
     } catch (err: any) {
       setError(err?.response?.data?.error ?? t('reservations.import.error'))

--- a/client/src/store/backgroundTasksStore.ts
+++ b/client/src/store/backgroundTasksStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { BookingImportPreviewItem } from '@trek/shared'
+import type { BookingImportPreviewItem, BookingImportMode } from '@trek/shared'
 
 /**
  * Tracks booking-import parses that run in the BACKGROUND (the async endpoint).
@@ -30,11 +30,13 @@ export interface BackgroundImportTask {
   /** The uploaded files this parse ran on — kept in memory so the review can attach the
    *  source document to each created booking. Not persisted (a File can't survive a reload). */
   sourceFiles?: File[]
+  /** Mode this run used — the widget only offers an AI retry if it wasn't already one. Not persisted. */
+  mode?: BookingImportMode
 }
 
 interface BackgroundTasksState {
   tasks: BackgroundImportTask[]
-  addTask: (task: { id: string; tripId: string; label: string; total: number; files?: File[] }) => void
+  addTask: (task: { id: string; tripId: string; label: string; total: number; files?: File[]; mode?: BookingImportMode }) => void
   setProgress: (id: string, tripId: string, done: number, total: number) => void
   setDone: (id: string, tripId: string, items: BookingImportPreviewItem[], warnings: string[]) => void
   setError: (id: string, tripId: string, error: string) => void
@@ -61,7 +63,7 @@ export const useBackgroundTasksStore = create<BackgroundTasksState>()(
 
       return {
         tasks: [],
-        addTask: ({ id, tripId, label, total, files }) => upsert(id, tripId, { label, total, status: 'running', done: 0, sourceFiles: files }),
+        addTask: ({ id, tripId, label, total, files, mode }) => upsert(id, tripId, { label, total, status: 'running', done: 0, sourceFiles: files, mode }),
         setProgress: (id, tripId, done, total) => upsert(id, tripId, { done, total, status: 'running' }),
         setDone: (id, tripId, items, warnings) => upsert(id, tripId, { status: 'done', items, warnings, done: items?.length ?? 0 }),
         setError: (id, tripId, error) => upsert(id, tripId, { status: 'error', error }),


### PR DESCRIPTION
## Description
The server has supported `force-ai` (LLM on every file, kitinerary skipped) since the AI Parsing addon landed, but nothing in the client ever sends it, and `BookingImportModal` only ever picks `fallback-on-empty` or `no-ai`.

When an import finishes with no reservations, the background widget now shows a **Try AI parsing** button under the empty-result message, which re-submits the same files with `mode: 'force-ai'`. This mainly helps when the model itself came back empty, such as a timeout or a truncated completion currently leaves no way to retry short of re-uploading.

### Changes

- `BackgroundTasksWidget` — the button, and the `force-ai` re-submit.
- `backgroundTasksStore` — `BackgroundImportTask` gains an optional `mode` so the widget can tell whether the finished run was already AI-only. Not persisted: `sourceFiles` can't survive a reload, so a rehydrated task isn't retryable anyway.
- `BookingImportModal` — passes the mode it picked through to `addTask`.

The task is dismissed only once the new job is accepted, so a failed retry marks the original task as errored instead of vanishing. Dismissing first would leave `setError` to `upsert` a stub task labelled `Import`.

The button only shows when: the addon is enabled, the finished run wasn't already `force-ai`, and the original `File` objects are still in memory.

In cases where the AI addon is enabled but no model configured will be surfaced on the task, but the button is still offered. Fixing it properly needs a per-user availability field on the features endpoint, which I've left out to keep this to one change.

### Notes

`reservations.import.tryAi` already ships in every locale, so no i18n changes. Client-only: no API, schema or migration changes.

## Related Issue or Discussion
Approved on discord with title "feat(booking-import): add "Try AI parsing" retry for empty imports"

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
