### PR TITLE
feat(plugin): session storage plugin api

### DIFF
--- a/client/src/components/Plugins/PluginFrame.test.tsx
+++ b/client/src/components/Plugins/PluginFrame.test.tsx
@@ -313,7 +313,7 @@ describe('PluginFrame', () => {
     });
   });
 
-  it('FE-PLUGINS-FRAME-015: brokered plugin session state round-trips through host sessionStorage', () => {
+  it('FE-PLUGINS-FRAME-020: brokered plugin session state round-trips through host sessionStorage', () => {
     const { container } = render(<PluginFrame pluginId="demo" />);
     const iframe = container.querySelector('iframe')!;
     const posted: Array<Record<string, unknown>> = [];
@@ -330,7 +330,7 @@ describe('PluginFrame', () => {
     expect(sessionStorage.key(0)).not.toBe('dismissed');
   });
 
-  it('FE-PLUGINS-FRAME-016: trip session state requires a trip and is partitioned from plugin scope', () => {
+  it('FE-PLUGINS-FRAME-021: trip session state requires a trip and is partitioned from plugin scope', () => {
     const noTrip = render(<PluginFrame pluginId="demo" />);
     const noTripFrame = noTrip.container.querySelector('iframe')!;
     const noTripPosted: Array<Record<string, unknown>> = [];

--- a/client/src/components/Plugins/PluginFrame.test.tsx
+++ b/client/src/components/Plugins/PluginFrame.test.tsx
@@ -25,6 +25,7 @@ function fromFrame(frame: HTMLIFrameElement, data: unknown) {
 
 afterEach(() => {
   cleanup();
+  sessionStorage.clear();
   navigate.mockClear();
   Object.values(toast).forEach((f) => f.mockClear());
   invoke.mockClear();
@@ -310,5 +311,45 @@ describe('PluginFrame', () => {
       expect(posted.length).toBe(before);
       expect(geo.clearWatch).toHaveBeenCalledWith(7);
     });
+  });
+
+  it('FE-PLUGINS-FRAME-015: brokered plugin session state round-trips through host sessionStorage', () => {
+    const { container } = render(<PluginFrame pluginId="demo" />);
+    const iframe = container.querySelector('iframe')!;
+    const posted: Array<Record<string, unknown>> = [];
+    (iframe.contentWindow as unknown as { postMessage: (m: unknown) => void }).postMessage = (m: unknown) => posted.push(m as Record<string, unknown>);
+
+    fromFrame(iframe, { type: 'trek:session:set', requestId: 's1', key: 'dismissed', value: { version: 1 } });
+    fromFrame(iframe, { type: 'trek:session:get', requestId: 's2', key: 'dismissed' });
+
+    expect(posted.find((m) => m.requestId === 's1')).toMatchObject({ type: 'trek:response' });
+    expect(posted.find((m) => m.requestId === 's2')).toMatchObject({ type: 'trek:response', data: { version: 1 } });
+    // The raw key is host-owned: it includes the authenticated user + plugin id,
+    // not just the value name supplied by the untrusted frame.
+    expect(sessionStorage.key(0)).toContain('trek:plugin-session:7:demo:plugin:');
+    expect(sessionStorage.key(0)).not.toBe('dismissed');
+  });
+
+  it('FE-PLUGINS-FRAME-016: trip session state requires a trip and is partitioned from plugin scope', () => {
+    const noTrip = render(<PluginFrame pluginId="demo" />);
+    const noTripFrame = noTrip.container.querySelector('iframe')!;
+    const noTripPosted: Array<Record<string, unknown>> = [];
+    (noTripFrame.contentWindow as unknown as { postMessage: (m: unknown) => void }).postMessage = (m: unknown) => noTripPosted.push(m as Record<string, unknown>);
+
+    fromFrame(noTripFrame, { type: 'trek:session:get', requestId: 's1', key: 'filters', scope: 'trip' });
+    expect(noTripPosted.find((m) => m.requestId === 's1')).toMatchObject({ type: 'trek:error', code: 'NO_TRIP_CONTEXT' });
+
+    noTrip.unmount();
+    const { container } = render(<PluginFrame pluginId="demo" tripId="42" />);
+    const iframe = container.querySelector('iframe')!;
+    const posted: Array<Record<string, unknown>> = [];
+    (iframe.contentWindow as unknown as { postMessage: (m: unknown) => void }).postMessage = (m: unknown) => posted.push(m as Record<string, unknown>);
+
+    fromFrame(iframe, { type: 'trek:session:set', requestId: 's2', key: 'filters', value: ['flight'], scope: 'trip' });
+    fromFrame(iframe, { type: 'trek:session:get', requestId: 's3', key: 'filters' });
+    fromFrame(iframe, { type: 'trek:session:get', requestId: 's4', key: 'filters', scope: 'trip' });
+
+    expect(posted.find((m) => m.requestId === 's3')).toMatchObject({ type: 'trek:response', data: undefined });
+    expect(posted.find((m) => m.requestId === 's4')).toMatchObject({ type: 'trek:response', data: ['flight'] });
   });
 });

--- a/client/src/components/Plugins/PluginFrame.test.tsx
+++ b/client/src/components/Plugins/PluginFrame.test.tsx
@@ -352,4 +352,29 @@ describe('PluginFrame', () => {
     expect(posted.find((m) => m.requestId === 's3')).toMatchObject({ type: 'trek:response', data: undefined });
     expect(posted.find((m) => m.requestId === 's4')).toMatchObject({ type: 'trek:response', data: ['flight'] });
   });
+
+  it('FE-PLUGINS-FRAME-022: session storage enforces key, value and key-count limits', () => {
+    const { container } = render(<PluginFrame pluginId="demo" />);
+    const iframe = container.querySelector('iframe')!;
+    const posted: Array<Record<string, unknown>> = [];
+    (iframe.contentWindow as unknown as { postMessage: (m: unknown) => void }).postMessage = (m: unknown) =>
+      posted.push(m as Record<string, unknown>);
+    const set = (requestId: string, key: string, value: unknown) => {
+      fromFrame(iframe, { type: 'trek:session:set', requestId, key, value });
+      return posted.find((message) => message.requestId === requestId);
+    };
+
+    expect(set('bad-key', 'x'.repeat(65), 1)).toMatchObject({ type: 'trek:error', code: 'SESSION_INVALID_KEY' });
+    expect(set('big-value', 'large', 'x'.repeat(1024))).toMatchObject({
+      type: 'trek:error',
+      code: 'SESSION_VALUE_TOO_LARGE',
+    });
+    expect(set('at-limits', 'x'.repeat(64), 'x'.repeat(1022))).toMatchObject({ type: 'trek:response' });
+
+    sessionStorage.clear();
+    for (let index = 0; index < 32; index += 1) {
+      expect(set(`key-${index}`, `key-${index}`, index)).toMatchObject({ type: 'trek:response' });
+    }
+    expect(set('too-many', 'key-32', 32)).toMatchObject({ type: 'trek:error', code: 'SESSION_KEY_LIMIT' });
+  });
 });

--- a/client/src/components/Plugins/PluginFrame.tsx
+++ b/client/src/components/Plugins/PluginFrame.tsx
@@ -415,6 +415,9 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
           break
         }
         case 'trek:session:clear': {
+          // Same guard the other request/response handlers apply: without an id
+          // the frame could never match our answer to its call.
+          if (typeof msg.requestId !== 'string' || !msg.requestId) break
           const scope = msg.scope === 'trip' ? 'trip' : 'plugin'
 
           // tripId required if we are on a trip-scoped key.
@@ -436,6 +439,7 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
         case 'trek:session:get':
         case 'trek:session:set':
         case 'trek:session:remove': {
+          if (typeof msg.requestId !== 'string' || !msg.requestId) break
           const scope = msg.scope === 'trip' ? 'trip' : 'plugin'
           if (scope === 'trip' && tripId == null) {
             post({ type: 'trek:error', requestId: msg.requestId, code: 'NO_TRIP_CONTEXT', message: 'trip session storage requires a trip context' })
@@ -551,7 +555,7 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
       // The frame is going away (or re-bridging) — never leave a live GPS watch behind.
       if (geoWatchRef.current != null) { navigator.geolocation.clearWatch(geoWatchRef.current); geoWatchRef.current = null }
     }
-  }, [pluginId, tripId, fill, navigate, postFrame, buildContext])
+  }, [pluginId, tripId, fill, navigate, postFrame, buildContext, userId])
 
   // Hosts swap pluginId in place (tab bar, /plugins/:id route) — the iframe below
   // is keyed so the document is a fresh first load, and the per-plugin bridge

--- a/client/src/components/Plugins/PluginFrame.tsx
+++ b/client/src/components/Plugins/PluginFrame.tsx
@@ -106,6 +106,8 @@ interface PluginFrameProps {
   path?: string
 }
 
+type PluginSessionStorageScope = 'plugin' | 'trip'
+
 type Inbound =
   | { type: 'trek:ready' }
   | { type: 'trek:context:request' }
@@ -113,6 +115,10 @@ type Inbound =
   | { type: 'trek:notify'; level?: 'info' | 'success' | 'warning' | 'error'; message?: string; duration?: number }
   | { type: 'trek:resize'; height?: number }
   | { type: 'trek:invoke'; requestId: string; sub: string; method?: string; body?: unknown }
+  | { type: 'trek:session:get'; requestId: string; key: string; scope?: PluginSessionStorageScope }
+  | { type: 'trek:session:set'; requestId: string; key: string; value: unknown; scope?: PluginSessionStorageScope }
+  | { type: 'trek:session:remove'; requestId: string; key: string; scope?: PluginSessionStorageScope }
+  | { type: 'trek:session:clear'; requestId: string; scope?: PluginSessionStorageScope }
   | { type: 'trek:confirm'; requestId: string; title?: string; message?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean }
   | { type: 'trek:openExternal'; url?: string }
   | { type: 'trek:geolocation'; requestId: string; action?: 'get' | 'watch' | 'clear' }
@@ -140,6 +146,38 @@ interface ConfirmRequest {
   confirmLabel?: string
   cancelLabel?: string
   danger: boolean
+}
+
+/**
+ * Creates the prefix and full key for host-owned plugin session storage.
+ *
+ *   trek:plugin-session:{userId}:{pluginId}:plugin:{key}
+ *   trek:plugin-session:{userId}:{pluginId}:trip:{tripId}:{key}
+ *
+ * Each dynamic segment is URI-encoded, so plugin-controlled values cannot alter
+ * the key format. For clear, omit logicalKey; the returned full key is then
+ * the same as the scoped prefix.
+ */
+function createPluginSessionStorageKeys(
+  userId: string | number | null,
+  pluginId: string,
+  scope: PluginSessionStorageScope,
+  tripId: string | null,
+  logicalKey?: string,
+) {
+  const namespace = 'trek:plugin-session:'
+  const encodedUserId = encodeURIComponent(String(userId))
+  const encodedPluginId = encodeURIComponent(pluginId)
+  const encodedTripId = scope === 'trip' ? encodeURIComponent(tripId!) : null
+  const encodedLogicalKey = logicalKey === undefined ? undefined : encodeURIComponent(logicalKey)
+
+  const storageScopeSegment = encodedTripId === null ? scope : `${scope}:${encodedTripId}`
+  const storageKeyPrefix = `${namespace}${encodedUserId}:${encodedPluginId}:${storageScopeSegment}:`
+  const storageKey = encodedLogicalKey === undefined ? storageKeyPrefix : `${storageKeyPrefix}${encodedLogicalKey}`
+  return {
+    storageKeyPrefix,
+    storageKey,
+  }
 }
 
 export default function PluginFrame({ pluginId, tripId = null, placeId = null, dayId = null, reservationId = null, fill = false, className, title, path = 'index.html' }: PluginFrameProps) {
@@ -347,6 +385,65 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
             (e) => { if (loadsRef.current <= 1) fail(geoErrorCode(e)) },
             geoOpts,
           )
+          break
+        }
+        case 'trek:session:clear': {
+          const scope = msg.scope === 'trip' ? 'trip' : 'plugin'
+
+          // tripId required if we are on a trip-scoped key.
+          if (scope === 'trip' && tripId == null) {
+            post({ type: 'trek:error', requestId: msg.requestId, code: 'NO_TRIP_CONTEXT', message: 'trip session storage requires a trip context' })
+            break
+          }
+
+          const { storageKeyPrefix } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId)
+          try {
+            const keysToRemove: string[] = []
+            for (let i = 0; i < sessionStorage.length; i += 1) {
+              const storageKey = sessionStorage.key(i)
+              if (storageKey?.startsWith(storageKeyPrefix)) keysToRemove.push(storageKey)
+            }
+            keysToRemove.forEach((storageKey) => sessionStorage.removeItem(storageKey))
+            post({ type: 'trek:response', requestId: msg.requestId, data: undefined })
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'session storage failed'
+            post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_STORAGE_ERROR', message })
+          }
+          break
+        }
+        case 'trek:session:get':
+        case 'trek:session:set':
+        case 'trek:session:remove': {
+          const scope = msg.scope === 'trip' ? 'trip' : 'plugin'
+          if (scope === 'trip' && tripId == null) {
+            post({ type: 'trek:error', requestId: msg.requestId, code: 'NO_TRIP_CONTEXT', message: 'trip session storage requires a trip context' })
+            break
+          }
+          const { storageKey } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId, msg.key)
+          try {
+            if (msg.type === 'trek:session:get') {
+              const storedValue = sessionStorage.getItem(storageKey)
+              post({ type: 'trek:response', requestId: msg.requestId, data: storedValue === null ? undefined : JSON.parse(storedValue) })
+              break
+            }
+
+            if (msg.type === 'trek:session:set') {
+              const serializedValue = JSON.stringify(msg.value)
+              if (serializedValue === undefined) {
+                post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_INVALID_VALUE', message: 'session value must be JSON-serialisable' })
+                break
+              }
+              sessionStorage.setItem(storageKey, serializedValue)
+              post({ type: 'trek:response', requestId: msg.requestId, data: undefined })
+              break
+            }
+
+            sessionStorage.removeItem(storageKey)
+            post({ type: 'trek:response', requestId: msg.requestId, data: undefined })
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'session storage failed'
+            post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_STORAGE_ERROR', message })
+          }
           break
         }
       }

--- a/client/src/components/Plugins/PluginFrame.tsx
+++ b/client/src/components/Plugins/PluginFrame.tsx
@@ -148,11 +148,38 @@ interface ConfirmRequest {
   danger: boolean
 }
 
+const PLUGIN_SESSION_NAMESPACE = 'trek:plugin-session:'
+const PLUGIN_SESSION_MAX_KEY_LENGTH = 64
+const PLUGIN_SESSION_MAX_KEYS = 32
+const PLUGIN_SESSION_MAX_VALUE_BYTES = 1024
+
+/**
+ * Returns all host-owned storage keys in one plugin scope (plugin-wide or a
+ * specific trip), excluding TREK state and every other plugin/scope.
+ */
+function getScopedSessionKeys(scopeKeyPrefix: string) {
+  const keys: string[] = []
+  for (let i = 0; i < sessionStorage.length; i += 1) {
+    const key = sessionStorage.key(i)
+    if (key?.startsWith(scopeKeyPrefix)) keys.push(key)
+  }
+  return keys
+}
+
 /**
  * Creates the prefix and full key for host-owned plugin session storage.
  *
+ *   Storage Keys:
  *   trek:plugin-session:{userId}:{pluginId}:plugin:{key}
  *   trek:plugin-session:{userId}:{pluginId}:trip:{tripId}:{key}
+ *
+ *   Scope Prefix:
+ *   trek:plugin-session:{userId}:{pluginId}:plugin
+ *   trek:plugin-session:{userId}:{pluginId}:trip:{tripId}
+ *
+ *   Plugin Prefix:
+ *   trek:plugin-session:{userId}:{pluginId}
+ *
  *
  * Each dynamic segment is URI-encoded, so plugin-controlled values cannot alter
  * the key format. For clear, omit logicalKey; the returned full key is then
@@ -165,17 +192,17 @@ function createPluginSessionStorageKeys(
   tripId: string | null,
   logicalKey?: string,
 ) {
-  const namespace = 'trek:plugin-session:'
-  const encodedUserId = encodeURIComponent(String(userId))
-  const encodedPluginId = encodeURIComponent(pluginId)
-  const encodedTripId = scope === 'trip' ? encodeURIComponent(tripId!) : null
-  const encodedLogicalKey = logicalKey === undefined ? undefined : encodeURIComponent(logicalKey)
+  const pluginKeyPrefix = `${PLUGIN_SESSION_NAMESPACE}${encodeURIComponent(String(userId))}:${encodeURIComponent(pluginId)}:`
 
-  const storageScopeSegment = encodedTripId === null ? scope : `${scope}:${encodedTripId}`
-  const storageKeyPrefix = `${namespace}${encodedUserId}:${encodedPluginId}:${storageScopeSegment}:`
-  const storageKey = encodedLogicalKey === undefined ? storageKeyPrefix : `${storageKeyPrefix}${encodedLogicalKey}`
+  // Scope is either :plugin: or :trip:${tripId}:
+  const scopeSegment = scope === 'trip' ? `trip:${encodeURIComponent(tripId!)}` : 'plugin'
+  const scopeKeyPrefix = `${pluginKeyPrefix}${scopeSegment}:`
+
+  const encodedLogicalKey = logicalKey === undefined ? undefined : encodeURIComponent(logicalKey)
+  const storageKey = encodedLogicalKey === undefined ? scopeKeyPrefix : `${scopeKeyPrefix}${encodedLogicalKey}`
   return {
-    storageKeyPrefix,
+    pluginKeyPrefix,
+    scopeKeyPrefix,
     storageKey,
   }
 }
@@ -396,14 +423,9 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
             break
           }
 
-          const { storageKeyPrefix } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId)
+          const { scopeKeyPrefix } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId)
           try {
-            const keysToRemove: string[] = []
-            for (let i = 0; i < sessionStorage.length; i += 1) {
-              const storageKey = sessionStorage.key(i)
-              if (storageKey?.startsWith(storageKeyPrefix)) keysToRemove.push(storageKey)
-            }
-            keysToRemove.forEach((storageKey) => sessionStorage.removeItem(storageKey))
+            getScopedSessionKeys(scopeKeyPrefix).forEach((storageKey) => sessionStorage.removeItem(storageKey))
             post({ type: 'trek:response', requestId: msg.requestId, data: undefined })
           } catch (error) {
             const message = error instanceof Error ? error.message : 'session storage failed'
@@ -419,7 +441,11 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
             post({ type: 'trek:error', requestId: msg.requestId, code: 'NO_TRIP_CONTEXT', message: 'trip session storage requires a trip context' })
             break
           }
-          const { storageKey } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId, msg.key)
+          if (typeof msg.key !== 'string' || msg.key.length === 0 || msg.key.length > PLUGIN_SESSION_MAX_KEY_LENGTH) {
+            post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_INVALID_KEY', message: `session key must be 1-${PLUGIN_SESSION_MAX_KEY_LENGTH} characters` })
+            break
+          }
+          const { scopeKeyPrefix, storageKey } = createPluginSessionStorageKeys(userId, pluginId, scope, tripId, msg.key)
           try {
             if (msg.type === 'trek:session:get') {
               const storedValue = sessionStorage.getItem(storageKey)
@@ -431,6 +457,18 @@ export default function PluginFrame({ pluginId, tripId = null, placeId = null, d
               const serializedValue = JSON.stringify(msg.value)
               if (serializedValue === undefined) {
                 post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_INVALID_VALUE', message: 'session value must be JSON-serialisable' })
+                break
+              }
+
+              // Validate length based on unicode byte sizes
+              const valueBytes = new TextEncoder().encode(serializedValue).byteLength
+              if (valueBytes > PLUGIN_SESSION_MAX_VALUE_BYTES) {
+                post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_VALUE_TOO_LARGE', message: `session value exceeds ${PLUGIN_SESSION_MAX_VALUE_BYTES} bytes` })
+                break
+              }
+              const keys = getScopedSessionKeys(scopeKeyPrefix)
+              if (!keys.includes(storageKey) && keys.length >= PLUGIN_SESSION_MAX_KEYS) {
+                post({ type: 'trek:error', requestId: msg.requestId, code: 'SESSION_KEY_LIMIT', message: `plugin session storage allows at most ${PLUGIN_SESSION_MAX_KEYS} keys` })
                 break
               }
               sessionStorage.setItem(storageKey, serializedValue)

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -10,6 +10,7 @@ import { setAuthed } from '../sync/authGate'
 import { unregisterSyncTriggers } from '../sync/syncTriggers'
 import { useSystemNoticeStore } from './systemNoticeStore.js'
 import { clearAppearanceSnapshot } from '../theme/applyAppearance'
+import { clearAllPluginSessions } from './pluginStore'
 
 interface AuthResponse {
   user: User
@@ -195,6 +196,9 @@ export const useAuthStore = create<AuthState>()(
     // Drop the per-device appearance snapshot so the next user on a shared
     // browser doesn't get a pre-paint flash of this user's theme.
     clearAppearanceSnapshot()
+    // Same reason for the brokered plugin session state: it is keyed by user id,
+    // but sessionStorage outlives a logout within the tab.
+    clearAllPluginSessions()
     // 4. Tell server to clear the httpOnly cookie (best-effort).
     await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
     // 5. Clear service worker caches containing sensitive data.

--- a/client/src/store/pluginStore.test.ts
+++ b/client/src/store/pluginStore.test.ts
@@ -7,6 +7,7 @@ const initial = usePluginStore.getState();
 
 beforeEach(() => {
   usePluginStore.setState(initial, true);
+  sessionStorage.clear();
 });
 
 describe('pluginStore', () => {
@@ -36,15 +37,39 @@ describe('pluginStore', () => {
   });
 
   it('FE-STORE-PLUGIN-002: a failed fetch still marks the store loaded (no crash)', async () => {
+    sessionStorage.setItem('trek:plugin-session:7:active:plugin:filters', '["flight"]');
     server.use(http.get('/api/plugins', () => HttpResponse.error()));
     await usePluginStore.getState().loadPlugins();
     expect(usePluginStore.getState().loaded).toBe(true);
     expect(usePluginStore.getState().plugins).toEqual([]);
+    expect(sessionStorage.getItem('trek:plugin-session:7:active:plugin:filters')).toBe('["flight"]');
   });
 
   it('FE-STORE-PLUGIN-003: tolerates a missing plugins array', async () => {
     server.use(http.get('/api/plugins', () => HttpResponse.json({})));
     await usePluginStore.getState().loadPlugins();
     expect(usePluginStore.getState().plugins).toEqual([]);
+  });
+
+  it('FE-STORE-PLUGIN-004: clears session state for disabled plugins after a successful refresh', async () => {
+    sessionStorage.setItem('trek:plugin-session:7:active:plugin:filters', '["flight"]');
+    sessionStorage.setItem('trek:plugin-session:7:disabled:plugin:filters', '["hotel"]');
+    sessionStorage.setItem('trek:plugin-session:7:disabled:trip:42:view', '"table"');
+    sessionStorage.setItem('trek_session', 'app-session');
+
+    server.use(
+      http.get('/api/plugins', () =>
+        HttpResponse.json({
+          plugins: [{ id: 'active', name: 'Active', type: 'widget', icon: null }],
+        }),
+      ),
+    );
+
+    await usePluginStore.getState().loadPlugins();
+
+    expect(sessionStorage.getItem('trek:plugin-session:7:active:plugin:filters')).toBe('["flight"]');
+    expect(sessionStorage.getItem('trek:plugin-session:7:disabled:plugin:filters')).toBeNull();
+    expect(sessionStorage.getItem('trek:plugin-session:7:disabled:trip:42:view')).toBeNull();
+    expect(sessionStorage.getItem('trek_session')).toBe('app-session');
   });
 });

--- a/client/src/store/pluginStore.test.ts
+++ b/client/src/store/pluginStore.test.ts
@@ -1,7 +1,7 @@
-// FE-STORE-PLUGIN-001 to 004
+// FE-STORE-PLUGIN-001 to 006
 import { http, HttpResponse } from 'msw';
 import { server } from '../../tests/helpers/msw/server';
-import { usePluginStore } from './pluginStore';
+import { usePluginStore, clearAllPluginSessions } from './pluginStore';
 
 const initial = usePluginStore.getState();
 
@@ -71,5 +71,32 @@ describe('pluginStore', () => {
     expect(sessionStorage.getItem('trek:plugin-session:7:disabled:plugin:filters')).toBeNull();
     expect(sessionStorage.getItem('trek:plugin-session:7:disabled:trip:42:view')).toBeNull();
     expect(sessionStorage.getItem('trek_session')).toBe('app-session');
+  });
+
+  it('FE-STORE-PLUGIN-005: clearAllPluginSessions drops every user and scope, but nothing else', () => {
+    sessionStorage.setItem('trek:plugin-session:7:active:plugin:filters', '["flight"]');
+    sessionStorage.setItem('trek:plugin-session:9:active:trip:42:view', '"table"');
+    sessionStorage.setItem('trek_session', 'app-session');
+
+    clearAllPluginSessions();
+
+    expect(sessionStorage.getItem('trek:plugin-session:7:active:plugin:filters')).toBeNull();
+    expect(sessionStorage.getItem('trek:plugin-session:9:active:trip:42:view')).toBeNull();
+    expect(sessionStorage.getItem('trek_session')).toBe('app-session');
+  });
+
+  it('FE-STORE-PLUGIN-006: a sessionStorage failure during the purge still keeps the loaded plugins', async () => {
+    const key = vi.spyOn(Storage.prototype, 'key').mockImplementation(() => { throw new Error('storage disabled'); });
+    server.use(
+      http.get('/api/plugins', () =>
+        HttpResponse.json({ plugins: [{ id: 'active', name: 'Active', type: 'widget', icon: null }] }),
+      ),
+    );
+
+    await usePluginStore.getState().loadPlugins();
+
+    expect(usePluginStore.getState().plugins.map((p) => p.id)).toEqual(['active']);
+    expect(usePluginStore.getState().loaded).toBe(true);
+    key.mockRestore();
   });
 });

--- a/client/src/store/pluginStore.ts
+++ b/client/src/store/pluginStore.ts
@@ -24,6 +24,20 @@ function clearInactivePluginSessions(activePluginIds: Set<string>) {
 }
 
 /**
+ * Drops every plugin's session state, whatever user or trip it belonged to.
+ * Logout calls this so the next user on a shared browser starts clean — the
+ * same reason the appearance snapshot and the user-scoped offline DB go.
+ */
+export function clearAllPluginSessions() {
+  const keysToRemove: string[] = []
+  for (let i = 0; i < sessionStorage.length; i += 1) {
+    const storageKey = sessionStorage.key(i)
+    if (storageKey?.startsWith(PLUGIN_SESSION_NAMESPACE)) keysToRemove.push(storageKey)
+  }
+  keysToRemove.forEach((storageKey) => sessionStorage.removeItem(storageKey))
+}
+
+/**
  * Active plugins the client renders (#plugins, M3). Page plugins become nav
  * entries + a full-page iframe route; widget plugins mount on the dashboard.
  * Cloned from addonStore — plugins have their own feed and lifecycle, so they
@@ -70,8 +84,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
     try {
       const data = await pluginsApi.active()
       const plugins = (data.plugins as ActivePlugin[]) || []
-      clearInactivePluginSessions(new Set(plugins.map((plugin) => plugin.id)))
       set({ plugins, loaded: true })
+      // After the state is committed: a sessionStorage failure (Safari private
+      // mode, quota) must not cost us the plugin list we just fetched.
+      try {
+        clearInactivePluginSessions(new Set(plugins.map((plugin) => plugin.id)))
+      } catch { /* leaving stale plugin state behind beats losing the nav entries */ }
     } catch {
       set({ loaded: true })
     }

--- a/client/src/store/pluginStore.ts
+++ b/client/src/store/pluginStore.ts
@@ -1,6 +1,28 @@
 import { create } from 'zustand'
 import { pluginsApi } from '../api/client'
 
+const PLUGIN_SESSION_NAMESPACE = 'trek:plugin-session:'
+
+/**
+ * Purges state for plugins absent from a successful active-plugin response.
+ * A failed request never calls this, because plugin status is then unknown.
+ */
+function clearInactivePluginSessions(activePluginIds: Set<string>) {
+  const keysToRemove: string[] = []
+  for (let i = 0; i < sessionStorage.length; i += 1) {
+    const storageKey = sessionStorage.key(i)
+    if (!storageKey?.startsWith(PLUGIN_SESSION_NAMESPACE)) continue
+    const encodedPluginId = storageKey.slice(PLUGIN_SESSION_NAMESPACE.length).split(':')[1]
+    if (encodedPluginId === undefined) continue
+    try {
+      if (!activePluginIds.has(decodeURIComponent(encodedPluginId))) keysToRemove.push(storageKey)
+    } catch {
+      // Ignore malformed keys outside the host-owned format.
+    }
+  }
+  keysToRemove.forEach((storageKey) => sessionStorage.removeItem(storageKey))
+}
+
 /**
  * Active plugins the client renders (#plugins, M3). Page plugins become nav
  * entries + a full-page iframe route; widget plugins mount on the dashboard.
@@ -47,7 +69,9 @@ export const usePluginStore = create<PluginState>((set, get) => ({
   loadPlugins: async () => {
     try {
       const data = await pluginsApi.active()
-      set({ plugins: (data.plugins as ActivePlugin[]) || [], loaded: true })
+      const plugins = (data.plugins as ActivePlugin[]) || []
+      clearInactivePluginSessions(new Set(plugins.map((plugin) => plugin.id)))
+      set({ plugins, loaded: true })
     } catch {
       set({ loaded: true })
     }

--- a/plugin-sdk/README.md
+++ b/plugin-sdk/README.md
@@ -76,6 +76,27 @@ const data = await trek.invoke('/status')   // calls your own route, host-proxie
 trek.notify('success', 'Saved')
 ```
 
+### Keep UI state for this browser tab
+
+The opaque frame cannot use browser storage directly. The bridge provides
+host-managed, JSON-only session state instead. It survives an iframe remount and
+page reload in the same browser tab, but is not durable data. Do not use it to
+store secrets.
+
+```js
+// Default: this user + this plugin + this browser tab.
+await trek.session.set('dismissed-onboarding', true)
+const dismissed = await trek.session.get('dismissed-onboarding')
+
+// Explicitly partition state by the trip in view (fails without a trip context).
+await trek.session.set('filters', ['flight', 'hotel'], { scope: 'trip' })
+```
+
+`get()` returns `undefined` for a missing key. `set`, `get`, `remove`, and
+`clear` accept `{ scope: 'plugin' | 'trip' }`; `plugin` is the default. Use your
+plugin's own logical key (for example `reservation:88:expanded`) for any finer
+partitioning.
+
 The kit applies the theme, mirrors the appearance flags (reduced-motion,
 no-transparency) and auto-reports your height. It also upgrades any native
 `<select>` into a host-styled, keyboard-accessible dropdown that matches TREK —

--- a/plugin-sdk/README.md
+++ b/plugin-sdk/README.md
@@ -95,7 +95,8 @@ await trek.session.set('filters', ['flight', 'hotel'], { scope: 'trip' })
 `get()` returns `undefined` for a missing key. `set`, `get`, `remove`, and
 `clear` accept `{ scope: 'plugin' | 'trip' }`; `plugin` is the default. Use your
 plugin's own logical key (for example `reservation:88:expanded`) for any finer
-partitioning.
+partitioning. Each plugin or individual trip scope is limited to 32 keys,
+64 characters per key, and 1 KiB per JSON value.
 
 The kit applies the theme, mirrors the appearance flags (reduced-motion,
 no-transparency) and auto-reports your height. It also upgrades any native

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -664,7 +664,10 @@ function ctx(){
 function postCtx(){ if(f.contentWindow) f.contentWindow.postMessage(ctx(),"*"); }
 var tt; function toast(msg){var el=document.getElementById("toast");el.textContent=msg;el.classList.add("on");clearTimeout(tt);tt=setTimeout(function(){el.classList.remove("on");},2200);}
 var SESSION_PREFIX="trek:plugin-session:1:"+encodeURIComponent(${JSON.stringify(id)})+":";
+var SESSION_MAX_KEYS=32,SESSION_MAX_KEY_LENGTH=64,SESSION_MAX_VALUE_BYTES=1024;
+function sessionFail(m,code,message){f.contentWindow.postMessage({type:"trek:error",requestId:m.requestId,code:code,message:message},"*");}
 function sessionMessage(m){
+  try {
   var trip=ctx().tripId, scope=m.scope==="trip"?"trip":"plugin";
   if(scope==="trip"&&!trip){f.contentWindow.postMessage({type:"trek:error",requestId:m.requestId,code:"NO_TRIP_CONTEXT",message:"trip session storage requires a trip context"},"*");return;}
   var prefix=SESSION_PREFIX+scope+(scope==="trip"?":"+encodeURIComponent(String(trip)):"")+":";
@@ -672,12 +675,23 @@ function sessionMessage(m){
   if(m.type==="trek:session:clear"){
     var doomed=[];for(var i=0;i<sessionStorage.length;i++){var stored=sessionStorage.key(i);if(stored&&stored.indexOf(prefix)===0)doomed.push(stored);}doomed.forEach(function(stored){sessionStorage.removeItem(stored);});
   } else {
+    if(typeof m.key!=="string"||!m.key||m.key.length>SESSION_MAX_KEY_LENGTH){sessionFail(m,"SESSION_INVALID_KEY","session key must be 1-"+SESSION_MAX_KEY_LENGTH+" characters");return;}
     var key=prefix+encodeURIComponent(m.key);
     if(m.type==="trek:session:get"){var raw=sessionStorage.getItem(key);data=raw===null?undefined:JSON.parse(raw);}
     else if(m.type==="trek:session:remove"){sessionStorage.removeItem(key);}
-    else {sessionStorage.setItem(key,JSON.stringify(m.value));}
+    else {
+      var json=JSON.stringify(m.value);
+      if(json===undefined){sessionFail(m,"SESSION_INVALID_VALUE","session value must be JSON-serialisable");return;}
+      var bytes=new TextEncoder().encode(json).length;
+      if(bytes>SESSION_MAX_VALUE_BYTES){sessionFail(m,"SESSION_VALUE_TOO_LARGE","session value exceeds "+SESSION_MAX_VALUE_BYTES+" bytes");return;}
+      var count=0,exists=false;
+      for(var j=0;j<sessionStorage.length;j++){var sk=sessionStorage.key(j);if(sk&&sk.indexOf(prefix)===0){count++;if(sk===key)exists=true;}}
+      if(!exists&&count>=SESSION_MAX_KEYS){sessionFail(m,"SESSION_KEY_LIMIT","plugin session storage allows at most "+SESSION_MAX_KEYS+" keys");return;}
+      sessionStorage.setItem(key,json);
+    }
   }
   f.contentWindow.postMessage({type:"trek:response",requestId:m.requestId,data:data},"*");
+  } catch(e) { sessionFail(m,"SESSION_STORAGE_ERROR",String(e&&e.message||e)); }
 }
 window.addEventListener("message", function(ev){
   if(ev.source!==f.contentWindow) return;

--- a/plugin-sdk/src/cli/dev.ts
+++ b/plugin-sdk/src/cli/dev.ts
@@ -663,6 +663,22 @@ function ctx(){
 }
 function postCtx(){ if(f.contentWindow) f.contentWindow.postMessage(ctx(),"*"); }
 var tt; function toast(msg){var el=document.getElementById("toast");el.textContent=msg;el.classList.add("on");clearTimeout(tt);tt=setTimeout(function(){el.classList.remove("on");},2200);}
+var SESSION_PREFIX="trek:plugin-session:1:"+encodeURIComponent(${JSON.stringify(id)})+":";
+function sessionMessage(m){
+  var trip=ctx().tripId, scope=m.scope==="trip"?"trip":"plugin";
+  if(scope==="trip"&&!trip){f.contentWindow.postMessage({type:"trek:error",requestId:m.requestId,code:"NO_TRIP_CONTEXT",message:"trip session storage requires a trip context"},"*");return;}
+  var prefix=SESSION_PREFIX+scope+(scope==="trip"?":"+encodeURIComponent(String(trip)):"")+":";
+  var data;
+  if(m.type==="trek:session:clear"){
+    var doomed=[];for(var i=0;i<sessionStorage.length;i++){var stored=sessionStorage.key(i);if(stored&&stored.indexOf(prefix)===0)doomed.push(stored);}doomed.forEach(function(stored){sessionStorage.removeItem(stored);});
+  } else {
+    var key=prefix+encodeURIComponent(m.key);
+    if(m.type==="trek:session:get"){var raw=sessionStorage.getItem(key);data=raw===null?undefined:JSON.parse(raw);}
+    else if(m.type==="trek:session:remove"){sessionStorage.removeItem(key);}
+    else {sessionStorage.setItem(key,JSON.stringify(m.value));}
+  }
+  f.contentWindow.postMessage({type:"trek:response",requestId:m.requestId,data:data},"*");
+}
 window.addEventListener("message", function(ev){
   if(ev.source!==f.contentWindow) return;
   var m=ev.data; if(!m||typeof m!=="object") return;
@@ -695,6 +711,9 @@ window.addEventListener("message", function(ev){
       f.contentWindow.postMessage({type:"trek:geolocation:update",position:pos},"*");
     }
     else { f.contentWindow.postMessage({type:"trek:geolocation:result",requestId:m.requestId,position:pos},"*"); }
+  }
+  else if(m.type==="trek:session:get"||m.type==="trek:session:set"||m.type==="trek:session:remove"||m.type==="trek:session:clear"){
+    sessionMessage(m);
   }
 });
 var geoTick=null;

--- a/plugin-sdk/src/index.ts
+++ b/plugin-sdk/src/index.ts
@@ -729,6 +729,27 @@ export {
   PermissionDenied, HOOK_PERMISSION, USER_DATA_PERMISSION, EVENTS_PERMISSION, JOBS_PERMISSION,
   grantGaps, grantedHosts, type GrantGap, type PluginEntryPoints,
 } from './permissions.js';
+
+/** Scope for host-managed, per-user session state in a sandboxed plugin UI. */
+export type PluginSessionStorageScope = 'plugin' | 'trip';
+
+/** Limits enforced independently for the plugin scope and each trip scope. */
+export const PLUGIN_SESSION_MAX_KEYS = 32;
+export const PLUGIN_SESSION_MAX_KEY_LENGTH = 64;
+export const PLUGIN_SESSION_MAX_VALUE_BYTES = 1024;
+
+export interface PluginSessionStorageOptions {
+  scope?: PluginSessionStorageScope;
+}
+
+/** The `window.trek.session` surface. Values must be JSON-serialisable. */
+export interface PluginSessionStorage {
+  get<T = unknown>(key: string, options?: PluginSessionStorageOptions): Promise<T | undefined>;
+  set(key: string, value: unknown, options?: PluginSessionStorageOptions): Promise<void>;
+  remove(key: string, options?: PluginSessionStorageOptions): Promise<void>;
+  clear(options?: PluginSessionStorageOptions): Promise<void>;
+}
+
 // The design kit for page/widget UIs: inline these into your client/index.html
 // (or drop a `<!-- trek:ui -->` marker and let `dev`/`pack` expand it) to get the
 // native TREK look — glass, hover, buttons, inputs — plus a `window.trek` bridge.

--- a/plugin-sdk/src/mock-host.ts
+++ b/plugin-sdk/src/mock-host.ts
@@ -242,17 +242,28 @@ export function createMockHost(opts: MockHostOptions = {}): MockHost {
   const emitted: MockHost['emitted'] = [];
   const notifications: MockHost['notifications'] = [];
   const sessionValues = new Map<string, string>();
+  // The real bridge rejects with a plain Error carrying the code on `.code`
+  // (ui/kit.ts). Keep the `CODE: message` text the rest of this mock uses, but
+  // attach `.code` too, so a plugin that branches on it behaves the same here.
+  const sessionError = (code: string, message: string) => {
+    const err = new Error(`${code}: ${message}`) as Error & { code: string };
+    err.code = code;
+    return err;
+  };
   const sessionPrefix = (scope: 'plugin' | 'trip') => {
     if (scope === 'trip' && opts.sessionTripId === undefined) {
-      throw new Error('NO_TRIP_CONTEXT: trip session storage requires a trip context');
+      throw sessionError('NO_TRIP_CONTEXT', 'trip session storage requires a trip context');
     }
     return scope === 'trip' ? `trip:${opts.sessionTripId}:` : 'plugin:';
   };
   const sessionKey = (key: string, scope: 'plugin' | 'trip') => {
+    // Scope before key, in the host's order — otherwise the same bad call
+    // reports a different code here than it does in the app.
+    const prefix = sessionPrefix(scope);
     if (!key || key.length > PLUGIN_SESSION_MAX_KEY_LENGTH) {
-      throw new Error(`SESSION_INVALID_KEY: session key must be 1-${PLUGIN_SESSION_MAX_KEY_LENGTH} characters`);
+      throw sessionError('SESSION_INVALID_KEY', `session key must be 1-${PLUGIN_SESSION_MAX_KEY_LENGTH} characters`);
     }
-    return `${sessionPrefix(scope)}${key}`;
+    return `${prefix}${key}`;
   };
   const session: PluginSessionStorage = {
     async get(key, options) {
@@ -262,15 +273,15 @@ export function createMockHost(opts: MockHostOptions = {}): MockHost {
     async set(key, value, options) {
       const fullKey = sessionKey(key, options?.scope === 'trip' ? 'trip' : 'plugin');
       const serialized = JSON.stringify(value);
-      if (serialized === undefined) throw new Error('SESSION_INVALID_VALUE: session value must be JSON-serialisable');
+      if (serialized === undefined) throw sessionError('SESSION_INVALID_VALUE', 'session value must be JSON-serialisable');
       const valueBytes = Buffer.byteLength(serialized, 'utf8');
       if (valueBytes > PLUGIN_SESSION_MAX_VALUE_BYTES) {
-        throw new Error(`SESSION_VALUE_TOO_LARGE: session value exceeds ${PLUGIN_SESSION_MAX_VALUE_BYTES} bytes`);
+        throw sessionError('SESSION_VALUE_TOO_LARGE', `session value exceeds ${PLUGIN_SESSION_MAX_VALUE_BYTES} bytes`);
       }
       const prefix = sessionPrefix(options?.scope === 'trip' ? 'trip' : 'plugin');
       const scopedKeyCount = [...sessionValues.keys()].filter((storedKey) => storedKey.startsWith(prefix)).length;
       if (!sessionValues.has(fullKey) && scopedKeyCount >= PLUGIN_SESSION_MAX_KEYS) {
-        throw new Error(`SESSION_KEY_LIMIT: plugin session storage allows at most ${PLUGIN_SESSION_MAX_KEYS} keys`);
+        throw sessionError('SESSION_KEY_LIMIT', `plugin session storage allows at most ${PLUGIN_SESSION_MAX_KEYS} keys`);
       }
       sessionValues.set(fullKey, serialized);
     },

--- a/plugin-sdk/src/mock-host.ts
+++ b/plugin-sdk/src/mock-host.ts
@@ -1,4 +1,5 @@
-import type { PluginContext, PluginDefinition, PluginRequest, PluginResponse, Trip, Place, Day, Reservation, PackingItem, TripFile, BudgetItem, User, NotificationMessage, PluginActionResult } from './index.js';
+import { PLUGIN_SESSION_MAX_KEYS, PLUGIN_SESSION_MAX_KEY_LENGTH, PLUGIN_SESSION_MAX_VALUE_BYTES } from './index.js';
+import type { PluginContext, PluginDefinition, PluginRequest, PluginResponse, Trip, Place, Day, Reservation, PackingItem, TripFile, BudgetItem, User, NotificationMessage, PluginActionResult, PluginSessionStorage } from './index.js';
 import { CHANNEL_EVENTS } from './manifest.js';
 import { PermissionDenied, HOOK_PERMISSION, USER_DATA_PERMISSION, EVENTS_PERMISSION, JOBS_PERMISSION } from './permissions.js';
 
@@ -49,6 +50,8 @@ export interface MockHostOptions {
   queryResults?: Record<string, unknown[]>;
   /** The host-bound acting user for costs.* (a job/onLoad has none → refused). */
   actingUserId?: number;
+  /** Trip bound to the mock plugin UI's `session` helper. Required for scope: 'trip'. */
+  sessionTripId?: number | string;
   /** Whether the Costs (budget) addon is enabled; gates all costs.* (default true). */
   budgetAddonEnabled?: boolean;
   /** Same idea for the other gated subsystems (default true): journey gates
@@ -157,6 +160,8 @@ export interface MockHost {
    * read or write refuses with RESOURCE_FORBIDDEN). Shares this host's fixtures,
    * grants and recorders. */
   userlessCtx: PluginContext;
+  /** In-memory equivalent of `window.trek.session`, with production quota enforcement. */
+  session: PluginSessionStorage;
   /** Everything the plugin did, for assertions. */
   calls: { method: string; args: unknown[] }[];
   logs: { level: string; msg: string }[];
@@ -236,6 +241,49 @@ export function createMockHost(opts: MockHostOptions = {}): MockHost {
   const broadcasts: MockHost['broadcasts'] = [];
   const emitted: MockHost['emitted'] = [];
   const notifications: MockHost['notifications'] = [];
+  const sessionValues = new Map<string, string>();
+  const sessionPrefix = (scope: 'plugin' | 'trip') => {
+    if (scope === 'trip' && opts.sessionTripId === undefined) {
+      throw new Error('NO_TRIP_CONTEXT: trip session storage requires a trip context');
+    }
+    return scope === 'trip' ? `trip:${opts.sessionTripId}:` : 'plugin:';
+  };
+  const sessionKey = (key: string, scope: 'plugin' | 'trip') => {
+    if (!key || key.length > PLUGIN_SESSION_MAX_KEY_LENGTH) {
+      throw new Error(`SESSION_INVALID_KEY: session key must be 1-${PLUGIN_SESSION_MAX_KEY_LENGTH} characters`);
+    }
+    return `${sessionPrefix(scope)}${key}`;
+  };
+  const session: PluginSessionStorage = {
+    async get(key, options) {
+      const raw = sessionValues.get(sessionKey(key, options?.scope === 'trip' ? 'trip' : 'plugin'));
+      return raw === undefined ? undefined : JSON.parse(raw);
+    },
+    async set(key, value, options) {
+      const fullKey = sessionKey(key, options?.scope === 'trip' ? 'trip' : 'plugin');
+      const serialized = JSON.stringify(value);
+      if (serialized === undefined) throw new Error('SESSION_INVALID_VALUE: session value must be JSON-serialisable');
+      const valueBytes = Buffer.byteLength(serialized, 'utf8');
+      if (valueBytes > PLUGIN_SESSION_MAX_VALUE_BYTES) {
+        throw new Error(`SESSION_VALUE_TOO_LARGE: session value exceeds ${PLUGIN_SESSION_MAX_VALUE_BYTES} bytes`);
+      }
+      const prefix = sessionPrefix(options?.scope === 'trip' ? 'trip' : 'plugin');
+      const scopedKeyCount = [...sessionValues.keys()].filter((storedKey) => storedKey.startsWith(prefix)).length;
+      if (!sessionValues.has(fullKey) && scopedKeyCount >= PLUGIN_SESSION_MAX_KEYS) {
+        throw new Error(`SESSION_KEY_LIMIT: plugin session storage allows at most ${PLUGIN_SESSION_MAX_KEYS} keys`);
+      }
+      sessionValues.set(fullKey, serialized);
+    },
+    async remove(key, options) {
+      sessionValues.delete(sessionKey(key, options?.scope === 'trip' ? 'trip' : 'plugin'));
+    },
+    async clear(options) {
+      const prefix = sessionPrefix(options?.scope === 'trip' ? 'trip' : 'plugin');
+      for (const key of sessionValues.keys()) {
+        if (key.startsWith(prefix)) sessionValues.delete(key);
+      }
+    },
+  };
   // Validated once, up front: a fixture the host could never have installed should fail
   // the test at construction, not silently at the first get().
   const userSettings = settingsBlob(opts.userSettings, 'userSettings');
@@ -1486,7 +1534,7 @@ export function createMockHost(opts: MockHostOptions = {}): MockHost {
     },
   });
 
-  return { ctx, userlessCtx, calls, logs, broadcasts, emitted, notifications, scheduled: scheduledTasks, run };
+  return { ctx, userlessCtx, session, calls, logs, broadcasts, emitted, notifications, scheduled: scheduledTasks, run };
 }
 
 // `trek-plugin-sdk/testing` resolves to this module, so re-export what a test needs to

--- a/plugin-sdk/src/ui/kit.ts
+++ b/plugin-sdk/src/ui/kit.ts
@@ -457,9 +457,41 @@ export const TREK_THEME_JS = `(function () {
     mount: function (node, target) { (target || document.body).appendChild(node); return node; }
   };
 
+  var session = {
+    get: function (key, opts) {
+      var id = 's' + (++seq);
+      return new Promise(function (resolve, reject) {
+        pending[id] = { resolve: resolve, reject: reject };
+        send({ type: 'trek:session:get', requestId: id, key: key, scope: opts && opts.scope });
+      });
+    },
+    set: function (key, value, opts) {
+      var id = 's' + (++seq);
+      return new Promise(function (resolve, reject) {
+        pending[id] = { resolve: resolve, reject: reject };
+        send({ type: 'trek:session:set', requestId: id, key: key, value: value, scope: opts && opts.scope });
+      });
+    },
+    remove: function (key, opts) {
+      var id = 's' + (++seq);
+      return new Promise(function (resolve, reject) {
+        pending[id] = { resolve: resolve, reject: reject };
+        send({ type: 'trek:session:remove', requestId: id, key: key, scope: opts && opts.scope });
+      });
+    },
+    clear: function (opts) {
+      var id = 's' + (++seq);
+      return new Promise(function (resolve, reject) {
+        pending[id] = { resolve: resolve, reject: reject };
+        send({ type: 'trek:session:clear', requestId: id, scope: opts && opts.scope });
+      });
+    }
+  };
+
   var api = {
     context: null,
     ui: ui,
+    session: session,
     ready: function () { send({ type: 'trek:ready' }); },
     requestContext: function () { send({ type: 'trek:context:request' }); },
     onContext: function (cb) {

--- a/plugin-sdk/test/sdk.test.ts
+++ b/plugin-sdk/test/sdk.test.ts
@@ -131,6 +131,30 @@ describe('validateManifest', () => {
 });
 
 describe('createMockHost', () => {
+  it('mocks plugin UI session storage with scope isolation and production limits', async () => {
+    const host = createMockHost({ sessionTripId: 42 });
+    await host.session.set('filters', ['hotel']);
+    await host.session.set('filters', ['flight'], { scope: 'trip' });
+    await expect(host.session.get('filters')).resolves.toEqual(['hotel']);
+    await expect(host.session.get('filters', { scope: 'trip' })).resolves.toEqual(['flight']);
+
+    await expect(host.session.set('x'.repeat(65), true)).rejects.toThrow(/SESSION_INVALID_KEY/);
+    await expect(host.session.set('large', 'x'.repeat(1024))).rejects.toThrow(/SESSION_VALUE_TOO_LARGE/);
+    await expect(host.session.set('x'.repeat(64), 'x'.repeat(1022))).resolves.toBeUndefined();
+
+    await host.session.clear();
+    await host.session.clear({ scope: 'trip' });
+    for (let index = 0; index < 32; index += 1) await host.session.set(`key-${index}`, index);
+    await expect(host.session.set('key-32', 32)).rejects.toThrow(/SESSION_KEY_LIMIT/);
+    await expect(host.session.set('trip-key', true, { scope: 'trip' })).resolves.toBeUndefined();
+
+  });
+
+  it('requires a trip context for trip-scoped mock session storage', async () => {
+    const { session } = createMockHost();
+    await expect(session.get('filters', { scope: 'trip' })).rejects.toThrow(/NO_TRIP_CONTEXT/);
+  });
+
   it('enforces the granted permission set', async () => {
     const { ctx } = createMockHost({ grants: ['db:own'] });
     await expect(ctx.db.migrate('1', 'CREATE TABLE t (x)')).resolves.toEqual({ applied: true });

--- a/plugin-sdk/test/ui-kit.test.ts
+++ b/plugin-sdk/test/ui-kit.test.ts
@@ -27,6 +27,9 @@ describe('design kit', () => {
     expect(TREK_THEME_JS).toContain('trek:resize');
     // Trusts only the real parent window (opaque frame has a 'null' origin).
     expect(TREK_THEME_JS).toContain('ev.source !== window.parent');
+    // Host-managed tab state uses the same request/response channel.
+    expect(TREK_THEME_JS).toContain("trek:session:get");
+    expect(TREK_THEME_JS).toContain('session: session');
   });
 
   it('never contains a closing tag that would break <style>/<script> inlining', () => {

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -501,14 +501,25 @@ window.parent.postMessage({ type: 'trek:invoke', requestId: '1', sub: '/status',
 | `trek:confirm` | `{ requestId, title?, message?, confirmLabel?, cancelLabel?, danger? }` | host-rendered ConfirmDialog; answered as `trek:confirm:result` |
 | `trek:openExternal` | `{ url }` | open an `http(s)` URL in a new `noopener` tab; anything else is dropped |
 | `trek:geolocation` | `{ requestId, action?: 'get'\|'watch'\|'clear' }` | host-brokered browser position (needs `geolocation:read`); answered as `trek:geolocation:result`, watch updates stream as `trek:geolocation:update` |
+| `trek:session:get` | `{ requestId, key, scope?: 'plugin'\|'trip' }` | read tab-scoped state; answered as `trek:response` with `data` (`undefined` when unset) |
+| `trek:session:set` | `{ requestId, key, value, scope? }` | store a JSON-serialisable value; answered as `trek:response` |
+| `trek:session:remove` | `{ requestId, key, scope? }` | drop one key; answered as `trek:response` |
+| `trek:session:clear` | `{ requestId, scope? }` | drop every key in that scope; answered as `trek:response` |
+
+The session messages are rejected as `trek:error` with `code` set to `NO_TRIP_CONTEXT`
+(trip scope outside a trip), `SESSION_INVALID_KEY` (empty or over 64 characters),
+`SESSION_INVALID_VALUE` (not JSON-serialisable), `SESSION_VALUE_TOO_LARGE` (over 1 KiB
+serialised), `SESSION_KEY_LIMIT` (over 32 keys in that scope) or `SESSION_STORAGE_ERROR`
+(the browser refused the write). The storage key itself is host-owned and includes the
+signed-in user and your plugin id, so scopes never collide.
 
 **Messages TREK sends you:**
 
 | Message | Payload |
 |---|---|
 | `trek:context` | `{ tripId, placeId, dayId, reservationId, userId, theme, locale, dir, hostOrigin, user, formats, tokens, appearance }` (see below) — re-sent whenever the theme, appearance, **locale or formats** change |
-| `trek:response` | `{ requestId, data }` — a successful `trek:invoke` |
-| `trek:error` | `{ requestId, code, message }` — a failed `trek:invoke` (`code` is the HTTP status or `"error"`) |
+| `trek:response` | `{ requestId, data }` — a successful `trek:invoke` or `trek:session:*` |
+| `trek:error` | `{ requestId, code, message }` — a failed request; for `trek:invoke` `code` is the HTTP status or `"error"`, for `trek:session:*` one of the `SESSION_*` / `NO_TRIP_CONTEXT` codes above |
 | `trek:confirm:result` | `{ requestId, confirmed }` — the user's answer to your `trek:confirm` |
 | `trek:event` | `{ event, tripId }` — a core event fired on the trip in view; **names only, never payloads** — refetch what you need via `trek:invoke` |
 | `trek:geolocation:result` | `{ requestId, position? \| watching? \| cleared? \| error? }` — the answer to a `trek:geolocation` request (`error` ∈ `forbidden`/`denied`/`timeout`/`unavailable`/`unsupported`) |

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -456,6 +456,7 @@ works. Add `data-trek-native` to a field to keep the browser default; `multiple`
 | `trek.onContext(cb)` | run `cb(context)` now (if already received) and on every update; returns an unsubscribe fn |
 | `trek.context` | the last context (or `null`) |
 | `trek.invoke(sub, { method, body })` | call your own route; returns a `Promise` (rejects with an `Error`, `.code` = HTTP status) |
+| `trek.session.get(key, options?)`, `.set(key, value, options?)`, `.remove(key, options?)`, `.clear(options?)` | Host-managed JSON session state for this browser tab. `scope: 'plugin'` is the default; `scope: 'trip'` additionally partitions it by the trip in view and rejects with `NO_TRIP_CONTEXT` outside a trip. Missing `get()` values are `undefined`. Do not use it to store secrets. |
 | `trek.notify(level, message, duration?)` | toast (`info`/`success`/`warning`/`error`); optional duration in ms (clamped 1.5–15s) |
 | `trek.confirm({ title?, message, confirmLabel?, cancelLabel?, danger? })` | host-rendered native confirm dialog; resolves `true`/`false` (one at a time — a second concurrent request resolves `false`) |
 | `trek.navigate(to)` | in-app navigation (relative paths only) |

--- a/wiki/Plugin-Development.md
+++ b/wiki/Plugin-Development.md
@@ -456,7 +456,7 @@ works. Add `data-trek-native` to a field to keep the browser default; `multiple`
 | `trek.onContext(cb)` | run `cb(context)` now (if already received) and on every update; returns an unsubscribe fn |
 | `trek.context` | the last context (or `null`) |
 | `trek.invoke(sub, { method, body })` | call your own route; returns a `Promise` (rejects with an `Error`, `.code` = HTTP status) |
-| `trek.session.get(key, options?)`, `.set(key, value, options?)`, `.remove(key, options?)`, `.clear(options?)` | Host-managed JSON session state for this browser tab. `scope: 'plugin'` is the default; `scope: 'trip'` additionally partitions it by the trip in view and rejects with `NO_TRIP_CONTEXT` outside a trip. Missing `get()` values are `undefined`. Do not use it to store secrets. |
+| `trek.session.get(key, options?)`, `.set(key, value, options?)`, `.remove(key, options?)`, `.clear(options?)` | Host-managed JSON session state for this browser tab. `scope: 'plugin'` is the default; `scope: 'trip'` additionally partitions it by the trip in view and rejects with `NO_TRIP_CONTEXT` outside a trip. Missing `get()` values are `undefined`. Each plugin or individual trip scope is limited to 32 keys, 64 characters/key, and 1 KiB/value. Do not use it to store secrets. |
 | `trek.notify(level, message, duration?)` | toast (`info`/`success`/`warning`/`error`); optional duration in ms (clamped 1.5–15s) |
 | `trek.confirm({ title?, message, confirmLabel?, cancelLabel?, danger? })` | host-rendered native confirm dialog; resolves `true`/`false` (one at a time — a second concurrent request resolves `false`) |
 | `trek.navigate(to)` | in-app navigation (relative paths only) |


### PR DESCRIPTION
## Description
Adds host-managed session storage for sandboxed plugin UIs.

Plugin iframes run with an opaque origin and cannot access `sessionStorage` directly. This adds a `window.trek.session` bridge with `get`, `set`, `remove`, and `clear` operations.

Storage can be scoped either to the current user and plugin or additionally to the current trip. To protect TREK's shared browser storage, each scope is limited to:
  - 32 keys
  - 64 characters per key
  - 1 KiB per JSON-serialized value

The same contract is implemented by the development preview and SDK mock host. Public SDK types and limit constants are exported for plugin authors. Session keys are removed when a successful active-plugin refresh reports that a plugin is no longer active.

Tests cover storage round trips, scope isolation, missing trip context, quota enforcement, boundary values, inactive-plugin cleanup, and failed-feed preservation.

## Related Issue or Discussion
Approved on Discord discussion

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [X] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [X] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [X] I have tested my changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have updated documentation if needed
