### PR TITLE
feat(feed): TripIt-style hotel and car-rental events in the ICS feed, and fix floating flight times

### DIFF
--- a/server/src/services/reservationService.ts
+++ b/server/src/services/reservationService.ts
@@ -222,6 +222,14 @@ function saveEndpoints(reservationId: number, endpoints: EndpointInput[]): void 
   tx(reservationId, endpoints);
 }
 
+// accommodation_id is a TEXT column; the integer FK reads back as a numeric
+// string (e.g. "14.0"). Normalize to an int so consumers can use it as a key.
+export function normalizeAccommodationId(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Math.trunc(Number(value));
+  return Number.isFinite(n) ? n : null;
+}
+
 export function listReservations(tripId: string | number) {
   const reservations = db.prepare(`
     SELECT r.*, d.day_number, p.name as place_name, r.assignment_id,
@@ -256,9 +264,7 @@ export function listReservations(tripId: string | number) {
     r.day_positions = posMap.get(r.id) || null;
     r.endpoints = endpointsMap.get(r.id) || [];
     r.travelers = travelersMap.get(r.id) || [];
-    // accommodation_id is a TEXT column; the integer FK reads back as a numeric
-    // string (e.g. "14.0"). Normalize to an int so clients can parse it.
-    r.accommodation_id = r.accommodation_id == null ? null : Math.trunc(Number(r.accommodation_id));
+    r.accommodation_id = normalizeAccommodationId(r.accommodation_id);
   }
 
   return reservations;

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -9,7 +9,7 @@ import { Trip, User } from '../types';
 import { listDays, listAccommodations, addDays, resyncAccommodationDays, restampReservationDates } from './dayService';
 import { listBudgetItems, removeUserFromBudgetItems } from './budgetService';
 import { listItems as listPackingItems } from '../nest/packing/packing.bridge';
-import { listReservations, loadEndpointsByTrip, resyncReservationDays } from './reservationService';
+import { listReservations, loadEndpointsByTrip, normalizeAccommodationId, resyncReservationDays } from './reservationService';
 import { listNotes as listCollabNotes } from '../nest/collab/collab.bridge';
 import { shiftOwnerEntriesForTripWindow } from './vacayService';
 import { resolveTimeZone } from './timezoneService';
@@ -806,26 +806,33 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
     const m = t ? t.match(/^(\d{2}:\d{2})/) : null;
     return m ? m[1] : null;
   };
-  // Local wall-clock arithmetic → YYYYMMDDTHHMMSS. Reads local Date components
-  // back out (never toISOString), so the result is server-timezone independent.
-  const addMinutesLocal = (date: string, time: string, mins: number): string => {
-    const [y, mo, d] = date.split('-').map(Number);
+  // Pure wall-clock arithmetic (no Date object, so no server-DST edge cases):
+  // "YYYY-MM-DD" + "HH:MM" + minutes → "YYYY-MM-DDTHH:MM", carrying days via
+  // the UTC-safe addDays.
+  const addMinutesWall = (date: string, time: string, mins: number): string => {
     const [h, mi] = time.split(':').map(Number);
-    const dt = new Date(y, mo - 1, d, h, mi + mins);
+    const total = h * 60 + mi + mins;
+    const dayCarry = Math.floor(total / 1440);
+    const rest = total - dayCarry * 1440;
     const p = (n: number) => String(n).padStart(2, '0');
-    return `${dt.getFullYear()}${p(dt.getMonth() + 1)}${p(dt.getDate())}T${p(dt.getHours())}${p(dt.getMinutes())}00`;
+    return `${dayCarry ? addDays(date, dayCarry) : date}T${p(Math.floor(rest / 60))}:${p(rest % 60)}`;
   };
 
   // A short free (non-busy) marker event: hotel check-in/check-out, car rental
-  // pickup/drop-off. Without a time it degrades to a transparent all-day event.
+  // pickup/drop-off. endTime (a window end like check_in_end "20:00") wins over
+  // the default one-hour duration. Without a time it degrades to a transparent
+  // all-day event.
   const emitWindowEvent = (opts: {
     uid: string; summary: string; date: string; time: string | null; zone: string | null;
-    durationMin?: number; description?: string; location?: string;
+    endTime?: string | null; durationMin?: number; description?: string; location?: string;
   }): string => {
     let ev = `BEGIN:VEVENT\r\nUID:${opts.uid}\r\nDTSTAMP:${now}\r\n`;
     if (opts.time) {
       ev += dtLine('DTSTART', `${opts.date}T${opts.time}`, opts.zone);
-      ev += dtLine('DTEND', addMinutesLocal(opts.date, opts.time, opts.durationMin ?? 60), opts.zone);
+      const endWall = opts.endTime && opts.endTime > opts.time
+        ? `${opts.date}T${opts.endTime}`
+        : addMinutesWall(opts.date, opts.time, opts.durationMin ?? 60);
+      ev += dtLine('DTEND', endWall, opts.zone);
     } else {
       ev += `DTSTART;VALUE=DATE:${fmtDate(opts.date)}\r\n`;
     }
@@ -880,11 +887,18 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
       const startDt = fmtDateTime(r.reservation_time);
       let out = dtLine('DTSTART', r.reservation_time, zone);
       if (r.reservation_end_time) {
-        const endDt = fmtDateTime(r.reservation_end_time, r.reservation_time);
+        let endWall = r.reservation_end_time;
+        let endDt = fmtDateTime(endWall, r.reservation_time);
+        // A time-only end earlier than the start crosses midnight (a bar that
+        // closes at 01:00): anchor it to the NEXT day instead of the start's.
+        if (!endWall.includes('T') && isTime(endWall) && endDt.length >= 15 && endDt < startDt) {
+          endWall = `${addDays(datePart(r.reservation_time)!, 1)}T${timePart(endWall)}`;
+          endDt = fmtDateTime(endWall);
+        }
         // Guard: same-zone wall clocks are chronologically comparable as
         // fixed-width strings; drop an end that isn't after the start (bad
         // overnight data produced invalid negative-duration VEVENTs).
-        if (endDt.length >= 15 && endDt > startDt) out += dtLine('DTEND', r.reservation_end_time, zone, r.reservation_time);
+        if (endDt.length >= 15 && endDt > startDt) out += dtLine('DTEND', endWall, zone, r.reservation_time);
       }
       return out;
     }
@@ -918,20 +932,23 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
 
   // Accommodation rows give hotels their stay range (day dates), check-in/
   // check-out times, and a place for LOCATION + zone; check_in/check_out may be
-  // "HH:MM" (UI) or full ISO (booking import).
+  // "HH:MM" (UI) or full ISO (booking import). Only loaded when the trip
+  // actually has hotel reservations.
   const accommodations = new Map<number, any>();
-  const accRows = db.prepare(`
-    SELECT a.id, a.check_in, a.check_out,
-           ds.date AS start_date, de.date AS end_date,
-           p.name AS place_name, p.address AS place_address,
-           p.lat AS place_lat, p.lng AS place_lng
-    FROM day_accommodations a
-    LEFT JOIN days ds ON a.start_day_id = ds.id
-    LEFT JOIN days de ON a.end_day_id = de.id
-    LEFT JOIN places p ON a.place_id = p.id
-    WHERE a.trip_id = ?
-  `).all(tripId) as any[];
-  for (const a of accRows) accommodations.set(a.id, a);
+  if (reservations.some(r => r.type === 'hotel')) {
+    const accRows = db.prepare(`
+      SELECT a.id, a.check_in, a.check_in_end, a.check_out,
+             ds.date AS start_date, de.date AS end_date,
+             p.name AS place_name, p.address AS place_address,
+             p.lat AS place_lat, p.lng AS place_lng
+      FROM day_accommodations a
+      LEFT JOIN days ds ON a.start_day_id = ds.id
+      LEFT JOIN days de ON a.end_day_id = de.id
+      LEFT JOIN places p ON a.place_id = p.id
+      WHERE a.trip_id = ?
+    `).all(tripId) as any[];
+    for (const a of accRows) accommodations.set(a.id, a);
+  }
 
   // Reservations as events
   for (const r of reservations) {
@@ -940,25 +957,28 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
     // Hotels: a pair of short transparent Check-in / Check-out marker events
     // (like TripIt) instead of a single all-day event on the check-in date.
     if (r.type === 'hotel') {
-      // accommodation_id is TEXT and may read back as "14.0" — normalize.
-      const accId = r.accommodation_id != null ? Math.trunc(Number(r.accommodation_id)) : NaN;
-      const acc = Number.isFinite(accId) ? accommodations.get(accId) : undefined;
+      const accId = normalizeAccommodationId(r.accommodation_id);
+      const acc = accId != null ? accommodations.get(accId) : undefined;
+      const checkinDate = acc?.start_date || datePart(acc?.check_in) || datePart(r.reservation_time);
+      if (!checkinDate) continue;
+
       const desc = buildReservationDescription(r, meta);
       const location = r.location || acc?.place_address || acc?.place_name || undefined;
       const zone = resolveTimeZone(r.place_lat, r.place_lng) || resolveTimeZone(acc?.place_lat, acc?.place_lng);
 
-      const checkinDate = acc?.start_date || datePart(acc?.check_in) || datePart(r.reservation_time);
-      if (!checkinDate) continue;
       const checkinTime = timePart(meta.check_in_time) || timePart(acc?.check_in) || timePart(r.reservation_time) || '15:00';
       ics += emitWindowEvent({
         uid: `trek-res-${r.id}-checkin@trek`,
         summary: `Check-in: ${r.title}`,
-        date: checkinDate, time: checkinTime, zone, description: desc, location,
+        date: checkinDate, time: checkinTime, zone,
+        // Hotels advertise a check-in window ("15:00–20:00"); use its end when stored.
+        endTime: timePart(meta.check_in_end_time) || timePart(acc?.check_in_end),
+        description: desc, location,
       });
 
       const checkoutDate = acc?.end_date || datePart(acc?.check_out) || datePart(r.reservation_end_time);
       if (checkoutDate) {
-        const checkoutTime = timePart(meta.check_out_time) || timePart(acc?.check_out) || '11:00';
+        const checkoutTime = timePart(meta.check_out_time) || timePart(acc?.check_out) || timePart(r.reservation_end_time) || '11:00';
         ics += emitWindowEvent({
           uid: `trek-res-${r.id}-checkout@trek`,
           summary: `Check-out: ${r.title}`,
@@ -972,9 +992,14 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
     // opaque event spanning the whole rental period.
     if (r.type === 'car') {
       const eps = [...(endpointsMap.get(r.id) || [])].sort((a, b) => a.sequence - b.sequence);
-      const dated = eps.filter(e => isDate(e.local_date));
-      const first = dated[0];
-      const last = dated.length > 1 ? dated[dated.length - 1] : undefined;
+      // Sides come from the endpoint role — import can drop one endpoint
+      // (failed geocoding), and a surviving return endpoint must not
+      // masquerade as the pickup. Positional first/last is only a fallback
+      // when roles are absent, and each side must be dated to count.
+      const pickupEp = eps.find(e => e.role === 'from') ?? (eps.length > 1 ? eps[0] : undefined);
+      const dropEp = eps.find(e => e.role === 'to') ?? (eps.length > 1 ? eps[eps.length - 1] : undefined);
+      const first = pickupEp && isDate(pickupEp.local_date) ? pickupEp : undefined;
+      const last = dropEp && dropEp !== pickupEp && isDate(dropEp.local_date) ? dropEp : undefined;
       const desc = buildReservationDescription(r, meta);
 
       // Per-side fallback: import may drop endpoints (failed geocoding) but

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -793,15 +793,16 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
   const endpointsMap = loadEndpointsByTrip(tripId);
   const isDate = (s: string | null | undefined) => !!s && /^\d{4}-\d{2}-\d{2}$/.test(s);
   const isTime = (s: string | null | undefined) => !!s && /^\d{2}:\d{2}/.test(s);
-  // "YYYY-MM-DD", "YYYY-MM-DDTHH:MM[..]" → "YYYY-MM-DD"; anything else → null
-  const datePart = (s: string | null | undefined): string | null => {
-    if (!s) return null;
+  // "YYYY-MM-DD", "YYYY-MM-DDTHH:MM[..]" → "YYYY-MM-DD"; anything else → null.
+  // Inputs may come from metadata JSON, so non-strings are tolerated, not thrown on.
+  const datePart = (s: unknown): string | null => {
+    if (typeof s !== 'string' || !s) return null;
     const d = s.includes('T') ? s.split('T')[0] : s;
     return isDate(d) ? d : null;
   };
   // "HH:MM[:SS]", "YYYY-MM-DDTHH:MM[..]" → "HH:MM"; bare dates → null
-  const timePart = (s: string | null | undefined): string | null => {
-    if (!s) return null;
+  const timePart = (s: unknown): string | null => {
+    if (typeof s !== 'string' || !s) return null;
     const t = s.includes('T') ? s.split('T')[1] : s;
     const m = t ? t.match(/^(\d{2}:\d{2})/) : null;
     return m ? m[1] : null;
@@ -873,10 +874,15 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
           }
           return out;
         }
-        return `DTSTART;VALUE=DATE:${fmtDate(first.local_date)}\r\n`;
+        // Endpoint has a date but no clock: a timed reservation_time is more
+        // precise, so only render all-day when no timed fallback exists.
+        if (!(typeof r.reservation_time === 'string' && r.reservation_time.includes('T'))) {
+          return `DTSTART;VALUE=DATE:${fmtDate(first.local_date)}\r\n`;
+        }
       }
-      // Endpoints exist but are undated (relative "Day N" trips) — fall through
-      // to reservation_time rather than dropping the reservation outright.
+      // Otherwise (undated endpoints, or dated-but-timeless with a timed
+      // reservation_time) fall through to reservation_time rather than
+      // dropping or downgrading the reservation.
     }
 
     if (!r.reservation_time) return null;
@@ -952,7 +958,14 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
 
   // Reservations as events
   for (const r of reservations) {
-    const meta = r.metadata ? (typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata) : {};
+    // One corrupt metadata blob must not take down the whole feed.
+    let meta: any = {};
+    if (r.metadata) {
+      try {
+        meta = typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata;
+      } catch { /* render the event without metadata fields */ }
+      if (!meta || typeof meta !== 'object') meta = {};
+    }
 
     // Hotels: a pair of short transparent Check-in / Check-out marker events
     // (like TripIt) instead of a single all-day event on the check-in date.

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -838,52 +838,57 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
   };
 
   // Build the DTSTART/DTEND lines for a reservation, or null when it has no
-  // calendar-placeable time. Restaurants/events use reservation_time; flights
-  // fall back to their first/last endpoint.
+  // calendar-placeable time. Endpoints (transports) are checked first: they
+  // carry per-side wall clocks AND zones, while reservation_time — which
+  // imports/edits can leave set on the same reservation — has no zone of its
+  // own, so preferring it rendered flights as floating times (#1453 remnant).
   const buildReservationTimeLines = (r: any): string | null => {
-    if (r.reservation_time) {
-      if (!datePart(r.reservation_time)) return null; // time-only (relative "Day N" trips)
-      if (r.reservation_time.includes('T')) {
-        // Restaurants/events: derive the zone from the linked place, if any.
-        const zone = resolveTimeZone(r.place_lat, r.place_lng);
-        const startDt = fmtDateTime(r.reservation_time);
-        let out = dtLine('DTSTART', r.reservation_time, zone);
-        if (r.reservation_end_time) {
-          const endDt = fmtDateTime(r.reservation_end_time, r.reservation_time);
-          // Guard: same-zone wall clocks are chronologically comparable as
-          // fixed-width strings; drop an end that isn't after the start (bad
-          // overnight data produced invalid negative-duration VEVENTs).
-          if (endDt.length >= 15 && endDt > startDt) out += dtLine('DTEND', r.reservation_end_time, zone, r.reservation_time);
+    const eps = endpointsMap.get(r.id);
+    if (eps && eps.length > 0) {
+      const ordered = [...eps].sort((a, b) => a.sequence - b.sequence);
+      const first = ordered[0];
+      const last = ordered[ordered.length - 1];
+      if (isDate(first.local_date)) {
+        if (isTime(first.local_time)) {
+          // Transport: departure endpoint zone drives DTSTART, arrival drives DTEND.
+          // Prefer the stored IANA zone; fall back to the endpoint's coordinates.
+          const startZone = first.timezone || resolveTimeZone(first.lat, first.lng);
+          const startDt = fmtDateTime(`${first.local_date}T${first.local_time}`);
+          let out = dtLine('DTSTART', `${first.local_date}T${first.local_time}`, startZone);
+          if (last !== first && isDate(last.local_date) && isTime(last.local_time)) {
+            const endZone = last.timezone || resolveTimeZone(last.lat, last.lng);
+            const endDt = fmtDateTime(`${last.local_date}T${last.local_time}`);
+            // Wall clocks are only comparable within one zone — a valid HND→JFK
+            // arrival can read "earlier" than departure. Same zone (or both
+            // floating) with end ≤ start is bad overnight data: drop the DTEND.
+            const comparable = (startZone || null) === (endZone || null);
+            if (!comparable || endDt > startDt) out += dtLine('DTEND', `${last.local_date}T${last.local_time}`, endZone);
+          }
+          return out;
         }
-        return out;
+        return `DTSTART;VALUE=DATE:${fmtDate(first.local_date)}\r\n`;
       }
-      return `DTSTART;VALUE=DATE:${fmtDate(r.reservation_time)}\r\n`;
+      // Endpoints exist but are undated (relative "Day N" trips) — fall through
+      // to reservation_time rather than dropping the reservation outright.
     }
 
-    const eps = endpointsMap.get(r.id);
-    if (!eps || eps.length === 0) return null;
-    const ordered = [...eps].sort((a, b) => a.sequence - b.sequence);
-    const first = ordered[0];
-    const last = ordered[ordered.length - 1];
-    if (!isDate(first.local_date)) return null;
-    if (isTime(first.local_time)) {
-      // Transport: departure endpoint zone drives DTSTART, arrival drives DTEND.
-      // Prefer the stored IANA zone; fall back to the endpoint's coordinates.
-      const startZone = first.timezone || resolveTimeZone(first.lat, first.lng);
-      const startDt = fmtDateTime(`${first.local_date}T${first.local_time}`);
-      let out = dtLine('DTSTART', `${first.local_date}T${first.local_time}`, startZone);
-      if (last !== first && isDate(last.local_date) && isTime(last.local_time)) {
-        const endZone = last.timezone || resolveTimeZone(last.lat, last.lng);
-        const endDt = fmtDateTime(`${last.local_date}T${last.local_time}`);
-        // Wall clocks are only comparable within one zone — a valid HND→JFK
-        // arrival can read "earlier" than departure. Same zone (or both
-        // floating) with end ≤ start is bad overnight data: drop the DTEND.
-        const comparable = (startZone || null) === (endZone || null);
-        if (!comparable || endDt > startDt) out += dtLine('DTEND', `${last.local_date}T${last.local_time}`, endZone);
+    if (!r.reservation_time) return null;
+    if (!datePart(r.reservation_time)) return null; // time-only (relative "Day N" trips)
+    if (r.reservation_time.includes('T')) {
+      // Restaurants/events: derive the zone from the linked place, if any.
+      const zone = resolveTimeZone(r.place_lat, r.place_lng);
+      const startDt = fmtDateTime(r.reservation_time);
+      let out = dtLine('DTSTART', r.reservation_time, zone);
+      if (r.reservation_end_time) {
+        const endDt = fmtDateTime(r.reservation_end_time, r.reservation_time);
+        // Guard: same-zone wall clocks are chronologically comparable as
+        // fixed-width strings; drop an end that isn't after the start (bad
+        // overnight data produced invalid negative-duration VEVENTs).
+        if (endDt.length >= 15 && endDt > startDt) out += dtLine('DTEND', r.reservation_end_time, zone, r.reservation_time);
       }
       return out;
     }
-    return `DTSTART;VALUE=DATE:${fmtDate(first.local_date)}\r\n`;
+    return `DTSTART;VALUE=DATE:${fmtDate(r.reservation_time)}\r\n`;
   };
 
   const buildReservationDescription = (r: any, meta: any): string => {

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -712,7 +712,7 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
   // last day on any server east of Greenwich (#1453).
   if (trip.start_date && trip.end_date) {
     const endStr = fmtDate(addDays(trip.end_date, 1));
-    ics += `BEGIN:VEVENT\r\nUID:${uid(trip.id, 'trip')}\r\nDTSTAMP:${now}\r\nDTSTART;VALUE=DATE:${fmtDate(trip.start_date)}\r\nDTEND;VALUE=DATE:${endStr}\r\nSUMMARY:${esc(trip.title || 'Trip')}\r\n`;
+    ics += `BEGIN:VEVENT\r\nUID:${uid(trip.id, 'trip')}\r\nDTSTAMP:${now}\r\nDTSTART;VALUE=DATE:${fmtDate(trip.start_date)}\r\nDTEND;VALUE=DATE:${endStr}\r\nTRANSP:TRANSPARENT\r\nSUMMARY:${esc(trip.title || 'Trip')}\r\n`;
     if (trip.description) ics += `DESCRIPTION:${esc(trip.description)}\r\n`;
     ics += `END:VEVENT\r\n`;
   }
@@ -764,6 +764,7 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
 
       ics += `BEGIN:VEVENT\r\nUID:${uid(day.id, 'day')}\r\nDTSTAMP:${now}\r\n`;
       ics += `DTSTART;VALUE=DATE:${fmtDate(day.date)}\r\nDTEND;VALUE=DATE:${endStr}\r\n`;
+      ics += 'TRANSP:TRANSPARENT\r\n';
       ics += `SUMMARY:${esc(dayTitle)}\r\n`;
 
       let desc = '';
@@ -792,21 +793,67 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
   const endpointsMap = loadEndpointsByTrip(tripId);
   const isDate = (s: string | null | undefined) => !!s && /^\d{4}-\d{2}-\d{2}$/.test(s);
   const isTime = (s: string | null | undefined) => !!s && /^\d{2}:\d{2}/.test(s);
+  // "YYYY-MM-DD", "YYYY-MM-DDTHH:MM[..]" → "YYYY-MM-DD"; anything else → null
+  const datePart = (s: string | null | undefined): string | null => {
+    if (!s) return null;
+    const d = s.includes('T') ? s.split('T')[0] : s;
+    return isDate(d) ? d : null;
+  };
+  // "HH:MM[:SS]", "YYYY-MM-DDTHH:MM[..]" → "HH:MM"; bare dates → null
+  const timePart = (s: string | null | undefined): string | null => {
+    if (!s) return null;
+    const t = s.includes('T') ? s.split('T')[1] : s;
+    const m = t ? t.match(/^(\d{2}:\d{2})/) : null;
+    return m ? m[1] : null;
+  };
+  // Local wall-clock arithmetic → YYYYMMDDTHHMMSS. Reads local Date components
+  // back out (never toISOString), so the result is server-timezone independent.
+  const addMinutesLocal = (date: string, time: string, mins: number): string => {
+    const [y, mo, d] = date.split('-').map(Number);
+    const [h, mi] = time.split(':').map(Number);
+    const dt = new Date(y, mo - 1, d, h, mi + mins);
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${dt.getFullYear()}${p(dt.getMonth() + 1)}${p(dt.getDate())}T${p(dt.getHours())}${p(dt.getMinutes())}00`;
+  };
+
+  // A short free (non-busy) marker event: hotel check-in/check-out, car rental
+  // pickup/drop-off. Without a time it degrades to a transparent all-day event.
+  const emitWindowEvent = (opts: {
+    uid: string; summary: string; date: string; time: string | null; zone: string | null;
+    durationMin?: number; description?: string; location?: string;
+  }): string => {
+    let ev = `BEGIN:VEVENT\r\nUID:${opts.uid}\r\nDTSTAMP:${now}\r\n`;
+    if (opts.time) {
+      ev += dtLine('DTSTART', `${opts.date}T${opts.time}`, opts.zone);
+      ev += dtLine('DTEND', addMinutesLocal(opts.date, opts.time, opts.durationMin ?? 60), opts.zone);
+    } else {
+      ev += `DTSTART;VALUE=DATE:${fmtDate(opts.date)}\r\n`;
+    }
+    ev += 'TRANSP:TRANSPARENT\r\n';
+    ev += `SUMMARY:${esc(opts.summary)}\r\n`;
+    if (opts.description) ev += `DESCRIPTION:${esc(opts.description)}\r\n`;
+    if (opts.location) ev += `LOCATION:${esc(opts.location)}\r\n`;
+    ev += 'END:VEVENT\r\n';
+    return ev;
+  };
 
   // Build the DTSTART/DTEND lines for a reservation, or null when it has no
-  // calendar-placeable time. Hotels/restaurants use reservation_time; flights
+  // calendar-placeable time. Restaurants/events use reservation_time; flights
   // fall back to their first/last endpoint.
   const buildReservationTimeLines = (r: any): string | null => {
     if (r.reservation_time) {
-      const datePart = r.reservation_time.includes('T') ? r.reservation_time.split('T')[0] : r.reservation_time;
-      if (!isDate(datePart)) return null; // time-only (relative "Day N" trips)
+      if (!datePart(r.reservation_time)) return null; // time-only (relative "Day N" trips)
       if (r.reservation_time.includes('T')) {
-        // Hotels/restaurants: derive the zone from the linked place, if any.
+        // Restaurants/events: derive the zone from the linked place, if any.
         const zone = resolveTimeZone(r.place_lat, r.place_lng);
+        const startDt = fmtDateTime(r.reservation_time);
         let out = dtLine('DTSTART', r.reservation_time, zone);
         if (r.reservation_end_time) {
           const endDt = fmtDateTime(r.reservation_end_time, r.reservation_time);
-          if (endDt.length >= 15) out += dtLine('DTEND', r.reservation_end_time, zone, r.reservation_time);
+          // Guard: same-zone wall clocks are chronologically comparable as
+          // fixed-width strings; drop an end that isn't after the start (bad
+          // overnight data produced invalid negative-duration VEVENTs).
+          if (endDt.length >= 15 && endDt > startDt) out += dtLine('DTEND', r.reservation_end_time, zone, r.reservation_time);
         }
         return out;
       }
@@ -823,26 +870,23 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
       // Transport: departure endpoint zone drives DTSTART, arrival drives DTEND.
       // Prefer the stored IANA zone; fall back to the endpoint's coordinates.
       const startZone = first.timezone || resolveTimeZone(first.lat, first.lng);
+      const startDt = fmtDateTime(`${first.local_date}T${first.local_time}`);
       let out = dtLine('DTSTART', `${first.local_date}T${first.local_time}`, startZone);
       if (last !== first && isDate(last.local_date) && isTime(last.local_time)) {
         const endZone = last.timezone || resolveTimeZone(last.lat, last.lng);
-        out += dtLine('DTEND', `${last.local_date}T${last.local_time}`, endZone);
+        const endDt = fmtDateTime(`${last.local_date}T${last.local_time}`);
+        // Wall clocks are only comparable within one zone — a valid HND→JFK
+        // arrival can read "earlier" than departure. Same zone (or both
+        // floating) with end ≤ start is bad overnight data: drop the DTEND.
+        const comparable = (startZone || null) === (endZone || null);
+        if (!comparable || endDt > startDt) out += dtLine('DTEND', `${last.local_date}T${last.local_time}`, endZone);
       }
       return out;
     }
     return `DTSTART;VALUE=DATE:${fmtDate(first.local_date)}\r\n`;
   };
 
-  // Reservations as events
-  for (const r of reservations) {
-    const timeLines = buildReservationTimeLines(r);
-    if (!timeLines) continue;
-    const meta = r.metadata ? (typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata) : {};
-
-    ics += `BEGIN:VEVENT\r\nUID:${uid(r.id, 'res')}\r\nDTSTAMP:${now}\r\n`;
-    ics += timeLines;
-    ics += `SUMMARY:${esc(r.title)}\r\n`;
-
+  const buildReservationDescription = (r: any, meta: any): string => {
     let desc = r.type ? `Type: ${r.type}` : '';
     if (r.confirmation_number) desc += `\nConfirmation: ${r.confirmation_number}`;
     if (meta.airline) desc += `\nAirline: ${meta.airline}`;
@@ -864,6 +908,105 @@ export function exportICS(tripId: string | number): { ics: string; filename: str
     }
     if (meta.train_number) desc += `\nTrain: ${meta.train_number}`;
     if (r.notes) desc += `\n${r.notes}`;
+    return desc;
+  };
+
+  // Accommodation rows give hotels their stay range (day dates), check-in/
+  // check-out times, and a place for LOCATION + zone; check_in/check_out may be
+  // "HH:MM" (UI) or full ISO (booking import).
+  const accommodations = new Map<number, any>();
+  const accRows = db.prepare(`
+    SELECT a.id, a.check_in, a.check_out,
+           ds.date AS start_date, de.date AS end_date,
+           p.name AS place_name, p.address AS place_address,
+           p.lat AS place_lat, p.lng AS place_lng
+    FROM day_accommodations a
+    LEFT JOIN days ds ON a.start_day_id = ds.id
+    LEFT JOIN days de ON a.end_day_id = de.id
+    LEFT JOIN places p ON a.place_id = p.id
+    WHERE a.trip_id = ?
+  `).all(tripId) as any[];
+  for (const a of accRows) accommodations.set(a.id, a);
+
+  // Reservations as events
+  for (const r of reservations) {
+    const meta = r.metadata ? (typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata) : {};
+
+    // Hotels: a pair of short transparent Check-in / Check-out marker events
+    // (like TripIt) instead of a single all-day event on the check-in date.
+    if (r.type === 'hotel') {
+      // accommodation_id is TEXT and may read back as "14.0" — normalize.
+      const accId = r.accommodation_id != null ? Math.trunc(Number(r.accommodation_id)) : NaN;
+      const acc = Number.isFinite(accId) ? accommodations.get(accId) : undefined;
+      const desc = buildReservationDescription(r, meta);
+      const location = r.location || acc?.place_address || acc?.place_name || undefined;
+      const zone = resolveTimeZone(r.place_lat, r.place_lng) || resolveTimeZone(acc?.place_lat, acc?.place_lng);
+
+      const checkinDate = acc?.start_date || datePart(acc?.check_in) || datePart(r.reservation_time);
+      if (!checkinDate) continue;
+      const checkinTime = timePart(meta.check_in_time) || timePart(acc?.check_in) || timePart(r.reservation_time) || '15:00';
+      ics += emitWindowEvent({
+        uid: `trek-res-${r.id}-checkin@trek`,
+        summary: `Check-in: ${r.title}`,
+        date: checkinDate, time: checkinTime, zone, description: desc, location,
+      });
+
+      const checkoutDate = acc?.end_date || datePart(acc?.check_out) || datePart(r.reservation_end_time);
+      if (checkoutDate) {
+        const checkoutTime = timePart(meta.check_out_time) || timePart(acc?.check_out) || '11:00';
+        ics += emitWindowEvent({
+          uid: `trek-res-${r.id}-checkout@trek`,
+          summary: `Check-out: ${r.title}`,
+          date: checkoutDate, time: checkoutTime, zone, description: desc, location,
+        });
+      }
+      continue;
+    }
+
+    // Car rentals: transparent Pick up / Drop off marker events instead of one
+    // opaque event spanning the whole rental period.
+    if (r.type === 'car') {
+      const eps = [...(endpointsMap.get(r.id) || [])].sort((a, b) => a.sequence - b.sequence);
+      const dated = eps.filter(e => isDate(e.local_date));
+      const first = dated[0];
+      const last = dated.length > 1 ? dated[dated.length - 1] : undefined;
+      const desc = buildReservationDescription(r, meta);
+
+      // Per-side fallback: import may drop endpoints (failed geocoding) but
+      // still store the rental window on reservation_time/reservation_end_time.
+      const pickupDate = first?.local_date || datePart(r.reservation_time);
+      const pickupTime = first ? timePart(first.local_time) : timePart(r.reservation_time);
+      const pickupZone = first ? (first.timezone || resolveTimeZone(first.lat, first.lng)) : resolveTimeZone(r.place_lat, r.place_lng);
+      const dropDate = last?.local_date || datePart(r.reservation_end_time);
+      const dropTime = last ? timePart(last.local_time) : timePart(r.reservation_end_time);
+      const dropZone = last ? (last.timezone || resolveTimeZone(last.lat, last.lng)) : resolveTimeZone(r.place_lat, r.place_lng);
+
+      if (pickupDate) {
+        ics += emitWindowEvent({
+          uid: `trek-res-${r.id}-pickup@trek`,
+          summary: `Pick up: ${r.title}`,
+          date: pickupDate, time: pickupTime, zone: pickupZone, description: desc,
+          location: first?.name || r.location || undefined,
+        });
+      }
+      if (dropDate) {
+        ics += emitWindowEvent({
+          uid: `trek-res-${r.id}-dropoff@trek`,
+          summary: `Drop off: ${r.title}`,
+          date: dropDate, time: dropTime, zone: dropZone, description: desc,
+          location: last?.name || r.location || undefined,
+        });
+      }
+      continue;
+    }
+
+    const timeLines = buildReservationTimeLines(r);
+    if (!timeLines) continue;
+
+    ics += `BEGIN:VEVENT\r\nUID:${uid(r.id, 'res')}\r\nDTSTAMP:${now}\r\n`;
+    ics += timeLines;
+    ics += `SUMMARY:${esc(r.title)}\r\n`;
+    const desc = buildReservationDescription(r, meta);
     if (desc) ics += `DESCRIPTION:${esc(desc)}\r\n`;
     if (r.location) ics += `LOCATION:${esc(r.location)}\r\n`;
     ics += `END:VEVENT\r\n`;

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -702,6 +702,28 @@ describe('exportICS', () => {
     expect(flight).not.toContain('DTEND');
   });
 
+  it('TRIP-SVC-030: flight with BOTH reservation_time and endpoints uses the endpoint zones', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Both Fields Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'SEA → HND', type: 'flight' });
+    // Import/manual edits can leave reservation_time set alongside endpoints;
+    // the endpoints carry the per-side zones and must win.
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2026-07-06T11:50:00', '2026-07-07T14:15:00', reservation.id);
+    const insertEp = testDb.prepare(
+      'INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, code, lat, lng, timezone, local_time, local_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    insertEp.run(reservation.id, 'from', 0, 'Seattle', 'SEA', 47.45, -122.31, 'America/Los_Angeles', '11:50', '2026-07-06');
+    insertEp.run(reservation.id, 'to', 1, 'Tokyo Haneda', 'HND', 35.55, 139.78, 'Asia/Tokyo', '14:15', '2026-07-07');
+
+    const { ics } = exportICS(trip.id);
+
+    const flight = blockWithSummary(ics, 'SEA → HND');
+    expect(flight).toContain('DTSTART;TZID=America/Los_Angeles:20260706T115000');
+    expect(flight).toContain('DTEND;TZID=Asia/Tokyo:20260707T141500');
+    expect(flight).not.toContain('DTSTART:20260706T115000');
+  });
+
   it('TRIP-SVC-029: trip banner and day-summary events are free (TRANSP:TRANSPARENT)', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Banner Trip', start_date: '2025-06-01', end_date: '2025-06-03' });

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -796,6 +796,44 @@ describe('exportICS', () => {
     expect(bar).toContain('DTEND:20250603T010000');
   });
 
+  it('TRIP-SVC-035: corrupt or non-string metadata never crashes the export', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Robust Trip' });
+    const broken = createReservation(testDb, trip.id, { title: 'Broken Meta', type: 'activity' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, metadata=? WHERE id=?')
+      .run('2025-06-02T09:00', '{not valid json', broken.id);
+    const hotel = createReservation(testDb, trip.id, { title: 'Numeric Meta Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, metadata=? WHERE id=?')
+      .run('2025-06-02', JSON.stringify({ check_in_time: 1600 }), hotel.id);
+
+    let ics = '';
+    expect(() => { ics = exportICS(trip.id).ics; }).not.toThrow();
+
+    // The corrupt-metadata event still renders, just without metadata fields.
+    expect(ics).toContain('SUMMARY:Broken Meta');
+    // The numeric check_in_time is ignored in favor of the default.
+    expect(blockWithSummary(ics, 'Check-in: Numeric Meta Hotel')).toContain('DTSTART:20250602T150000');
+  });
+
+  it('TRIP-SVC-036: a dated but timeless endpoint does not downgrade a timed reservation_time to all-day', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Timeless Endpoint Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Ferry Ride', type: 'ferry' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2025-06-02T09:00', '2025-06-02T11:30', reservation.id);
+    // Endpoint carries only a date (no local_time) — the precise reservation_time must win.
+    testDb.prepare(
+      'INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, code, lat, lng, timezone, local_time, local_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(reservation.id, 'from', 0, 'Harbor', null, 26.2, 127.65, 'Asia/Tokyo', null, '2025-06-02');
+
+    const { ics } = exportICS(trip.id);
+
+    const ferry = blockWithSummary(ics, 'Ferry Ride');
+    expect(ferry).toContain('DTSTART:20250602T090000');
+    expect(ferry).toContain('DTEND:20250602T113000');
+    expect(ferry).not.toContain('DTSTART;VALUE=DATE');
+  });
+
   it('TRIP-SVC-029: trip banner and day-summary events are free (TRANSP:TRANSPARENT)', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Banner Trip', start_date: '2025-06-01', end_date: '2025-06-03' });

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -834,6 +834,50 @@ describe('exportICS', () => {
     expect(ferry).not.toContain('DTSTART;VALUE=DATE');
   });
 
+  it('TRIP-SVC-037: every UID is unique within a feed and stable across fetches', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'UID Trip', start_date: '2025-06-01', end_date: '2025-06-05' });
+    const days = getDays(trip.id);
+
+    // One of every event-producing shape, so the UID namespaces all meet here.
+    const hotelPlace = createPlace(testDb, trip.id, { name: 'UID Hotel' });
+    const acc = createDayAccommodation(testDb, trip.id, hotelPlace.id, days[0].id, days[2].id, {
+      check_in: '15:00', check_out: '11:00',
+    });
+    const hotel = createReservation(testDb, trip.id, { title: 'UID Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET accommodation_id=? WHERE id=?').run(String(acc.id), hotel.id);
+
+    const car = createReservation(testDb, trip.id, { title: 'UID Rental', type: 'car' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2025-06-02T17:00', '2025-06-04T09:00', car.id);
+
+    const flight = createReservation(testDb, trip.id, { title: 'UID Flight', type: 'flight' });
+    testDb.prepare('UPDATE reservations SET reservation_time=? WHERE id=?').run('2025-06-01T08:00', flight.id);
+
+    const timedPlace = createPlace(testDb, trip.id, { name: 'UID Museum' });
+    const assignment = createDayAssignment(testDb, days[1].id, timedPlace.id);
+    testDb.prepare('UPDATE day_assignments SET assignment_time=? WHERE id=?').run('10:00', assignment.id);
+    createDayNote(testDb, days[3].id, trip.id, { text: 'UID note' });
+
+    const uidsOf = (ics: string) =>
+      eventBlocks(ics).map(b => b.match(/UID:([^\r\n]+)/)?.[1] ?? '');
+
+    const first = uidsOf(exportICS(trip.id).ics);
+    const second = uidsOf(exportICS(trip.id).ics);
+
+    // Unique: a duplicate UID makes clients collapse or overwrite events.
+    expect(new Set(first).size).toBe(first.length);
+    expect(first).not.toContain('');
+    // Stable: a changed UID across fetches makes a subscribed client delete and
+    // re-add the event (losing reminders), so this must not drift per fetch.
+    expect(second).toEqual(first);
+    // The hotel/car pairs are namespaced off their reservation id.
+    expect(first).toContain(`trek-res-${hotel.id}-checkin@trek`);
+    expect(first).toContain(`trek-res-${hotel.id}-checkout@trek`);
+    expect(first).toContain(`trek-res-${car.id}-pickup@trek`);
+    expect(first).toContain(`trek-res-${car.id}-dropoff@trek`);
+  });
+
   it('TRIP-SVC-029: trip banner and day-summary events are free (TRANSP:TRANSPARENT)', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Banner Trip', start_date: '2025-06-01', end_date: '2025-06-03' });

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../../src/config', () => ({
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createReservation, createPlace, createDay, createDayAssignment, createDayNote, addTripMember } from '../../helpers/factories';
+import { createUser, createTrip, createReservation, createPlace, createDay, createDayAssignment, createDayNote, createDayAccommodation, addTripMember } from '../../helpers/factories';
 import { exportICS, generateDays, deleteOldCover, updateTrip, transferOwnership, createGuest, renameGuest, deleteGuest, listMembers, addMember } from '../../../src/services/tripService';
 import { createAccommodation } from '../../../src/services/dayService';
 import fs from 'fs';
@@ -367,8 +367,8 @@ describe('exportICS', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Paris Trip' });
     const reservation = createReservation(testDb, trip.id, {
-      title: 'Hotel Check-in',
-      type: 'hotel',
+      title: 'Museum Day Pass',
+      type: 'other',
     });
     testDb
       .prepare('UPDATE reservations SET reservation_time=? WHERE id=?')
@@ -526,6 +526,195 @@ describe('exportICS', () => {
     expect(ics).toContain('DTSTART;TZID=Asia/Tokyo:20250602T090000');
     expect(ics).toContain('BEGIN:VTIMEZONE\r\nTZID:Asia/Tokyo');
     expect(ics).not.toContain('DTSTART:20250602T090000');
+  });
+
+  // Splits the ICS into VEVENT blocks so assertions can target a single event.
+  const eventBlocks = (ics: string): string[] =>
+    ics.split('BEGIN:VEVENT').slice(1).map(b => b.split('END:VEVENT')[0]);
+  const blockWithSummary = (ics: string, summary: string): string | undefined =>
+    eventBlocks(ics).find(b => b.includes(`SUMMARY:${summary}`));
+
+  it('TRIP-SVC-021: hotel with accommodation range and times → check-in/check-out window events', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Kyoto Trip', start_date: '2025-06-01', end_date: '2025-06-05' });
+    const days = getDays(trip.id);
+    // createPlace default coords (Paris) → Europe/Paris via tz-lookup.
+    const place = createPlace(testDb, trip.id, { name: 'Grand Hotel Kyoto' });
+    const acc = createDayAccommodation(testDb, trip.id, place.id, days[1].id, days[3].id, {
+      check_in: '16:00',
+      check_out: '10:00',
+    });
+    const reservation = createReservation(testDb, trip.id, { title: 'Grand Hotel Kyoto', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET accommodation_id=? WHERE id=?').run(String(acc.id), reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    const checkin = blockWithSummary(ics, 'Check-in: Grand Hotel Kyoto');
+    const checkout = blockWithSummary(ics, 'Check-out: Grand Hotel Kyoto');
+    expect(checkin).toBeDefined();
+    expect(checkout).toBeDefined();
+    expect(checkin).toContain('DTSTART;TZID=Europe/Paris:20250602T160000');
+    expect(checkin).toContain('DTEND;TZID=Europe/Paris:20250602T170000');
+    expect(checkin).toContain('TRANSP:TRANSPARENT');
+    expect(checkin).toContain(`UID:trek-res-${reservation.id}-checkin@trek`);
+    expect(checkout).toContain('DTSTART;TZID=Europe/Paris:20250604T100000');
+    expect(checkout).toContain('DTEND;TZID=Europe/Paris:20250604T110000');
+    expect(checkout).toContain('TRANSP:TRANSPARENT');
+    expect(checkout).toContain(`UID:trek-res-${reservation.id}-checkout@trek`);
+    // The old single check-in-date event is gone
+    expect(ics).not.toContain(`UID:trek-res-${reservation.id}@trek`);
+  });
+
+  it('TRIP-SVC-022: hotel accommodation without times → default 15:00 check-in / 11:00 check-out', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Osaka Trip', start_date: '2025-06-01', end_date: '2025-06-05' });
+    const days = getDays(trip.id);
+    const place = createPlace(testDb, trip.id, { name: 'Station Hotel' });
+    const acc = createDayAccommodation(testDb, trip.id, place.id, days[0].id, days[2].id);
+    const reservation = createReservation(testDb, trip.id, { title: 'Station Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET accommodation_id=? WHERE id=?').run(String(acc.id), reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    expect(blockWithSummary(ics, 'Check-in: Station Hotel')).toContain('DTSTART;TZID=Europe/Paris:20250601T150000');
+    expect(blockWithSummary(ics, 'Check-out: Station Hotel')).toContain('DTSTART;TZID=Europe/Paris:20250603T110000');
+  });
+
+  it('TRIP-SVC-023: hotel metadata check_in_time/check_out_time override accommodation times', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Tokyo Trip', start_date: '2025-06-01', end_date: '2025-06-05' });
+    const days = getDays(trip.id);
+    const place = createPlace(testDb, trip.id, { name: 'Tower Hotel' });
+    const acc = createDayAccommodation(testDb, trip.id, place.id, days[0].id, days[2].id, {
+      check_in: '15:00',
+      check_out: '11:00',
+    });
+    const reservation = createReservation(testDb, trip.id, { title: 'Tower Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET accommodation_id=?, metadata=? WHERE id=?').run(
+      String(acc.id),
+      JSON.stringify({ check_in_time: '14:00', check_out_time: '12:00' }),
+      reservation.id
+    );
+
+    const { ics } = exportICS(trip.id);
+
+    expect(blockWithSummary(ics, 'Check-in: Tower Hotel')).toContain('DTSTART;TZID=Europe/Paris:20250601T140000');
+    expect(blockWithSummary(ics, 'Check-out: Tower Hotel')).toContain('DTSTART;TZID=Europe/Paris:20250603T120000');
+  });
+
+  it('TRIP-SVC-024: imported hotel (no reservation_time, ISO datetimes in accommodation) is included', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Imported Trip' });
+    // Relative-trip days without dates: the accommodation ISO strings must supply date AND time.
+    const day1 = testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, 1, NULL)').run(trip.id);
+    const day2 = testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, 2, NULL)').run(trip.id);
+    const place = createPlace(testDb, trip.id, { name: 'Imported Inn' });
+    const acc = createDayAccommodation(
+      testDb, trip.id, place.id,
+      Number(day1.lastInsertRowid), Number(day2.lastInsertRowid),
+      { check_in: '2025-06-02T16:00', check_out: '2025-06-04T10:00' }
+    );
+    const reservation = createReservation(testDb, trip.id, { title: 'Imported Inn', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET reservation_time=NULL, accommodation_id=? WHERE id=?')
+      .run(String(acc.id), reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    expect(blockWithSummary(ics, 'Check-in: Imported Inn')).toContain('DTSTART;TZID=Europe/Paris:20250602T160000');
+    expect(blockWithSummary(ics, 'Check-out: Imported Inn')).toContain('DTSTART;TZID=Europe/Paris:20250604T100000');
+  });
+
+  it('TRIP-SVC-025: hotel with only a bare-date reservation_time → floating check-in event only', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Legacy Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Legacy Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET reservation_time=? WHERE id=?').run('2025-06-02', reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    // No linked place/accommodation → no zone to attach; stays a floating local time.
+    expect(blockWithSummary(ics, 'Check-in: Legacy Hotel')).toContain('DTSTART:20250602T150000');
+    expect(ics).not.toContain('Check-out: Legacy Hotel');
+  });
+
+  it('TRIP-SVC-026: car rental with endpoints → pickup and drop-off events instead of one spanning event', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Okinawa Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Toyota Rent a Car', type: 'car' });
+    testDb.prepare('UPDATE reservations SET reservation_time=NULL, confirmation_number=? WHERE id=?')
+      .run('99985723900', reservation.id);
+    const insertEp = testDb.prepare(
+      'INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, code, lat, lng, timezone, local_time, local_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    insertEp.run(reservation.id, 'from', 0, 'Naha Airport Shop', null, 26.2, 127.65, 'Asia/Tokyo', '17:30', '2025-06-02');
+    insertEp.run(reservation.id, 'to', 1, 'Naha Airport Shop', null, 26.2, 127.65, 'Asia/Tokyo', '09:30', '2025-06-05');
+
+    const { ics } = exportICS(trip.id);
+
+    const pickup = blockWithSummary(ics, 'Pick up: Toyota Rent a Car');
+    const dropoff = blockWithSummary(ics, 'Drop off: Toyota Rent a Car');
+    expect(pickup).toBeDefined();
+    expect(dropoff).toBeDefined();
+    expect(pickup).toContain('DTSTART;TZID=Asia/Tokyo:20250602T173000');
+    expect(pickup).toContain('DTEND;TZID=Asia/Tokyo:20250602T183000');
+    expect(pickup).toContain('TRANSP:TRANSPARENT');
+    expect(pickup).toContain(`UID:trek-res-${reservation.id}-pickup@trek`);
+    expect(pickup).toContain('LOCATION:Naha Airport Shop');
+    expect(pickup).toContain('Confirmation: 99985723900');
+    expect(dropoff).toContain('DTSTART;TZID=Asia/Tokyo:20250605T093000');
+    expect(dropoff).toContain('DTEND;TZID=Asia/Tokyo:20250605T103000');
+    expect(dropoff).toContain(`UID:trek-res-${reservation.id}-dropoff@trek`);
+    // No multi-day busy block anymore
+    expect(ics).not.toContain(`UID:trek-res-${reservation.id}@trek`);
+  });
+
+  it('TRIP-SVC-027: car rental without endpoints falls back to reservation_time/reservation_end_time', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Fuji Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Mishima Rental', type: 'car' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2025-06-02T17:00', '2025-06-05T09:00', reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    // No endpoints and no linked place → floating local times.
+    expect(blockWithSummary(ics, 'Pick up: Mishima Rental')).toContain('DTSTART:20250602T170000');
+    expect(blockWithSummary(ics, 'Drop off: Mishima Rental')).toContain('DTSTART:20250605T090000');
+  });
+
+  it('TRIP-SVC-028: same-zone DTEND that is not after DTSTART is dropped (overnight arrival data)', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Redeye Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'JFK → JAX', type: 'flight' });
+    testDb.prepare('UPDATE reservations SET reservation_time=NULL WHERE id=?').run(reservation.id);
+    const insertEp = testDb.prepare(
+      'INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, code, lat, lng, timezone, local_time, local_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    // Arrival wrongly recorded on the same local_date as departure — a real overnight-flight case.
+    insertEp.run(reservation.id, 'from', 0, 'New York JFK', 'JFK', 40.6, -73.8, 'America/New_York', '21:42', '2025-06-02');
+    insertEp.run(reservation.id, 'to', 1, 'Jacksonville', 'JAX', 30.5, -81.7, 'America/New_York', '00:31', '2025-06-02');
+
+    const { ics } = exportICS(trip.id);
+
+    const flight = blockWithSummary(ics, 'JFK → JAX');
+    expect(flight).toBeDefined();
+    expect(flight).toContain('DTSTART;TZID=America/New_York:20250602T214200');
+    expect(flight).not.toContain('DTEND');
+  });
+
+  it('TRIP-SVC-029: trip banner and day-summary events are free (TRANSP:TRANSPARENT)', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Banner Trip', start_date: '2025-06-01', end_date: '2025-06-03' });
+    const days = getDays(trip.id);
+    createDayNote(testDb, days[0].id, trip.id, { text: 'arrive late' });
+
+    const { ics } = exportICS(trip.id);
+
+    const banner = blockWithSummary(ics, 'Banner Trip');
+    const daySummary = eventBlocks(ics).find(b => b.includes(`UID:trek-day-${days[0].id}@trek`));
+    expect(banner).toContain('TRANSP:TRANSPARENT');
+    expect(daySummary).toBeDefined();
+    expect(daySummary).toContain('TRANSP:TRANSPARENT');
   });
 });
 

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -724,6 +724,78 @@ describe('exportICS', () => {
     expect(flight).not.toContain('DTSTART:20260706T115000');
   });
 
+  it('TRIP-SVC-031: hotel checkout uses the reservation_end_time clock when nothing else is stored', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'End Time Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Harbor Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2025-06-02T16:00', '2025-06-05T10:00', reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    expect(blockWithSummary(ics, 'Check-in: Harbor Hotel')).toContain('DTSTART:20250602T160000');
+    // 10:00 from reservation_end_time, not the 11:00 default
+    expect(blockWithSummary(ics, 'Check-out: Harbor Hotel')).toContain('DTSTART:20250605T100000');
+  });
+
+  it('TRIP-SVC-032: check-in window end (check_in_end) becomes the check-in event DTEND', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Window Trip', start_date: '2025-06-01', end_date: '2025-06-05' });
+    const days = getDays(trip.id);
+    const place = createPlace(testDb, trip.id, { name: 'Window Hotel' });
+    const acc = createDayAccommodation(testDb, trip.id, place.id, days[0].id, days[2].id, {
+      check_in: '15:00',
+      check_out: '11:00',
+    });
+    testDb.prepare('UPDATE day_accommodations SET check_in_end=? WHERE id=?').run('20:00', acc.id);
+    const reservation = createReservation(testDb, trip.id, { title: 'Window Hotel', type: 'hotel' });
+    testDb.prepare('UPDATE reservations SET accommodation_id=? WHERE id=?').run(String(acc.id), reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    const checkin = blockWithSummary(ics, 'Check-in: Window Hotel');
+    expect(checkin).toContain('DTSTART;TZID=Europe/Paris:20250601T150000');
+    // The stored 15:00–20:00 window, not a fixed +60 minutes
+    expect(checkin).toContain('DTEND;TZID=Europe/Paris:20250601T200000');
+  });
+
+  it('TRIP-SVC-033: car whose only dated endpoint is the return still labels it Drop off', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Half Data Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'One Way Rental', type: 'car' });
+    testDb.prepare('UPDATE reservations SET reservation_time=? WHERE id=?')
+      .run('2025-06-02T17:00', reservation.id);
+    const insertEp = testDb.prepare(
+      'INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, code, lat, lng, timezone, local_time, local_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    // Pickup endpoint was dropped (failed geocoding); only the return endpoint survived.
+    insertEp.run(reservation.id, 'to', 1, 'Airport Shop', null, 26.2, 127.65, 'Asia/Tokyo', '09:30', '2025-06-05');
+
+    const { ics } = exportICS(trip.id);
+
+    const pickup = blockWithSummary(ics, 'Pick up: One Way Rental');
+    const dropoff = blockWithSummary(ics, 'Drop off: One Way Rental');
+    // Pickup falls back to reservation_time; the dated return endpoint must NOT masquerade as the pickup.
+    expect(pickup).toContain('DTSTART:20250602T170000');
+    expect(dropoff).toContain('DTSTART;TZID=Asia/Tokyo:20250605T093000');
+    expect(dropoff).toContain('LOCATION:Airport Shop');
+  });
+
+  it('TRIP-SVC-034: a bare-time overnight end rolls to the next day instead of being dropped', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Late Night Trip' });
+    const reservation = createReservation(testDb, trip.id, { title: 'Jazz Bar', type: 'event' });
+    // Ends at 01:00 the following morning, stored as a time-only end.
+    testDb.prepare('UPDATE reservations SET reservation_time=?, reservation_end_time=? WHERE id=?')
+      .run('2025-06-02T22:00', '01:00', reservation.id);
+
+    const { ics } = exportICS(trip.id);
+
+    const bar = blockWithSummary(ics, 'Jazz Bar');
+    expect(bar).toContain('DTSTART:20250602T220000');
+    expect(bar).toContain('DTEND:20250603T010000');
+  });
+
   it('TRIP-SVC-029: trip banner and day-summary events are free (TRANSP:TRANSPARENT)', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Banner Trip', start_date: '2025-06-01', end_date: '2025-06-03' });


### PR DESCRIPTION
## Description

Brings the ICS calendar feed closer to how TripIt models bookings, so a subscribed calendar stays readable.

- **Hotels** emit a pair of short `TRANSP:TRANSPARENT` marker events, `Check-in: <hotel>` and `Check-out: <hotel>`, instead of one all-day event on the check-in date. Dates/times resolve from the linked `day_accommodations` row (day dates plus `check_in`/`check_out`, tolerating `"15:00"` from the UI and full ISO from booking import), then `metadata.check_in_time`/`check_out_time`, then `reservation_time`/`reservation_end_time`, defaulting to 15:00/11:00. A stored check-in window end (`check_in_end`) becomes the check-in event's DTEND.
  - This also fixes hotels created by **booking import never appearing in the feed at all** — they carry no `reservation_time`, so the old code skipped them silently.
- **Car rentals** emit `Pick up:` / `Drop off:` transparent point events (matching TripIt) instead of one opaque event spanning the whole rental, which marked the subscriber busy for days. Sides resolve by endpoint role, so a surviving return endpoint can't be mistaken for the pickup when import dropped the other side (lat/lng are NOT NULL, so a failed geocode drops the row); each side falls back to `reservation_time`/`reservation_end_time`.
- **Free/busy**: the whole-trip banner and the all-day day-summary events are now `TRANSP:TRANSPARENT`, so subscribing to a month-long trip no longer blocks a month of availability.
- **Timezones**: transports that carry both `reservation_time` and endpoints took the `reservation_time` branch, whose zone comes from the linked place — flights have none — so they still rendered as floating times after #1453. Endpoints are now consulted first, since they hold per-side IANA zones. A SEA→HND flight subscribed from another zone was showing as a ~26 hour block.
- **Invalid events**: a `DTEND` that isn't after its `DTSTART` is dropped when both ends share a zone (or are both floating); cross-zone pairs are left alone because their wall clocks aren't comparable. A time-only `reservation_end_time` earlier than the start (a bar closing at 01:00) now rolls to the next day instead. Real overnight-arrival data was producing negative-duration VEVENTs.
- **Robustness**: one reservation with corrupt `metadata` JSON used to throw and take down the entire feed (and drop the trip from the all-trips feed); it now renders without its metadata fields. Non-string metadata values are ignored rather than thrown on.

UIDs stay deterministic: they're derived from row ids only, and the split bookings add a suffix to the reservation id (`trek-res-42-checkin@trek`, `-pickup@trek`, …), so they can't collide with the single-event `trek-res-42@trek`. Nothing in the feed is keyed off an accommodation id.

## Related Issue or Discussion

Discussed and approved in `#github-pr` on Discord. Follows on from the timezone work in #1453.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Test plan

- 17 new unit tests in `tripService.test.ts` (`TRIP-SVC-021`–`037`): accommodation-sourced check-in/out windows with TZID from the accommodation's place; default, metadata and `reservation_end_time` clocks; the `check_in_end` window; import-shaped hotels (ISO datetimes, no `reservation_time`); legacy bare-date hotels; car endpoints with TZID; role-based car sides and per-side fallback; endpoint priority over `reservation_time`; the same-zone DTEND guard; the overnight bare-time roll; corrupt/non-string metadata; a dated-but-timeless endpoint not downgrading a timed reservation; TRANSP on banner and day events; and UID uniqueness + stability across two exports.
- `TRIP-SVC-004` now uses a non-hotel type — it still covers the generic date-only path, and hotels have dedicated tests.
- The UID test was sanity-checked by making a UID non-deterministic to confirm it fails, rather than trusting a green assertion.
- Full server suite green. Verified end-to-end against a real 27-day, 8-hotel, 7-flight, 2-rental trip on a test instance: 16 window events, correct per-side flight zones, zero invalid same-zone DTENDs.

## Note

Left out deliberately: there's no migration that backfilled hotel reservations for accommodations created before `createAccommodation` started auto-creating one, so in older databases an accommodation with no linked reservation would still be missing from the feed. Covering those means emitting accommodation-keyed events (`trek-acc-{id}-…`); happy to do that as a follow-up if wanted.
