### PR TITLE
fix(plugin): include blur booking codes on the plugin context

### DIFF
--- a/client/src/components/Plugins/PluginFrame.test.tsx
+++ b/client/src/components/Plugins/PluginFrame.test.tsx
@@ -12,7 +12,7 @@ vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }));
 vi.mock('../shared/Toast', () => ({ useToast: () => toast }));
 vi.mock('../../i18n', () => ({ useTranslation: () => ({ locale: 'en', t: (k: string) => k }) }));
 vi.mock('../../store/authStore', () => ({ useAuthStore: (sel: (s: unknown) => unknown) => sel({ user: { id: 7, username: 'ada', avatar_url: null, role: 'admin' } }) }));
-vi.mock('../../store/settingsStore', () => ({ useSettingsStore: (sel: (s: unknown) => unknown) => sel({ settings: { default_currency: 'EUR', time_format: '24h', distance_unit: 'metric', temperature_unit: 'celsius' } }) }));
+vi.mock('../../store/settingsStore', () => ({ useSettingsStore: (sel: (s: unknown) => unknown) => sel({ settings: { default_currency: 'EUR', time_format: '24h', distance_unit: 'metric', temperature_unit: 'celsius', blur_booking_codes: true } }) }));
 vi.mock('../../api/client', () => ({ pluginsApi: { invoke: (id: string, sub: string, init?: unknown) => invoke(id, sub, init) } }));
 vi.mock('../../api/websocket', () => ({
   addListener: (fn: (ev: Record<string, unknown>) => void) => wsListeners.add(fn),
@@ -84,7 +84,13 @@ describe('PluginFrame', () => {
     const ctx = posted.find((m) => m.type === 'trek:context') as Record<string, unknown> | undefined;
     expect(ctx).toBeTruthy();
     expect(ctx!.tokens).toBeTruthy(); // resolved design tokens (empty {} in jsdom, but present)
-    expect(ctx!.formats).toMatchObject({ currency: 'EUR', timeFormat: '24h', distanceUnit: 'metric' });
+    expect(ctx!.formats).toMatchObject({
+      currency: 'EUR',
+      timeFormat: '24h',
+      distanceUnit: 'metric',
+      temperatureUnit: 'celsius',
+      blurBookingCodes: true,
+    });
     // Display identity is present but carries NO secret (no email, role only as a boolean).
     expect(ctx!.user).toMatchObject({ name: 'ada', isAdmin: true });
     expect(JSON.stringify(ctx)).not.toContain('@'); // no email leaked

--- a/client/src/components/Plugins/PluginFrame.tsx
+++ b/client/src/components/Plugins/PluginFrame.tsx
@@ -218,6 +218,7 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
       distanceUnit: settings.distance_unit,
       temperatureUnit: settings.temperature_unit,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      blurBookingCodes: Boolean(settings.blur_booking_codes),
     },
     tokens: readThemeTokens(),
   }), [tripId, placeId, dayId, reservationId, userId, locale, userName, userAvatar, isAdmin, settings])

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -658,7 +658,7 @@ function ctx(){
     tripId: val("trip").checked?${tripId}:null, userId:"1",
     user:{name:"Dev User",avatar:null,isAdmin:true},
     appearance:{scheme:accent,density:"comfortable",reducedMotion:val("rm").checked,noTransparency:val("nt").checked},
-    formats:{locale:"en",currency:"EUR",timeFormat:"24h",distanceUnit:"metric",temperatureUnit:"celsius",timezone:Intl.DateTimeFormat().resolvedOptions().timeZone},
+    formats:{locale:"en",currency:"EUR",timeFormat:"24h",distanceUnit:"metric",temperatureUnit:"celsius",timezone:Intl.DateTimeFormat().resolvedOptions().timeZone,blurBookingCodes:false},
     tokens:tokens};
 }
 function postCtx(){ if(f.contentWindow) f.contentWindow.postMessage(ctx(),"*"); }

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -634,6 +634,7 @@ iframe{width:100%;border:0;background:transparent;min-height:120px;display:block
   <label>Accent <select id="accent"><option value="default">default</option><option value="indigo">indigo</option><option value="teal">teal</option><option value="rose">rose</option></select></label>
   <label><input type="checkbox" id="rm"> reduce motion</label>
   <label><input type="checkbox" id="nt"> no transparency</label>
+  <label><input type="checkbox" id="blur"> blur booking codes</label>
   <label><input type="checkbox" id="trip" checked> trip context</label>
 </header>
 <div class="stage"><div class="wrap"><iframe id="f" src="/ui/index.html" sandbox="allow-scripts allow-forms" referrerpolicy="no-referrer" title="${id}"></iframe></div></div>
@@ -658,7 +659,7 @@ function ctx(){
     tripId: val("trip").checked?${tripId}:null, userId:"1",
     user:{name:"Dev User",avatar:null,isAdmin:true},
     appearance:{scheme:accent,density:"comfortable",reducedMotion:val("rm").checked,noTransparency:val("nt").checked},
-    formats:{locale:"en",currency:"EUR",timeFormat:"24h",distanceUnit:"metric",temperatureUnit:"celsius",timezone:Intl.DateTimeFormat().resolvedOptions().timeZone,blurBookingCodes:false},
+    formats:{locale:"en",currency:"EUR",timeFormat:"24h",distanceUnit:"metric",temperatureUnit:"celsius",timezone:Intl.DateTimeFormat().resolvedOptions().timeZone,blurBookingCodes:val("blur").checked},
     tokens:tokens};
 }
 function postCtx(){ if(f.contentWindow) f.contentWindow.postMessage(ctx(),"*"); }
@@ -698,7 +699,7 @@ window.addEventListener("message", function(ev){
   }
 });
 var geoTick=null;
-["theme","accent","rm","nt","trip"].forEach(function(id){ val(id).addEventListener("change",postCtx); });
+["theme","accent","rm","nt","blur","trip"].forEach(function(id){ val(id).addEventListener("change",postCtx); });
 f.addEventListener("load", function(){ f.style.height="120px"; postCtx(); });
 var __v; setInterval(function(){ fetch("/__dev/version").then(function(r){return r.text();}).then(function(v){ if(__v&&v!==__v){ f.src=f.src; } __v=v; }).catch(function(){}); },1000);
 </script>

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -533,7 +533,7 @@ declared), no popups.
 | `locale` | e.g. `'en'` |
 | `hostOrigin` | the app origin |
 | `user` | `{ name, avatar, isAdmin } \| null` — **never** an email; role only as a boolean |
-| `formats` | `{ locale, currency, timeFormat, distanceUnit, temperatureUnit, timezone, blurBookingCodes }` |
+| `formats` | `{ locale, currency, timeFormat, distanceUnit, temperatureUnit, timezone, blurBookingCodes }` — `blurBookingCodes` mirrors the user's "blur booking codes" preference so your UI can hide confirmation numbers until they're revealed. It is a **display hint, not redaction**: the codes still reach your plugin in full over `trek:invoke`. |
 | `tokens` | TREK's resolved CSS design tokens for the current theme (see below) |
 | `appearance` | `{ scheme, density: 'comfortable'\|'compact', reducedMotion, noTransparency }` |
 

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -533,7 +533,7 @@ declared), no popups.
 | `locale` | e.g. `'en'` |
 | `hostOrigin` | the app origin |
 | `user` | `{ name, avatar, isAdmin } \| null` — **never** an email; role only as a boolean |
-| `formats` | `{ locale, currency, timeFormat, distanceUnit, temperatureUnit, timezone }` |
+| `formats` | `{ locale, currency, timeFormat, distanceUnit, temperatureUnit, timezone, blurBookingCodes }` |
 | `tokens` | TREK's resolved CSS design tokens for the current theme (see below) |
 | `appearance` | `{ scheme, density: 'comfortable'\|'compact', reducedMotion, noTransparency }` |
 


### PR DESCRIPTION
## Description
Adds missing 'blur booking codes' user setting to the plugin interface.

Added under 'context.formats.blurBookingCodes'.

## Related Issue or Discussion
Accepted under discord discussion.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [X] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [X] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [X] I have tested my changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have updated documentation if needed
