### PR TITLE
fix(vacay): import notificationService statically so the dispatch can't outlive the caller

### DIFF
--- a/server/src/nest/vacay/vacay.service.ts
+++ b/server/src/nest/vacay/vacay.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { broadcastToUser } from '../../websocket';
 import { DatabaseService } from '../database/database.service';
+// Imported statically on purpose: a deferred import() inside these synchronous
+// methods resolves after the caller has returned, so the module load outlives
+// the request — and, in tests, the module environment, which Vitest reports as
+// "Cannot load ... after the environment was torn down".
+import { send as sendNotification } from '../../services/notificationService';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -627,9 +632,7 @@ export class VacayService {
     } catch { /* websocket not available */ }
 
     // Notify invited user
-    import('../../services/notificationService').then(({ send }) => {
-      send({ event: 'vacay_invite', actorId: inviterId, scope: 'user', targetId: targetUserId, params: { actor: inviterEmail, planId: String(planId) } }).catch(() => {});
-    });
+    sendNotification({ event: 'vacay_invite', actorId: inviterId, scope: 'user', targetId: targetUserId, params: { actor: inviterEmail, planId: String(planId) } }).catch(() => {});
 
     return {};
   }
@@ -858,9 +861,7 @@ export class VacayService {
       broadcastToUser(ownerId, { type: 'vacay:share', from: { id: ownerId } }, socketId);
     } catch { /* websocket not available */ }
 
-    import('../../services/notificationService').then(({ send }) => {
-      send({ event: 'vacay_share', actorId: ownerId, scope: 'user', targetId: targetUserId, params: { actor: ownerEmail } }).catch(() => {});
-    });
+    sendNotification({ event: 'vacay_share', actorId: ownerId, scope: 'user', targetId: targetUserId, params: { actor: ownerEmail } }).catch(() => {});
 
     return {};
   }

--- a/server/tests/unit/nest/vacay.service.test.ts
+++ b/server/tests/unit/nest/vacay.service.test.ts
@@ -46,13 +46,9 @@ const svc = new VacayService(new DatabaseService(testDb));
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────────
 
-beforeAll(async () => {
+beforeAll(() => {
   createTables(testDb);
   runMigrations(testDb);
-  // Warm the (mocked) notificationService module: sendInvite/shareCalendar do a
-  // fire-and-forget dynamic import of it, and a cold load can otherwise race the
-  // worker teardown ("Cannot load ... after the environment was torn down").
-  await import('../../../src/services/notificationService');
 });
 
 beforeEach(() => {
@@ -1114,6 +1110,27 @@ describe('shareCalendar', () => {
       .prepare('SELECT * FROM vacay_shares WHERE owner_id = ? AND user_id = ?')
       .get(owner.id, target.id);
     expect(row).toBeDefined();
+  });
+
+  it('VACAY-SVC-073: dispatches the share notification before returning, not on a deferred module load', async () => {
+    const { send } = await import('../../../src/services/notificationService');
+    vi.mocked(send).mockClear();
+    const { user: owner } = setupUserWithPlan();
+    const { user: target } = createUser(testDb);
+
+    svc.shareCalendar(owner.id, owner.email, target.id);
+
+    // A deferred `import(...).then(...)` only dispatches after the caller has
+    // returned, so the chain outlives the test: Vitest tears the module
+    // environment down underneath it and the late load fails the whole run with
+    // "Cannot load ... after the environment was torn down". Dispatching before
+    // returning is what removes the need to pre-warm the module in beforeAll.
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(send).mock.calls[0][0]).toMatchObject({
+      event: 'vacay_share',
+      actorId: owner.id,
+      targetId: target.id,
+    });
   });
 
   it('VACAY-SVC-049: returns 400 when sharing with yourself', () => {


### PR DESCRIPTION
## Description

`VacayService.sendInvite` and `.shareCalendar` are synchronous, but dispatch their notification through a deferred `import('../../services/notificationService').then(...)`. Nothing holds that promise, so the module load resolves *after* the caller has returned.

In production that just means the notification fires slightly later. In tests the load can land after Vitest has torn the module environment down: `vacay.service.test.ts` mocks `notificationService`, so once the environment is gone the mock registry is gone with it, the late import falls through to a real module load, and it throws.

```
EnvironmentTeardownError: Cannot load '/src/services/notifications/builtins.ts'
imported from server/src/services/notificationPreferencesService.ts
after the environment was torn down.
  - notificationService.ts
  - vacay.service.ts
  - tests/unit/nest/vacay.service.test.ts
```

Every test still passes; `Errors 1 error` alone is enough to fail the Server Tests job. This is already known in the codebase — `vacay.service.test.ts` carries a `beforeAll` that pre-imports the mocked module, commented "a cold load can otherwise race the worker teardown". This PR fixes the cause, so that warm-up is removed.

The dispatch stays fire-and-forget: no `await` is added, no caller becomes async, and no timing users can observe changes. The module is simply resolved when `vacay.service` loads instead of mid-request. Verified there's no import cycle — nothing in `notificationService` → `notificationPreferencesService` → `notifications/*` → `inAppNotifications` imports back into the vacay service — and `notificationService` has no module-level side effects.

Scoped deliberately: the same pattern also exists in `collab`, `packing`, `trips`, `reservations` and `collectionsService`. I've left those alone so this stays one change while those modules are mid-DI-migration — happy to follow up once that settles.

## Related Issue or Discussion

Raised in `#github-pr` on Discord. Noticed because it intermittently fails the Server Tests job on unrelated PRs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Test plan

- New test `VACAY-SVC-073` asserts `shareCalendar` has dispatched the notification by the time it returns. Checked both ways: against `dev`'s service it fails (`expected "vi.fn()" to be called 1 times, but got 0 times` — the deferred import hasn't resolved yet), and it passes with the fix. That assertion *is* the defect, so it guards the pattern from coming back, and it's what makes the `beforeAll` warm-up unnecessary.
- `vacay.service.test.ts`: 106/106.
- Full server suite: **313/313 files, 5890 tests passed, no unhandled errors** (`TZ=UTC`), and `tsc --noEmit` clean.
