### PR TITLE
fix(tests): make trip-factory day generation timezone-independent

### DIFF
--- a/server/tests/helpers/factories.ts
+++ b/server/tests/helpers/factories.ts
@@ -93,13 +93,16 @@ export function createTrip(
     'INSERT INTO trips (user_id, title, description, start_date, end_date) VALUES (?, ?, ?, ?, ?)'
   ).run(userId, title, overrides.description ?? null, overrides.start_date ?? null, overrides.end_date ?? null);
 
-  // Auto-generate days if dates are provided
+  // Auto-generate days if dates are provided. Date-only strings parse as UTC
+  // midnight and `end` is compared in UTC, so the increment must be UTC too:
+  // a local setDate() walks the local calendar and stops a day early wherever
+  // local midnight isn't UTC midnight.
   if (overrides.start_date && overrides.end_date) {
     const start = new Date(overrides.start_date);
     const end = new Date(overrides.end_date);
     const tripId = result.lastInsertRowid as number;
     let dayNumber = 1;
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
       const dateStr = d.toISOString().slice(0, 10);
       db.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, ?)').run(tripId, dayNumber++, dateStr);
     }


### PR DESCRIPTION
## Description

`createTrip` in the test factory parses its date-only bounds as UTC midnight (`new Date('2025-11-01')`) and compares against a UTC-midnight `end`, but advances the loop with local `setDate()`. Walking the local calendar while comparing in UTC generates one day too few wherever local midnight isn't UTC midnight, so `TRIP-SVC-015` fails on any machine not set to UTC.

Measured on current `dev`, `server/tests/unit/services/tripService.test.ts`:

| TZ | result |
| --- | --- |
| `UTC` | 44/44 |
| `Europe/Berlin` | 43/44 |
| `Europe/London` | 43/44 |
| `Australia/Sydney` | 43/44 |
| `America/New_York` | 43/44 |

Incrementing with `setUTCDate` matches the parse. CI never caught it because it runs `TZ=UTC`.

## Related Issue or Discussion

Noticed while working on the ICS feed change discussed in `#github-pr` on Discord, and split out to keep that PR to one change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Test plan

No new tests: this fixes the harness itself, so the existing suite is the test.

- With the fix, `tripService.test.ts` is 44/44 under `UTC`, `Europe/Berlin`, `Europe/London`, `Australia/Sydney`, `America/New_York` and `Pacific/Kiritimati`.
- Full server suite green under `TZ=UTC` and under `TZ=America/New_York`.

## Note on CI

The Server Tests check may show red on an unrelated, timing-dependent error: all 5781 tests pass, but `vacayService` fires `import('../services/notificationService').then(...)` without awaiting it, so the import can resolve after Vitest tears the module environment down and the rejection is counted as a run error (`EnvironmentTeardownError` loading `notifications/builtins.ts`). It's independent of this one-line change — `setDate` and `setUTCDate` are equivalent under CI's `TZ=UTC`, so this diff is a no-op there. Happy to send a separate PR that awaits or retains those promises if that'd be useful.
