### PR TITLE
Give GPX tracks their own colour (#776)

### DIFF
--- a/client/src/components/Map/MapView.test.tsx
+++ b/client/src/components/Map/MapView.test.tsx
@@ -40,7 +40,22 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  Polyline: ({ positions }: any) => <div data-testid="polyline" data-points={JSON.stringify(positions)} />,
+  // pathOptions has to reach the DOM: the style props are what the track-colour
+  // feature (#776) actually asserts on, and the real Leaflet only repaints when
+  // that object's reference changes.
+  // bubblingMouseEvents and pane are surfaced too: a jsdom mock cannot reproduce
+  // Leaflet's event propagation or its pane stacking, so the tests assert the
+  // options that govern them instead.
+  Polyline: ({ positions, pathOptions, eventHandlers, bubblingMouseEvents, pane }: any) => (
+    <div
+      data-testid="polyline"
+      data-points={JSON.stringify(positions)}
+      data-path-options={JSON.stringify(pathOptions ?? null)}
+      data-bubbling={String(bubblingMouseEvents)}
+      data-pane={pane ?? ''}
+      onClick={() => eventHandlers?.click?.()}
+    />
+  ),
   CircleMarker: () => <div data-testid="circle-marker" />,
   Circle: () => <div data-testid="circle" />,
   Tooltip: ({ children }: any) => <>{children}</>,
@@ -154,7 +169,10 @@ describe('MapView', () => {
       buildMapPlace({ lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]' }),
     ]
     render(<MapView places={places} />)
-    expect(screen.getByTestId('polyline')).toBeTruthy()
+    // Three per track: casing, the visible line, and the invisible fat one
+    // that catches clicks. The casing is always mounted so that toggling a
+    // colour never remounts a path into the wrong stacking position.
+    expect(screen.getAllByTestId('polyline').length).toBe(3)
   })
 
   it('FE-COMP-MAPVIEW-010: MarkerClusterGroup is rendered', () => {
@@ -185,6 +203,67 @@ describe('MapView', () => {
     ]
     render(<MapView places={places} />)
     expect(screen.queryByTestId('polyline')).toBeNull()
+  })
+
+  // ── Track colours (#776) ──────────────────────────────────────────────────
+  // The style has to travel through pathOptions: react-leaflet only calls
+  // setStyle when that object's reference changes, so bare color/weight props
+  // would freeze at their mount-time value and a recolour would never show.
+  const trackOptions = () => screen.getAllByTestId('polyline')
+    .map(el => JSON.parse(el.getAttribute('data-path-options') || 'null'))
+    .filter(Boolean)
+
+  it('FE-COMP-MAPVIEW-025: a picked route_color beats the category colour', () => {
+    const places = [buildMapPlace({
+      lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+      category_color: '#00ff00', route_color: '#e11d48',
+    })]
+    render(<MapView places={places} />)
+    expect(trackOptions().some(o => o.color === '#e11d48')).toBe(true)
+    expect(trackOptions().some(o => o.color === '#00ff00')).toBe(false)
+  })
+
+  it('FE-COMP-MAPVIEW-026: without route_color the category colour still wins', () => {
+    const places = [buildMapPlace({
+      lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+      category_color: '#00ff00', route_color: null,
+    })]
+    render(<MapView places={places} />)
+    expect(trackOptions().some(o => o.color === '#00ff00')).toBe(true)
+  })
+
+  it('FE-COMP-MAPVIEW-027: with neither colour the track keeps the old blue', () => {
+    const places = [buildMapPlace({ lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]' })]
+    render(<MapView places={places} />)
+    expect(trackOptions().some(o => o.color === '#3b82f6' && o.weight === 3.5 && o.opacity === 0.75)).toBe(true)
+    // The casing is mounted but invisible — a track nobody coloured looks
+    // exactly as it did before.
+    expect(trackOptions().some(o => o.color === '#ffffff' && o.opacity === 0)).toBe(true)
+    expect(trackOptions().some(o => o.color === '#ffffff' && o.opacity > 0)).toBe(false)
+  })
+
+  it('FE-COMP-MAPVIEW-028: a coloured track gets a white casing underneath', () => {
+    const places = [buildMapPlace({
+      lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]', route_color: '#059669',
+    })]
+    render(<MapView places={places} />)
+    expect(trackOptions().some(o => o.color === '#ffffff' && o.weight === 6.5 && o.opacity === 0.7)).toBe(true)
+    expect(trackOptions().some(o => o.color === '#059669' && o.opacity === 0.9)).toBe(true)
+  })
+
+  it('FE-COMP-MAPVIEW-029: clicking a track selects its place', () => {
+    const onMarkerClick = vi.fn()
+    const places = [buildMapPlace({
+      id: 77, lat: 48.0, lng: 2.0, route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+    })]
+    render(<MapView places={places} onMarkerClick={onMarkerClick} />)
+    const hit = screen.getAllByTestId('polyline')
+      .find(el => JSON.parse(el.getAttribute('data-path-options') || '{}').weight === 14)
+    fireEvent.click(hit!)
+    expect(onMarkerClick).toHaveBeenCalledWith(77)
+    // Paths bubble to the map by default and the map click clears the selection
+    // this one just made — the mock cannot reproduce that, so assert the option.
+    expect(hit!.getAttribute('data-bubbling')).toBe('false')
   })
 
   it('FE-COMP-MAPVIEW-014: marker icon uses base64 image_url for photo places', () => {

--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -15,6 +15,7 @@ import { useTransportRoutes } from '../../hooks/useTransportRoutes'
 import { visibleRouteReservations } from '../../utils/reservationRoutes'
 import type { Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
+import { resolveTrackColor, hasManualTrackColor } from './trackColors'
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 import { computeMapViewport, TILE_SIZE_RASTER, type ViewportPadding } from '../../utils/mapViewport'
 
@@ -338,6 +339,28 @@ function ZoomTracker({ onZoomStart, onZoomEnd }: { onZoomStart: () => void; onZo
   return null
 }
 
+const TRACK_CASING_PANE = 'trek-track-casing'
+
+/**
+ * Pane that holds the white casing under GPX tracks (#776). Leaflet stacks paths
+ * in insertion order, so without a pane of its own a casing mounted later — a
+ * newly imported track, or one that just got a colour — would paint over an
+ * earlier track's line. Pane support is an optimization: a renderer without the
+ * pane API still draws everything, just in insertion order.
+ */
+function TrackCasingPane({ onReady }: { onReady: (ready: boolean) => void }) {
+  const map = useMap()
+  useEffect(() => {
+    if (typeof map.getPane !== 'function' || typeof map.createPane !== 'function') return
+    if (!map.getPane(TRACK_CASING_PANE)) {
+      const pane = map.createPane(TRACK_CASING_PANE)
+      if (pane) pane.style.zIndex = '398' // under overlayPane (400) and the plugin pane (399)
+    }
+    onReady(true)
+  }, [map, onReady])
+  return null
+}
+
 function MapClickHandler({ onClick }: MapClickHandlerProps) {
   const map = useMap()
   useEffect(() => {
@@ -574,6 +597,8 @@ export const MapView = memo(function MapView({
     return () => window.removeEventListener('scroll', clear, true)
   }, [hoveredPlace])
 
+  const [hasCasingPane, setHasCasingPane] = useState(false)
+
   const handleMarkerClick = useCallback((id: number) => {
     // Clear the hover card right away: the recenter that follows moves the
     // marker out from under the cursor, so no mouseout will ever fire (#1404).
@@ -686,22 +711,66 @@ export const MapView = memo(function MapView({
     )
   }), [places, selectedPlaceId, dayOrderMap, photoUrls, handleMarkerClick, handleMarkerHover, handleMarkerHoverOut])
 
-  const gpxPolylines = useMemo(() => places.flatMap(place => {
+  // Parsing track geometry is the expensive part (tracks run to tens of thousands
+  // of points), so it hangs off `places` alone — a selection change must not
+  // re-parse every track.
+  const gpxTracks = useMemo(() => places.flatMap(place => {
     if (!place.route_geometry) return []
     try {
       const coords = JSON.parse(place.route_geometry) as [number, number][]
       if (!coords || coords.length < 2) return []
-      return [(
+      return [{ place, coords, cased: hasManualTrackColor(place), color: resolveTrackColor(place) }]
+    } catch { return [] }
+  }), [places])
+
+  // Keeps the click handler out of the polyline memo below: `handleMarkerClick`
+  // changes on every selection, and depending on it would redraw all tracks.
+  const markerClickRef = useRef(handleMarkerClick)
+  markerClickRef.current = handleMarkerClick
+
+  const gpxPolylines = useMemo(() => (
+    <>
+      {/* Casings live in their own pane below the lines. Leaflet stacks paths by
+          insertion order, so drawing them inline would put the casing of a track
+          added later — or of one just given a colour — on top of an earlier
+          track's line. Always rendered, hidden via opacity when there is no
+          colour, so toggling one never remounts the path. */}
+      {gpxTracks.map(({ place, coords, cased }) => (
+        <Polyline
+          key={`gpx-${place.id}-casing`}
+          positions={coords}
+          pane={hasCasingPane ? TRACK_CASING_PANE : undefined}
+          pathOptions={{ color: '#ffffff', weight: 6.5, opacity: cased ? 0.7 : 0, lineCap: 'round', lineJoin: 'round' }}
+          interactive={false}
+        />
+      ))}
+      {/* pathOptions, not bare color/weight props: react-leaflet only calls
+          setStyle when the pathOptions reference changes, so bare props would
+          stick at their mount-time colour and a repaint would never arrive. */}
+      {gpxTracks.map(({ place, coords, cased, color }) => (
         <Polyline
           key={`gpx-${place.id}`}
           positions={coords}
-          color={place.category_color || '#3b82f6'}
-          weight={3.5}
-          opacity={0.75}
+          pathOptions={{ color, weight: 3.5, opacity: cased ? 0.9 : 0.75 }}
+          interactive={false}
         />
-      )]
-    } catch { return [] }
-  }), [places])
+      ))}
+      {/* Invisible fat line on top so the track can actually be hit — 3.5px is
+          not a target, least of all on touch, and the start markers cluster below
+          zoom 11. bubblingMouseEvents is essential: paths bubble to the map by
+          default (markers do not), and the map's own click handler clears the
+          selection this one just made. */}
+      {gpxTracks.map(({ place, coords }) => (
+        <Polyline
+          key={`gpx-${place.id}-hit`}
+          positions={coords}
+          pathOptions={{ color: '#000', weight: 14, opacity: 0, lineCap: 'round', lineJoin: 'round' }}
+          bubblingMouseEvents={false}
+          eventHandlers={{ click: () => markerClickRef.current(place.id) }}
+        />
+      ))}
+    </>
+  ), [gpxTracks, hasCasingPane])
 
   const TooltipOverlay = !hoverDisabled && hoveredPlace && tooltipPos && !isTouchDevice
   const CatIcon = TooltipOverlay ? getCategoryIcon(hoveredPlace.category_icon) : null
@@ -776,6 +845,7 @@ export const MapView = memo(function MapView({
       ] : [])}
 
       {/* GPX imported route geometries */}
+      <TrackCasingPane onReady={setHasCasingPane} />
       {gpxPolylines}
 
       <ReservationOverlay

--- a/client/src/components/Map/MapViewGL.test.tsx
+++ b/client/src/components/Map/MapViewGL.test.tsx
@@ -676,4 +676,38 @@ describe('MapViewGL', () => {
 
     expect(glMap.fitBounds.mock.calls.length).toBe(afterDayFit)
   })
+// ── Track colours (#776) ──────────────────────────────────────────────────
+  // The gpx layer paints from a per-feature property, so what matters is the
+  // GeoJSON handed to setData. getSource returns null by default in this suite,
+  // which makes the effect bail out — the source has to be stubbed per test.
+  const gpxFeatures = () => {
+    const gpxSource = { setData: vi.fn() }
+    glMap.getSource.mockImplementation((id: string) => (id === 'trip-gpx' ? gpxSource : null))
+    return () => {
+      const calls = gpxSource.setData.mock.calls
+      return calls.length ? (calls[calls.length - 1][0]?.features ?? []) : []
+    }
+  }
+
+  it('FE-COMP-MAPVIEWGL-021: a picked route_color reaches the feature, casing on', async () => {
+    const features = gpxFeatures()
+    const places = [buildMapPlace({
+      id: 5, lat: 48, lng: 2, route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+      category_color: '#00ff00', route_color: '#e11d48',
+    })]
+    render(<MapViewGL places={places} fitKey={1} glProvider="maplibre-gl" />)
+    await act(async () => {})
+    expect(features()[0]?.properties).toMatchObject({ color: '#e11d48', cased: true, place_id: 5 })
+  })
+
+  it('FE-COMP-MAPVIEWGL-022: without a pick it stays on the category colour and skips the casing', async () => {
+    const features = gpxFeatures()
+    const places = [buildMapPlace({
+      id: 6, lat: 48, lng: 2, route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+      category_color: '#00ff00',
+    })]
+    render(<MapViewGL places={places} fitKey={1} glProvider="maplibre-gl" />)
+    await act(async () => {})
+    expect(features()[0]?.properties).toMatchObject({ color: '#00ff00', cased: false })
+  })
 })

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -19,6 +19,7 @@ import LocationButton from './LocationButton'
 import { useGeolocation } from '../../hooks/useGeolocation'
 import type { Place, Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
+import { resolveTrackColor, hasManualTrackColor } from './trackColors'
 import { buildPoiPopupHtml } from './placePopup'
 import { pluginsApi, type PluginMapMarker, type PluginMapLayer } from '../../api/client'
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
@@ -41,6 +42,7 @@ const PLACE_CLUSTER_SOURCE_ID = 'trip-place-clusters'
 const PLACE_CLUSTER_CIRCLE_LAYER_ID = 'trip-place-clusters-circle'
 const PLACE_CLUSTER_COUNT_LAYER_ID = 'trip-place-clusters-count'
 const PLACE_UNCLUSTERED_LAYER_ID = 'trip-place-unclustered-hit'
+const GPX_HIT_LAYER_ID = 'trip-gpx-hit'
 
 type PlaceWithCoords = Place & { lat: number; lng: number }
 
@@ -517,6 +519,17 @@ export function MapViewGL({
       // gpx geometries source (place.route_geometry)
       if (!map.getSource('trip-gpx')) {
         map.addSource('trip-gpx', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } })
+        // Casing under the tracks that carry a picked colour (#776) — keeps them
+        // legible on satellite and dark styles. Untouched tracks are filtered
+        // out, so they look exactly as they did before.
+        map.addLayer({
+          id: 'trip-gpx-casing',
+          type: 'line',
+          source: 'trip-gpx',
+          filter: ['==', ['get', 'cased'], true],
+          paint: { 'line-color': '#ffffff', 'line-width': 6.5, 'line-opacity': 0.7 },
+          layout: { 'line-cap': 'round', 'line-join': 'round' },
+        })
         map.addLayer({
           id: 'trip-gpx-line',
           type: 'line',
@@ -524,10 +537,45 @@ export function MapViewGL({
           paint: {
             'line-color': ['coalesce', ['get', 'color'], '#3b82f6'],
             'line-width': 3.5,
-            'line-opacity': 0.75,
+            'line-opacity': ['case', ['==', ['get', 'cased'], true], 0.9, 0.75],
           },
           layout: { 'line-cap': 'round', 'line-join': 'round' },
         })
+        // Invisible fat line that catches the click — 3.5px is not a target,
+        // and the start markers cluster below zoom 11, so without this a track
+        // is unreachable at the very zoom where you compare walks side by side.
+        map.addLayer({
+          id: GPX_HIT_LAYER_ID,
+          type: 'line',
+          source: 'trip-gpx',
+          paint: { 'line-color': '#000', 'line-width': 14, 'line-opacity': 0 },
+          layout: { 'line-cap': 'round', 'line-join': 'round' },
+        })
+        const selectTrack = (e: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+          // A click on a cluster bubble sitting over a track belongs to the
+          // cluster (zoom-to-expand), not to the line underneath it.
+          if (
+            typeof map.getLayer === 'function'
+            && map.getLayer(PLACE_CLUSTER_CIRCLE_LAYER_ID)
+            && typeof map.queryRenderedFeatures === 'function'
+            && map.queryRenderedFeatures(e.point, { layers: [PLACE_CLUSTER_CIRCLE_LAYER_ID, PLACE_CLUSTER_COUNT_LAYER_ID] }).length > 0
+          ) return
+          const target = e.originalEvent?.target as HTMLElement | undefined
+          if (target?.closest?.('.mapboxgl-marker, .maplibregl-marker')) return
+          const placeId = e.features?.[0]?.properties?.place_id
+          if (typeof placeId === 'number') onClickRefs.current.marker?.(placeId)
+        }
+        const setTrackCursor = () => {
+          const canvas = typeof map.getCanvas === 'function' ? map.getCanvas() : null
+          if (canvas) canvas.style.cursor = 'pointer'
+        }
+        const clearTrackCursor = () => {
+          const canvas = typeof map.getCanvas === 'function' ? map.getCanvas() : null
+          if (canvas) canvas.style.cursor = ''
+        }
+        map.on('click', GPX_HIT_LAYER_ID, selectTrack)
+        map.on('mouseenter', GPX_HIT_LAYER_ID, setTrackCursor)
+        map.on('mouseleave', GPX_HIT_LAYER_ID, clearTrackCursor)
       }
       if (!map.getSource(PLACE_CLUSTER_SOURCE_ID)) {
         map.addSource(PLACE_CLUSTER_SOURCE_ID, {
@@ -673,6 +721,14 @@ export function MapViewGL({
         && map.getLayer(PLACE_CLUSTER_CIRCLE_LAYER_ID)
         && typeof map.queryRenderedFeatures === 'function'
         && map.queryRenderedFeatures(e.point, { layers: [PLACE_CLUSTER_CIRCLE_LAYER_ID, PLACE_CLUSTER_COUNT_LAYER_ID] }).length > 0
+      ) return
+      // Same for a click that landed on a track — it selects the track, it does
+      // not drop a new place on top of the line.
+      if (
+        typeof map.getLayer === 'function'
+        && map.getLayer(GPX_HIT_LAYER_ID)
+        && typeof map.queryRenderedFeatures === 'function'
+        && map.queryRenderedFeatures(e.point, { layers: [GPX_HIT_LAYER_ID] }).length > 0
       ) return
       onClickRefs.current.map?.({ latlng: { lat: e.lngLat.lat, lng: e.lngLat.lng } })
     })
@@ -1155,7 +1211,11 @@ export function MapViewGL({
         if (!coords || coords.length < 2) return []
         return [{
           type: 'Feature' as const,
-          properties: { color: (place as Place & { category_color?: string }).category_color || '#3b82f6' },
+          properties: {
+            color: resolveTrackColor(place),
+            cased: hasManualTrackColor(place),
+            place_id: place.id,
+          },
           geometry: { type: 'LineString' as const, coordinates: coords.map(([lat, lng]) => [lng, lat]) },
         }]
       } catch { return [] }

--- a/client/src/components/Map/trackColors.ts
+++ b/client/src/components/Map/trackColors.ts
@@ -1,0 +1,32 @@
+import { TRACK_COLOR_FALLBACK } from '@trek/shared'
+import type { Place } from '../../types'
+
+/**
+ * The colour a track's polyline is drawn in (#776): a manually picked colour
+ * wins, then the category colour, then the blue every imported track used to
+ * get. Both map renderers and the sidebar chip go through here so a track
+ * never reads as one colour in the list and another on the map.
+ *
+ * `category_color` is a SQL alias joined onto the row, not part of the place
+ * contract, which is why it needs the cast.
+ */
+export function resolveTrackColor(place: Place): string {
+  const withCategory = place as Place & { category_color?: string | null }
+  return place.route_color || withCategory.category_color || TRACK_COLOR_FALLBACK
+}
+
+/**
+ * What the track would fall back to if its colour were cleared — the category
+ * colour, or the old blue. Deliberately ignores route_color: this is what the
+ * picker's auto cell previews, and previewing the current colour there would
+ * promise the opposite of what clicking it does.
+ */
+export function inheritedTrackColor(place: Place): string {
+  const withCategory = place as Place & { category_color?: string | null }
+  return withCategory.category_color || TRACK_COLOR_FALLBACK
+}
+
+/** True once a track carries a deliberately chosen colour rather than an inherited one. */
+export function hasManualTrackColor(place: Place): boolean {
+  return Boolean(place.route_color)
+}

--- a/client/src/components/Planner/PlaceInspector.test.tsx
+++ b/client/src/components/Planner/PlaceInspector.test.tsx
@@ -732,4 +732,35 @@ describe('PlaceInspector', () => {
     expect(screen.queryByRole('button', { name: 'Change image' })).toBeNull();
   });
 
+// ── Track colour (#776) ──────────────────────────────────────────────────────
+
+  it('FE-PLANNER-INSPECTOR-051: the colour row only exists for a place with geometry', () => {
+    const { rerender } = render(<PlaceInspector {...defaultProps} />);
+    expect(screen.queryByText('Track color')).toBeNull();
+
+    rerender(<PlaceInspector {...defaultProps} place={{ ...place, route_geometry: '[[48.0,2.0],[49.0,3.0]]' }} />);
+    expect(screen.getAllByText('Track color').length).toBeGreaterThan(0);
+  });
+
+  it('FE-PLANNER-INSPECTOR-052: picking a swatch saves that colour', () => {
+    const onUpdatePlace = vi.fn();
+    const track = { ...place, route_geometry: '[[48.0,2.0],[49.0,3.0]]' };
+    render(<PlaceInspector {...defaultProps} place={track} onUpdatePlace={onUpdatePlace} />);
+
+    fireEvent.click(screen.getAllByText('Track color')[0]);
+    fireEvent.click(screen.getByRole('button', { name: '#059669' }));
+    expect(onUpdatePlace).toHaveBeenCalledWith(track.id, { route_color: '#059669' });
+  });
+
+  it('FE-PLANNER-INSPECTOR-053: the auto cell saves null, not undefined', () => {
+    const onUpdatePlace = vi.fn();
+    const track = { ...place, route_geometry: '[[48.0,2.0],[49.0,3.0]]', route_color: '#059669' };
+    render(<PlaceInspector {...defaultProps} place={track} onUpdatePlace={onUpdatePlace} />);
+
+    fireEvent.click(screen.getAllByText('Track color')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Automatic color' }));
+    // null is what clears the column; undefined would leave the colour in place.
+    expect(onUpdatePlace).toHaveBeenCalledWith(track.id, { route_color: null });
+  });
+
 });

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -4,10 +4,12 @@ import { openFile } from '../../utils/fileDownload'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import { X, Clock, MapPin, ExternalLink, Phone, Banknote, Edit2, Trash2, Plus, Minus, ChevronDown, ChevronUp, FileText, Upload, File, FileImage, Star, Navigation, Map as MapIcon, Users, Mountain, TrendingUp, Bookmark, BookmarkCheck, Copy } from 'lucide-react'
+import { X, Clock, MapPin, ExternalLink, Phone, Banknote, Edit2, Trash2, Plus, Minus, ChevronDown, ChevronUp, FileText, Upload, File, FileImage, Star, Navigation, Map as MapIcon, Users, Mountain, TrendingUp, Bookmark, BookmarkCheck, Copy, Route } from 'lucide-react'
 import PlaceAvatar from '../shared/PlaceAvatar'
 import PlaceAvatarUpload from '../shared/PlaceAvatarUpload'
 import PlaceRating from '../shared/StarRating'
+import TrackColorPicker from '../shared/TrackColorPicker'
+import { resolveTrackColor, inheritedTrackColor } from '../Map/trackColors'
 import GuestBadge from '../shared/GuestBadge'
 import StatusBadge from '../Collections/StatusBadge'
 import { mapsApi, pluginsApi } from '../../api/client'
@@ -392,7 +394,7 @@ export default function PlaceInspector({
             setHoursExpanded={setHoursExpanded} timeFormat={timeFormat} t={t} place={place} placeFiles={placeFiles}
             onFileUpload={onFileUpload} filesExpanded={filesExpanded} setFilesExpanded={setFilesExpanded}
             fileInputRef={fileInputRef} handleFileUpload={handleFileUpload} isUploading={isUploading}
-            distanceUnit={distanceUnit} />
+            distanceUnit={distanceUnit} onUpdatePlace={onUpdatePlace} />
 
           {/* Extra native rows from placeDetailProvider plugins (#1429). */}
           {mode === 'trip' && providerDetails.length > 0 && (
@@ -856,8 +858,51 @@ function PlaceReservationParticipants({ selectedAssignmentId, reservations, assi
   )
 }
 
+/**
+ * Track colour row (#776) — only for places that carry GPX geometry. Sits next
+ * to the stats block rather than inside it: that block bails out on unparsable
+ * geometry, and the colour control has no business disappearing with it.
+ */
+function TrackColorRow({ place, trackColor, onUpdatePlace, t }: any) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="bg-surface-hover" style={{ borderRadius: 10, padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+          background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <Route size={13} color="#9ca3af" />
+          <span className="text-content-secondary" style={{ fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 500 }}>
+            {t('inspector.trackColor')}
+          </span>
+        </div>
+        <span
+          className="ring-1 ring-inset ring-black/10 dark:ring-white/15"
+          style={{ width: 20, height: 20, borderRadius: 999, backgroundColor: trackColor, flexShrink: 0 }}
+        />
+      </button>
+      {open && (
+        <div className="border-edge" style={{ borderTopWidth: 1, paddingTop: 8 }}>
+          <TrackColorPicker
+            value={place.route_color ?? null}
+            inheritedColor={inheritedTrackColor(place)}
+            onChange={color => onUpdatePlace?.(place.id, { route_color: color })}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
 function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpanded, timeFormat, t, place,
-  placeFiles, onFileUpload, filesExpanded, setFilesExpanded, fileInputRef, handleFileUpload, isUploading, distanceUnit }: any) {
+  placeFiles, onFileUpload, filesExpanded, setFilesExpanded, fileInputRef, handleFileUpload, isUploading, distanceUnit,
+  onUpdatePlace }: any) {
+  const trackColor = resolveTrackColor(place)
   return (
           <div className={`grid grid-cols-1 ${openingHours?.length > 0 ? 'sm:grid-cols-2' : ''} gap-2`}>
           {openingHours && openingHours.length > 0 && (
@@ -892,6 +937,10 @@ function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpand
             </div>
           )}
 
+
+          {place.route_geometry && (
+            <TrackColorRow place={place} trackColor={trackColor} onUpdatePlace={onUpdatePlace} t={t} />
+          )}
 
           {/* GPX Track stats */}
           {place.route_geometry && (() => {
@@ -949,7 +998,7 @@ function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpand
                   </div>
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                     <div className="text-content" style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 600 }}>
-                      <MapPin size={12} color="#3b82f6" />
+                      <MapPin size={12} color={trackColor} />
                       {formatDistance(distKm, distanceUnit)}
                     </div>
                     {hasEle && (
@@ -972,12 +1021,12 @@ function PlaceExtras({ openingHours, weekdayIndex, hoursExpanded, setHoursExpand
                     <svg width="100%" viewBox={`0 0 ${chartW} ${chartH}`} preserveAspectRatio="none" className="bg-surface-tertiary" style={{ display: 'block', borderRadius: 6 }}>
                       <defs>
                         <linearGradient id={`ele-grad-${place.id}`} x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.25" />
-                          <stop offset="100%" stopColor="#3b82f6" stopOpacity="0.02" />
+                          <stop offset="0%" stopColor={trackColor} stopOpacity="0.25" />
+                          <stop offset="100%" stopColor={trackColor} stopOpacity="0.02" />
                         </linearGradient>
                       </defs>
                       <path d={`${pathD} L${chartW},${chartH} L0,${chartH} Z`} fill={`url(#ele-grad-${place.id})`} />
-                      <path d={pathD} fill="none" stroke="#3b82f6" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+                      <path d={pathD} fill="none" stroke={trackColor} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
                     </svg>
                   )}
                 </div>

--- a/client/src/components/Planner/PlacesSidebar.test.tsx
+++ b/client/src/components/Planner/PlacesSidebar.test.tsx
@@ -650,3 +650,23 @@ describe('touch device at desktop width (#1432)', () => {
     expect(screen.getByText('Drop to import')).toBeInTheDocument();
   });
 });
+
+// The map draws no legend of its own, so the stroke in the row is the only
+// thing tying a coloured line back to a place (#776).
+describe('track colour legend (#776)', () => {
+  it('FE-PLANNER-SIDEBAR-049: a track row carries a stroke in the colour the map draws', () => {
+    const track = buildPlace({ id: 11, name: 'Coloured Track', route_geometry: '[[48.0,2.0],[49.0,3.0]]', route_color: '#e11d48' });
+    render(<PlacesSidebar {...defaultProps} places={[track]} />);
+    const row = screen.getByText('Coloured Track').closest('div[draggable]')!;
+    const strokes = Array.from(row.querySelectorAll('span')).filter(el => (el as HTMLElement).style.borderRadius === '999px');
+    expect(strokes.some(el => (el as HTMLElement).style.background.includes('225, 29, 72') || (el as HTMLElement).style.background.includes('#e11d48'))).toBe(true);
+  });
+
+  it('FE-PLANNER-SIDEBAR-050: a place without geometry gets no stroke at all', () => {
+    const plain = buildPlace({ id: 12, name: 'Plain Place' });
+    render(<PlacesSidebar {...defaultProps} places={[plain]} />);
+    const row = screen.getByText('Plain Place').closest('div[draggable]')!;
+    const strokes = Array.from(row.querySelectorAll('span')).filter(el => (el as HTMLElement).style.borderRadius === '999px');
+    expect(strokes).toHaveLength(0);
+  });
+});

--- a/client/src/components/Planner/PlacesSidebarRow.tsx
+++ b/client/src/components/Planner/PlacesSidebarRow.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Plus, Check, Route, Star } from 'lucide-react'
+import { Plus, Check, Star } from 'lucide-react'
 import PlaceAvatar from '../shared/PlaceAvatar'
 import { getCategoryIcon } from '../shared/categoryIcons'
+import { resolveTrackColor } from '../Map/trackColors'
 import type { Place, Category } from '../../types'
 
 interface MemoPlaceRowProps {
@@ -81,7 +82,15 @@ export const MemoPlaceRow = React.memo(function MemoPlaceRow({
       <PlaceAvatar place={place} category={cat} size={34} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden' }}>
-          {hasGeometry && <span title="Track / Route" style={{ display: 'inline-flex', flexShrink: 0 }}><Route size={11} strokeWidth={2} color="var(--text-faint)" /></span>}
+          {/* A stroke of the colour the track is drawn in — the map has no legend
+              of its own, so this is what tells you which line is this row (#776).
+              A line rather than another 11px icon, so it doesn't read as a second
+              category glyph next to the one below. */}
+          {hasGeometry && (
+            <span title={t('places.trackIndicator')} style={{ display: 'inline-flex', flexShrink: 0 }}>
+              <span style={{ display: 'block', width: 14, height: 3, borderRadius: 999, background: resolveTrackColor(place) }} />
+            </span>
+          )}
           {cat && (() => {
             const CatIcon = getCategoryIcon(cat.icon)
             return <span title={cat.name} style={{ display: 'inline-flex', flexShrink: 0 }}><CatIcon size={11} strokeWidth={2} color={cat.color || '#6366f1'} /></span>

--- a/client/src/components/shared/TrackColorPicker.test.tsx
+++ b/client/src/components/shared/TrackColorPicker.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '../../../tests/helpers/render'
+import { fireEvent } from '@testing-library/react'
+import { resetAllStores } from '../../../tests/helpers/store'
+import TrackColorPicker from './TrackColorPicker'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  resetAllStores()
+})
+
+function setup(props: Partial<React.ComponentProps<typeof TrackColorPicker>> = {}) {
+  const onChange = vi.fn()
+  render(<TrackColorPicker value={null} inheritedColor="#16a34a" onChange={onChange} {...props} />)
+  return { onChange }
+}
+
+describe('TrackColorPicker (#776)', () => {
+  it('FE-COMP-TRACKCOLOR-001: a swatch commits its colour', () => {
+    const { onChange } = setup()
+    fireEvent.click(screen.getByRole('button', { name: '#059669' }))
+    expect(onChange).toHaveBeenCalledWith('#059669')
+  })
+
+  it('FE-COMP-TRACKCOLOR-002: the auto cell commits null, not undefined', () => {
+    const { onChange } = setup({ value: '#059669' })
+    fireEvent.click(screen.getByRole('button', { name: 'Automatic color' }))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('FE-COMP-TRACKCOLOR-003: the auto cell previews what clearing would give, not the current colour', () => {
+    setup({ value: '#e11d48' })
+    const auto = screen.getByRole('button', { name: 'Automatic color' })
+    // jsdom rewrites the hex to rgb(). #16a34a is the inherited colour; showing
+    // the picked #e11d48 here would promise the opposite of what the button does.
+    expect(auto.getAttribute('style')).toContain('rgb(22, 163, 74)')
+    expect(auto.getAttribute('style')).not.toContain('rgb(225, 29, 72)')
+  })
+
+  it('FE-COMP-TRACKCOLOR-004: dragging inside the native picker does not commit', () => {
+    const { onChange } = setup()
+    const input = document.querySelector('input[type="color"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    // React maps onChange on a colour input to the native `input` event, which
+    // fires on every drag — each one would be a PUT and a 409 candidate.
+    input.value = '#123456'
+    fireEvent.input(input)
+    expect(onChange).not.toHaveBeenCalled()
+
+    // The native `change` fires once, when the picker closes.
+    fireEvent.change(input)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('#123456')
+  })
+})

--- a/client/src/components/shared/TrackColorPicker.tsx
+++ b/client/src/components/shared/TrackColorPicker.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react'
+import { Pipette, RotateCcw } from 'lucide-react'
+import { TRACK_COLORS } from '@trek/shared'
+import { useTranslation } from '../../i18n'
+
+interface TrackColorPickerProps {
+  /** The picked colour, or null while the track still inherits one. */
+  value: string | null
+  /** What the track is drawn in when nothing is picked — shown in the auto cell. */
+  inheritedColor: string
+  onChange: (color: string | null) => void
+}
+
+/**
+ * Swatch row for a GPX track's line colour (#776).
+ *
+ * First cell resets to the inherited colour, then the shared palette, then a
+ * native picker for anything else. Selection is drawn with `--accent` so the
+ * row follows whatever accent the user runs rather than pinning one hue.
+ */
+export default function TrackColorPicker({ value, inheritedColor, onChange }: TrackColorPickerProps) {
+  const { t } = useTranslation()
+  const customInputRef = useRef<HTMLInputElement>(null)
+  const isPreset = value !== null && (TRACK_COLORS as readonly string[]).includes(value)
+  const selected = 'outline outline-2 outline-[var(--accent)] outline-offset-2 scale-110'
+
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
+  // Native `change`, deliberately not React's onChange — see the input below.
+  useEffect(() => {
+    const input = customInputRef.current
+    if (!input) return
+    const commit = () => onChangeRef.current(input.value)
+    input.addEventListener('change', commit)
+    return () => input.removeEventListener('change', commit)
+  }, [])
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        aria-pressed={value === null}
+        aria-label={t('inspector.trackColorAuto')}
+        title={t('inspector.trackColorAuto')}
+        className={`w-7 h-7 rounded-full grid place-items-center border-2 border-dashed transition-transform duration-150 hover:scale-110 motion-reduce:hover:scale-100 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--accent)] ${
+          value === null ? `border-solid border-transparent ${selected}` : 'border-edge-secondary hover:border-edge'
+        }`}
+        // A tint of the inherited colour so it is obvious what "auto" would give you.
+        style={{ backgroundColor: `color-mix(in srgb, ${inheritedColor} 25%, transparent)` }}
+      >
+        <RotateCcw size={12} className="text-content-muted" />
+      </button>
+
+      {TRACK_COLORS.map(color => (
+        <button
+          key={color}
+          type="button"
+          onClick={() => onChange(color)}
+          aria-pressed={value === color}
+          aria-label={color}
+          title={color}
+          className={`w-7 h-7 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/15 transition-transform duration-150 hover:scale-110 motion-reduce:hover:scale-100 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--accent)] ${
+            value === color ? selected : ''
+          }`}
+          style={{ backgroundColor: color }}
+        />
+      ))}
+
+      {/* No React onChange here: for a colour input React maps it to the native
+          `input` event, which fires on every drag inside the OS picker — dozens
+          of PUTs, each one a 409 candidate against the base-version header. The
+          native `change` event fires once, when the picker closes. */}
+      <input
+        ref={customInputRef}
+        type="color"
+        defaultValue={value ?? inheritedColor}
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+      <button
+        type="button"
+        onClick={() => {
+          const input = customInputRef.current
+          if (!input) return
+          // Uncontrolled input, so seed it with the current colour before opening
+          // — otherwise the OS picker starts from whatever it was last mounted with.
+          input.value = value ?? inheritedColor
+          input.click()
+        }}
+        aria-label={t('inspector.trackColorCustom')}
+        title={t('inspector.trackColorCustom')}
+        className={`w-7 h-7 rounded-full grid place-items-center border-2 transition-transform duration-150 hover:scale-110 motion-reduce:hover:scale-100 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--accent)] ${
+          value !== null && !isPreset ? `border-transparent ${selected}` : 'border-dashed border-edge-secondary hover:border-edge'
+        }`}
+        style={value !== null && !isPreset ? { backgroundColor: value } : undefined}
+      >
+        {(value === null || isPreset) && <Pipette size={12} className="text-content-muted" />}
+      </button>
+    </div>
+  )
+}

--- a/client/src/mobile/screens/trip/places/MPlacesBrowser.tsx
+++ b/client/src/mobile/screens/trip/places/MPlacesBrowser.tsx
@@ -8,6 +8,7 @@ import { useTripStore } from '../../../../store/tripStore'
 import { useAddonStore } from '../../../../store/addonStore'
 import PlaceAvatar from '../../../../components/shared/PlaceAvatar'
 import { getCategoryIcon } from '../../../../components/shared/categoryIcons'
+import { resolveTrackColor } from '../../../../components/Map/trackColors'
 import MConfirmSheet from '../../settings/MConfirmSheet'
 import type { MPlacesBrowserProps } from '../MTripShell'
 import type { Place } from '../../../../types'
@@ -290,6 +291,15 @@ export default function MPlacesBrowser({ planner, shell }: MPlacesBrowserProps) 
                   <PlaceAvatar place={place} category={cat} size={40} />
                   <span className="min-w-0 flex-1">
                     <span className="flex items-center gap-[6px]">
+                      {/* Stroke in the track's colour — the mobile map is full-bleed
+                          with no sidebar, so this is the only thing tying a line to
+                          a row (#776). */}
+                      {place.route_geometry && (
+                        <span
+                          className="h-[3px] w-[14px] flex-none rounded-full"
+                          style={{ background: resolveTrackColor(place) }}
+                        />
+                      )}
                       <CatIcon size={12} strokeWidth={2.2} className="flex-none" style={{ color: cat?.color || 'var(--m-muted)' }} />
                       <span className="truncate text-[0.8125rem] font-semibold text-m-ink">{place.name}</span>
                     </span>

--- a/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react'
 import {
   Bookmark, Camera, ExternalLink, Loader2, Map as MapIcon, Navigation, Paperclip,
-  Pencil, Phone, Plus, Trash2, Upload, X,
+  Pencil, Phone, Plus, Route, Trash2, Upload, X,
 } from 'lucide-react'
 import MSheet from '../../../components/MSheet'
 import type { MTripSheetsProps } from '../MTripShell'
@@ -14,6 +14,8 @@ import { useSaveToCollectionStore } from '../../../../store/saveToCollectionStor
 import { collectionTargetFromPlace } from '../lib/collectionTarget'
 import { getCategoryIcon } from '../../../../components/shared/categoryIcons'
 import PlaceRating from '../../../../components/shared/StarRating'
+import TrackColorPicker from '../../../../components/shared/TrackColorPicker'
+import { resolveTrackColor, inheritedTrackColor } from '../../../../components/Map/trackColors'
 import { avatarSrc } from '../../../../utils/avatarSrc'
 import { openFile } from '../../../../utils/fileDownload'
 import { getGoogleMapsUrlForPlace } from '../../../../components/Planner/placeGoogleMaps'
@@ -42,6 +44,7 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
   const [participantPickerOpen, setParticipantPickerOpen] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [imgBusy, setImgBusy] = useState(false)
+  const [colorPickerOpen, setColorPickerOpen] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const imageInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -129,6 +132,15 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
       planner.toast.error(translateApiError(t, err, 'places.imageUploadError'))
     } finally {
       setImgBusy(false)
+    }
+  }
+
+  const handleTrackColor = async (color: string | null) => {
+    if (!place) return
+    try {
+      await planner.tripActions.updatePlace(planner.tripId, place.id, { route_color: color })
+    } catch (err: unknown) {
+      planner.toast.error(translateApiError(t, err, 'common.unknownError'))
     }
   }
 
@@ -286,6 +298,43 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
                 <Eyebrow className="mb-[6px] mt-3">{t('mobileTrip.notes')}</Eyebrow>
                 <div className={`rounded-[14px] px-3 py-[10px] ${INNER_CLS}`}>
                   <div className="whitespace-pre-wrap font-geist text-[0.75rem] leading-[1.5] text-m-muted">{place.notes}</div>
+                </div>
+              </>
+            )}
+
+            {/* ── Track colour (#776) ── */}
+            {place.route_geometry && (
+              <>
+                <Eyebrow className="mb-[6px] mt-3">{t('inspector.trackColor')}</Eyebrow>
+                <div className={`rounded-[14px] px-3 py-[10px] ${INNER_CLS}`}>
+                  <button
+                    type="button"
+                    onClick={() => setColorPickerOpen(v => !v)}
+                    aria-expanded={colorPickerOpen}
+                    className="flex w-full items-center justify-between gap-3"
+                  >
+                    {/* The eyebrow above already names the section — this row says
+                        which colour is in effect, not the same word again. */}
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Route size={14} className="shrink-0 text-m-muted" />
+                      <span className="truncate font-geist text-[0.75rem] font-medium">
+                        {place.route_color ?? t('inspector.trackColorAuto')}
+                      </span>
+                    </span>
+                    <span
+                      className="h-6 w-6 shrink-0 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/15"
+                      style={{ background: resolveTrackColor(place) }}
+                    />
+                  </button>
+                  {colorPickerOpen && (
+                    <div className="mt-[10px] border-t border-[color:var(--m-faint)] pt-[10px]">
+                      <TrackColorPicker
+                        value={place.route_color ?? null}
+                        inheritedColor={inheritedTrackColor(place)}
+                        onChange={handleTrackColor}
+                      />
+                    </div>
+                  )}
                 </div>
               </>
             )}

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -565,6 +565,9 @@ export function useTripPlanner() {
             address: capturedPlace.address,
             category_id: capturedPlace.category_id,
             price: capturedPlace.price,
+            // An undone track has to come back as a track, not a bare point.
+            route_geometry: capturedPlace.route_geometry,
+            route_color: capturedPlace.route_color,
           })
           for (const { dayId, orderIndex } of capturedAssignments) {
             await tripActions.assignPlaceToDay(tripId, dayId, newPlace.id, orderIndex)
@@ -595,6 +598,7 @@ export function useTripPlanner() {
               name: place.name, description: place.description,
               lat: place.lat, lng: place.lng, address: place.address,
               category_id: place.category_id, price: place.price,
+              route_geometry: place.route_geometry, route_color: place.route_color,
             })
             for (const a of capturedAssignments.filter(x => x.placeId === place.id)) {
               await tripActions.assignPlaceToDay(tripId, a.dayId, newPlace.id, a.orderIndex)

--- a/client/tests/helpers/factories.ts
+++ b/client/tests/helpers/factories.ts
@@ -112,6 +112,7 @@ export function buildPlace(overrides: Partial<Place> = {}): Place {
     google_place_id: null,
     osm_id: null,
     route_geometry: null,
+    route_color: null,
     place_time: null,
     end_time: null,
     duration_minutes: 60,

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3822,6 +3822,14 @@ function runMigrations(db: Database.Database): void {
         );
       `);
     },
+    // Manual GPX track colour (#776): imported tracks all render in the same blue
+    // because the importer never assigns a category, so several walks in the same
+    // area are indistinguishable. NULL keeps the old behaviour (category colour,
+    // then the #3b82f6 fallback) for every existing row.
+    () => {
+      const hasRouteColor = db.prepare("SELECT 1 FROM pragma_table_info('places') WHERE name = 'route_color'").get();
+      if (!hasRouteColor) db.exec('ALTER TABLE places ADD COLUMN route_color TEXT');
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/nest/places/places.controller.ts
+++ b/server/src/nest/places/places.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
+import { hexColorSchema } from '@trek/shared';
 import { readEnv } from '../../app-config';
 import type { User } from '../../types';
 import { PlacesService } from './places.service';
@@ -36,6 +37,16 @@ function validateLengths(body: Record<string, unknown>): void {
     if (value && typeof value === 'string' && value.length > max) {
       throw new HttpException({ error: `${field} must be ${max} characters or less` }, 400);
     }
+  }
+}
+
+// A bad hex makes MapLibre fail hard when it parses the paint property, and the
+// update body is an open record that Zod does not police — so check it here.
+function validateRouteColor(body: Record<string, unknown>): void {
+  const value = body.route_color;
+  if (value === undefined || value === null) return;
+  if (typeof value !== 'string' || !hexColorSchema.safeParse(value).success) {
+    throw new HttpException({ error: 'route_color must be a hex colour like #4f46e5' }, 400);
   }
 }
 
@@ -93,6 +104,7 @@ export class PlacesController {
   ) {
     const trip = this.requireTrip(tripId, user);
     validateLengths(body);
+    validateRouteColor(body);
     this.requireEdit(trip, user);
     if (!body.name) {
       throw new HttpException({ error: 'Place name is required' }, 400);
@@ -358,6 +370,7 @@ export class PlacesController {
   ) {
     const trip = this.requireTrip(tripId, user);
     validateLengths(body);
+    validateRouteColor(body);
     this.requireEdit(trip, user);
     const result = this.places.update(tripId, id, body as never, ifMatch);
     if (!result) {

--- a/server/src/nest/places/places.service.ts
+++ b/server/src/nest/places/places.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { TRACK_COLORS } from '@trek/shared';
 import { broadcast } from '../../websocket';
 import { DatabaseService } from '../database/database.service';
 import { checkPermission } from '../../services/permissions';
@@ -7,6 +8,8 @@ import * as svc from '../../services/placeService';
 import { onPlaceCreated, onPlaceUpdated, onPlaceDeleted } from '../../services/journeyService';
 
 type Trip = { user_id: number };
+
+type ImportedPlace = { id: number; route_geometry?: string | null; route_color?: string | null };
 
 /**
  * Thin Nest wrapper around the existing place service. Trip access mirrors the
@@ -63,11 +66,53 @@ export class PlacesService {
     buffer: Buffer,
     opts: { importWaypoints: boolean; importRoutes: boolean; importTracks: boolean; defaultName?: string },
   ) {
-    return svc.importGpx(tripId, buffer, opts);
+    return this.colorizeImportedTracks(tripId, svc.importGpx(tripId, buffer, opts));
   }
 
-  importMapFile(tripId: string, buffer: Buffer, filename: string, opts: svc.KmlImportOptions) {
-    return svc.importMapFile(tripId, buffer, filename, opts);
+  async importMapFile(tripId: string, buffer: Buffer, filename: string, opts: svc.KmlImportOptions) {
+    return this.colorizeImportedTracks(tripId, await svc.importMapFile(tripId, buffer, filename, opts));
+  }
+
+  /**
+   * Hand every freshly imported track its own colour (#776).
+   *
+   * The importers never assign a category, so without this every track in a
+   * trip renders in the same #3b82f6 — which is the actual complaint behind
+   * the request: several walks in one area are impossible to tell apart.
+   *
+   * Picks the palette entries the trip is not already using rather than
+   * counting rows: counting collides as soon as somebody recolours a track by
+   * hand or deletes one, which is exactly when distinguishability matters.
+   * Once all ten are taken it wraps around — ten walks in one trip is already
+   * past what a colour alone can separate.
+   *
+   * Only rows that carry geometry are touched, and only ones that have no
+   * colour yet; plain waypoints and existing places stay untouched.
+   */
+  private colorizeImportedTracks<T extends { places: ImportedPlace[] } | null>(tripId: string, result: T): T {
+    const tracks = result?.places?.filter((p) => p.route_geometry && !p.route_color) ?? [];
+    if (tracks.length === 0) return result;
+
+    // Read and write in one transaction so two concurrent imports cannot both
+    // read the same set of free colours.
+    this.dbs.transaction((conn) => {
+      const taken = new Set(
+        (conn
+          .prepare('SELECT DISTINCT route_color AS c FROM places WHERE trip_id = ? AND route_color IS NOT NULL')
+          .all(tripId) as { c: string }[]).map((r) => r.c),
+      );
+      const free = TRACK_COLORS.filter((c) => !taken.has(c));
+      const stmt = conn.prepare('UPDATE places SET route_color = ? WHERE id = ?');
+      tracks.forEach((track, i) => {
+        // Free ones first, then wrap through the whole palette — never reuse a
+        // free colour twice within the same import.
+        const color = i < free.length ? free[i] : TRACK_COLORS[(i - free.length) % TRACK_COLORS.length];
+        stmt.run(color, track.id);
+        track.route_color = color;
+      });
+    });
+
+    return result;
   }
 
   importGoogleList(tripId: string, url: string, opts?: Parameters<typeof svc.importGoogleList>[2]) {

--- a/server/src/services/placeService.ts
+++ b/server/src/services/placeService.ts
@@ -125,26 +125,28 @@ export function createPlace(
     place_time?: string; end_time?: string;
     duration_minutes?: number; notes?: string; image_url?: string;
     google_place_id?: string; google_ftid?: string; osm_id?: string; website?: string; phone?: string;
-    transport_mode?: string; tags?: number[];
+    transport_mode?: string; route_geometry?: string; route_color?: string; tags?: number[];
   },
 ) {
   const {
     name, description, lat, lng, address, category_id, price, currency,
     place_time, end_time,
     duration_minutes, notes, image_url, google_place_id, google_ftid, osm_id, website, phone,
-    transport_mode, tags = [],
+    transport_mode, route_geometry, route_color, tags = [],
   } = body;
 
   const result = db.prepare(`
     INSERT INTO places (trip_id, name, description, lat, lng, address, category_id, price, currency,
       place_time, end_time,
-      duration_minutes, notes, image_url, google_place_id, google_ftid, osm_id, website, phone, transport_mode)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      duration_minutes, notes, image_url, google_place_id, google_ftid, osm_id, website, phone, transport_mode,
+      route_geometry, route_color)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     tripId, name, description || null, lat || null, lng || null, address || null,
     category_id || null, price || null, currency || null,
     place_time || null, end_time || null, duration_minutes || 60, notes || null, image_url || null,
     google_place_id || null, google_ftid || null, osm_id || null, website || null, phone || null, transport_mode || 'walking',
+    route_geometry || null, route_color || null,
   );
 
   const placeId = result.lastInsertRowid;
@@ -182,7 +184,7 @@ export function updatePlace(
     place_time?: string; end_time?: string;
     duration_minutes?: number; notes?: string; image_url?: string;
     google_place_id?: string; google_ftid?: string; osm_id?: string; website?: string; phone?: string;
-    transport_mode?: string; tags?: number[];
+    transport_mode?: string; route_color?: string | null; tags?: number[];
   },
   ifMatch?: string,
 ): ReturnType<typeof getPlaceWithTags> | UpdateConflict | null {
@@ -200,7 +202,7 @@ export function updatePlace(
     name, description, lat, lng, address, category_id, price, currency,
     place_time, end_time,
     duration_minutes, notes, image_url, google_place_id, google_ftid, osm_id, website, phone,
-    transport_mode, tags,
+    transport_mode, route_color, tags,
   } = body;
 
   db.prepare(`
@@ -224,6 +226,7 @@ export function updatePlace(
       website = ?,
       phone = ?,
       transport_mode = COALESCE(?, transport_mode),
+      route_color = ?,
       updated_at = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(
@@ -246,6 +249,9 @@ export function updatePlace(
     website !== undefined ? website : existingPlace.website,
     phone !== undefined ? phone : existingPlace.phone,
     transport_mode || null,
+    // Deliberately not COALESCE: an explicit null is how the picker resets a
+    // track back to its category colour (#776).
+    route_color !== undefined ? route_color : existingPlace.route_color,
     placeId,
   );
 

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -917,14 +917,15 @@ export function copyTripById(sourceTripId: string | number, newOwnerId: number, 
     const insertPlace = db.prepare(`
       INSERT INTO places (trip_id, name, description, lat, lng, address, category_id, price, currency,
         reservation_status, reservation_notes, reservation_datetime, place_time, end_time,
-        duration_minutes, notes, image_url, google_place_id, google_ftid, website, phone, transport_mode, osm_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        duration_minutes, notes, image_url, google_place_id, google_ftid, website, phone, transport_mode, osm_id,
+        route_geometry, route_color)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const p of oldPlaces) {
       const r = insertPlace.run(newTripId, p.name, p.description, p.lat, p.lng, p.address, p.category_id,
         p.price, p.currency, p.reservation_status, p.reservation_notes, p.reservation_datetime,
         p.place_time, p.end_time, p.duration_minutes, p.notes, p.image_url, p.google_place_id,
-        p.google_ftid, p.website, p.phone, p.transport_mode, p.osm_id);
+        p.google_ftid, p.website, p.phone, p.transport_mode, p.osm_id, p.route_geometry, p.route_color);
       placeMap.set(p.id, r.lastInsertRowid);
     }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -73,6 +73,8 @@ export interface Place {
   google_place_id?: string | null;
   google_ftid?: string | null;
   osm_id?: string | null;
+  route_geometry?: string | null;
+  route_color?: string | null;
   website?: string | null;
   phone?: string | null;
   transport_mode?: string;

--- a/server/tests/e2e/places.e2e.test.ts
+++ b/server/tests/e2e/places.e2e.test.ts
@@ -110,6 +110,24 @@ describe('Places e2e (real auth guard + temp SQLite)', () => {
     expect(bad.body).toEqual({ error: 'ids must be an array of numbers' });
   });
 
+  it('PUT route_color: hex through, null through, garbage rejected (#776)', async () => {
+    pl.updatePlace.mockReturnValue({ id: 9, route_color: '#e11d48' });
+    const ok = await request(server).put('/api/trips/5/places/9').set('Cookie', sessionCookie(1)).send({ route_color: '#e11d48' });
+    expect(ok.status).toBe(200);
+    expect(ok.body).toEqual({ place: { id: 9, route_color: '#e11d48' } });
+    expect(pl.updatePlace).toHaveBeenCalledWith('5', '9', expect.objectContaining({ route_color: '#e11d48' }), undefined);
+
+    // null is the reset back to the inherited category colour.
+    pl.updatePlace.mockReturnValue({ id: 9, route_color: null });
+    const cleared = await request(server).put('/api/trips/5/places/9').set('Cookie', sessionCookie(1)).send({ route_color: null });
+    expect(cleared.status).toBe(200);
+    expect(pl.updatePlace).toHaveBeenLastCalledWith('5', '9', expect.objectContaining({ route_color: null }), undefined);
+
+    const bad = await request(server).put('/api/trips/5/places/9').set('Cookie', sessionCookie(1)).send({ route_color: 'red' });
+    expect(bad.status).toBe(400);
+    expect(bad.body).toEqual({ error: 'route_color must be a hex colour like #4f46e5' });
+  });
+
   it('404 trip when not accessible', async () => {
     canAccessTrip.mockReturnValue(undefined);
     const res = await request(server).get('/api/trips/5/places').set('Cookie', sessionCookie(1));

--- a/server/tests/unit/nest/places.controller.test.ts
+++ b/server/tests/unit/nest/places.controller.test.ts
@@ -236,6 +236,37 @@ describe('PlacesController (parity with the legacy /api/trips/:tripId/places rou
     expect(onUpdated).toHaveBeenCalledWith(9);
   });
 
+  describe('route_color (#776)', () => {
+    it('400s on anything that is not a hex colour, before the permission check', () => {
+      const canEdit = vi.fn().mockReturnValue(false); // would 403 if it got that far
+      const err = { status: 400, body: { error: 'route_color must be a hex colour like #4f46e5' } };
+      expect(thrown(() => new PlacesController(svc({ canEdit })).update(user, '5', '9', { route_color: 'red' }))).toEqual(err);
+      expect(thrown(() => new PlacesController(svc({ canEdit })).update(user, '5', '9', { route_color: '#12345' }))).toEqual(err);
+      expect(thrown(() => new PlacesController(svc({ canEdit })).update(user, '5', '9', { route_color: 123 }))).toEqual(err);
+      expect(thrown(() => new PlacesController(svc({ canEdit })).create(user, '5', { name: 'T', route_color: 'red' }))).toEqual(err);
+      expect(canEdit).not.toHaveBeenCalled();
+    });
+
+    it('passes a valid hex through, and null through as the reset to auto', () => {
+      const update = vi.fn().mockReturnValue({ id: 9, route_color: '#e11d48' });
+      const broadcast = vi.fn();
+      const s = svc({ update, broadcast } as Partial<PlacesService>);
+      expect(new PlacesController(s).update(user, '5', '9', { route_color: '#e11d48' }, 'sock'))
+        .toEqual({ place: { id: 9, route_color: '#e11d48' } });
+      expect(update).toHaveBeenCalledWith('5', '9', expect.objectContaining({ route_color: '#e11d48' }), undefined);
+      // The colour has to reach the other members too, not just the DB.
+      expect(broadcast).toHaveBeenCalledWith('5', 'place:updated', { place: { id: 9, route_color: '#e11d48' } }, 'sock');
+
+      new PlacesController(svc({ update } as Partial<PlacesService>)).update(user, '5', '9', { route_color: null });
+      expect(update).toHaveBeenLastCalledWith('5', '9', expect.objectContaining({ route_color: null }), undefined);
+    });
+
+    it('accepts the short #abc form', () => {
+      const update = vi.fn().mockReturnValue({ id: 9 });
+      expect(new PlacesController(svc({ update } as Partial<PlacesService>)).update(user, '5', '9', { route_color: '#abc' })).toEqual({ place: { id: 9 } });
+    });
+  });
+
   it('PUT /:id forwards the base-version token and 409s on a conflict (#1135)', () => {
     const update = vi.fn().mockReturnValue({ conflict: true, server: { id: 9, name: 'Theirs' } });
     const onUpdated = vi.fn(); const broadcast = vi.fn();

--- a/server/tests/unit/nest/places.service.test.ts
+++ b/server/tests/unit/nest/places.service.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for PlacesService — PLACES-SVC-001 through PLACES-SVC-005.
+ *
+ * Covers the one piece of logic the Nest wrapper owns rather than delegates:
+ * handing every freshly imported track its own colour (#776). The importers
+ * never assign a category, so without this each track in a trip renders in the
+ * same blue and several walks in one area are impossible to tell apart.
+ *
+ * Uses a real in-memory SQLite DB so the SQL is exercised faithfully; the
+ * service is constructed directly, no Nest container needed.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { TRACK_COLORS } from '@trek/shared';
+
+// ── DB setup ──────────────────────────────────────────────────────────────────
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: (placeId: any) => db.prepare('SELECT * FROM places WHERE id = ?').get(placeId) ?? null,
+    canAccessTrip: () => null,
+    isOwner: () => false,
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-secret',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb } from '../../helpers/test-db';
+import { createUser, createTrip } from '../../helpers/factories';
+import { DatabaseService } from '../../../src/nest/database/database.service';
+import { PlacesService } from '../../../src/nest/places/places.service';
+
+// Three tracks plus a plain waypoint — the shared fixture only has waypoints,
+// and the whole point here is what happens to geometry.
+const GPX_WITH_TRACKS = `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="TREK Tests" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="48.8566" lon="2.3522"><name>Trailhead</name></wpt>
+  <trk><name>Morning walk</name><trkseg>
+    <trkpt lat="48.10" lon="2.10"/><trkpt lat="48.11" lon="2.11"/>
+  </trkseg></trk>
+  <trk><name>Afternoon walk</name><trkseg>
+    <trkpt lat="48.20" lon="2.20"/><trkpt lat="48.21" lon="2.21"/>
+  </trkseg></trk>
+  <trk><name>Evening walk</name><trkseg>
+    <trkpt lat="48.30" lon="2.30"/><trkpt lat="48.31" lon="2.31"/>
+  </trkseg></trk>
+</gpx>`;
+
+const svc = new PlacesService(new DatabaseService(testDb));
+
+function importFixture(tripId: number) {
+  return svc.importGpx(String(tripId), Buffer.from(GPX_WITH_TRACKS), {
+    importWaypoints: true, importRoutes: true, importTracks: true,
+  });
+}
+
+function tracksOf(tripId: number) {
+  return testDb.prepare('SELECT id, route_color FROM places WHERE trip_id = ? AND route_geometry IS NOT NULL ORDER BY id')
+    .all(tripId) as { id: number; route_color: string | null }[];
+}
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+describe('PlacesService — automatic track colours (#776)', () => {
+  it('PLACES-SVC-001 — every imported track gets a colour from the shared palette', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    importFixture(trip.id);
+
+    const tracks = tracksOf(trip.id);
+    expect(tracks.length).toBeGreaterThan(0);
+    for (const track of tracks) {
+      expect(TRACK_COLORS).toContain(track.route_color);
+    }
+  });
+
+  it('PLACES-SVC-002 — the returned places carry the colour, not just the DB rows', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const result = importFixture(trip.id) as { places: any[] } | null;
+
+    const returnedTracks = (result?.places ?? []).filter(p => p.route_geometry);
+    expect(returnedTracks.length).toBeGreaterThan(0);
+    for (const track of returnedTracks) {
+      expect(TRACK_COLORS).toContain(track.route_color);
+    }
+  });
+
+  it('PLACES-SVC-003 — plain waypoints keep no colour at all', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    importFixture(trip.id);
+
+    const waypoints = testDb.prepare(
+      'SELECT route_color FROM places WHERE trip_id = ? AND route_geometry IS NULL',
+    ).all(trip.id) as { route_color: string | null }[];
+    for (const wp of waypoints) {
+      expect(wp.route_color).toBeNull();
+    }
+  });
+
+  it('PLACES-SVC-004 — a second import continues the palette instead of repeating it', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    importFixture(trip.id);
+    const first = tracksOf(trip.id).map(t => t.route_color);
+
+    // Same fixture again: dedup skips the identical rows, so seed a distinct
+    // track directly and let the service colour the next import round.
+    testDb.prepare(
+      "INSERT INTO places (trip_id, name, lat, lng, route_geometry) VALUES (?, 'Second walk', 1, 1, '[[1,1],[2,2]]')",
+    ).run(trip.id);
+    const seeded = testDb.prepare('SELECT id FROM places WHERE name = ?').get('Second walk') as { id: number };
+    (svc as any).colorizeImportedTracks(String(trip.id), {
+      places: [{ id: seeded.id, route_geometry: '[[1,1],[2,2]]', route_color: null }],
+    });
+
+    const seededColor = (testDb.prepare('SELECT route_color FROM places WHERE id = ?').get(seeded.id) as any).route_color;
+    expect(TRACK_COLORS).toContain(seededColor);
+    expect(first).not.toContain(seededColor);
+  });
+
+  it('PLACES-SVC-006 — a colour already in use by hand is not handed out again', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    // Someone recoloured an existing track to the palette's second entry. A
+    // plain row count would hand exactly that colour to the next import.
+    testDb.prepare(
+      "INSERT INTO places (trip_id, name, lat, lng, route_geometry, route_color) VALUES (?, 'Old walk', 1, 1, '[[1,1],[2,2]]', ?)",
+    ).run(trip.id, TRACK_COLORS[1]);
+
+    importFixture(trip.id);
+
+    const colors = tracksOf(trip.id).map(t => t.route_color);
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+
+  it('PLACES-SVC-007 — gaps left by deleted tracks are reused, not skipped past', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    importFixture(trip.id);
+    // Drop the first track; its colour becomes free again.
+    const first = tracksOf(trip.id)[0];
+    testDb.prepare('DELETE FROM places WHERE id = ?').run(first.id);
+
+    const seeded = testDb.prepare(
+      "INSERT INTO places (trip_id, name, lat, lng, route_geometry) VALUES (?, 'Later walk', 9, 9, '[[9,9],[8,8]]') RETURNING id",
+    ).get(trip.id) as { id: number };
+    (svc as any).colorizeImportedTracks(String(trip.id), {
+      places: [{ id: seeded.id, route_geometry: '[[9,9],[8,8]]', route_color: null }],
+    });
+
+    const colors = tracksOf(trip.id).map(t => t.route_color);
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+
+  it('PLACES-SVC-005 — an import that yields nothing is passed straight through', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    expect((svc as any).colorizeImportedTracks(String(trip.id), null)).toBeNull();
+    expect((svc as any).colorizeImportedTracks(String(trip.id), { places: [] })).toEqual({ places: [] });
+  });
+});

--- a/server/tests/unit/services/placeService.test.ts
+++ b/server/tests/unit/services/placeService.test.ts
@@ -232,6 +232,49 @@ describe('updatePlace', () => {
     const updated = updatePlace(String(trip.id), String(place.id), { tags: [] }) as any;
     expect(updated.tags).toHaveLength(0);
   });
+
+  // ── Track colour (#776) ─────────────────────────────────────────────────────
+
+  it('PLACE-SVC-052 — stores a picked route_color', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Walk' }) as any;
+    const updated = updatePlace(String(trip.id), String(place.id), { route_color: '#e11d48' }) as any;
+    expect(updated.route_color).toBe('#e11d48');
+  });
+
+  it('PLACE-SVC-053 — an explicit null clears it again (the reset to auto)', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Walk' }) as any;
+    updatePlace(String(trip.id), String(place.id), { route_color: '#e11d48' });
+    // Guards the COALESCE trap: name/currency/transport_mode can never be
+    // emptied, and route_color built that way would be a one-way door.
+    const cleared = updatePlace(String(trip.id), String(place.id), { route_color: null }) as any;
+    expect(cleared.route_color).toBeNull();
+  });
+
+  it('PLACE-SVC-054 — an unrelated update leaves the colour alone', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Walk' }) as any;
+    updatePlace(String(trip.id), String(place.id), { route_color: '#059669' });
+    const renamed = updatePlace(String(trip.id), String(place.id), { name: 'Hike' }) as any;
+    expect(renamed.name).toBe('Hike');
+    expect(renamed.route_color).toBe('#059669');
+  });
+
+  it('PLACE-SVC-055 — createPlace carries geometry and colour instead of dropping them', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const created = svcCreatePlace(String(trip.id), {
+      name: 'Restored track',
+      route_geometry: '[[48.0,2.0],[49.0,3.0]]',
+      route_color: '#7c3aed',
+    }) as any;
+    expect(created.route_geometry).toBe('[[48.0,2.0],[49.0,3.0]]');
+    expect(created.route_color).toBe('#7c3aed');
+  });
 });
 
 // ── updatePlacesMany ────────────────────────────────────────────────────────────

--- a/shared/src/i18n/ar/inspector.ts
+++ b/shared/src/i18n/ar/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'تعديل الحجز',
   'inspector.participants': 'المشاركون',
   'inspector.trackStats': 'بيانات المسار',
+  'inspector.trackColor': 'لون المسار',
+  'inspector.trackColorAuto': 'لون تلقائي',
+  'inspector.trackColorCustom': 'اختيار لون مخصص',
 };
 export default inspector;

--- a/shared/src/i18n/ar/places.ts
+++ b/shared/src/i18n/ar/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'إضافة مكان/نشاط',
   'places.importFile': 'استيراد ملف',
+  'places.trackIndicator': 'مسار / طريق',
   'places.sidebarDrop': 'أفلت للاستيراد',
   'places.importFileHint':
     'استورد ملفات .gpx أو .kml أو .kmz من أدوات مثل Google My Maps وGoogle Earth أو جهاز تتبع GPS.',

--- a/shared/src/i18n/br/inspector.ts
+++ b/shared/src/i18n/br/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Editar reserva',
   'inspector.participants': 'Participantes',
   'inspector.trackStats': 'Dados da trilha',
+  'inspector.trackColor': 'Cor da trilha',
+  'inspector.trackColorAuto': 'Cor automática',
+  'inspector.trackColorCustom': 'Escolher cor personalizada',
 };
 export default inspector;

--- a/shared/src/i18n/br/places.ts
+++ b/shared/src/i18n/br/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Adicionar lugar/atividade',
   'places.importFile': 'Importar arquivo',
+  'places.trackIndicator': 'Trilha / rota',
   'places.sidebarDrop': 'Solte para importar',
   'places.importFileHint':
     'Importe arquivos .gpx, .kml ou .kmz de ferramentas como Google My Maps, Google Earth ou um rastreador GPS.',

--- a/shared/src/i18n/ca/inspector.ts
+++ b/shared/src/i18n/ca/inspector.ts
@@ -18,6 +18,9 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Edita la reserva',
   'inspector.participants': 'Participants',
   'inspector.trackStats': 'Dades de la ruta',
+  'inspector.trackColor': 'Color de la ruta',
+  'inspector.trackColorAuto': 'Color automàtic',
+  'inspector.trackColorCustom': 'Tria un color personalitzat',
 
   'inspector.openStreetMap': 'OpenStreetMap',
   'inspector.saveToCollection': 'Desar a la col·lecció',

--- a/shared/src/i18n/ca/places.ts
+++ b/shared/src/i18n/ca/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Afegeix un lloc / activitat',
   'places.importFile': 'Importa un fitxer',
+  'places.trackIndicator': 'Track / ruta',
   'places.sidebarDrop': 'Deixa anar per importar',
   'places.importFileHint':
     "Importa fitxers .gpx, .kml o .kmz d'eines com Google My Maps, Google Earth o un rastrejador GPS.",

--- a/shared/src/i18n/cs/inspector.ts
+++ b/shared/src/i18n/cs/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Upravit rezervaci',
   'inspector.participants': 'Účastníci',
   'inspector.trackStats': 'Data trasy',
+  'inspector.trackColor': 'Barva trasy',
+  'inspector.trackColorAuto': 'Automatická barva',
+  'inspector.trackColorCustom': 'Vybrat vlastní barvu',
 };
 export default inspector;

--- a/shared/src/i18n/cs/places.ts
+++ b/shared/src/i18n/cs/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Přidat místo/aktivitu',
   'places.importFile': 'Importovat soubor',
+  'places.trackIndicator': 'Trasa',
   'places.sidebarDrop': 'Pusťte pro import',
   'places.importFileHint':
     'Importujte soubory .gpx, .kml nebo .kmz z nástrojů jako Google My Maps, Google Earth nebo GPS tracker.',

--- a/shared/src/i18n/de/inspector.ts
+++ b/shared/src/i18n/de/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Reservierung bearbeiten',
   'inspector.participants': 'Teilnehmer',
   'inspector.trackStats': 'Streckendaten',
+  'inspector.trackColor': 'Streckenfarbe',
+  'inspector.trackColorAuto': 'Automatische Farbe',
+  'inspector.trackColorCustom': 'Eigene Farbe wählen',
 };
 export default inspector;

--- a/shared/src/i18n/de/places.ts
+++ b/shared/src/i18n/de/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Ort/Aktivität hinzufügen',
   'places.importFile': 'Dateimport',
+  'places.trackIndicator': 'Strecke / Route',
   'places.sidebarDrop': 'Ablegen zum Importieren',
   'places.importFileHint':
     '.gpx-, .kml- oder .kmz-Dateien aus Tools wie Google My Maps, Google Earth oder einem GPS-Tracker importieren.',

--- a/shared/src/i18n/en/inspector.ts
+++ b/shared/src/i18n/en/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Edit Reservation',
   'inspector.participants': 'Participants',
   'inspector.trackStats': 'Track Stats',
+  'inspector.trackColor': 'Track color',
+  'inspector.trackColorAuto': 'Automatic color',
+  'inspector.trackColorCustom': 'Choose custom color',
 };
 export default inspector;

--- a/shared/src/i18n/en/places.ts
+++ b/shared/src/i18n/en/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Add Place/Activity',
   'places.importFile': 'Import file',
+  'places.trackIndicator': 'Track / route',
   'places.sidebarDrop': 'Drop to import',
   'places.importFileHint':
     'Import .gpx, .kml or .kmz files from tools like Google My Maps, Google Earth, or a GPS tracker.',

--- a/shared/src/i18n/es/inspector.ts
+++ b/shared/src/i18n/es/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Editar reserva',
   'inspector.participants': 'Participantes',
   'inspector.trackStats': 'Datos de la ruta',
+  'inspector.trackColor': 'Color de la ruta',
+  'inspector.trackColorAuto': 'Color automático',
+  'inspector.trackColorCustom': 'Elegir color personalizado',
 };
 export default inspector;

--- a/shared/src/i18n/es/places.ts
+++ b/shared/src/i18n/es/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Añadir lugar/actividad',
   'places.importFile': 'Importar archivo',
+  'places.trackIndicator': 'Ruta / recorrido',
   'places.sidebarDrop': 'Soltar para importar',
   'places.importFileHint':
     'Importa archivos .gpx, .kml o .kmz de herramientas como Google My Maps, Google Earth o un rastreador GPS.',

--- a/shared/src/i18n/fr/inspector.ts
+++ b/shared/src/i18n/fr/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Modifier la réservation',
   'inspector.participants': 'Participants',
   'inspector.trackStats': 'Données du parcours',
+  'inspector.trackColor': 'Couleur du parcours',
+  'inspector.trackColorAuto': 'Couleur automatique',
+  'inspector.trackColorCustom': 'Choisir une couleur personnalisée',
 };
 export default inspector;

--- a/shared/src/i18n/fr/places.ts
+++ b/shared/src/i18n/fr/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Ajouter un lieu/activité',
   'places.importFile': 'Importer un fichier',
+  'places.trackIndicator': 'Parcours / itinéraire',
   'places.sidebarDrop': 'Déposer pour importer',
   'places.importFileHint':
     'Importez des fichiers .gpx, .kml ou .kmz depuis des outils comme Google My Maps, Google Earth ou un traceur GPS.',

--- a/shared/src/i18n/gr/inspector.ts
+++ b/shared/src/i18n/gr/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Επεξεργασία Κράτησης',
   'inspector.participants': 'Συμμετέχοντες',
   'inspector.trackStats': 'Στατιστικά Διαδρομής',
+  'inspector.trackColor': 'Χρώμα διαδρομής',
+  'inspector.trackColorAuto': 'Αυτόματο χρώμα',
+  'inspector.trackColorCustom': 'Επιλογή προσαρμοσμένου χρώματος',
 };
 export default inspector;

--- a/shared/src/i18n/gr/places.ts
+++ b/shared/src/i18n/gr/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Προσθήκη Μέρους/Δραστηριότητας',
   'places.importFile': 'Εισαγωγή αρχείου',
+  'places.trackIndicator': 'Ίχνος / διαδρομή',
   'places.sidebarDrop': 'Αφήστε για εισαγωγή',
   'places.importFileHint':
     'Εισαγωγή αρχείων .gpx, .kml ή .kmz από εργαλεία όπως Google My Maps, Google Earth ή GPS tracker.',

--- a/shared/src/i18n/hu/inspector.ts
+++ b/shared/src/i18n/hu/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Foglalás szerkesztése',
   'inspector.participants': 'Résztvevők',
   'inspector.trackStats': 'Útvonal adatok',
+  'inspector.trackColor': 'Útvonal színe',
+  'inspector.trackColorAuto': 'Automatikus szín',
+  'inspector.trackColorCustom': 'Egyéni szín kiválasztása',
 };
 export default inspector;

--- a/shared/src/i18n/hu/places.ts
+++ b/shared/src/i18n/hu/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Hely/Tevékenység hozzáadása',
   'places.importFile': 'Fájl importálása',
+  'places.trackIndicator': 'Nyomvonal / útvonal',
   'places.sidebarDrop': 'Ejtse el az importáláshoz',
   'places.importFileHint':
     '.gpx, .kml vagy .kmz fájlok importálása olyan eszközökből, mint a Google My Maps, Google Earth vagy egy GPS tracker.',

--- a/shared/src/i18n/id/inspector.ts
+++ b/shared/src/i18n/id/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Edit Reservasi',
   'inspector.participants': 'Peserta',
   'inspector.trackStats': 'Statistik Jalur',
+  'inspector.trackColor': 'Warna jalur',
+  'inspector.trackColorAuto': 'Warna otomatis',
+  'inspector.trackColorCustom': 'Pilih warna kustom',
 };
 export default inspector;

--- a/shared/src/i18n/id/places.ts
+++ b/shared/src/i18n/id/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Tambah Tempat/Aktivitas',
   'places.importFile': 'Impor file',
+  'places.trackIndicator': 'Jalur / rute',
   'places.sidebarDrop': 'Lepas untuk mengimpor',
   'places.importFileHint': 'Impor file .gpx, .kml, atau .kmz dari Google My Maps, Google Earth, atau pelacak GPS.',
   'places.importFileDropHere': 'Klik untuk memilih file atau seret dan lepas di sini',

--- a/shared/src/i18n/it/inspector.ts
+++ b/shared/src/i18n/it/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Modifica prenotazione',
   'inspector.participants': 'Partecipanti',
   'inspector.trackStats': 'Dati del percorso',
+  'inspector.trackColor': 'Colore del percorso',
+  'inspector.trackColorAuto': 'Colore automatico',
+  'inspector.trackColorCustom': 'Scegli colore personalizzato',
 };
 export default inspector;

--- a/shared/src/i18n/it/places.ts
+++ b/shared/src/i18n/it/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Aggiungi Luogo/Attività',
   'places.importFile': 'Importa file',
+  'places.trackIndicator': 'Percorso / itinerario',
   'places.sidebarDrop': 'Rilascia per importare',
   'places.importFileHint':
     'Importa file .gpx, .kml o .kmz da strumenti come Google My Maps, Google Earth o un tracker GPS.',

--- a/shared/src/i18n/ja/inspector.ts
+++ b/shared/src/i18n/ja/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': '予約を編集',
   'inspector.participants': '参加者',
   'inspector.trackStats': '統計を記録',
+  'inspector.trackColor': 'トラックの色',
+  'inspector.trackColorAuto': '自動の色',
+  'inspector.trackColorCustom': 'カスタムカラーを選択',
 };
 export default inspector;

--- a/shared/src/i18n/ja/places.ts
+++ b/shared/src/i18n/ja/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': '場所／アクティビティを追加',
   'places.importFile': 'ファイルをインポート',
+  'places.trackIndicator': 'トラック / ルート',
   'places.sidebarDrop': 'ドロップしてインポート',
   'places.importFileHint':
     'Google My Maps、Google Earth、GPSトラッカーなどの .gpx、.kml、.kmz ファイルをインポートできます。',

--- a/shared/src/i18n/ko/inspector.ts
+++ b/shared/src/i18n/ko/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': '예약 편집',
   'inspector.participants': '참가자',
   'inspector.trackStats': '트랙 통계',
+  'inspector.trackColor': '트랙 색상',
+  'inspector.trackColorAuto': '자동 색상',
+  'inspector.trackColorCustom': '사용자 지정 색상 선택',
 };
 export default inspector;

--- a/shared/src/i18n/ko/places.ts
+++ b/shared/src/i18n/ko/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': '장소/활동 추가',
   'places.importFile': '파일 가져오기',
+  'places.trackIndicator': '트랙 / 경로',
   'places.sidebarDrop': '끌어다 가져오기',
   'places.importFileHint': 'Google My Maps, Google Earth 또는 GPS 추적기 등의 .gpx, .kml, .kmz 파일을 가져옵니다.',
   'places.importFileDropHere': '파일을 선택하거나 여기에 끌어다 놓으세요',

--- a/shared/src/i18n/nl/inspector.ts
+++ b/shared/src/i18n/nl/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Reservering bewerken',
   'inspector.participants': 'Deelnemers',
   'inspector.trackStats': 'Routegegevens',
+  'inspector.trackColor': 'Routekleur',
+  'inspector.trackColorAuto': 'Automatische kleur',
+  'inspector.trackColorCustom': 'Kies een aangepaste kleur',
 };
 export default inspector;

--- a/shared/src/i18n/nl/places.ts
+++ b/shared/src/i18n/nl/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Plaats/activiteit toevoegen',
   'places.importFile': 'Bestand importeren',
+  'places.trackIndicator': 'Track / route',
   'places.sidebarDrop': 'Loslaten om te importeren',
   'places.importFileHint':
     'Importeer .gpx-, .kml- of .kmz-bestanden uit tools zoals Google My Maps, Google Earth of een GPS-tracker.',

--- a/shared/src/i18n/pl/inspector.ts
+++ b/shared/src/i18n/pl/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Edytuj rezerwację',
   'inspector.participants': 'Uczestnicy',
   'inspector.trackStats': 'Statystyki trasy',
+  'inspector.trackColor': 'Kolor trasy',
+  'inspector.trackColorAuto': 'Kolor automatyczny',
+  'inspector.trackColorCustom': 'Wybierz własny kolor',
 };
 export default inspector;

--- a/shared/src/i18n/pl/places.ts
+++ b/shared/src/i18n/pl/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Dodaj miejsce/atrakcję',
   'places.importFile': 'Importuj plik',
+  'places.trackIndicator': 'Trasa / ślad',
   'places.sidebarDrop': 'Upuść, aby zaimportować',
   'places.importFileHint':
     'Importuj pliki .gpx, .kml lub .kmz z narzędzi takich jak Google My Maps, Google Earth lub tracker GPS.',

--- a/shared/src/i18n/ru/inspector.ts
+++ b/shared/src/i18n/ru/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Редактировать бронирование',
   'inspector.participants': 'Участники',
   'inspector.trackStats': 'Данные маршрута',
+  'inspector.trackColor': 'Цвет маршрута',
+  'inspector.trackColorAuto': 'Автоматический цвет',
+  'inspector.trackColorCustom': 'Выбрать свой цвет',
 };
 export default inspector;

--- a/shared/src/i18n/ru/places.ts
+++ b/shared/src/i18n/ru/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Добавить место/активность',
   'places.importFile': 'Импортировать файл',
+  'places.trackIndicator': 'Трек / маршрут',
   'places.sidebarDrop': 'Отпустите для импорта',
   'places.importFileHint':
     'Импортируйте файлы .gpx, .kml или .kmz из инструментов, таких как Google My Maps, Google Earth или GPS-трекер.',

--- a/shared/src/i18n/sv/inspector.ts
+++ b/shared/src/i18n/sv/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Redigera bokning',
   'inspector.participants': 'Deltagare',
   'inspector.trackStats': 'Spåra statistik',
+  'inspector.trackColor': 'Spårfärg',
+  'inspector.trackColorAuto': 'Automatisk färg',
+  'inspector.trackColorCustom': 'Välj egen färg',
 };
 export default inspector;

--- a/shared/src/i18n/sv/places.ts
+++ b/shared/src/i18n/sv/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Lägg till plats/aktivitet',
   'places.importFile': 'Importera fil',
+  'places.trackIndicator': 'Spår / rutt',
   'places.sidebarDrop': 'Släpp för att importera',
   'places.importFileHint':
     'Importera .gpx-, .kml- eller .kmz-filer från verktyg som Google My Maps, Google Earth eller en GPS-spårare.',

--- a/shared/src/i18n/tr/inspector.ts
+++ b/shared/src/i18n/tr/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Rezervasyonu Düzenle',
   'inspector.participants': 'Katılımcılar',
   'inspector.trackStats': 'İstatistikleri Takip Et',
+  'inspector.trackColor': 'İz rengi',
+  'inspector.trackColorAuto': 'Otomatik renk',
+  'inspector.trackColorCustom': 'Özel renk seç',
 };
 export default inspector;

--- a/shared/src/i18n/tr/places.ts
+++ b/shared/src/i18n/tr/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Yer/etkinlik Ekle',
   'places.importFile': 'Dosyayı içe aktar',
+  'places.trackIndicator': 'İz / rota',
   'places.sidebarDrop': 'İçe aktarmak için bırakın',
   'places.importFileHint':
     'Google Haritalarım, Google Earth veya GPS izleyici gibi araçlardan .gpx, .kml veya .kmz dosyalarını içe aktarın.',

--- a/shared/src/i18n/uk/inspector.ts
+++ b/shared/src/i18n/uk/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Редагувати бронювання',
   'inspector.participants': 'Учасники',
   'inspector.trackStats': 'Дані маршруту',
+  'inspector.trackColor': 'Колір маршруту',
+  'inspector.trackColorAuto': 'Автоматичний колір',
+  'inspector.trackColorCustom': 'Вибрати свій колір',
 };
 export default inspector;

--- a/shared/src/i18n/uk/places.ts
+++ b/shared/src/i18n/uk/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Додати місце/активність',
   'places.importFile': 'Імпортувати файл',
+  'places.trackIndicator': 'Трек / маршрут',
   'places.sidebarDrop': 'Відпустіть для імпорту',
   'places.importFileHint':
     'Імпортуйте файли .gpx, .kml або .kmz із інструментів, таких як Google My Maps, Google Earth або GPS-трекер.',

--- a/shared/src/i18n/vi/inspector.ts
+++ b/shared/src/i18n/vi/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': 'Chỉnh sửa đặt chỗ',
   'inspector.participants': 'Người tham gia',
   'inspector.trackStats': 'Theo dõi số liệu thống kê',
+  'inspector.trackColor': 'Màu đường đi',
+  'inspector.trackColorAuto': 'Màu tự động',
+  'inspector.trackColorCustom': 'Chọn màu tùy chỉnh',
 };
 export default inspector;

--- a/shared/src/i18n/vi/places.ts
+++ b/shared/src/i18n/vi/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': 'Thêm địa điểm/Hoạt động',
   'places.importFile': 'Nhập tập tin',
+  'places.trackIndicator': 'Đường đi / tuyến đường',
   'places.sidebarDrop': 'Thả để nhập',
   'places.importFileHint':
     'Nhập tệp.gpx,.kml hoặc.kmz từ các công cụ như Google My Maps, Google Earth hoặc trình theo dõi GPS.',

--- a/shared/src/i18n/zh-TW/inspector.ts
+++ b/shared/src/i18n/zh-TW/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': '編輯預訂',
   'inspector.participants': '參與者',
   'inspector.trackStats': '軌跡資料',
+  'inspector.trackColor': '軌跡顏色',
+  'inspector.trackColorAuto': '自動顏色',
+  'inspector.trackColorCustom': '選擇自定義顏色',
 };
 export default inspector;

--- a/shared/src/i18n/zh-TW/places.ts
+++ b/shared/src/i18n/zh-TW/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': '新增地點/活動',
   'places.importFile': '匯入檔案',
+  'places.trackIndicator': '軌跡 / 路線',
   'places.sidebarDrop': '拖放以匯入',
   'places.importFileHint': '從 Google My Maps、Google Earth 或 GPS 追蹤器等工具匯入 .gpx、.kml 或 .kmz 檔案。',
   'places.importFileDropHere': '點選以選取檔案或拖放至此處',

--- a/shared/src/i18n/zh/inspector.ts
+++ b/shared/src/i18n/zh/inspector.ts
@@ -21,5 +21,8 @@ const inspector: TranslationStrings = {
   'inspector.editRes': '编辑预订',
   'inspector.participants': '参与者',
   'inspector.trackStats': '轨迹数据',
+  'inspector.trackColor': '轨迹颜色',
+  'inspector.trackColorAuto': '自动颜色',
+  'inspector.trackColorCustom': '选择自定义颜色',
 };
 export default inspector;

--- a/shared/src/i18n/zh/places.ts
+++ b/shared/src/i18n/zh/places.ts
@@ -3,6 +3,7 @@ import type { TranslationStrings } from '../types';
 const places: TranslationStrings = {
   'places.addPlace': '添加地点/活动',
   'places.importFile': '导入文件',
+  'places.trackIndicator': '轨迹 / 路线',
   'places.sidebarDrop': '拖放以导入',
   'places.importFileHint': '从 Google My Maps、Google Earth 或 GPS 追踪器等工具导入 .gpx、.kml 或 .kmz 文件。',
   'places.importFileDropHere': '点击选择文件或拖放到此处',

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -31,6 +31,7 @@ export * from './airtrail/airtrail.schema';
 export * from './day/day.schema';
 export * from './assignment/assignment.schema';
 export * from './place/place.schema';
+export * from './place/track-colors';
 export * from './collection/collection.schema';
 export * from './trip/trip.schema';
 export * from './trip-invite/trip-invite.schema';

--- a/shared/src/place/place.schema.spec.ts
+++ b/shared/src/place/place.schema.spec.ts
@@ -1,6 +1,29 @@
-import { placeCreateRequestSchema, placeBulkDeleteRequestSchema, placeImportListRequestSchema } from './place.schema';
+import {
+  placeCreateRequestSchema,
+  placeBulkDeleteRequestSchema,
+  placeImportListRequestSchema,
+  placeSchema,
+} from './place.schema';
 
 import { describe, it, expect } from 'vitest';
+
+describe('placeSchema route_color (#776)', () => {
+  const place = { id: 1, trip_id: 1, name: 'Walk' };
+
+  it('takes a hex colour, null, or nothing at all', () => {
+    expect(placeSchema.safeParse({ ...place, route_color: '#e11d48' }).success).toBe(true);
+    expect(placeSchema.safeParse({ ...place, route_color: '#abc' }).success).toBe(true);
+    // null is how a track goes back to inheriting its category colour.
+    expect(placeSchema.safeParse({ ...place, route_color: null }).success).toBe(true);
+    expect(placeSchema.safeParse(place).success).toBe(true);
+  });
+
+  it('rejects anything a map renderer could not parse', () => {
+    expect(placeSchema.safeParse({ ...place, route_color: 'blue' }).success).toBe(false);
+    expect(placeSchema.safeParse({ ...place, route_color: '#12345' }).success).toBe(false);
+    expect(placeSchema.safeParse({ ...place, route_color: 'e11d48' }).success).toBe(false);
+  });
+});
 
 describe('placeCreateRequestSchema', () => {
   it('requires a name and keeps the other place fields open', () => {

--- a/shared/src/place/place.schema.ts
+++ b/shared/src/place/place.schema.ts
@@ -16,6 +16,9 @@ import { z } from 'zod';
 
 const open = z.record(z.string(), z.unknown());
 
+/** `#rgb` / `#rrggbb`, the form both map renderers and CSS accept. */
+export const hexColorSchema = z.string().regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+
 /**
  * Embedded category as returned on a place — a trimmed projection of the
  * categories row (id/name/color/icon), built inline by placeService and
@@ -70,6 +73,8 @@ export const placeSchema = z.object({
   google_ftid: z.string().nullable().optional(),
   osm_id: z.string().nullable().optional(),
   route_geometry: z.string().nullable().optional(),
+  // Manual track colour (#776). null = inherit the category colour like before.
+  route_color: hexColorSchema.nullable().optional(),
   website: z.string().nullable().optional(),
   phone: z.string().nullable().optional(),
   transport_mode: z.string().nullable().optional(),

--- a/shared/src/place/track-colors.ts
+++ b/shared/src/place/track-colors.ts
@@ -1,0 +1,32 @@
+/**
+ * Track colour palette (#776) — shared so the importer's automatic assignment
+ * and the picker in the UI hand out the exact same set.
+ *
+ * Tuned against map tiles rather than UI surfaces: the 600 tier survives thin
+ * 3.5px lines on light basemaps where 400/500 washes out, and nothing here is
+ * a neutral grey (invisible on CartoDB Dark) or a pale pastel (invisible at
+ * any size). Blue is deliberately blue-700 — darker than both the #3b82f6 GPX
+ * fallback and the #0a84ff day route, so a blue track reads as chosen rather
+ * than defaulted.
+ *
+ * The order matters: the importer assigns these round-robin, so the first five
+ * are the ones most tracks get. They follow the Okabe-Ito idea of staying
+ * separable under red-green colour blindness (blue, orange, green, magenta,
+ * cyan) instead of running through the rainbow and handing out four adjacent
+ * warm tones in a row.
+ */
+export const TRACK_COLORS = [
+  '#1d4ed8', // blue-700
+  '#ea580c', // orange-600
+  '#059669', // emerald-600
+  '#c026d3', // fuchsia-600
+  '#0891b2', // cyan-600
+  '#e11d48', // rose-600
+  '#d97706', // amber-600
+  '#65a30d', // lime-600
+  '#7c3aed', // violet-600
+  '#4f46e5', // indigo-600
+] as const;
+
+/** Colour a track falls back to when it has neither a manual nor a category colour. */
+export const TRACK_COLOR_FALLBACK = '#3b82f6';

--- a/wiki/Map-Features.md
+++ b/wiki/Map-Features.md
@@ -30,6 +30,16 @@ When zoomed out, nearby markers are grouped into clusters. Clicking a cluster zo
 
 When you have a day selected, a dark dashed line connects consecutive places in that day's order.
 
+## GPX tracks
+
+Tracks and routes imported from a `.gpx`, `.kml`, or `.kmz` file are drawn as lines on the map. Each track imported into a trip is given its own colour automatically, so several walks in the same area stay distinguishable without any setup.
+
+To change a track's colour, open the place and use the **Track color** row: pick one of the presets, choose your own with the colour picker, or hit the dashed cell to go back to the automatic colour — the category colour if the place has one, otherwise the default blue.
+
+Any track that carries a colour — assigned at import or picked by you — is drawn with a thin white casing so it stays readable on satellite imagery and dark basemaps. Tracks imported before this version keep their previous look until you give them a colour.
+
+Clicking a line on the map selects that track and opens its details — useful when the start markers are still clustered together. In the places list, each track shows a short stroke in the colour it is drawn in, which is how you tell which line belongs to which entry.
+
 ## Route time pills
 
 At zoom level 12 or higher, small pill-shaped labels appear between consecutive places and show the estimated **walking time** and **driving time** for each segment. Below zoom 12 they are hidden to keep the map clean.

--- a/wiki/Places-and-Search.md
+++ b/wiki/Places-and-Search.md
@@ -63,6 +63,8 @@ The same control is available on saved places in [Collections](Collections#place
 
 Drag a `.gpx`, `.kml`, or `.kmz` file onto the Places sidebar to import all waypoints or features at once. You can also import a saved-list share URL using the **Import list** button in the sidebar header — both Google Maps and Naver Maps list URLs are supported.
 
+Imported tracks each get their own line colour so multiple routes stay apart on the map; you can override it per track from the place details. See [Map Features](Map-Features) for the details.
+
 > **Admin:** Google Maps API key is set in [User-Settings](User-Settings). Without it, OSM search is used automatically.
 
 **See also:** [Day-Plans-and-Notes](Day-Plans-and-Notes) · [Map-Features](Map-Features) · [Tags-and-Categories](Tags-and-Categories)


### PR DESCRIPTION
Closes the request in #776: GPX tracks can now be given their own colour.

## Why it was needed

Imported tracks all rendered in the same blue. Not because category colours collided — the GPX/KML importers never assign a category at all, so `category_color` is null for every imported track and they all fell through to the `#3b82f6` default. Two people in the discussion described the same consequence: several walks in one area, or two variants of a route, that cannot be told apart.

## What it does

**Colours are assigned at import.** Each new track gets one of ten palette entries, picked from the ones the trip is not already using — so a second import, a hand-recoloured track, or a deleted one never causes a repeat. That alone solves the reported case without anyone touching a setting. The palette sits in `@trek/shared` so the importer and the picker hand out the same set; the order is chosen so the first entries stay separable under red-green colour blindness rather than running through the rainbow.

**Colours can be overridden.** A **Track color** row in the place inspector (and in the mobile place sheet) offers the presets, a native picker for anything else, and a reset back to the automatic colour. `route_color` is nullable and deliberately outside the `COALESCE` group in `updatePlace`, so that reset actually clears the column.

**Tracks are findable.** The line itself is clickable now — the start markers cluster below zoom 11, which is exactly the zoom where you compare walks side by side, so previously a track had no reachable hit target at all. In both places lists the track icon became a short stroke in the colour the line is drawn in; the map has no legend of its own, so that stroke is what ties a line back to a row.

**Coloured tracks get a white casing** so they stay readable on satellite imagery and dark basemaps — the tile URL is user-configurable, so the palette cannot assume a background.

Tracks imported before this change keep `route_color = null` and render exactly as they did: category colour, then the old blue, no casing.

## Notes for review

**Where the server code lives.** The colour assignment is new logic, so it went into `nest/places/places.service.ts` over the injected `DatabaseService`, not into the legacy place service — a new counting query there would have been new surface area in the legacy layer. The `route_color` field itself is only threaded through the existing update/create statements, which the proportionality rule in `server/src/nest/README.md` covers; migrating ~700 lines of importers behind a colour field would not be proportionate. The hex is validated in the controller rather than in the shared contract, because tightening `placeUpdateRequestSchema` would mean removing `PlacesController.update` from the ratchet-only body-contract allow-list.

**Two fixes that were already broken.** `duplicateTrip` has an explicit column list that silently dropped `route_geometry`, so duplicating a trip lost its tracks; the undo after deleting a place rebuilt it from a seven-field snapshot and brought a track back as a bare point. Both now carry geometry and colour.

**The Leaflet polyline needed reworking.** It passed its style as bare `color`/`weight` props, and react-leaflet only calls `setStyle` when the `pathOptions` reference changes — a recoloured track would have kept its mount-time colour until the next reload. Every other vector layer in the file already used `pathOptions`. The casings also needed a pane of their own: Leaflet stacks paths by insertion order, so a casing mounted later ends up over an earlier track's line.

## Known limits

- Guests of a shared trip still see no tracks at all — `SharedTripPage` renders markers only, and the day-assignment projections do not carry `route_geometry`. Pre-existing, untouched here.
- Colour is per trip, not per member. Places are shared, so the colour is too.
- `update_place` over MCP keeps its own explicit field list and does not accept `route_color`.
- Tracks still follow the category filter in the sidebar, so a manually coloured track can disappear under a filter for reasons its colour no longer hints at.
