### PR TITLE
Set every client coverage threshold to 85

### DIFF
--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -25,13 +25,13 @@ export default defineConfig({
       exclude: ['src/main.tsx', 'src/vite-env.d.ts'],
       // Without these the Client Tests job produced a report, uploaded it and
       // passed no matter what the number was — which is how coverage drifted
-      // down to ~48% unnoticed. Set a few points below the current run so an
-      // ordinary PR doesn't trip them; raise them when the number rises.
+      // down to ~48% unnoticed. 85 across the board is the floor we do not want
+      // to fall through, not a target: the suite currently sits well above it.
       thresholds: {
-        statements: 94,
-        branches: 87,
-        functions: 94,
-        lines: 96,
+        statements: 85,
+        branches: 85,
+        functions: 85,
+        lines: 85,
       },
     },
     css: false,


### PR DESCRIPTION
Follow-up to #1734, which introduced the thresholds at 94/87/94/96 — a few
points under the run at the time. This puts all four at 85.

```js
thresholds: {
  statements: 85,
  branches: 85,
  functions: 85,
  lines: 85,
},
```

The gate is meant as a floor, not a target. The suite currently sits at
97.56 / 90.62 / 96.93 / 98.82, so there is real headroom: a change that
legitimately trades a couple of points can land without having to move the
numbers first, and the job still goes red the moment coverage slides back
towards where it was (~48%).

Config only, no test or source changes.
