### PR TITLE
Fix seven reported bugs

### DIFF
--- a/client/src/components/Admin/DefaultUserSettingsTab.test.tsx
+++ b/client/src/components/Admin/DefaultUserSettingsTab.test.tsx
@@ -18,7 +18,7 @@ const MAPBOX_STANDARD = 'mapbox://styles/mapbox/standard';
 const MAPBOX_DARK = 'mapbox://styles/mapbox/dark-v11';
 const MAPBOX_NAV_NIGHT = 'mapbox://styles/mapbox/navigation-night-v1';
 const OFM_LIBERTY = 'https://tiles.openfreemap.org/styles/liberty';
-const TILE_PLACEHOLDER = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const TILE_PLACEHOLDER = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
 /** Stateful stand-in for the admin defaults endpoint: PUT merges, null deletes. */
 function stubDefaults(initial: Record<string, unknown> = {}) {

--- a/client/src/components/Admin/DefaultUserSettingsTab.tsx
+++ b/client/src/components/Admin/DefaultUserSettingsTab.tsx
@@ -8,6 +8,7 @@ import CustomSelect from '../shared/CustomSelect'
 import { MapView } from '../Map/MapView'
 import { SYMBOLS, currenciesWith } from '../Budget/BudgetPanel.constants'
 import type { DistanceUnit, Place } from '../../types'
+import { normalizeTileUrl } from '../../utils/tileUrl'
 import {
   MAPBOX_DEFAULT_STYLE,
   defaultStyleForProvider,
@@ -19,7 +20,7 @@ import {
 } from '../Map/glProviders'
 
 const MAP_PRESETS = [
-  { name: 'OpenStreetMap', url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' },
+  { name: 'OpenStreetMap', url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' },
   { name: 'OpenStreetMap DE', url: 'https://tile.openstreetmap.de/{z}/{x}/{y}.png' },
   { name: 'CartoDB Light', url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png' },
   { name: 'CartoDB Dark', url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' },
@@ -114,7 +115,7 @@ export default function DefaultUserSettingsTab(): React.ReactElement {
     adminApi.getDefaultUserSettings().then((data: Defaults) => {
       const provider = normalizeProvider(data.map_provider)
       setDefaults(data)
-      setMapTileUrl(data.map_tile_url || '')
+      setMapTileUrl(normalizeTileUrl(data.map_tile_url || ''))
       setMapboxToken(data.mapbox_access_token || '')
       setMapboxStyle(provider === 'leaflet' ? (data.mapbox_style || '') : styleForProvider(provider, provider === 'maplibre-gl' ? data.maplibre_style : data.mapbox_style))
       setLoaded(true)
@@ -328,7 +329,7 @@ export default function DefaultUserSettingsTab(): React.ReactElement {
           value={mapTileUrl}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMapTileUrl(e.target.value)}
           onBlur={() => save({ map_tile_url: mapTileUrl })}
-          placeholder="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          placeholder="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-slate-400 focus:border-transparent"
         />
         <p className="text-xs mt-1 text-content-faint">{t('settings.mapDefaultHint')}</p>

--- a/client/src/components/Planner/DayDetailPanel.test.tsx
+++ b/client/src/components/Planner/DayDetailPanel.test.tsx
@@ -1830,3 +1830,43 @@ describe('DayDetailPanel remaining branches, part two', () => {
     expect(await screen.findByText(/Add accommodation/i)).toBeInTheDocument();
   });
 });
+
+// FE-DDP1725-001 to -003 — the day panel reads times through the shared formatter, so a
+// value that was stored with a meridiem still follows the configured format (#1725).
+describe('DayDetailPanel time format', () => {
+  const meridiemRes = (overrides: Record<string, unknown> = {}) =>
+    buildReservation({
+      id: 9, type: 'event', title: 'Matinee', day_id: 1,
+      reservation_time: '3:00 PM', reservation_end_time: '11:00 PM', status: 'confirmed',
+      ...overrides,
+    });
+
+  it('FE-DDP1725-001: a reservation stored with a meridiem shows in 24h', async () => {
+    render(<DayDetailPanel {...defaultProps} reservations={[meridiemRes()]} />);
+    expect(await screen.findByText('15:00 – 23:00')).toBeInTheDocument();
+  });
+
+  it('FE-DDP1725-002: the same reservation keeps its afternoon in 12h', async () => {
+    seedStore(useSettingsStore, { settings: { time_format: '12h', temperature_unit: 'celsius', blur_booking_codes: false } });
+    render(<DayDetailPanel {...defaultProps} reservations={[meridiemRes()]} />);
+    expect(await screen.findByText('3:00 PM – 11:00 PM')).toBeInTheDocument();
+  });
+
+  it('FE-DDP1725-003: an accommodation check-in stored with a meridiem shows in 24h', async () => {
+    server.use(
+      http.get('/api/trips/1/accommodations', () =>
+        HttpResponse.json({
+          accommodations: [{
+            id: 1, place_id: 5, place_name: 'Grand Hotel', place_address: 'Paris',
+            start_day_id: 1, end_day_id: 3, check_in: '3:00 PM', check_in_end: null,
+            check_out: '11:00 AM', confirmation: null,
+          }],
+        }),
+      ),
+    );
+    render(<DayDetailPanel {...defaultProps} />);
+
+    expect(await screen.findByText('15:00')).toBeInTheDocument();
+    expect(screen.getByText('11:00')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Planner/DayDetailPanel.tsx
+++ b/client/src/components/Planner/DayDetailPanel.tsx
@@ -16,7 +16,7 @@ import { useSettingsStore } from '../../store/settingsStore'
 import { getLocaleForLanguage, useTranslation } from '../../i18n'
 import type { Day, Place, Category, Reservation, AssignmentsMap } from '../../types'
 import { isDayInAccommodationRange } from '../../utils/dayOrder'
-import { splitReservationDateTime } from '../../utils/formatters'
+import { formatClockTime, splitReservationDateTime } from '../../utils/formatters'
 import { useDayDetail } from './useDayDetail'
 
 const WEATHER_ICON_MAP = {
@@ -35,16 +35,6 @@ function WIcon({ main, size = 14 }: WIconProps) {
 }
 
 function cTemp(c, f) { return Math.round(f ? c * 9 / 5 + 32 : c) }
-
-function formatTime12(val, is12h) {
-  if (!val) return val
-  const [h, m] = val.split(':').map(Number)
-  if (isNaN(h) || isNaN(m)) return val
-  if (!is12h) return val
-  const period = h >= 12 ? 'PM' : 'AM'
-  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h
-  return `${h12}:${String(m).padStart(2, '0')} ${period}`
-}
 
 interface DayDetailPanelProps {
   day: Day
@@ -78,7 +68,7 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
   const fmtTime = (v) => {
     if (!v) return v
     if (v.includes('T')) return new Date(v).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: is12h })
-    return formatTime12(v, is12h)
+    return formatClockTime(v, is12h)
   }
   const unit = isFahrenheit ? '°F' : '°C'
   const collapsed = collapsedProp
@@ -313,8 +303,8 @@ export default function DayDetailPanel({ day, days, places, categories = [], tri
                           if (!startTime && !endTime) return null
                           return (
                             <span style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', color: 'var(--text-muted)', whiteSpace: 'nowrap', flexShrink: 0 }}>
-                              {startTime ? formatTime12(startTime, is12h) : ''}
-                              {endTime ? ` – ${formatTime12(endTime, is12h)}` : ''}
+                              {startTime ? formatClockTime(startTime, is12h) : ''}
+                              {endTime ? ` – ${formatClockTime(endTime, is12h)}` : ''}
                             </span>
                           )
                         })()}

--- a/client/src/components/Planner/PlaceInspector.test.tsx
+++ b/client/src/components/Planner/PlaceInspector.test.tsx
@@ -1211,6 +1211,66 @@ describe('PlaceInspector', () => {
     expect(screen.getByText('LH400')).toBeTruthy();
   });
 
+  // ── Open/closed ring (#1680) ─────────────────────────────────────────────────
+
+  it('FE-PLANNER-INSPECTOR-095: the ring follows the periods, not the cached open_now', async () => {
+    const seoul = buildPlace({ id: 708, name: 'Round the clock', google_place_id: 'gp-708', lat: 37.5665, lng: 126.978 });
+    vi.mocked(mapsApi.details).mockResolvedValue({
+      place: {
+        open_now: false,
+        // A period with no close is Google's round-the-clock place. The weekday lines
+        // arrive in the user's language and are shown, never parsed.
+        opening_hours: ['月曜日: 24 時間営業'],
+        opening_periods: [{ open: { day: 0, hour: 0, minute: 0 } }],
+      },
+    } as any);
+    render(<PlaceInspector {...defaultProps} place={seoul} />);
+    expect(await screen.findByText('Open')).toBeTruthy();
+  });
+
+  it('FE-PLANNER-INSPECTOR-096: the ring is read in the timezone of the place', async () => {
+    // Sunday 20:00 UTC — already Monday 05:00 in Seoul, still Sunday 22:00 in Paris.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-26T20:00:00Z'));
+    try {
+      const periods = [{ open: { day: 1, hour: 0, minute: 0 }, close: { day: 1, hour: 12, minute: 0 } }];
+      vi.mocked(mapsApi.details).mockResolvedValue({
+        place: { open_now: false, opening_periods: periods },
+      } as any);
+
+      const seoul = buildPlace({ id: 709, name: 'Seoul spot', google_place_id: 'gp-709', lat: 37.5665, lng: 126.978 });
+      const { unmount } = render(<PlaceInspector {...defaultProps} place={seoul} />);
+      expect(await screen.findByText('Open')).toBeTruthy();
+      unmount();
+
+      const paris = buildPlace({ id: 710, name: 'Paris spot', google_place_id: 'gp-710', lat: 48.8566, lng: 2.3522 });
+      render(<PlaceInspector {...defaultProps} place={paris} />);
+      expect(await screen.findByText('Closed')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('FE-PLANNER-INSPECTOR-097: a holiday in the payload leaves the verdict to the server', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Wednesday 12:00 in Seoul, inside the regular Wednesday period.
+    vi.setSystemTime(new Date('2026-07-29T03:00:00Z'));
+    try {
+      vi.mocked(mapsApi.details).mockResolvedValue({
+        place: {
+          open_now: false,
+          opening_periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 18, minute: 0 } }],
+          opening_special_days: ['2026-07-29'],
+        },
+      } as any);
+      const seoul = buildPlace({ id: 711, name: 'Holiday spot', google_place_id: 'gp-711', lat: 37.5665, lng: 126.978 });
+      render(<PlaceInspector {...defaultProps} place={seoul} />);
+      expect(await screen.findByText('Closed')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('FE-PLANNER-INSPECTOR-089: picking a file hands it to onUploadImage', async () => {
     const onUploadImage = vi.fn(async () => {});
     render(<PlaceInspector {...defaultProps} onUploadImage={onUploadImage} />);

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -29,6 +29,7 @@ import { useTripStore } from '../../store/tripStore'
 import { formatDistance, formatElevation } from '../../utils/units'
 import { getGoogleMapsUrlForPlace } from './placeGoogleMaps'
 import { getOpenStreetMapUrlForPlace } from './placeOpenStreetMap'
+import { resolveOpenNow, resolvePlaceTimeZone, placeWeekdayIndex } from './placeOpenState'
 
 const detailsCache = new Map()
 
@@ -61,10 +62,10 @@ function usePlaceDetails(googlePlaceId, osmId, language) {
   return details
 }
 
-function getWeekdayIndex(dateStr) {
+function getWeekdayIndex(dateStr, timeZone) {
   // weekdayDescriptions[0] = Monday … [6] = Sunday
-  const d = dateStr ? new Date(dateStr + 'T12:00:00') : new Date()
-  const jsDay = d.getDay()
+  if (!dateStr) return placeWeekdayIndex(new Date(), timeZone)
+  const jsDay = new Date(dateStr + 'T12:00:00').getDay()
   return jsDay === 0 ? 6 : jsDay - 1
 }
 
@@ -259,8 +260,18 @@ export default function PlaceInspector({
       ?? dayAssignments.find(a => a.place?.id === place.id))
     : null
 
+  // The weekday lines are display text; the ring is computed from the structured
+  // periods next to them, in the place's own timezone. open_now stays the fallback.
   const openingHours = googleDetails?.opening_hours || null
-  const openNow = googleDetails?.open_now ?? null
+  const detailLat = place.lat ?? googleDetails?.lat
+  const detailLng = place.lng ?? googleDetails?.lng
+  const placeTimeZone = resolvePlaceTimeZone(detailLat, detailLng)
+  const openNow = resolveOpenNow(
+    { periods: googleDetails?.opening_periods, specialDays: googleDetails?.opening_special_days },
+    detailLat,
+    detailLng,
+    googleDetails?.open_now,
+  )
   // Prefer the place's stored ftid; if it has none yet, use the one just fetched from Google.
   const googleMapsUrl = getGoogleMapsUrlForPlace(
     place ? { ...place, google_ftid: place.google_ftid || googleDetails?.google_ftid || null } : null,
@@ -268,7 +279,7 @@ export default function PlaceInspector({
   )
   const openStreetMapUrl = getOpenStreetMapUrlForPlace(place)
   const selectedDay = days?.find(d => d.id === selectedDayId)
-  const weekdayIndex = getWeekdayIndex(selectedDay?.date)
+  const weekdayIndex = getWeekdayIndex(selectedDay?.date, placeTimeZone)
 
   const placeFiles = (files || []).filter(f => String(f.place_id) === String(place.id) || (f.linked_place_ids || []).includes(place.id))
 

--- a/client/src/components/Planner/placeOpenState.test.ts
+++ b/client/src/components/Planner/placeOpenState.test.ts
@@ -1,0 +1,177 @@
+import { resolveOpenNow, resolvePlaceTimeZone, placeWeekdayIndex } from './placeOpenState';
+import type { OpeningPeriod } from './placeOpenState';
+
+// Seoul is UTC+9, Paris UTC+2 in summer — far enough apart that a viewer's clock and
+// the place's clock disagree on both the hour and the weekday.
+const SEOUL: [number, number] = [37.5665, 126.978];
+const PARIS: [number, number] = [48.8566, 2.3522];
+
+// Periods count days Google's way: Sunday is 0.
+const SUN = 0, MON = 1, TUE = 2, WED = 3, THU = 4, SAT = 6;
+
+function period(day: number, openHour: number, closeDay: number, closeHour: number): OpeningPeriod {
+  return {
+    open: { day, hour: openHour, minute: 0 },
+    close: { day: closeDay, hour: closeHour, minute: 0 },
+  };
+}
+
+describe('resolvePlaceTimeZone', () => {
+  it('FE-PLANNER-OPENSTATE-001: maps coordinates to an IANA zone', () => {
+    expect(resolvePlaceTimeZone(...SEOUL)).toBe('Asia/Seoul');
+    expect(resolvePlaceTimeZone(...PARIS)).toBe('Europe/Paris');
+  });
+
+  it('FE-PLANNER-OPENSTATE-002: returns null for missing or non-finite coordinates', () => {
+    expect(resolvePlaceTimeZone(null, null)).toBeNull();
+    expect(resolvePlaceTimeZone(undefined, 2.3)).toBeNull();
+    expect(resolvePlaceTimeZone('48.8', '2.3')).toBeNull();
+    expect(resolvePlaceTimeZone(NaN, 2.3)).toBeNull();
+    expect(resolvePlaceTimeZone(48.8, Infinity)).toBeNull();
+  });
+
+  it('FE-PLANNER-OPENSTATE-003: returns null when the lookup rejects the coordinate', () => {
+    expect(resolvePlaceTimeZone(1200, 4000)).toBeNull();
+  });
+});
+
+describe('placeWeekdayIndex', () => {
+  it('FE-PLANNER-OPENSTATE-004: is Monday-based and read in the place timezone', () => {
+    // Sunday 20:00 UTC is already Monday 05:00 in Seoul.
+    const at = new Date('2026-07-26T20:00:00Z');
+    expect(placeWeekdayIndex(at, 'Asia/Seoul')).toBe(0);
+    expect(placeWeekdayIndex(at, 'UTC')).toBe(6);
+  });
+
+  it('FE-PLANNER-OPENSTATE-005: falls back to the viewer weekday without a timezone', () => {
+    const at = new Date('2026-07-29T12:00:00Z');
+    const jsDay = at.getDay();
+    expect(placeWeekdayIndex(at, null)).toBe(jsDay === 0 ? 6 : jsDay - 1);
+  });
+
+  it('FE-PLANNER-OPENSTATE-006: falls back to the viewer weekday for an unusable timezone', () => {
+    const at = new Date('2026-07-29T12:00:00Z');
+    const jsDay = at.getDay();
+    expect(placeWeekdayIndex(at, 'Not/AZone')).toBe(jsDay === 0 ? 6 : jsDay - 1);
+  });
+});
+
+describe('resolveOpenNow', () => {
+  it('FE-PLANNER-OPENSTATE-010: judges the periods in the place timezone, not the viewer one', () => {
+    // Sunday 20:00 UTC → Monday 05:00 in Seoul. The server said closed.
+    const hours = { periods: [period(MON, 0, MON, 12)] };
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-26T20:00:00Z'))).toBe(true);
+    // The same instant is still Sunday 22:00 in Paris, where Monday has not begun.
+    expect(resolveOpenNow(hours, ...PARIS, true, new Date('2026-07-26T20:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-011: reports closed when the place clock is outside the hours', () => {
+    const hours = { periods: [period(MON, 9, MON, 18)] };
+    // Sunday 23:00 UTC → Monday 08:00 Seoul is still an hour before opening.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-26T23:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-012: a weekday with no period of its own counts as closed', () => {
+    const hours = { periods: [period(MON, 9, MON, 18), period(TUE, 9, TUE, 18)] };
+    // Wednesday 12:00 in Seoul.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T03:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-013: minutes are honoured on both ends of a period', () => {
+    const hours = {
+      periods: [{ open: { day: WED, hour: 9, minute: 30 }, close: { day: WED, hour: 17, minute: 15 } }],
+    };
+    // 09:29 Seoul — a minute short.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T00:29:00Z'))).toBe(false);
+    // 09:30 Seoul.
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T00:30:00Z'))).toBe(true);
+    // 17:15 Seoul — the closing minute itself is shut.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T08:15:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-014: handles a second period after a midday break', () => {
+    const hours = { periods: [period(WED, 9, WED, 12), period(WED, 14, WED, 20)] };
+    // 13:00 Seoul — in the break.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T04:00:00Z'))).toBe(false);
+    // 15:00 Seoul — second period.
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T06:00:00Z'))).toBe(true);
+  });
+
+  it('FE-PLANNER-OPENSTATE-015: a period running past midnight stays open after the start', () => {
+    const hours = { periods: [period(WED, 20, THU, 2)] };
+    // 23:00 Seoul on Wednesday.
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T14:00:00Z'))).toBe(true);
+    // 01:00 Seoul on Thursday, which has no period of its own.
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T16:00:00Z'))).toBe(true);
+    // 03:00 Seoul on Thursday — the night is over.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T18:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-016: a Saturday night period carries over into Sunday', () => {
+    const hours = { periods: [period(SAT, 22, SUN, 4)] };
+    // Sunday 02:00 Seoul — the period started the previous day and wraps the week end.
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-25T17:00:00Z'))).toBe(true);
+    // Sunday 05:00 Seoul.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-25T20:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-017: a period without a close is a round-the-clock place', () => {
+    // Google describes 24/7 as one period opening Sunday midnight and never closing —
+    // no text in any language is involved.
+    const hours = { periods: [{ open: { day: SUN, hour: 0, minute: 0 } }] };
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T03:00:00Z'))).toBe(true);
+    expect(resolveOpenNow({ periods: [{ open: { day: SUN, hour: 0, minute: 0 }, close: null }] }, ...SEOUL, false,
+      new Date('2026-07-29T18:00:00Z'))).toBe(true);
+  });
+
+  it('FE-PLANNER-OPENSTATE-018: a full week of daily periods is open at every hour', () => {
+    const hours = { periods: [0, 1, 2, 3, 4, 5, 6].map(d => ({ open: { day: d, hour: 0, minute: 0 }, close: { day: (d + 1) % 7, hour: 0, minute: 0 } })) };
+    for (const iso of ['2026-07-29T03:00:00Z', '2026-07-29T14:59:00Z', '2026-07-25T16:00:00Z']) {
+      expect(resolveOpenNow(hours, ...SEOUL, false, new Date(iso))).toBe(true);
+    }
+  });
+
+  it('FE-PLANNER-OPENSTATE-019: keeps the server verdict on a special day', () => {
+    // 2026-07-29 is a holiday in the payload, so Google's own verdict decides.
+    const hours = { periods: [period(WED, 9, WED, 18)], specialDays: ['2026-07-29'] };
+    expect(resolveOpenNow(hours, ...SEOUL, false, new Date('2026-07-29T03:00:00Z'))).toBe(false);
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-29T03:00:00Z'))).toBe(true);
+    // The day before is a normal Tuesday with no period — recomputed, not deferred.
+    expect(resolveOpenNow(hours, ...SEOUL, true, new Date('2026-07-28T03:00:00Z'))).toBe(false);
+  });
+
+  it('FE-PLANNER-OPENSTATE-020: keeps the server verdict without usable periods', () => {
+    const at = new Date('2026-07-29T03:00:00Z');
+    expect(resolveOpenNow(null, ...SEOUL, true, at)).toBe(true);
+    expect(resolveOpenNow({ periods: [] }, ...SEOUL, false, at)).toBe(false);
+    expect(resolveOpenNow({ periods: null }, ...SEOUL, true, at)).toBe(true);
+    expect(resolveOpenNow({}, ...SEOUL, undefined, at)).toBeNull();
+  });
+
+  it('FE-PLANNER-OPENSTATE-021: keeps the server verdict without coordinates', () => {
+    const hours = { periods: [period(WED, 0, WED, 23)] };
+    expect(resolveOpenNow(hours, null, null, true, new Date('2026-07-29T03:00:00Z'))).toBe(true);
+    expect(resolveOpenNow(hours, null, null, undefined, new Date('2026-07-29T03:00:00Z'))).toBeNull();
+  });
+
+  it('FE-PLANNER-OPENSTATE-022: drops malformed periods instead of guessing', () => {
+    const at = new Date('2026-07-29T03:00:00Z');
+    // Wednesday 12:00 Seoul would be inside every one of these if they were trusted.
+    const junk = [
+      { open: { day: 9, hour: 0, minute: 0 }, close: { day: 9, hour: 23, minute: 0 } },
+      { open: { day: WED, hour: 24, minute: 0 }, close: { day: WED, hour: 23, minute: 0 } },
+      { open: { day: WED, hour: '09', minute: 0 } },
+      { close: { day: WED, hour: 23, minute: 0 } },
+      null,
+    ];
+    // Nothing usable is left, so the server verdict stands instead of a stray "open".
+    expect(resolveOpenNow({ periods: junk as never }, ...SEOUL, false, at)).toBe(false);
+    // A period whose close point is broken is dropped rather than read as 24/7 — the
+    // Monday period keeps the list usable, so the state is still recomputed.
+    const brokenClose = [
+      period(MON, 9, MON, 10),
+      { open: { day: WED, hour: 9, minute: 0 }, close: { day: WED, hour: 61, minute: 0 } },
+    ];
+    expect(resolveOpenNow({ periods: brokenClose }, ...SEOUL, true, at)).toBe(false);
+  });
+});

--- a/client/src/components/Planner/placeOpenState.ts
+++ b/client/src/components/Planner/placeOpenState.ts
@@ -1,0 +1,138 @@
+import tzlookup from 'tz-lookup'
+
+// The open/closed ring used to show whatever `open_now` the details endpoint had
+// handed back — a boolean Google computed when the payload was fetched and that the
+// server then cached for days. Read from another continent that value is wrong twice
+// over: it is stale, and nothing in the chain ever looked at the place's own clock.
+// The details payload also carries machine-readable periods — day/hour/minute, the
+// same shape for Google and for OSM places — and those are what the ring is recomputed
+// from, in the timezone of the coordinates. The weekday lines stay what they always
+// were: display text in the user's language, unusable as a data source. Issue #1680.
+
+const MINUTES_PER_DAY = 24 * 60
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY
+
+// Periods count days the way Google does: Sunday is 0. Intl reports the weekday by
+// name, so this maps one to the other.
+const WEEKDAY_NUMBER: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }
+
+export interface OpeningTimePoint {
+  day: number
+  hour: number
+  minute: number
+}
+
+export interface OpeningPeriod {
+  open: OpeningTimePoint
+  /** Absent or null means the place never closes. */
+  close?: OpeningTimePoint | null
+}
+
+export interface PlaceOpeningHours {
+  periods?: OpeningPeriod[] | null
+  /** YYYY-MM-DD dates the weekly periods do not describe (holidays and the like). */
+  specialDays?: string[] | null
+}
+
+export function resolvePlaceTimeZone(lat: unknown, lng: unknown): string | null {
+  if (typeof lat !== 'number' || typeof lng !== 'number' || !Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  try {
+    return tzlookup(lat, lng)
+  } catch {
+    return null
+  }
+}
+
+/** Monday-based weekday index for `now` in `timeZone`; the viewer's own zone when it is null. */
+export function placeWeekdayIndex(now: Date, timeZone: string | null): number {
+  const local = localParts(now, timeZone)
+  if (local) return (local.day + 6) % 7
+  const jsDay = now.getDay()
+  return jsDay === 0 ? 6 : jsDay - 1
+}
+
+/** Weekday (Sunday = 0), minute of day and calendar date of `now` in `timeZone`. */
+function localParts(now: Date, timeZone: string | null): { day: number; minutes: number; date: string } | null {
+  if (!timeZone) return null
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      weekday: 'short',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(now)
+    const value = (type: Intl.DateTimeFormatPartTypes) => parts.find(p => p.type === type)?.value ?? ''
+    const day = WEEKDAY_NUMBER[value('weekday')]
+    const hour = parseInt(value('hour'), 10)
+    const minute = parseInt(value('minute'), 10)
+    if (day === undefined || Number.isNaN(hour) || Number.isNaN(minute)) return null
+    return {
+      day,
+      minutes: (hour % 24) * 60 + minute,
+      date: `${value('year')}-${value('month')}-${value('day')}`,
+    }
+  } catch {
+    return null
+  }
+}
+
+function isTimePoint(point: unknown): point is OpeningTimePoint {
+  if (!point || typeof point !== 'object') return false
+  const { day, hour, minute } = point as OpeningTimePoint
+  if (typeof day !== 'number' || typeof hour !== 'number' || typeof minute !== 'number') return false
+  return day >= 0 && day <= 6 && hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59
+}
+
+/** Periods with a usable open point; a close point is optional but must be usable if present. */
+function usablePeriods(periods: unknown): OpeningPeriod[] {
+  if (!Array.isArray(periods)) return []
+  return periods.filter(
+    (p): p is OpeningPeriod =>
+      !!p && isTimePoint((p as OpeningPeriod).open) && ((p as OpeningPeriod).close == null || isTimePoint((p as OpeningPeriod).close)),
+  )
+}
+
+function pointMinutes(point: OpeningTimePoint): number {
+  return point.day * MINUTES_PER_DAY + point.hour * 60 + point.minute
+}
+
+/**
+ * Open/closed state of a place at `now`, judged by its own local clock.
+ * Returns `fallback` (the server's `open_now`) whenever the periods cannot decide it.
+ */
+export function resolveOpenNow(
+  hours: PlaceOpeningHours | null | undefined,
+  lat: unknown,
+  lng: unknown,
+  fallback: boolean | null | undefined,
+  now: Date = new Date(),
+): boolean | null {
+  const fb = fallback ?? null
+  const periods = usablePeriods(hours?.periods)
+  if (periods.length === 0) return fb
+
+  const local = localParts(now, resolvePlaceTimeZone(lat, lng))
+  if (!local) return fb
+
+  // A holiday is not in the weekly periods, but Google knew about it when it computed
+  // open_now — on such a day its verdict stands rather than our recomputation.
+  const specialDays = hours?.specialDays
+  if (Array.isArray(specialDays) && specialDays.includes(local.date)) return fb
+
+  const nowMinutes = local.day * MINUTES_PER_DAY + local.minutes
+  for (const period of periods) {
+    if (period.close == null) return true
+    const start = pointMinutes(period.open)
+    let end = pointMinutes(period.close)
+    // A closing time at or before the opening time runs past midnight, and past the end
+    // of the week when it opens on Saturday — hence the second comparison.
+    if (end <= start) end += MINUTES_PER_WEEK
+    if (nowMinutes >= start && nowMinutes < end) return true
+    if (nowMinutes + MINUTES_PER_WEEK >= start && nowMinutes + MINUTES_PER_WEEK < end) return true
+  }
+  return false
+}

--- a/client/src/components/Settings/MapSettingsTab.tsx
+++ b/client/src/components/Settings/MapSettingsTab.tsx
@@ -24,7 +24,7 @@ interface MapPreset {
 }
 
 const MAP_PRESETS: MapPreset[] = [
-  { name: 'OpenStreetMap', url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' },
+  { name: 'OpenStreetMap', url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' },
   { name: 'OpenStreetMap DE', url: 'https://tile.openstreetmap.de/{z}/{x}/{y}.png' },
   { name: 'CartoDB Light', url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png' },
   { name: 'CartoDB Dark', url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' },
@@ -307,7 +307,7 @@ export default function MapSettingsTab(): React.ReactElement {
             type="text"
             value={mapTileUrl}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMapTileUrl(e.target.value)}
-            placeholder="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            placeholder="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
             className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-slate-400 focus:border-transparent"
           />
           <p className="text-xs text-slate-400 mt-1">{t('settings.mapDefaultHint')}</p>

--- a/client/src/components/shared/CustomTimePicker.test.tsx
+++ b/client/src/components/shared/CustomTimePicker.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { render, screen, fireEvent, act } from '../../../tests/helpers/render';
 import userEvent from '@testing-library/user-event';
 import CustomTimePicker from './CustomTimePicker';
@@ -455,6 +456,19 @@ describe('CustomTimePicker branches', () => {
     expect(onChange).toHaveBeenCalledWith('05:30');
   });
 
+  it('FE-W5TP-030: a meridiem typed while 24h is configured survives until blur', () => {
+    render(<CustomTimePicker value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '5:30 pm' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('5:30 pm');
+  });
+
+  it('FE-W5TP-031: blur reads a meridiem correctly while 24h is configured', () => {
+    render(<CustomTimePicker value="5:30 pm" onChange={onChange} />);
+    fireEvent.blur(screen.getByRole('textbox'));
+    expect(onChange).toHaveBeenCalledWith('17:30');
+  });
+
   it('FE-W5TP-024: the steppers and the clear button highlight on hover', () => {
     use12h();
     render(<CustomTimePicker value="00:30" onChange={onChange} />);
@@ -474,5 +488,98 @@ describe('CustomTimePicker branches', () => {
     expect(clear.style.color).toBe('rgb(239, 68, 68)');
     fireEvent.mouseLeave(clear);
     expect(clear.style.color).toBe('var(--text-faint)');
+  });
+});
+
+// FE-TP1725-001 to -006 — the configured time format decides how a time is shown,
+// including values that were stored with a meridiem (booking check-in/check-out
+// times entered while 12h was set, or carried in by an import).
+describe('CustomTimePicker honours the configured time format', () => {
+  const onChange = vi.fn();
+  const steppers = () => screen.getAllByRole('button').filter(b => b.textContent?.trim() === '');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAllStores();
+  });
+
+  const use = (time_format: string) => seedStore(useSettingsStore, { settings: buildSettings({ time_format }) });
+
+  it('FE-TP1725-001: shows a stored meridiem value in 24h', () => {
+    use('24h');
+    render(<CustomTimePicker value="3:00 PM" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('value', '15:00');
+  });
+
+  it('FE-TP1725-002: keeps a stored meridiem value in 12h', () => {
+    use('12h');
+    render(<CustomTimePicker value="3:00 PM" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('value', '3:00 PM');
+  });
+
+  it('FE-TP1725-003: converts a 24h value for a 12h user', () => {
+    use('12h');
+    render(<CustomTimePicker value="15:00" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('value', '3:00 PM');
+  });
+
+  it('FE-TP1725-004: the dropdown steppers start from the converted value', () => {
+    use('24h');
+    render(<CustomTimePicker value="3:00 PM" onChange={onChange} />);
+    fireEvent.click(steppers()[0]);
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('00')).toBeInTheDocument();
+    fireEvent.click(steppers()[1]);
+    expect(onChange).toHaveBeenLastCalledWith('16:00');
+  });
+
+  it('FE-TP1725-005: the empty-field hint follows the setting', () => {
+    use('24h');
+    const { unmount } = render(<CustomTimePicker value="" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('placeholder', '00:00');
+    unmount();
+
+    use('12h');
+    render(<CustomTimePicker value="" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('placeholder', '2:30 PM');
+  });
+
+  it('FE-TP1725-006: a 24h value is left alone in 24h', () => {
+    use('24h');
+    render(<CustomTimePicker value="14:30" onChange={onChange} />);
+    expect(screen.getByRole('textbox')).toHaveProperty('value', '14:30');
+  });
+
+  // Display alone is not enough: a value stored as "3:00 PM" stays that way in the
+  // database until someone edits the field. The picker hands the parsed HH:MM back to
+  // the form instead, so the next save writes a clean value.
+  const Controlled = ({ initial }: { initial: string }) => {
+    const [v, setV] = useState(initial);
+    return <CustomTimePicker value={v} onChange={nv => { onChange(nv); setV(nv); }} />;
+  };
+
+  it('FE-TP1725-007: a stored meridiem value is handed back as HH:MM without an edit', () => {
+    use('24h');
+    render(<Controlled initial="3:00 PM" />);
+    expect(onChange).toHaveBeenCalledWith('15:00');
+    expect(screen.getByRole('textbox')).toHaveProperty('value', '15:00');
+  });
+
+  it('FE-TP1725-008: typing a meridiem is left alone until the field is left', () => {
+    use('24h');
+    render(<Controlled initial="" />);
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '5:30 pm' } });
+    expect(input).toHaveProperty('value', '5:30 pm');
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenLastCalledWith('17:30');
+    expect(input).toHaveProperty('value', '17:30');
+  });
+
+  it('FE-TP1725-009: a clean value is not written back', () => {
+    use('24h');
+    render(<Controlled initial="14:30" />);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/shared/CustomTimePicker.tsx
+++ b/client/src/components/shared/CustomTimePicker.tsx
@@ -2,16 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { Clock, ChevronUp, ChevronDown } from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
-
-function formatDisplay(val: string, is12h: boolean): string {
-  if (!val) return ''
-  const [h, m] = val.split(':').map(Number)
-  if (isNaN(h) || isNaN(m)) return val
-  if (!is12h) return val
-  const period = h >= 12 ? 'PM' : 'AM'
-  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h
-  return `${h12}:${String(m).padStart(2, '0')} ${period}`
-}
+import { formatClockTime, parseMeridiemTime } from '../../utils/formatters'
 
 interface CustomTimePickerProps {
   value: string
@@ -27,7 +18,7 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
   const ref = useRef<HTMLDivElement>(null)
   const dropRef = useRef<HTMLDivElement>(null)
 
-  const [h, m] = (value || '').split(':').map(Number)
+  const [h, m] = (parseMeridiemTime(value) ?? value ?? '').split(':').map(Number)
   const hour = isNaN(h) ? null : h
   const minute = isNaN(m) ? null : m
 
@@ -40,6 +31,16 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
     if (open) document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
+
+  // A value that arrives with a meridiem ("3:00 PM" — stored while 12h was configured,
+  // or carried in by a booking import) is handed back as HH:MM right away, so the form
+  // saves a clean value even when the field is never touched (#1725). While the input
+  // has focus this stays out of the way — handleBlur parses what was typed.
+  useEffect(() => {
+    if (inputFocused) return
+    const norm = parseMeridiemTime(value)
+    if (norm && norm !== value) onChange(norm)
+  }, [value, inputFocused])
 
   const update = (newH: number, newM: number) => {
     const hh = String(Math.max(0, Math.min(23, newH))).padStart(2, '0')
@@ -69,7 +70,9 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value
     onChange(raw)
-    if (is12h) return // let handleBlur parse 12h formats
+    // Anything with letters in it ("5:30 pm") is left to handleBlur — stripping
+    // them here would swallow the meridiem and turn 5:30 pm into 05:30.
+    if (is12h || /[a-z]/i.test(raw)) return
     const clean = raw.replace(/[^0-9:]/g, '')
     if (/^\d{2}:\d{2}$/.test(clean)) onChange(clean)
     else if (/^\d{4}$/.test(clean)) onChange(clean.slice(0, 2) + ':' + clean.slice(2))
@@ -83,18 +86,13 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
     if (!value) return
     const raw = value.trim()
 
-    // Parse 12h input like "5:30 PM", "5:30pm", "530pm"
-    if (is12h) {
-      const match12 = raw.match(/^(\d{1,2}):?(\d{2})?\s*(am|pm)$/i)
-      if (match12) {
-        let h = parseInt(match12[1])
-        const m = match12[2] ? parseInt(match12[2]) : 0
-        const isPm = match12[3].toLowerCase() === 'pm'
-        if (h === 12) h = isPm ? 12 : 0
-        else if (isPm) h += 12
-        onChange(String(Math.min(23, h)).padStart(2, '0') + ':' + String(Math.min(59, m)).padStart(2, '0'))
-        return
-      }
+    // Parse 12h input like "5:30 PM", "5:30pm", "530pm". A meridiem is
+    // unambiguous, so it is honoured whatever the configured format is —
+    // otherwise the cleanup below reads "5:30 PM" as 05:30 (#1725).
+    const parsed12h = parseMeridiemTime(raw)
+    if (parsed12h) {
+      onChange(parsed12h)
+      return
     }
 
     const clean = raw.replace(/[^0-9:]/g, '')
@@ -124,7 +122,7 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
       }}>
         <input
           type="text"
-          value={inputFocused ? value : formatDisplay(value, is12h)}
+          value={inputFocused ? value : formatClockTime(value, is12h)}
           onChange={handleInput}
           onFocus={() => setInputFocused(true)}
           onBlur={() => { setInputFocused(false); handleBlur() }}

--- a/client/src/mobile/screens/admin/MAdminDefaultUserSettings.tsx
+++ b/client/src/mobile/screens/admin/MAdminDefaultUserSettings.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../../../components/shared/Toast'
 import { MapView } from '../../../components/Map/MapView'
 import { SYMBOLS, currenciesWith } from '../../../components/Budget/BudgetPanel.constants'
 import { getApiErrorMessage, type DistanceUnit, type Place } from '../../../types'
+import { normalizeTileUrl } from '../../../utils/tileUrl'
 import {
   MAPBOX_DEFAULT_STYLE,
   defaultStyleForProvider,
@@ -22,7 +23,7 @@ import { MSetSelectRow } from '../settings/MSettingsUi'
 import MSetPickerSheet from '../settings/MSetPickerSheet'
 
 const MAP_PRESETS = [
-  { name: 'OpenStreetMap', url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' },
+  { name: 'OpenStreetMap', url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' },
   { name: 'OpenStreetMap DE', url: 'https://tile.openstreetmap.de/{z}/{x}/{y}.png' },
   { name: 'CartoDB Light', url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png' },
   { name: 'CartoDB Dark', url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' },
@@ -76,7 +77,7 @@ export default function MAdminDefaultUserSettings(): React.ReactElement {
     adminApi.getDefaultUserSettings().then((data: Defaults) => {
       const provider = normalizeProvider(data.map_provider)
       setDefaults(data)
-      setMapTileUrl(data.map_tile_url || '')
+      setMapTileUrl(normalizeTileUrl(data.map_tile_url || ''))
       setMapboxToken(data.mapbox_access_token || '')
       setMapboxStyle(provider === 'leaflet' ? (data.mapbox_style || '') : styleForProvider(provider, provider === 'maplibre-gl' ? data.maplibre_style : data.mapbox_style))
       setLoaded(true)
@@ -282,7 +283,7 @@ export default function MAdminDefaultUserSettings(): React.ReactElement {
               value={mapTileUrl}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMapTileUrl(e.target.value)}
               onBlur={() => save({ map_tile_url: mapTileUrl })}
-              placeholder="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              placeholder="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
           </MAdminField>
 

--- a/client/src/mobile/screens/settings/MSettingsMap.tsx
+++ b/client/src/mobile/screens/settings/MSettingsMap.tsx
@@ -24,7 +24,7 @@ interface MapPreset {
 }
 
 const MAP_PRESETS: MapPreset[] = [
-  { name: 'OpenStreetMap', url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' },
+  { name: 'OpenStreetMap', url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' },
   { name: 'OpenStreetMap DE', url: 'https://tile.openstreetmap.de/{z}/{x}/{y}.png' },
   { name: 'CartoDB Light', url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png' },
   { name: 'CartoDB Dark', url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' },
@@ -185,7 +185,7 @@ export default function MSettingsMap() {
             className="mt-[6px]"
             value={mapTileUrl}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMapTileUrl(e.target.value)}
-            placeholder="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            placeholder="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
           <MSetHint>{t('settings.mapDefaultHint')}</MSetHint>
         </>

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -4,6 +4,7 @@ import type { Settings } from '../types'
 import { DEFAULT_APPEARANCE } from '@trek/shared'
 import { getApiErrorMessage } from '../types'
 import { SUPPORTED_LANGUAGE_CODES } from '../i18n/supportedLanguages'
+import { normalizeTileUrl } from '../utils/tileUrl'
 
 interface SettingsState {
   settings: Settings
@@ -56,6 +57,16 @@ export const DEFAULT_SETTINGS: Settings = {
 // periodic) can all fire a retry at once — collapse them into one in-flight GET.
 let _loadInFlight: Promise<void> | null = null
 
+// Every tile consumer (planner map, journey map, tile prefetcher, the settings
+// preview) reads the template from this store, so the retired
+// {s}.tile.openstreetmap.org host is rewritten here — on the way in from the
+// server and on the way out to it. Rewriting only on read would let a template
+// typed by hand survive in the database until the next load put it back (#1733).
+function withNormalizedTileUrl<T extends Partial<Settings>>(patch: T): T {
+  if (typeof patch.map_tile_url !== 'string') return patch
+  return { ...patch, map_tile_url: normalizeTileUrl(patch.map_tile_url) }
+}
+
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   settings: { ...DEFAULT_SETTINGS },
   isLoaded: false,
@@ -65,8 +76,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     _loadInFlight = (async () => {
       try {
         const data = await settingsApi.get()
+        // Rewritten here so the Map settings input already shows the host that
+        // still resolves, and persists it on the next save.
+        const incoming = withNormalizedTileUrl({ ...data.settings } as Partial<Settings>)
         set((state) => ({
-          settings: { ...state.settings, ...data.settings },
+          settings: { ...state.settings, ...incoming },
           isLoaded: true,
         }))
       } catch (err: unknown) {
@@ -83,12 +97,14 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   updateSetting: async (key: keyof Settings, value: Settings[keyof Settings]) => {
+    const next =
+      key === 'map_tile_url' && typeof value === 'string' ? normalizeTileUrl(value) : value
     set((state) => ({
-      settings: { ...state.settings, [key]: value },
+      settings: { ...state.settings, [key]: next },
     }))
-    if (key === 'language') localStorage.setItem('app_language', value as string)
+    if (key === 'language') localStorage.setItem('app_language', next as string)
     try {
-      await settingsApi.set(key, value)
+      await settingsApi.set(key, next)
     } catch (err: unknown) {
       console.error('Failed to save setting:', err)
       throw new Error(getApiErrorMessage(err, 'Error saving setting'))
@@ -109,11 +125,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   updateSettings: async (settingsObj: Partial<Settings>) => {
+    const patch = withNormalizedTileUrl(settingsObj)
     set((state) => ({
-      settings: { ...state.settings, ...settingsObj },
+      settings: { ...state.settings, ...patch },
     }))
     try {
-      await settingsApi.setBulk(settingsObj)
+      await settingsApi.setBulk(patch)
     } catch (err: unknown) {
       console.error('Failed to save settings:', err)
       throw new Error(getApiErrorMessage(err, 'Error saving settings'))

--- a/client/src/sync/tilePrefetcher.ts
+++ b/client/src/sync/tilePrefetcher.ts
@@ -21,6 +21,7 @@
 import type { Place } from '../types'
 import { offlineDb, upsertSyncMeta } from '../db/offlineDb'
 import { isAuthed } from './authGate'
+import { normalizeTileUrl } from '../utils/tileUrl'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -52,14 +53,21 @@ const TILE_CACHE = 'map-tiles'
 const DEFAULT_TILE_URL =
   'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
 
-const SUBDOMAINS = ['a', 'b', 'c', 'd']
+/**
+ * Must stay identical to Leaflet's `subdomains` default ('abc'), because the
+ * index is taken modulo the list length: a fourth entry here shifts the host
+ * for most tiles away from the one the TileLayer will ask for, so the prefetch
+ * fills the cache under URLs the map never requests. It also produced the dead
+ * d.tile.openstreetmap.org lookups in #1733.
+ */
+const SUBDOMAINS = ['a', 'b', 'c']
 
 /**
  * Pick the subdomain from the tile coordinates, the way Leaflet does.
  *
  * It has to be a pure function of x/y: a rotating counter hands the same tile a
  * different host on every run, which both defeats the cache lookup below and
- * stores the tile up to four times under four URLs.
+ * stores the tile once per host.
  */
 function subdomainFor(x: number, y: number): string {
   return SUBDOMAINS[Math.abs(x + y) % SUBDOMAINS.length]
@@ -145,10 +153,14 @@ export function countTiles(bbox: TileBbox, minZoom: number, maxZoom: number): nu
 
 /**
  * Build the concrete tile URL for given z/x/y from a Leaflet template.
- * Rotates through subdomains (a–d).
+ * Rotates through subdomains (a–c).
+ *
+ * The template is normalized first: this function is also reached with a raw
+ * admin default rather than the value from the settings store, so the OSM
+ * sharding rewrite has to happen here too.
  */
 export function buildTileUrl(template: string, z: number, x: number, y: number): string {
-  return template
+  return normalizeTileUrl(template)
     .replace('{z}', String(z))
     .replace('{x}', String(x))
     .replace('{y}', String(y))

--- a/client/src/utils/formatters.test.ts
+++ b/client/src/utils/formatters.test.ts
@@ -220,4 +220,16 @@ describe('splitReservationDateTime', () => {
   it('returns nulls for unrecognized string', () => {
     expect(splitReservationDateTime('garbage')).toEqual({ date: null, time: null })
   })
+
+  // #1725 — slicing the time part to five characters used to swallow the meridiem,
+  // so an afternoon booking came back as a morning one.
+  it('converts a meridiem time part instead of cutting it off', () => {
+    expect(splitReservationDateTime('2026-08-01T3:00 PM')).toEqual({ date: '2026-08-01', time: '15:00' })
+    expect(splitReservationDateTime('2026-08-01T12:30 am')).toEqual({ date: '2026-08-01', time: '00:30' })
+  })
+
+  it('converts a bare meridiem time', () => {
+    expect(splitReservationDateTime('3:00 PM')).toEqual({ date: null, time: '15:00' })
+    expect(splitReservationDateTime('3 PM')).toEqual({ date: null, time: '15:00' })
+  })
 })

--- a/client/src/utils/formatters.ts
+++ b/client/src/utils/formatters.ts
@@ -128,31 +128,67 @@ export function formatDate(dateStr: string | null | undefined, locale: string, t
   return date.toLocaleDateString(locale, opts)
 }
 
+// Times are stored as HH:MM, but a value can still carry a meridiem — typed while
+// 12h was configured, or handed over by a booking import. Convert those to 24h so
+// the configured time format decides how a time is shown, not the way it happens
+// to be stored. Returns null when there is no meridiem to convert.
+export function parseMeridiemTime(value: string | null | undefined): string | null {
+  const match = (value || '').trim().match(/^(\d{1,2}):?(\d{2})?\s*(am|pm)$/i)
+  if (!match) return null
+  let h = parseInt(match[1])
+  const m = match[2] ? parseInt(match[2]) : 0
+  const isPm = match[3].toLowerCase() === 'pm'
+  if (h === 12) h = isPm ? 12 : 0
+  else if (isPm) h += 12
+  return `${String(Math.min(23, h)).padStart(2, '0')}:${String(Math.min(59, m)).padStart(2, '0')}`
+}
+
+function to12h(h: number, m: number): string {
+  const period = h >= 12 ? 'PM' : 'AM'
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h
+  return `${h12}:${String(m).padStart(2, '0')} ${period}`
+}
+
 export function formatTime(timeStr: string | null | undefined, locale: string, timeFormat: string): string {
   if (!timeStr) return ''
   try {
-    const parts = timeStr.split(':')
+    const parts = (parseMeridiemTime(timeStr) ?? timeStr).split(':')
     const h = Number(parts[0]) || 0
     const m = Number(parts[1]) || 0
     if (isNaN(h)) return timeStr
-    if (timeFormat === '12h') {
-      const period = h >= 12 ? 'PM' : 'AM'
-      const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h
-      return `${h12}:${String(m).padStart(2, '0')} ${period}`
-    }
+    if (timeFormat === '12h') return to12h(h, m)
     const str = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
     return locale?.startsWith('de') ? `${str} Uhr` : str
   } catch { return timeStr }
 }
 
+/**
+ * Clock time for the compact spots that have no locale to work with — the time picker
+ * input and the dense day/booking rows. Same 12h/24h decision as formatTime, but it
+ * leaves a 24h value exactly as it is instead of adding the German "Uhr" suffix.
+ * A stored meridiem is normalised first, so the setting decides in both directions.
+ */
+export function formatClockTime(value: string | null | undefined, is12h: boolean): string {
+  if (!value) return ''
+  const norm = parseMeridiemTime(value) ?? value
+  const [h, m] = norm.split(':').map(Number)
+  if (isNaN(h) || isNaN(m)) return value
+  return is12h ? to12h(h, m) : norm
+}
+
 export function splitReservationDateTime(value?: string | null): { date: string | null; time: string | null } {
   if (!value) return { date: null, time: null }
   const isoDate = /^\d{4}-\d{2}-\d{2}$/
+  // Cutting the time part after five characters would drop the meridiem and turn
+  // "3:00 PM" into "3:00", i.e. 3 AM — convert it instead (#1725).
+  const timePart = (t: string) => parseMeridiemTime(t) ?? t.slice(0, 5)
   if (value.includes('T')) {
     const [d, t] = value.split('T')
-    return { date: isoDate.test(d) ? d : null, time: t ? t.slice(0, 5) : null }
+    return { date: isoDate.test(d) ? d : null, time: t ? timePart(t) : null }
   }
   if (isoDate.test(value)) return { date: value, time: null }
+  const meridiem = parseMeridiemTime(value)
+  if (meridiem) return { date: null, time: meridiem }
   if (/^\d{1,2}:\d{2}/.test(value)) return { date: null, time: value.slice(0, 5) }
   return { date: null, time: null }
 }

--- a/client/src/utils/tileUrl.test.ts
+++ b/client/src/utils/tileUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeTileUrl } from './tileUrl'
+
+describe('normalizeTileUrl', () => {
+  it('drops the {s} placeholder from an OSM template', () => {
+    expect(normalizeTileUrl('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'))
+      .toBe('https://tile.openstreetmap.org/{z}/{x}/{y}.png')
+  })
+
+  it('rewrites a hard-coded shard host', () => {
+    for (const shard of ['a', 'b', 'c', 'd']) {
+      expect(normalizeTileUrl(`https://${shard}.tile.openstreetmap.org/{z}/{x}/{y}.png`))
+        .toBe('https://tile.openstreetmap.org/{z}/{x}/{y}.png')
+    }
+  })
+
+  it('rewrites a protocol-relative template', () => {
+    // Older templates were often stored without a scheme so they'd follow the
+    // page. Those reach the network just like the https ones, so the shard
+    // rewrite has to see them too.
+    expect(normalizeTileUrl('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'))
+      .toBe('//tile.openstreetmap.org/{z}/{x}/{y}.png')
+    expect(normalizeTileUrl('//d.tile.openstreetmap.org/{z}/{x}/{y}.png'))
+      .toBe('//tile.openstreetmap.org/{z}/{x}/{y}.png')
+  })
+
+  it('keeps http and an explicit port', () => {
+    expect(normalizeTileUrl('http://{s}.tile.openstreetmap.org:8080/{z}/{x}/{y}.png'))
+      .toBe('http://tile.openstreetmap.org:8080/{z}/{x}/{y}.png')
+  })
+
+  it('leaves the already-correct host alone', () => {
+    const url = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+    expect(normalizeTileUrl(url)).toBe(url)
+  })
+
+  it('leaves other providers untouched', () => {
+    const carto = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
+    expect(normalizeTileUrl(carto)).toBe(carto)
+
+    const osmDe = 'https://tile.openstreetmap.de/{z}/{x}/{y}.png'
+    expect(normalizeTileUrl(osmDe)).toBe(osmDe)
+  })
+
+  it('does not touch a look-alike host', () => {
+    // Only the {s} placeholder and single shard letters are rewritten — a
+    // self-hosted mirror keeps its own hostname.
+    const mirror = 'https://mirror.tile.openstreetmap.org.example.com/{z}/{x}/{y}.png'
+    expect(normalizeTileUrl(mirror)).toBe(mirror)
+
+    const proxy = 'https://tiles.example.com/https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    expect(normalizeTileUrl(proxy)).toBe(proxy)
+  })
+
+  it('passes an empty template through', () => {
+    expect(normalizeTileUrl('')).toBe('')
+  })
+})

--- a/client/src/utils/tileUrl.ts
+++ b/client/src/utils/tileUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * OpenStreetMap has not needed the a/b/c.tile.openstreetmap.org subdomains
+ * since 2022 — tile.openstreetmap.org serves the whole grid on its own — and
+ * d.tile.openstreetmap.org has meanwhile lost its DNS record entirely. A
+ * template that still carries the `{s}` placeholder therefore depends on which
+ * letters the renderer substitutes: everything that lands on `d` fails with
+ * ERR_NAME_NOT_RESOLVED, which is console noise plus holes in the offline tile
+ * cache (#1733).
+ *
+ * The presets ship the single-host form now, but a template the user (or an
+ * admin default) saved earlier is still in the database. Rewriting it on read
+ * fixes those instances without a migration; the settings store rewrites it on
+ * save as well, so a legacy URL typed by hand converges on the same host
+ * instead of coming back on the next load. Other providers are left untouched.
+ */
+
+/** `{s}.` or a bare shard letter in front of tile.openstreetmap.org. */
+const OSM_SHARD = /^((?:https?:)?\/\/)(?:\{s\}|[a-d])\.tile\.openstreetmap\.org(?=[/:]|$)/i
+
+/** Collapse a sharded OSM tile template onto the single supported host. */
+export function normalizeTileUrl(url: string): string {
+  if (!url) return url
+  return url.replace(OSM_SHARD, '$1tile.openstreetmap.org')
+}

--- a/client/tests/unit/mobile/admin/MAdminDefaultUserSettings.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminDefaultUserSettings.test.tsx
@@ -187,7 +187,7 @@ describe('MAdminDefaultUserSettings', () => {
     await screen.findByText('Default User Settings');
 
     // Typed through fireEvent: the {z}/{x}/{y} placeholders collide with userEvent's key syntax
-    const input = screen.getByPlaceholderText('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+    const input = screen.getByPlaceholderText('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
     fireEvent.change(input, { target: { value: 'https://tiles.example.org/{z}/{x}/{y}.png' } });
     fireEvent.blur(input);
 
@@ -207,7 +207,7 @@ describe('MAdminDefaultUserSettings', () => {
 
     const url = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
     await waitFor(() => expect(puts).toEqual([{ map_tile_url: url }]));
-    expect(screen.getByPlaceholderText('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')).toHaveValue(url);
+    expect(screen.getByPlaceholderText('https://tile.openstreetmap.org/{z}/{x}/{y}.png')).toHaveValue(url);
     await waitFor(() => expect(screen.getByRole('button', { name: 'CartoDB Dark' })).toBeInTheDocument());
   });
 
@@ -221,7 +221,7 @@ describe('MAdminDefaultUserSettings', () => {
     await user.click(resetLink('Map Template'));
 
     await waitFor(() => expect(puts).toEqual([{ map_tile_url: null }]));
-    await waitFor(() => expect(screen.getByPlaceholderText('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')).toHaveValue(''));
+    await waitFor(() => expect(screen.getByPlaceholderText('https://tile.openstreetmap.org/{z}/{x}/{y}.png')).toHaveValue(''));
   });
 
   it('FE-MOB-MDUS-014: leaflet hides the GL-only token and style fields', async () => {

--- a/client/tests/unit/mobile/admin/MAdminPluginsPanel.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminPluginsPanel.test.tsx
@@ -77,6 +77,15 @@ function toastMessages() {
   return toasts.map(t => t.message);
 }
 
+// MSheet binds its Escape listener in an effect, so a key fired the moment the
+// sheet's content appears can land before the listener exists. Retry until the
+// sheet is actually gone rather than pressing once and hoping.
+const escapeUntilGone = (text: string) =>
+  waitFor(() => {
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText(text)).not.toBeInTheDocument();
+  });
+
 describe('MAdminPluginsPanel — load states', () => {
   it('FE-MOB-PLUGP-001: shows the load error when the plugin list cannot be fetched', async () => {
     server.use(http.get('*/api/admin/plugins', () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
@@ -1290,14 +1299,12 @@ describe('MAdminPluginsPanel — edge paths', () => {
     fireEvent.click(screen.getByTestId('plugin-row-menu-btn-trek-gotify'));
     fireEvent.click(screen.getByText('View error log'));
     await screen.findByText('No errors logged.');
-    fireEvent.keyDown(document, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByText('No errors logged.')).not.toBeInTheDocument());
+    await escapeUntilGone('No errors logged.');
 
     // Allowed hosts → Escape, from the row chip.
     fireEvent.click(screen.getByRole('button', { name: '1 allowed host(s)' }));
     await screen.findByText('No hosts added yet.');
-    fireEvent.keyDown(document, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByText('No hosts added yet.')).not.toBeInTheDocument());
+    await escapeUntilGone('No hosts added yet.');
   });
 
   it('FE-MOB-PLUGP-087: the hosts sheet closes from its own close button too', async () => {

--- a/client/tests/unit/mobile/settings/MSettingsMap.test.tsx
+++ b/client/tests/unit/mobile/settings/MSettingsMap.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../../../../src/components/Settings/MapboxPreview', () => ({
   ),
 }));
 
-const OSM_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
 function seedMap(over: Partial<Settings> = {}, updateSettings = vi.fn().mockResolvedValue(undefined)) {
   seedStore(useSettingsStore, {

--- a/client/tests/unit/stores/settingsStore.test.ts
+++ b/client/tests/unit/stores/settingsStore.test.ts
@@ -241,4 +241,91 @@ describe('settingsStore', () => {
       expect(useSettingsStore.getState().settings.default_currency).toBe('EUR');
     });
   });
+
+  describe('FE-STORE-SETTINGS-018: loadSettings normalizes a legacy OSM tile template (#1733)', () => {
+    it('rewrites the retired {s}.tile.openstreetmap.org host on read', async () => {
+      const settings = buildSettings({
+        map_tile_url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      });
+      server.use(http.get('/api/settings', () => HttpResponse.json({ settings })));
+
+      await useSettingsStore.getState().loadSettings();
+
+      // d.tile.openstreetmap.org no longer resolves, so a template stored before
+      // OSM dropped sharding must not reach the map or the tile prefetcher.
+      expect(useSettingsStore.getState().settings.map_tile_url).toBe(
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+      );
+    });
+
+    it('leaves a custom template from another provider untouched', async () => {
+      const url = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+      server.use(
+        http.get('/api/settings', () =>
+          HttpResponse.json({ settings: buildSettings({ map_tile_url: url }) })
+        )
+      );
+
+      await useSettingsStore.getState().loadSettings();
+
+      expect(useSettingsStore.getState().settings.map_tile_url).toBe(url);
+    });
+  });
+
+  describe('FE-STORE-SETTINGS-019: saving normalizes the tile template too (#1733)', () => {
+    it('rewrites a hand-typed legacy host in updateSetting and persists the rewrite', async () => {
+      const bodies: unknown[] = [];
+      server.use(
+        http.put('/api/settings', async ({ request }) => {
+          bodies.push(await request.json());
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      await useSettingsStore
+        .getState()
+        .updateSetting('map_tile_url', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+
+      // Normalizing only on read would leave the dead host in the database and
+      // hand it straight back on the next load.
+      expect(useSettingsStore.getState().settings.map_tile_url).toBe(
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+      );
+      expect(bodies).toEqual([
+        { key: 'map_tile_url', value: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' },
+      ]);
+    });
+
+    it('rewrites the template inside a bulk save and persists the rewrite', async () => {
+      const bodies: Array<{ settings: Record<string, unknown> }> = [];
+      server.use(
+        http.post('/api/settings/bulk', async ({ request }) => {
+          bodies.push((await request.json()) as { settings: Record<string, unknown> });
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      await useSettingsStore.getState().updateSettings({
+        map_tile_url: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        map_provider: 'leaflet',
+      });
+
+      expect(useSettingsStore.getState().settings.map_tile_url).toBe(
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+      );
+      expect(bodies[0].settings).toEqual({
+        map_tile_url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        map_provider: 'leaflet',
+      });
+    });
+
+    it('leaves other settings and other providers alone', async () => {
+      await useSettingsStore.getState().updateSetting('default_currency', 'CHF');
+      expect(useSettingsStore.getState().settings.default_currency).toBe('CHF');
+
+      const carto = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+      await useSettingsStore.getState().updateSettings({ map_tile_url: carto });
+      expect(useSettingsStore.getState().settings.map_tile_url).toBe(carto);
+    });
+  });
 });

--- a/client/tests/unit/sync/tilePrefetcher.test.ts
+++ b/client/tests/unit/sync/tilePrefetcher.test.ts
@@ -4,6 +4,8 @@
  * Covers: bbox computation, tile math, URL building, size guard,
  * offline/no-SW guard, syncMeta update.
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import 'fake-indexeddb/auto';
 import {
@@ -123,13 +125,13 @@ describe('buildTileUrl', () => {
   it('replaces {s} with a subdomain character', () => {
     const tmpl = 'https://{s}.tiles.example.com/{z}/{x}/{y}.png';
     const url = buildTileUrl(tmpl, 10, 0, 0);
-    expect(url).toMatch(/^https:\/\/[abcd]\.tiles\.example\.com\/10\/0\/0\.png$/);
+    expect(url).toMatch(/^https:\/\/[abc]\.tiles\.example\.com\/10\/0\/0\.png$/);
   });
 
   it('picks the subdomain deterministically so a tile keeps one URL', () => {
     const tmpl = 'https://{s}.tiles.example.com/{z}/{x}/{y}.png';
     // A rotating counter would hand out a different host on each call, which
-    // both breaks the cache lookup and stores the tile four times over.
+    // both breaks the cache lookup and stores the tile once per host.
     const first = buildTileUrl(tmpl, 10, 479, 329);
     buildTileUrl(tmpl, 10, 480, 330);
     expect(buildTileUrl(tmpl, 10, 479, 329)).toBe(first);
@@ -138,9 +140,30 @@ describe('buildTileUrl', () => {
   it('spreads neighbouring tiles across subdomains', () => {
     const tmpl = 'https://{s}.tiles.example.com/{z}/{x}/{y}.png';
     const hosts = new Set(
-      [0, 1, 2, 3].map(dy => buildTileUrl(tmpl, 10, 479, 329 + dy).slice(8, 9)),
+      [0, 1, 2].map(dy => buildTileUrl(tmpl, 10, 479, 329 + dy).slice(8, 9)),
     );
-    expect(hosts.size).toBe(4);
+    expect(hosts.size).toBe(3);
+  });
+
+  it('uses the same subdomain rotation as Leaflet', () => {
+    // Leaflet's TileLayer defaults to subdomains 'abc' and indexes it with
+    // Math.abs(x + y) % length. A different list length here would cache each
+    // tile under a host the map never asks for.
+    const tmpl = 'https://{s}.tiles.example.com/{z}/{x}/{y}.png';
+    const leaflet = 'abc';
+    for (const [x, y] of [[479, 329], [480, 330], [12, 7], [0, 0], [5, 4]]) {
+      const expected = leaflet[Math.abs(x + y) % leaflet.length];
+      expect(buildTileUrl(tmpl, 10, x, y)).toBe(
+        `https://${expected}.tiles.example.com/10/${x}/${y}.png`,
+      );
+    }
+  });
+
+  it('collapses the retired OSM subdomain sharding onto the single host', () => {
+    // d.tile.openstreetmap.org stopped resolving after OSM dropped sharding, so
+    // a template saved before that must not reach the network as-is (#1733).
+    const url = buildTileUrl('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', 13, 4091, 2722);
+    expect(url).toBe('https://tile.openstreetmap.org/13/4091/2722.png');
   });
 
   it('removes {r} (retina placeholder)', () => {
@@ -418,5 +441,39 @@ describe('prefetchTilesForTrip — repeat runs', () => {
 describe('MAX_TILES budget', () => {
   it('matches the Workbox map-tiles maxEntries in vite.config.js (drift guard)', () => {
     expect(MAX_TILES).toBe(12288);
+  });
+});
+
+// ── service worker rule coherence ───────────────────────────────────────────────
+
+describe('the map-tiles rule for OpenStreetMap (#1733)', () => {
+  // Vitest runs with the client package as its root, so cwd is stable here.
+  const config = readFileSync(resolve(process.cwd(), 'vite.config.js'), 'utf8');
+
+  // Pull the OSM runtimeCaching pattern back out of the config and exercise it,
+  // so this stays a statement about matching behaviour rather than about the
+  // exact characters someone typed.
+  const osmRule = /urlPattern:\s*(\/\^https[^\n]*openstreetmap[^\n]*\/i),/.exec(config);
+  if (!osmRule) throw new Error('no OpenStreetMap runtimeCaching rule found in vite.config.js');
+  const literal = osmRule[1];
+  const pattern = new RegExp(literal.slice(1, literal.lastIndexOf('/')), 'i');
+
+  it('caches the single-host URLs the prefetcher now builds', () => {
+    // Without this the prefetch writes nothing to map-tiles, cache.match() never
+    // hits, and the offline tile store stays empty.
+    const url = buildTileUrl('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', 13, 4091, 2722);
+    expect(url).toBe('https://tile.openstreetmap.org/13/4091/2722.png');
+    expect(pattern.test(url)).toBe(true);
+  });
+
+  it('still matches the sharded URLs already sitting in existing caches', () => {
+    for (const shard of ['a', 'b', 'c']) {
+      expect(pattern.test(`https://${shard}.tile.openstreetmap.org/13/4091/2722.png`)).toBe(true);
+    }
+  });
+
+  it('does not swallow a look-alike host', () => {
+    expect(pattern.test('https://tile.openstreetmap.org.example.com/13/4091/2722.png')).toBe(false);
+    expect(pattern.test('https://tile.openstreetmap.de/13/4091/2722.png')).toBe(false);
   });
 });

--- a/client/tests/unit/utils/formatters.test.ts
+++ b/client/tests/unit/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatTime, dayTotalCost, currencyDecimals } from '../../../src/utils/formatters';
+import { formatDate, formatTime, formatClockTime, dayTotalCost, currencyDecimals, parseMeridiemTime } from '../../../src/utils/formatters';
 import type { AssignmentsMap } from '../../../src/types';
 
 // dayTotalCost intentionally exercises edge-case price inputs (string / non-numeric),
@@ -59,6 +59,68 @@ describe('formatTime', () => {
     expect(formatTime('00:00', 'en-US', '12h')).toBe('12:00 AM');
     expect(formatTime('12:00', 'en-US', '12h')).toBe('12:00 PM');
     expect(formatTime('01:00', 'en-US', '12h')).toBe('1:00 AM');
+  });
+
+  // #1725 — a value stored with a meridiem must still follow the configured format
+  it('converts a stored meridiem value to the configured format', () => {
+    expect(formatTime('3:00 PM', 'en-US', '24h')).toBe('15:00');
+    expect(formatTime('12:30 am', 'en-US', '24h')).toBe('00:30');
+    expect(formatTime('3:00 PM', 'en-US', '12h')).toBe('3:00 PM');
+    expect(formatTime('15:00', 'de-DE', '24h')).toBe('15:00 Uhr');
+  });
+});
+
+describe('parseMeridiemTime', () => {
+  it('returns null when there is no meridiem to convert', () => {
+    expect(parseMeridiemTime(null)).toBeNull();
+    expect(parseMeridiemTime(undefined)).toBeNull();
+    expect(parseMeridiemTime('')).toBeNull();
+    expect(parseMeridiemTime('14:30')).toBeNull();
+    expect(parseMeridiemTime('later')).toBeNull();
+  });
+
+  it('converts a meridiem time to HH:MM', () => {
+    expect(parseMeridiemTime('5:30 pm')).toBe('17:30');
+    expect(parseMeridiemTime('5:30 AM')).toBe('05:30');
+    expect(parseMeridiemTime('530pm')).toBe('17:30');
+    expect(parseMeridiemTime('5pm')).toBe('17:00');
+  });
+
+  it('maps 12 AM to midnight and 12 PM to noon', () => {
+    expect(parseMeridiemTime('12:30 AM')).toBe('00:30');
+    expect(parseMeridiemTime('12:30 PM')).toBe('12:30');
+  });
+});
+
+// The locale-free counterpart of formatTime, shared by the time picker and the dense
+// day/booking rows so those two do not carry their own copy of the rules (#1725).
+describe('formatClockTime', () => {
+  it('returns an empty string for a missing value', () => {
+    expect(formatClockTime(null, false)).toBe('');
+    expect(formatClockTime(undefined, true)).toBe('');
+    expect(formatClockTime('', true)).toBe('');
+  });
+
+  it('leaves a 24h value untouched in 24h and never adds a locale suffix', () => {
+    expect(formatClockTime('14:30', false)).toBe('14:30');
+    expect(formatClockTime('09:05', false)).toBe('09:05');
+  });
+
+  it('converts a 24h value for a 12h user', () => {
+    expect(formatClockTime('14:30', true)).toBe('2:30 PM');
+    expect(formatClockTime('00:15', true)).toBe('12:15 AM');
+    expect(formatClockTime('12:45', true)).toBe('12:45 PM');
+  });
+
+  it('converts a stored meridiem value down to 24h', () => {
+    expect(formatClockTime('3:00 PM', false)).toBe('15:00');
+    expect(formatClockTime('12:30 am', false)).toBe('00:30');
+    expect(formatClockTime('3:00 PM', true)).toBe('3:00 PM');
+  });
+
+  it('hands back anything it cannot read', () => {
+    expect(formatClockTime('later', false)).toBe('later');
+    expect(formatClockTime('later', true)).toBe('later');
   });
 });
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -46,7 +46,10 @@ export default defineConfig({
             // OpenStreetMap tiles (fallback / alternative)
             // Shares the 'map-tiles' cache; keep maxEntries equal to the Carto
             // rule above and MAX_TILES in src/sync/tilePrefetcher.ts (12288).
-            urlPattern: /^https:\/\/[a-c]\.tile\.openstreetmap\.org\/.*/i,
+            // Both spellings have to stay in the pattern: templates are rewritten
+            // onto the apex host (src/utils/tileUrl.ts), but caches filled before
+            // that still hold a/b/c URLs and must keep serving offline.
+            urlPattern: /^https:\/\/(?:[a-c]\.)?tile\.openstreetmap\.org\/.*/i,
             handler: 'CacheFirst',
             options: {
               cacheName: 'map-tiles',

--- a/server/src/middleware/globalMiddleware.ts
+++ b/server/src/middleware/globalMiddleware.ts
@@ -128,7 +128,12 @@ export function applyGlobalMiddleware(
           "https://nominatim.openstreetmap.org", "https://overpass-api.de",
           "https://places.googleapis.com", "https://api.openweathermap.org",
           "https://en.wikipedia.org", "https://commons.wikimedia.org",
-          "https://*.basemaps.cartocdn.com", "https://*.tile.openstreetmap.org",
+          "https://*.basemaps.cartocdn.com",
+          // Both forms: a CSP wildcard host never matches the apex, and OSM
+          // serves everything from the bare tile.openstreetmap.org since it
+          // retired the a/b/c/d shards (#1733). The sharded hosts stay listed
+          // for tile templates users saved before that.
+          "https://tile.openstreetmap.org", "https://*.tile.openstreetmap.org",
           "https://unpkg.com", "https://open-meteo.com", "https://api.open-meteo.com",
           "https://geocoding-api.open-meteo.com", "https://api.frankfurter.dev",
           "https://router.project-osrm.org/route/v1/", "https://routing.openstreetmap.de/",

--- a/server/src/nest/llm-parse/mime-email.ts
+++ b/server/src/nest/llm-parse/mime-email.ts
@@ -1,0 +1,254 @@
+/**
+ * Minimal MIME reader for uploaded `.eml` files.
+ *
+ * A real mail keeps its body inside multipart containers and encodes it as
+ * base64 or quoted-printable, so the raw bytes carry no readable booking data —
+ * reading the file as text yields the plaintext headers plus an encoded blob.
+ * Only the body parts matter for the LLM prompt, so the part tree is walked
+ * here instead of pulling in a full mail-parser dependency: unfold headers,
+ * split on the boundary, decode transfer encoding, then the charset.
+ * Attachments are skipped.
+ */
+
+/** Guards against a hand-crafted mail nesting multiparts without end. */
+const MAX_DEPTH = 10;
+
+type Headers = Map<string, string>;
+
+interface MessagePart {
+  headers: Headers;
+  body: string;
+}
+
+interface ContentType {
+  type: string;
+  params: Record<string, string>;
+}
+
+export interface ParsedMail {
+  /** Decoded `text/html` body part, `null` when the mail has none. */
+  html: string | null;
+  /** Decoded `text/plain` body part, `null` when the mail has none. */
+  text: string | null;
+  /** `From`/`To`/`Subject`/`Date` as decoded `Name: value` lines. */
+  headerLines: string[];
+}
+
+/** Header names that mark a buffer as an actual mail rather than a stray text file. */
+const MAIL_HEADERS = [
+  'from',
+  'to',
+  'subject',
+  'date',
+  'message-id',
+  'received',
+  'mime-version',
+  'return-path',
+  'delivered-to',
+];
+
+/** Headers worth keeping in the prompt — a booking reference often lives in the subject. */
+const SUMMARY_HEADERS: [string, string][] = [
+  ['from', 'From'],
+  ['to', 'To'],
+  ['subject', 'Subject'],
+  ['date', 'Date'],
+];
+
+/**
+ * Parse a `.eml` buffer into its decoded text bodies.
+ * Returns `null` when the buffer is not a mail, so callers can fall back to
+ * their previous handling instead of losing content.
+ */
+export function parseEmail(buffer: Buffer): ParsedMail | null {
+  // latin1 keeps one char per byte, so the structure can be walked as a string
+  // while every part is still re-encodable byte-exact for its own charset.
+  const raw = buffer.toString('latin1').replace(/^\u00ef\u00bb\u00bf/, '');
+  const message = splitMessage(raw);
+  if (!looksLikeMail(raw, message.headers)) return null;
+
+  const bodies: { html: string | null; text: string | null } = { html: null, text: null };
+  walkPart(message, bodies, 0);
+
+  return {
+    html: bodies.html,
+    text: bodies.text,
+    headerLines: summarizeHeaders(message.headers),
+  };
+}
+
+/**
+ * A mail opens with a header field and names at least one of the usual
+ * envelope headers; a bare HTML or text file saved as `.eml` does neither and
+ * is better served by the caller's raw handling.
+ */
+function looksLikeMail(raw: string, headers: Headers): boolean {
+  return /^[!-9;-~]+:/.test(raw) && MAIL_HEADERS.some(name => headers.has(name));
+}
+
+function summarizeHeaders(headers: Headers): string[] {
+  const lines: string[] = [];
+  for (const [name, label] of SUMMARY_HEADERS) {
+    const value = headers.get(name);
+    if (value) lines.push(`${label}: ${decodeEncodedWords(value)}`);
+  }
+  return lines;
+}
+
+/** Collect the first `text/html` and `text/plain` body across the part tree. */
+function walkPart(part: MessagePart, bodies: { html: string | null; text: string | null }, depth: number): void {
+  if (depth > MAX_DEPTH) return;
+  const contentType = parseContentType(part.headers.get('content-type'));
+  const type = contentType.type || 'text/plain';
+
+  if (type.startsWith('multipart/')) {
+    const boundary = contentType.params.boundary;
+    if (!boundary) return;
+    for (const raw of splitParts(part.body, boundary)) {
+      walkPart(splitMessage(raw), bodies, depth + 1);
+    }
+    return;
+  }
+
+  // A forwarded confirmation arrives as an embedded message — walk into it.
+  if (type === 'message/rfc822') {
+    walkPart(splitMessage(decodeToBuffer(part).toString('latin1')), bodies, depth + 1);
+    return;
+  }
+
+  if (isAttachment(part.headers)) return;
+  if (type === 'text/html') {
+    if (bodies.html === null) bodies.html = decodePartText(part, contentType);
+  } else if (type === 'text/plain') {
+    if (bodies.text === null) bodies.text = decodePartText(part, contentType);
+  }
+}
+
+function isAttachment(headers: Headers): boolean {
+  return parseContentType(headers.get('content-disposition')).type === 'attachment';
+}
+
+/** Split a message (or a part) into its unfolded headers and its still-encoded body. */
+function splitMessage(raw: string): MessagePart {
+  const separator = /\r?\n\r?\n/.exec(raw);
+  const headerBlock = separator ? raw.slice(0, separator.index) : raw;
+  const body = separator ? raw.slice(separator.index + separator[0].length) : '';
+  return { headers: parseHeaders(headerBlock), body };
+}
+
+function parseHeaders(block: string): Headers {
+  const headers: Headers = new Map();
+  let current = '';
+  const commit = () => {
+    const colon = current.indexOf(':');
+    // Keep the first occurrence: a re-sent mail can carry a header twice.
+    if (colon > 0) {
+      const name = current.slice(0, colon).trim().toLowerCase();
+      if (!headers.has(name)) headers.set(name, current.slice(colon + 1).trim());
+    }
+    current = '';
+  };
+  for (const line of block.split(/\r?\n/)) {
+    // A leading space or tab continues the previous header (RFC 5322 folding).
+    if (/^[ \t]/.test(line) && current) current += ' ' + line.trim();
+    else {
+      commit();
+      current = line;
+    }
+  }
+  commit();
+  return headers;
+}
+
+function parseContentType(value: string | undefined): ContentType {
+  const params: Record<string, string> = {};
+  if (!value) return { type: '', params };
+  const semicolon = value.indexOf(';');
+  const type = (semicolon < 0 ? value : value.slice(0, semicolon)).trim().toLowerCase();
+  const param = /;\s*([\w-]+)\s*=\s*(?:"([^"]*)"|([^;]*))/g;
+  let match: RegExpExecArray | null;
+  while ((match = param.exec(value)) !== null) {
+    params[match[1].toLowerCase()] = (match[2] ?? match[3] ?? '').trim();
+  }
+  return { type, params };
+}
+
+/**
+ * Cut a multipart body at its `--boundary` delimiters. The CRLF in front of a
+ * delimiter belongs to it, so it is matched (not captured) and stripped from
+ * the part that follows.
+ */
+function splitParts(body: string, boundary: string): string[] {
+  const delimiter = new RegExp(`(?:\\r?\\n|^)--${escapeRegExp(boundary)}(--)?[ \\t]*(?=\\r?\\n|$)`, 'g');
+  const parts: string[] = [];
+  let start = -1;
+  let match: RegExpExecArray | null;
+  while ((match = delimiter.exec(body)) !== null) {
+    if (start >= 0) parts.push(body.slice(start, match.index).replace(/^\r?\n/, ''));
+    if (match[1]) break; // closing delimiter
+    start = delimiter.lastIndex;
+  }
+  return parts;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Undo the transfer encoding of a part, yielding its raw bytes. */
+function decodeToBuffer(part: MessagePart): Buffer {
+  const encoding = (part.headers.get('content-transfer-encoding') ?? '').trim().toLowerCase();
+  if (encoding === 'base64') return decodeBase64(part.body);
+  if (encoding === 'quoted-printable') return decodeQuotedPrintable(part.body);
+  return Buffer.from(part.body, 'latin1');
+}
+
+function decodePartText(part: MessagePart, contentType: ContentType): string {
+  return decodeCharset(decodeToBuffer(part), contentType.params.charset).replace(/\r\n?/g, '\n');
+}
+
+function decodeBase64(payload: string): Buffer {
+  return Buffer.from(payload.replace(/[^A-Za-z0-9+/=]/g, ''), 'base64');
+}
+
+function decodeQuotedPrintable(payload: string): Buffer {
+  const joined = payload.replace(/=\r?\n/g, ''); // soft line breaks
+  const out = Buffer.allocUnsafe(joined.length);
+  let len = 0;
+  for (let i = 0; i < joined.length; i++) {
+    const hex = joined[i] === '=' ? joined.slice(i + 1, i + 3) : '';
+    if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+      out[len++] = parseInt(hex, 16);
+      i += 2;
+    } else {
+      out[len++] = joined.charCodeAt(i) & 0xff;
+    }
+  }
+  return out.subarray(0, len);
+}
+
+function decodeCharset(bytes: Buffer, charset: string | undefined): string {
+  const label = (charset ?? '').trim().toLowerCase().replace(/^["']|["']$/g, '');
+  if (!label || label === 'utf-8' || label === 'utf8' || label === 'us-ascii' || label === 'ascii') {
+    return bytes.toString('utf8');
+  }
+  try {
+    return new TextDecoder(label).decode(bytes);
+  } catch {
+    // Unknown label — utf8 is still the best guess for modern mail.
+    return bytes.toString('utf8');
+  }
+}
+
+/** Resolve RFC 2047 encoded-words (`=?utf-8?B?…?=`), as used in subject lines. */
+function decodeEncodedWords(value: string): string {
+  return value
+    .replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (whole, charset: string, encoding: string, payload: string) => {
+      const bytes =
+        encoding.toUpperCase() === 'B' ? decodeBase64(payload) : decodeQuotedPrintable(payload.replace(/_/g, ' '));
+      const decoded = decodeCharset(bytes, charset);
+      return decoded || whole;
+    })
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/server/src/nest/llm-parse/text-extract.ts
+++ b/server/src/nest/llm-parse/text-extract.ts
@@ -1,3 +1,4 @@
+import { parseEmail } from './mime-email';
 import { extname } from 'node:path';
 import { PDFParse } from 'pdf-parse';
 
@@ -12,16 +13,116 @@ export function isPdf(fileName: string): boolean {
   return extname(fileName).toLowerCase() === '.pdf';
 }
 
-/** Strip HTML/XML tags and collapse whitespace for a cleaner LLM prompt. */
+/**
+ * Entity names for U+00A0–U+00FF in code-point order. Booking mails are full of
+ * this block: umlauts, currency signs, the degree sign.
+ */
+const LATIN1_ENTITIES = (
+  'nbsp iexcl cent pound curren yen brvbar sect uml copy ordf laquo not shy reg macr ' +
+  'deg plusmn sup2 sup3 acute micro para middot cedil sup1 ordm raquo frac14 frac12 frac34 iquest ' +
+  'Agrave Aacute Acirc Atilde Auml Aring AElig Ccedil Egrave Eacute Ecirc Euml Igrave Iacute Icirc Iuml ' +
+  'ETH Ntilde Ograve Oacute Ocirc Otilde Ouml times Oslash Ugrave Uacute Ucirc Uuml Yacute THORN szlig ' +
+  'agrave aacute acirc atilde auml aring aelig ccedil egrave eacute ecirc euml igrave iacute icirc iuml ' +
+  'eth ntilde ograve oacute ocirc otilde ouml divide oslash ugrave uacute ucirc uuml yacute thorn yuml'
+).split(' ');
+
+/** Named entities a mail body realistically carries, resolved to their character. */
+const HTML_ENTITIES = new Map<string, string>([
+  ['amp', '&'],
+  ['lt', '<'],
+  ['gt', '>'],
+  ['quot', '"'],
+  ['apos', "'"],
+  ['ndash', '–'],
+  ['mdash', '—'],
+  ['hellip', '…'],
+  ['lsquo', '‘'],
+  ['rsquo', '’'],
+  ['sbquo', '‚'],
+  ['ldquo', '“'],
+  ['rdquo', '”'],
+  ['bdquo', '„'],
+  ['bull', '•'],
+  ['dagger', '†'],
+  ['Dagger', '‡'],
+  ['permil', '‰'],
+  ['lsaquo', '‹'],
+  ['rsaquo', '›'],
+  ['trade', '™'],
+  ['euro', '€'],
+  ['minus', '−'],
+  ['ne', '≠'],
+  ['le', '≤'],
+  ['ge', '≥'],
+  ['larr', '←'],
+  ['rarr', '→'],
+  ['harr', '↔'],
+  ...LATIN1_ENTITIES.map((name, i): [string, string] => [name, String.fromCharCode(0xa0 + i)]),
+]);
+
+function entityCodePoint(code: number): string | null {
+  // Surrogate halves and out-of-range values would throw or produce garbage.
+  if (!Number.isFinite(code) || code <= 0 || code > 0x10ffff) return null;
+  if (code >= 0xd800 && code <= 0xdfff) return null;
+  return String.fromCodePoint(code);
+}
+
+/**
+ * Resolve HTML entities so the model sees "Zimmer für zwei – 120,00 €" instead
+ * of the escaped source. Numeric references come in decimal (`&#88;`) and hex
+ * (`&#x58;`) form; an unknown name is left as written rather than dropped.
+ */
+function decodeEntities(s: string): string {
+  if (!s.includes('&')) return s;
+  return s.replace(/&(#\d{1,7}|#[xX][0-9a-fA-F]{1,6}|[A-Za-z][A-Za-z0-9]{1,30});/g, (whole, ref: string) => {
+    if (ref[0] === '#') {
+      const hex = ref[1] === 'x' || ref[1] === 'X';
+      return entityCodePoint(parseInt(hex ? ref.slice(2) : ref.slice(1), hex ? 16 : 10)) ?? whole;
+    }
+    // Case matters (&Uuml; vs &uuml;); only fall back to lower case for names
+    // that are shouted in old templates.
+    return HTML_ENTITIES.get(ref) ?? HTML_ENTITIES.get(ref.toLowerCase()) ?? whole;
+  });
+}
+
+/** Strip HTML/XML tags, resolve entities and collapse whitespace for a cleaner LLM prompt. */
 function stripMarkup(s: string): string {
-  return s
+  const withoutTags = s
     .replace(/<script[\s\S]*?<\/script>/gi, ' ')
     .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/[ \t]+/g, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  // Entities come last so that a decoded `&lt;` cannot turn into a tag the
+  // stripper would then eat.
+  return decodeEntities(withoutTags)
+    .replace(/[ \t\u00a0]+/g, ' ')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+/** Whitespace cleanup for text that is already plain — no tags to strip out. */
+function collapseWhitespace(s: string): string {
+  return s
+    .replace(/[ \t\u00a0]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Decode a `.eml` upload: walk the MIME tree, prefer the `text/html` body over
+ * `text/plain`, and keep the interesting headers in front of it. Returns an
+ * empty string when the buffer is not a MIME message or when the walk finds no
+ * readable body, which leaves the caller on its raw-bytes path — the headers
+ * alone would be a worse prompt than the undecoded file.
+ */
+function extractEmailText(buffer: Buffer): string {
+  const mail = parseEmail(buffer);
+  if (!mail) return '';
+  // An empty html part must not shadow a filled text/plain alternative, so both
+  // are cleaned up before one is picked.
+  const html = mail.html !== null ? stripMarkup(mail.html) : '';
+  const body = html || (mail.text !== null ? collapseWhitespace(mail.text) : '');
+  if (!body) return '';
+  return [mail.headerLines.join('\n'), body].filter(section => section.length > 0).join('\n\n');
 }
 
 /** Extract the embedded text layer from a PDF (empty for scanned/image-only PDFs). */
@@ -56,7 +157,8 @@ function cleanPdfText(text: string): string {
 /**
  * Extract text from a booking file for the OpenAI-compatible/local LLM path
  * (Ollama can't ingest PDFs or `file` parts, so everything becomes text).
- *  - txt/html/htm/eml → decoded (markup stripped)
+ *  - eml              → MIME-decoded body part (markup stripped)
+ *  - txt/html/htm     → decoded (markup stripped)
  *  - pdf              → embedded text layer via pdf-parse
  *  - anything else    → best-effort UTF-8 decode
  * A scanned/image-only PDF yields empty text — that case needs a vision provider
@@ -65,6 +167,13 @@ function cleanPdfText(text: string): string {
 export async function extractText(buffer: Buffer, fileName: string): Promise<string> {
   const ext = extname(fileName).toLowerCase();
   if (isPdf(fileName)) return extractPdfText(buffer);
+  if (ext === '.eml') {
+    // Real mail hides its body behind base64/quoted-printable, so decode the MIME
+    // structure first; a file that isn't a message, or a message whose only content
+    // sits in parts we don't read, falls through to the raw bytes.
+    const mailText = extractEmailText(buffer);
+    if (mailText) return mailText;
+  }
   const raw = buffer.toString('utf8');
   if (ext === '.html' || ext === '.htm' || ext === '.eml') return stripMarkup(raw);
   return raw.trim();

--- a/server/src/nest/maps/maps.controller.ts
+++ b/server/src/nest/maps/maps.controller.ts
@@ -160,6 +160,9 @@ export class MapsController {
     if (!placeId.startsWith('coords:') && this.maps.photosDisabled()) {
       return { photoUrl: null };
     }
+    // A place with no photo resolves to the same { photoUrl: null } body. It is an
+    // empty result, not a missing resource, and one 404 per photo-less place gets
+    // the user's IP banned by any 404-rate IPS in front of TREK (#1727).
     try {
       return await this.maps.photo(user.id, placeId, parseFloat(lat as string), parseFloat(lng as string), name);
     } catch (err: unknown) {
@@ -173,22 +176,35 @@ export class MapsController {
   placePhotoBytes(@Param('placeId') placeId: string, @Res() res: Response): void {
     const fp = this.maps.photoBytesPath(placeId);
     if (!fp) {
-      res.status(404).json({ error: 'Photo not cached' });
+      // Same reasoning as the JSON endpoint above, and the bigger half of #1727:
+      // places keep this URL in image_url, so a trip render asks for one photo per
+      // place and every entry the cache sweep dropped answered 404 — a whole map
+      // worth of them from one IP in one second. An empty 204 leaves the <img>
+      // with nothing to show, exactly like the 404 did.
+      this.emptyPhoto(res);
       return;
     }
     // Stream the cached file directly instead of res.sendFile(): the send library
     // bundled under @nestjs/platform-express rejects absolute Windows paths (drive
     // letter, no `root`) with a NotFoundError that surfaced as an unhandled 500,
     // even though the file exists. A plain read stream serves the bytes
-    // cross-platform; a read error still yields the legacy 404. Cached photos are
-    // always JPEG (placePhotoCache writes `<hash>.jpg`).
+    // cross-platform. Cached photos are always JPEG (placePhotoCache writes
+    // `<hash>.jpg`).
     res.set('Cache-Control', 'public, max-age=2592000, immutable');
     res.type('image/jpeg');
     const stream = createReadStream(fp);
     stream.on('error', () => {
-      if (!res.headersSent) res.status(404).json({ error: 'Photo not cached' });
+      if (!res.headersSent) this.emptyPhoto(res);
     });
     stream.pipe(res);
+  }
+
+  // 204 for "no bytes to serve". Overrides the immutable Cache-Control the hit
+  // path already set — a photo that reappears in the cache must not stay hidden
+  // behind a month-old empty response.
+  private emptyPhoto(res: Response): void {
+    res.set('Cache-Control', 'no-store');
+    res.status(204).end();
   }
 
   @Get('reverse')

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -15,11 +15,11 @@ import pathMod from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { PermissionsService } from '../../permissions/permissions.service';
 import { TripsService, NotFoundError, ValidationError } from '../../trips/trips.service';
-import { createPlace, updatePlace, deletePlace } from '../../../services/placeService';
+import { createPlace, updatePlace, deletePlace, getPlace } from '../../../services/placeService';
 import { AddonsService } from '../../addons/addons.service';
 import { isDemoEmail } from '../../../services/demo';
 import { ADDON_IDS } from '../../../addons';
-import { listJourneys, listEntries as listJournalEntriesSvc, createEntry as createJournalEntrySvc, updateEntry as updateJournalEntrySvc, deleteEntry as deleteJournalEntrySvc, createJourney as createJourneySvc, deleteJourney as deleteJourneySvc } from '../../../services/journeyService';
+import { listJourneys, listEntries as listJournalEntriesSvc, createEntry as createJournalEntrySvc, updateEntry as updateJournalEntrySvc, deleteEntry as deleteJournalEntrySvc, createJourney as createJourneySvc, deleteJourney as deleteJourneySvc, onPlaceCreated, onPlaceUpdated, onPlaceDeleted } from '../../../services/journeyService';
 import { listVisitedCountries, listManuallyVisitedRegions, listBucketList, markCountryVisited, unmarkCountryVisited, markRegionVisited, unmarkRegionVisited, createBucketItem as createBucketItemSvc, deleteBucketItem as deleteBucketItemSvc } from '../../../services/atlasService';
 import { listCollections, getCollection, createCollection, updateCollection, savePlace as saveCollectionPlaceSvc, copyToTrip as copyCollectionToTripSvc, deletePlace as deleteCollectionPlaceSvc } from '../../../services/collectionsService';
 import { BudgetService } from '../../budget/budget.service';
@@ -54,6 +54,13 @@ function mapCollectionError<T>(fn: () => T): T {
     if (status === 400 || status === 409) throw new BadParams(msg);
     throw e;
   }
+}
+
+// Journey mirroring is best-effort on every other path that triggers it
+// (places.service wraps the same hooks, assignments.service wraps the reconcile),
+// so a broken journey link can never turn a successful write into an RPC error.
+function mirrorJourneys(run: () => void): void {
+  try { run(); } catch { /* non-fatal */ }
 }
 
 // --- #858 packing privacy: viewer-scoped fan-out mirrored from
@@ -461,20 +468,34 @@ export class PluginHostDepsFactory {
         return { deleted: true };
       },
       // --- Places (place_edit). Delegate to the same placeService the REST/MCP paths
-      // use, then broadcast the same events so open web sessions update live. ---
+      // use, then broadcast the same events so open web sessions update live, and run
+      // the journey hooks places.controller runs on the same three writes: a journey
+      // linked to the trip carries a skeleton entry per day-assigned place, and
+      // without the hooks it keeps the old title/location — or a dead entry — until
+      // somebody reloads it. ---
       canEditPlaces: (tripId, userId) => this.canEditTripAs('place_edit', tripId, userId),
       createPlace: (tripId, input) => {
         const place = createPlace(String(tripId), input as Parameters<typeof createPlace>[1]);
         this.realtime.broadcast(tripId, 'place:created', { place });
+        mirrorJourneys(() => onPlaceCreated(Number(tripId), place.id));
         return place;
       },
       updatePlace: (tripId, placeId, input) => {
         const place = updatePlace(String(tripId), String(placeId), input as Parameters<typeof updatePlace>[2]);
         if (place === null) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
         this.realtime.broadcast(tripId, 'place:updated', { place });
+        mirrorJourneys(() => onPlaceUpdated(Number(placeId)));
         return place;
       },
       deletePlace: (tripId, placeId) => {
+        // Scope the id to the trip before anything else: onPlaceDeleted keys on the
+        // place alone, so an id belonging to a foreign trip would detach that trip's
+        // journey entries even though the delete below refuses it.
+        if (!getPlace(String(tripId), String(placeId))) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
+        // Ahead of the DELETE, like the REST route and the MCP tool: journey_entries
+        // .source_place_id is ON DELETE SET NULL, so afterwards the hook finds nothing
+        // left to detach and the entries linger as orphans.
+        mirrorJourneys(() => onPlaceDeleted(Number(placeId)));
         const deleted = deletePlace(String(tripId), String(placeId));
         if (!deleted) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
         this.realtime.broadcast(tripId, 'place:deleted', { placeId });
@@ -510,6 +531,7 @@ export class PluginHostDepsFactory {
         if (!this.assignments.placeExists(placeId, tripId)) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
         const assignment = this.assignments.createAssignment(dayId, placeId, notes);
         this.realtime.broadcast(tripId, 'assignment:created', { assignment });
+        this.assignments.reconcile(tripId);
         return assignment;
       },
       unassignPlace: (tripId, assignmentId) => {
@@ -517,8 +539,15 @@ export class PluginHostDepsFactory {
         if (!existing) throw new ForbiddenResource(`no assignment ${assignmentId} on trip ${tripId}`);
         this.assignments.deleteAssignment(assignmentId);
         // Same payload shape as the REST/MCP delete, so client stores can
-        // evict the assignment from the right day.
+        // evict the assignment from the right day. The dayId is what the client
+        // reducer keys the eviction on — without it nothing leaves the day.
         this.realtime.broadcast(tripId, 'assignment:deleted', { assignmentId, dayId: existing.day_id });
+        // Create, delete, move and time re-mirror the linked journey skeletons
+        // afterwards, in the controller and in the MCP tool alike (reorder,
+        // transport and participants don't). Without it an open journey keeps
+        // the removed place until the next reload. No sid — a plugin has no
+        // originating socket.
+        this.assignments.reconcile(tripId);
         return { deleted: true };
       },
       // --- Trip creation (trip_create; owner = acting user). No broadcast — a new trip

--- a/server/src/services/mapsService.ts
+++ b/server/src/services/mapsService.ts
@@ -61,9 +61,22 @@ interface GoogleAutocompleteSuggestion {
   };
 }
 
+interface GoogleTimePoint {
+  day?: number;
+  hour?: number;
+  minute?: number;
+}
+
+interface GoogleOpeningHours {
+  weekdayDescriptions?: string[];
+  openNow?: boolean;
+  periods?: { open?: GoogleTimePoint; close?: GoogleTimePoint }[];
+  specialDays?: { date?: { year?: number; month?: number; day?: number } }[];
+}
+
 interface GooglePlaceDetails extends GooglePlaceResult {
   userRatingCount?: number;
-  regularOpeningHours?: { weekdayDescriptions?: string[]; openNow?: boolean };
+  regularOpeningHours?: GoogleOpeningHours;
   editorialSummary?: { text: string };
   reviews?: {
     authorAttribution?: { displayName?: string; photoUri?: string };
@@ -531,10 +544,107 @@ export async function searchOverpassPois(
 
 // ── Opening hours parsing ────────────────────────────────────────────────────
 
-export function parseOpeningHours(ohString: string): { weekdayDescriptions: string[]; openNow: boolean | null } {
+// Machine-readable opening hours, in Google's numbering: day 0 = Sunday … 6 = Saturday.
+// The weekday descriptions next to them are display text in the requested language and
+// cannot be parsed reliably; these can. A period without `close` is Google's way of
+// saying the place never closes.
+export interface OpeningTimePoint {
+  day: number;
+  hour: number;
+  minute: number;
+}
+export interface OpeningPeriod {
+  open: OpeningTimePoint;
+  close: OpeningTimePoint | null;
+}
+
+// Places (New) speaks proto3 JSON, which leaves out fields that hold the default
+// value — a period starting Sunday midnight arrives as `{}`, not as three zeroes.
+function toTimePoint(point: GoogleTimePoint | undefined): OpeningTimePoint | null {
+  if (!point || typeof point !== 'object') return null;
+  const field = (value: unknown): number | null => {
+    if (value === undefined || value === null) return 0;
+    return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : null;
+  };
+  const day = field(point.day);
+  const hour = field(point.hour);
+  const minute = field(point.minute);
+  if (day === null || hour === null || minute === null) return null;
+  if (day < 0 || day > 6 || hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return { day, hour, minute };
+}
+
+export function normalizeOpeningPeriods(periods: GoogleOpeningHours['periods']): OpeningPeriod[] | null {
+  if (!Array.isArray(periods) || periods.length === 0) return null;
+  const result: OpeningPeriod[] = [];
+  for (const period of periods) {
+    const open = toTimePoint(period?.open);
+    if (!open) continue;
+    // A missing close means "never closes"; a close that is there but unusable makes
+    // the whole period a guess, so it is dropped rather than read as round-the-clock.
+    const close = period?.close == null ? null : toTimePoint(period.close);
+    if (period?.close != null && !close) continue;
+    result.push({ open, close });
+  }
+  return result.length > 0 ? result : null;
+}
+
+// Holidays and other exceptional days that the weekly periods do not describe. Google
+// reports them as calendar dates; they travel to the client as YYYY-MM-DD so it can
+// compare them against the place's own local date.
+export function normalizeSpecialDays(specialDays: GoogleOpeningHours['specialDays']): string[] | null {
+  if (!Array.isArray(specialDays) || specialDays.length === 0) return null;
+  const dates: string[] = [];
+  for (const entry of specialDays) {
+    const date = entry?.date;
+    if (!date) continue;
+    const { year, month, day } = date;
+    if (typeof year !== 'number' || typeof month !== 'number' || typeof day !== 'number') continue;
+    if (month < 1 || month > 12 || day < 1 || day > 31) continue;
+    const iso = `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    if (!dates.includes(iso)) dates.push(iso);
+  }
+  return dates.length > 0 ? dates : null;
+}
+
+// "09:00-18:00", also the "20:00-02:00" and "00:00-24:00" spellings OSM uses.
+const OSM_TIME_RANGE = /(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})/g;
+
+/** Periods for one OSM weekday line. `dayIdx` is Monday-based, the output is not. */
+function osmPeriods(dayIdx: number, timePart: string): OpeningPeriod[] {
+  const day = (dayIdx + 1) % 7;
+  const periods: OpeningPeriod[] = [];
+  for (const match of timePart.matchAll(OSM_TIME_RANGE)) {
+    const openHour = parseInt(match[1], 10);
+    const openMinute = parseInt(match[2], 10);
+    let closeHour = parseInt(match[3], 10);
+    const closeMinute = parseInt(match[4], 10);
+    if (openHour > 23 || openMinute > 59 || closeHour > 24 || closeMinute > 59) continue;
+    // OSM writes the end of a day as 24:00, a clock reading Google's numbering has no
+    // hour 24 — that is midnight of the following day, same as any range that wraps.
+    let nextDay = closeHour * 60 + closeMinute <= openHour * 60 + openMinute;
+    if (closeHour === 24) {
+      if (closeMinute !== 0) continue;
+      closeHour = 0;
+      nextDay = true;
+    }
+    periods.push({
+      open: { day, hour: openHour, minute: openMinute },
+      close: { day: nextDay ? (day + 1) % 7 : day, hour: closeHour, minute: closeMinute },
+    });
+  }
+  return periods;
+}
+
+export function parseOpeningHours(ohString: string): {
+  weekdayDescriptions: string[];
+  openNow: boolean | null;
+  periods: OpeningPeriod[];
+} {
   const DAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
   const LONG = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   const result: string[] = LONG.map((d) => `${d}: ?`);
+  const periods: OpeningPeriod[] = [];
 
   // Parse segments like "Mo-Fr 09:00-18:00; Sa 10:00-14:00"
   for (const segment of ohString.split(';')) {
@@ -560,6 +670,7 @@ export function parseOpeningHours(ohString: string): { weekdayDescriptions: stri
     }
     for (const idx of dayIndices) {
       result[idx] = `${LONG[idx]}: ${timePart.trim()}`;
+      periods.push(...osmPeriods(idx, timePart));
     }
   }
 
@@ -583,7 +694,7 @@ export function parseOpeningHours(ohString: string): { weekdayDescriptions: stri
     /* best effort */
   }
 
-  return { weekdayDescriptions: result, openNow };
+  return { weekdayDescriptions: result, openNow, periods };
 }
 
 // ── Build standardized OSM details ───────────────────────────────────────────
@@ -591,12 +702,14 @@ export function parseOpeningHours(ohString: string): { weekdayDescriptions: stri
 export function buildOsmDetails(tags: Record<string, string>, osmType: string, osmId: string) {
   let opening_hours: string[] | null = null;
   let open_now: boolean | null = null;
+  let opening_periods: OpeningPeriod[] | null = null;
   if (tags.opening_hours) {
     const parsed = parseOpeningHours(tags.opening_hours);
     const hasData = parsed.weekdayDescriptions.some((line) => !line.endsWith('?'));
     if (hasData) {
       opening_hours = parsed.weekdayDescriptions;
       open_now = parsed.openNow;
+      opening_periods = parsed.periods.length > 0 ? parsed.periods : null;
     }
   }
   return {
@@ -604,6 +717,7 @@ export function buildOsmDetails(tags: Record<string, string>, osmType: string, o
     phone: tags['contact:phone'] || tags.phone || null,
     opening_hours,
     open_now,
+    opening_periods,
     osm_url: `https://www.openstreetmap.org/${osmType}/${osmId}`,
     summary: tags.description || null,
     source: 'openstreetmap' as const,
@@ -834,6 +948,21 @@ async function autocompleteNominatim(
 
 // ── Place details (Google or OSM) ────────────────────────────────────────────
 
+// Ids that can never resolve against the Google Places API: coordinate pseudo-ids
+// (right-click places, in both the coords: and the bare "lat,lng" spelling the
+// collection views send), OSM ids the client sends when a place has no
+// google_place_id, and the raw photo URLs legacy rows keep in image_url. Google
+// answers those with a billable 400 INVALID_ARGUMENT, so every lookup sorts them
+// out before the call and uses the OSM/Wikimedia path instead.
+const NON_GOOGLE_PLACE_ID = /^(?:coords|node|way|relation):|^https?:\/\/|^-?\d+(?:\.\d+)?,\s*-?\d+(?:\.\d+)?$/i;
+// The subset that still has a provider behind it — Overpass for details,
+// Wikimedia for photos.
+const OSM_PLACE_ID = /^(?:node|way|relation):/i;
+
+export function isGooglePlaceId(placeId: string): boolean {
+  return !NON_GOOGLE_PLACE_ID.test(placeId);
+}
+
 export async function getPlaceDetails(
   userId: number,
   placeId: string,
@@ -912,6 +1041,11 @@ export async function getPlaceDetails(
     phone: data.nationalPhoneNumber || null,
     opening_hours: data.regularOpeningHours?.weekdayDescriptions || null,
     open_now: data.regularOpeningHours?.openNow ?? null,
+    // open_now is a snapshot Google took when this payload was fetched and it is cached
+    // for days; the periods let the client recompute the state in the place's own
+    // timezone, which the localised weekday lines above cannot do. Issue #1680.
+    opening_periods: normalizeOpeningPeriods(data.regularOpeningHours?.periods),
+    opening_special_days: normalizeSpecialDays(data.regularOpeningHours?.specialDays),
     google_maps_url: data.googleMapsUri || null,
     summary: null,
     reviews: [],
@@ -935,7 +1069,16 @@ export async function getPlaceDetailsExpanded(
   placeId: string,
   lang?: string,
   refresh = false,
-): Promise<{ place: Record<string, unknown> }> {
+): Promise<{ place: Record<string, unknown> | null }> {
+  // Reviews and the editorial summary only exist at Google, but the id does not
+  // have to be a Google one — the client sends whatever the place carries. OSM ids
+  // keep the details they do have (Overpass, via the plain lookup); coordinate
+  // pseudo-ids and legacy image URLs have no details source at all. Neither may be
+  // forwarded to Google, which bills the 400 INVALID_ARGUMENT it answers with.
+  if (!isGooglePlaceId(placeId)) {
+    return OSM_PLACE_ID.test(placeId) ? getPlaceDetails(userId, placeId, lang) : { place: null };
+  }
+
   const langKey = toApiLang(lang, 'de');
   const apiKey = getMapsKey(userId);
   if (!apiKey) throw Object.assign(new Error('Google Maps API key not configured'), { status: 400 });
@@ -982,6 +1125,8 @@ export async function getPlaceDetailsExpanded(
     phone: data.nationalPhoneNumber || null,
     opening_hours: data.regularOpeningHours?.weekdayDescriptions || null,
     open_now: data.regularOpeningHours?.openNow ?? null,
+    opening_periods: normalizeOpeningPeriods(data.regularOpeningHours?.periods),
+    opening_special_days: normalizeSpecialDays(data.regularOpeningHours?.specialDays),
     google_maps_url: data.googleMapsUri || null,
     summary: data.editorialSummary?.text || null,
     reviews: (data.reviews || []).slice(0, 5).map((r: NonNullable<GooglePlaceDetails['reviews']>[number]) => ({
@@ -1014,29 +1159,38 @@ export async function getPlacePhoto(
   lat: number,
   lng: number,
   name?: string,
-): Promise<{ photoUrl: string; attribution: string | null }> {
+): Promise<{ photoUrl: string | null; attribution: string | null }> {
   // Disk cache hit — serve immediately, no Google call
   const diskHit = placePhotoCache.get(placeId);
   if (diskHit) return { photoUrl: diskHit.photoUrl, attribution: diskHit.attribution };
 
-  // Recent error — don't hammer the API
-  if (placePhotoCache.getErrored(placeId)) {
-    throw Object.assign(new Error('(Cache) No photo available'), { status: 404 });
-  }
+  // "No photo for this place" is an empty result, not a missing resource: a trip
+  // view asks for one photo per place, so answering each miss with a 404 makes a
+  // normal itinerary render look like a 404 scan to fail2ban/CrowdSec and gets
+  // the user's IP banned. Every miss below returns photoUrl: null instead — the
+  // same shape the photos kill-switch already returns.
+  const noPhoto = { photoUrl: null, attribution: null };
+
+  // Recent miss — don't hammer the API
+  if (placePhotoCache.getErrored(placeId)) return noPhoto;
 
   // Deduplicate concurrent requests for the same placeId
   const existing = placePhotoCache.getInFlight(placeId);
   if (existing) {
     const result = await existing;
-    if (!result) throw Object.assign(new Error('(Cache) No photo available'), { status: 404 });
+    if (!result) return noPhoto;
     return { photoUrl: `/api/maps/place-photo/${encodeURIComponent(placeId)}/bytes`, attribution: result.attribution };
   }
+
+  // Tells the two empty outcomes apart for the negative cache below: a place that
+  // has no photo anywhere is worth remembering for a day, a provider that refused
+  // or timed out only for a few minutes.
+  let providerFailed = false;
 
   const fetchPromise = (async (): Promise<{ filePath: string; attribution: string | null } | null> => {
     await acquirePhotoFetchSlot();
     try {
       const apiKey = getMapsKey(userId);
-      const isCoordLookup = placeId.startsWith('coords:');
 
       // Coordinate-based Wikipedia/Wikimedia lookup. Used for coordinate-only
       // (right-click) places and as a fallback when a Google place yields no photo,
@@ -1050,21 +1204,25 @@ export async function getPlacePhoto(
           // Follow redirects manually so each hop (the image URL can 3xx to a CDN
           // host) is re-validated against the SSRF guard, not just the first URL.
           const imgRes = await safeFetchFollow(wiki.photoUrl, undefined, { bypassInternalIpAllowed: true });
-          if (!imgRes.ok) return null;
+          if (!imgRes.ok) {
+            providerFailed = true;
+            return null;
+          }
           const bytes = Buffer.from(await imgRes.arrayBuffer());
           const cached = await placePhotoCache.put(placeId, bytes, wiki.attribution);
           return { filePath: cached.filePath, attribution: cached.attribution };
         } catch {
+          providerFailed = true;
           return null;
         }
       };
 
-      // Google Places photo for a Google place_id. Returns null (without marking an
-      // error) on any miss — no key, URL-shaped id, request rejected, no photos, or
-      // a failed media download — so the caller can fall back to Wikimedia.
+      // Google Places photo for a Google place_id. Returns null on any miss — no
+      // key, request rejected, no photos, or a failed media download — so the
+      // caller can fall back to Wikimedia; the misses that were Google's fault
+      // flag providerFailed on the way out.
       const fetchGooglePhoto = async (): Promise<{ filePath: string; attribution: string | null } | null> => {
-        // URL-shaped placeIds aren't Google IDs — legacy DBs may store raw photo URLs in image_url
-        if (!apiKey || /^https?:\/\//i.test(placeId)) return null;
+        if (!apiKey) return null;
 
         // Fetch details to get the photo name
         const detailsRes = await googleFetch(
@@ -1080,12 +1238,14 @@ export async function getPlacePhoto(
         const body = await detailsRes.text();
         if (!detailsRes.ok) {
           console.error('Google Places photo details error:', detailsRes.status, body.slice(0, 200));
+          providerFailed = true;
           return null;
         }
         let details: GooglePlaceDetails & { error?: { message?: string } };
         try {
           details = body ? JSON.parse(body) : { photos: [] };
         } catch {
+          providerFailed = true;
           return null;
         }
         if (!details.photos?.length) return null;
@@ -1100,10 +1260,17 @@ export async function getPlacePhoto(
           `getPlacePhoto/media(${placeId})`,
           { headers: { 'X-Goog-Api-Key': apiKey } },
         );
-        if (!mediaRes.ok) return null;
+        // The place does have a photo — only the download for it went wrong.
+        if (!mediaRes.ok) {
+          providerFailed = true;
+          return null;
+        }
 
         const bytes = Buffer.from(await mediaRes.arrayBuffer());
-        if (!bytes.length) return null;
+        if (!bytes.length) {
+          providerFailed = true;
+          return null;
+        }
 
         const cached = await placePhotoCache.put(placeId, bytes, attribution);
 
@@ -1121,8 +1288,8 @@ export async function getPlacePhoto(
 
       // Prefer the Google photo (higher quality); if Google yields nothing, fall
       // back to the same coordinate-based Wikipedia/OSM lookup that right-click
-      // places use. Coordinate-only ids skip Google entirely.
-      if (!isCoordLookup) {
+      // places use. Ids Google cannot resolve skip it entirely.
+      if (isGooglePlaceId(placeId)) {
         const googlePhoto = await fetchGooglePhoto();
         if (googlePhoto) return googlePhoto;
       }
@@ -1130,7 +1297,7 @@ export async function getPlacePhoto(
       const fallback = await fetchWikimediaFallback();
       if (fallback) return fallback;
 
-      placePhotoCache.markError(placeId);
+      placePhotoCache.markError(placeId, providerFailed ? 'provider-error' : 'no-photo');
       return null;
     } finally {
       releasePhotoFetchSlot();
@@ -1140,7 +1307,7 @@ export async function getPlacePhoto(
   placePhotoCache.setInFlight(placeId, fetchPromise);
 
   const result = await fetchPromise;
-  if (!result) throw Object.assign(new Error('No photo available'), { status: 404 });
+  if (!result) return noPhoto;
   return { photoUrl: `/api/maps/place-photo/${encodeURIComponent(placeId)}/bytes`, attribution: result.attribution };
 }
 

--- a/server/src/services/placeEnrichment.ts
+++ b/server/src/services/placeEnrichment.ts
@@ -121,8 +121,9 @@ async function enrichOne(tripId: string, userId: number, place: EnrichablePlace,
      WHERE id = ? AND trip_id = ?`,
   ).run(gpid, gftid, str(match.address), str(match.website), str(match.phone), place.id, tripId);
 
-  // Photo is best-effort: Google often has none, and getPlacePhoto throws 404 in
-  // that case — a missing photo must never abort the rest of the enrichment.
+  // Photo is best-effort: Google often has none, in which case getPlacePhoto
+  // resolves with photoUrl: null. A missing photo (or a provider outage, which
+  // still throws) must never abort the rest of the enrichment.
   try {
     const photo = await getPlacePhoto(userId, gpid, place.lat, place.lng, place.name);
     if (photo?.photoUrl) {

--- a/server/src/services/placePhotoCache.ts
+++ b/server/src/services/placePhotoCache.ts
@@ -10,7 +10,22 @@ import path from 'node:path';
 // Overridable for tests (mirrors the TREK_DB_FILE seam) so the suite never touches
 // the real uploads tree.
 const GOOGLE_PHOTO_DIR = readEnv().paths.placePhotoDir || path.join(__dirname, '../../uploads/photos/google');
-const ERROR_TTL = 5 * 60 * 1000;
+// How long a "no photo for this place" answer stays remembered. Nothing about it
+// changes until a photo appears upstream, so it is worth keeping: without it every
+// trip open replays the whole provider fan-out, one lookup per place. A day is
+// still short enough that a newly configured API key takes effect overnight.
+// Entries are dropped outright when the place goes away (removeIfUnreferenced /
+// sweepOrphans).
+const MISSING_TTL = 24 * 60 * 60 * 1000;
+// A provider call that failed says nothing about the place — only that the API was
+// unreachable or unhappy just now. It is remembered just long enough to stop a
+// screenful of markers from hammering an API that is down, and only in memory, so
+// a restart retries right away.
+const FAILURE_TTL = 5 * 60 * 1000;
+const recentFailures = new Map<string, number>();
+// Sweep expired failures once the map grows past this. Whatever survives the sweep
+// is younger than FAILURE_TTL and expires on its own shortly after.
+const FAILURE_SWEEP_AT = 500;
 
 // Marker photos are displayed tiny — cap stored images so an oversized source
 // (e.g. a Wikimedia Commons full-res original) can't bloat the cache. Matches
@@ -72,15 +87,36 @@ export function get(placeId: string): CachedPhoto | null {
 }
 
 export function getErrored(placeId: string): boolean {
+  const failedAt = recentFailures.get(placeId);
+  if (failedAt !== undefined) {
+    if (Date.now() - failedAt < FAILURE_TTL) return true;
+    recentFailures.delete(placeId);
+  }
+
   const row = db
     .prepare('SELECT error_at FROM google_place_photo_meta WHERE place_id = ? AND error_at IS NOT NULL')
     .get(placeId) as { error_at: number } | undefined;
 
   if (!row) return false;
-  return Date.now() - row.error_at < ERROR_TTL;
+  return Date.now() - row.error_at < MISSING_TTL;
 }
 
-export function markError(placeId: string): void {
+// Remember that a lookup came back empty. 'no-photo' is the lasting answer — no
+// provider has an image for this place — and is persisted; 'provider-error' is a
+// failed attempt and is only held in memory for a few minutes.
+export function markError(placeId: string, kind: 'no-photo' | 'provider-error' = 'no-photo'): void {
+  if (kind === 'provider-error') {
+    if (recentFailures.size >= FAILURE_SWEEP_AT) {
+      const cutoff = Date.now() - FAILURE_TTL;
+      for (const [id, at] of recentFailures) {
+        if (at <= cutoff) recentFailures.delete(id);
+      }
+    }
+    recentFailures.set(placeId, Date.now());
+    return;
+  }
+
+  recentFailures.delete(placeId);
   knownOnDisk.delete(placeId);
   db.prepare(
     'INSERT OR REPLACE INTO google_place_photo_meta (place_id, attribution, fetched_at, error_at) VALUES (?, NULL, ?, ?)',
@@ -111,6 +147,7 @@ export async function put(placeId: string, bytes: Buffer, attribution: string | 
   await fsPromises.rename(tmp, fp);
 
   knownOnDisk.add(placeId);
+  recentFailures.delete(placeId);
 
   db.prepare(
     'INSERT OR REPLACE INTO google_place_photo_meta (place_id, attribution, fetched_at, error_at) VALUES (?, ?, ?, NULL)',

--- a/server/src/services/transitService.ts
+++ b/server/src/services/transitService.ts
@@ -302,7 +302,11 @@ export async function plan(q: PlanQuery): Promise<{ itineraries: TransitItinerar
       duration: typeof leg.duration === 'number' ? leg.duration : 0,
       distance: typeof leg.distance === 'number' ? Math.round(leg.distance) : null,
       headsign: leg.headsign || null,
-      line: leg.routeShortName || leg.displayName || null,
+      // displayName is the public identifier MOTIS resolved for the run, taking
+      // the trip number into account where the feed has one. Plenty of operators
+      // (German long distance among them) keep routeShortName as an internal line
+      // number, so preferring it showed "20" instead of "ICE 72" (#1715).
+      line: leg.displayName || leg.routeShortName || null,
       lineColor: safeColor(leg.routeColor),
       lineTextColor: safeColor(leg.routeTextColor),
       agency: leg.agencyName || null,

--- a/server/tests/integration/maps.test.ts
+++ b/server/tests/integration/maps.test.ts
@@ -265,15 +265,43 @@ describe('Maps happy paths (mocked service)', () => {
   it('MAPS-004 — getPlacePhoto error with status returns that status', async () => {
     const { user } = createUser(testDb);
     vi.mocked(mapsService.getPlacePhoto).mockRejectedValueOnce(
-      Object.assign(new Error('Photo not found'), { status: 404 })
+      Object.assign(new Error('Photo provider unavailable'), { status: 503 })
     );
 
     const res = await request(app)
       .get('/api/maps/place-photo/some-place-id?lat=48.8&lng=2.3')
       .set('Cookie', authCookie(user.id));
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(503);
     expect(res.body).toHaveProperty('error');
+  });
+
+  // A photo-less place must answer 200 { photoUrl: null }: one 404 per place turns
+  // a normal itinerary render into a 404 storm that fail2ban/CrowdSec bans (#1727).
+  it('MAPS-004b — a place with no photo answers 200 with photoUrl null', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(mapsService.getPlacePhoto).mockResolvedValueOnce({ photoUrl: null, attribution: null });
+
+    const res = await request(app)
+      .get('/api/maps/place-photo/node%3A5255005321?lat=36.76&lng=-3.84&name=Nerja')
+      .set('Cookie', authCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ photoUrl: null, attribution: null });
+  });
+
+  // Places keep the bytes URL in image_url, so an evicted cache entry means one
+  // request per place on the next trip render — the second half of the same ban
+  // vector. Nothing to serve is an empty 204, not a 404.
+  it('MAPS-004c — the bytes proxy answers 204 for a photo that is not cached', async () => {
+    const { user } = createUser(testDb);
+
+    const res = await request(app)
+      .get('/api/maps/place-photo/ChIJnot-cached/bytes')
+      .set('Cookie', authCookie(user.id));
+
+    expect(res.status).toBe(204);
+    expect(res.text).toBeFalsy();
   });
 
   it('MAPS-005 — reverseGeocode error returns null values', async () => {

--- a/server/tests/unit/middleware/globalMiddleware.csp.test.ts
+++ b/server/tests/unit/middleware/globalMiddleware.csp.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { applyGlobalMiddleware } from '../../../src/middleware/globalMiddleware';
+
+async function connectSrcSources(): Promise<string[]> {
+  const app = express();
+  applyGlobalMiddleware(app, { bodyParser: false });
+  app.get('/probe', (_req, res) => res.json({ ok: true }));
+
+  const res = await request(app).get('/probe');
+  const csp = String(res.headers['content-security-policy'] || '');
+  const directive = csp
+    .split(';')
+    .map(d => d.trim())
+    .find(d => d.startsWith('connect-src'));
+
+  return directive ? directive.split(/\s+/).slice(1) : [];
+}
+
+describe('global CSP: OpenStreetMap tile hosts (#1733)', () => {
+  it('allows the bare tile.openstreetmap.org host', async () => {
+    // A CSP wildcard host never matches the apex, so `*.tile.openstreetmap.org`
+    // alone would block the tile prefetcher's fetch() against the single host
+    // OSM has served from since it retired a/b/c/d sharding.
+    expect(await connectSrcSources()).toContain('https://tile.openstreetmap.org');
+  });
+
+  it('still allows the sharded hosts for templates saved earlier', async () => {
+    expect(await connectSrcSources()).toContain('https://*.tile.openstreetmap.org');
+  });
+});

--- a/server/tests/unit/nest/llm-parse/mime-email.test.ts
+++ b/server/tests/unit/nest/llm-parse/mime-email.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseEmail } from '../../../../src/nest/llm-parse/mime-email';
+
+/** Mail is CRLF-delimited on the wire — build the fixtures the same way. */
+const mail = (...lines: string[]) => Buffer.from(lines.join('\r\n'), 'latin1');
+
+const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+describe('mime-email', () => {
+  it('rejects a buffer that is not a message', () => {
+    expect(parseEmail(Buffer.from('<html><body>Flight AB123</body></html>'))).toBeNull();
+    expect(parseEmail(Buffer.from(''))).toBeNull();
+    // Looks like a header field, but names none of the envelope headers.
+    expect(parseEmail(Buffer.from('note:\r\n\r\nnothing here'))).toBeNull();
+  });
+
+  it('tolerates a leading utf-8 BOM', () => {
+    const parsed = parseEmail(
+      Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        mail('From: a@example.com', 'Subject: Hi', 'Content-Type: text/plain', '', 'Booking 4711', ''),
+      ]),
+    );
+    expect(parsed?.text).toBe('Booking 4711\n');
+  });
+
+  it('decodes a base64 body and keeps the summary headers', () => {
+    const parsed = parseEmail(
+      mail(
+        'Return-Path: <noreply@airline.example>',
+        'From: Airline <noreply@airline.example>',
+        'To: traveller@example.com',
+        'Subject: Your booking',
+        'Date: Mon, 12 May 2025 09:00:00 +0200',
+        'MIME-Version: 1.0',
+        'Content-Type: text/html; charset=utf-8',
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64('<html><body><p>Flight AB123</p></body></html>'),
+        '',
+      ),
+    );
+    expect(parsed?.html).toBe('<html><body><p>Flight AB123</p></body></html>');
+    expect(parsed?.text).toBeNull();
+    expect(parsed?.headerLines).toEqual([
+      'From: Airline <noreply@airline.example>',
+      'To: traveller@example.com',
+      'Subject: Your booking',
+      'Date: Mon, 12 May 2025 09:00:00 +0200',
+    ]);
+  });
+
+  it('decodes quoted-printable including soft line breaks', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: hotel@example.com',
+        'Subject: Reservation',
+        'Content-Type: text/plain; charset=utf-8',
+        'Content-Transfer-Encoding: quoted-printable',
+        '',
+        'Zimmer f=C3=BCr zwei Personen, Preis 120,00 =E2=82=AC. Buchungsnummer=',
+        ' XYZ-42',
+        '',
+      ),
+    );
+    expect(parsed?.text).toBe('Zimmer für zwei Personen, Preis 120,00 €. Buchungsnummer XYZ-42\n');
+  });
+
+  it('reads both parts of a multipart/alternative', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: rail@example.com',
+        'Subject: Ticket',
+        'MIME-Version: 1.0',
+        'Content-Type: multipart/alternative; boundary="=_alt_1"',
+        '',
+        'This is a multi-part message in MIME format.',
+        '--=_alt_1',
+        'Content-Type: text/plain; charset=utf-8',
+        'Content-Transfer-Encoding: quoted-printable',
+        '',
+        'Train IC 2043, coach 7',
+        '--=_alt_1',
+        'Content-Type: text/html; charset=utf-8',
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64('<p>Train IC 2043, coach 7</p>'),
+        '--=_alt_1--',
+        '',
+      ),
+    );
+    expect(parsed?.text).toBe('Train IC 2043, coach 7');
+    expect(parsed?.html).toBe('<p>Train IC 2043, coach 7</p>');
+  });
+
+  it('walks nested multiparts and skips attachments', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: rental@example.com',
+        'Subject: Voucher',
+        'Content-Type: multipart/mixed; boundary=outer',
+        '',
+        '--outer',
+        'Content-Type: multipart/related; boundary="inner"',
+        '',
+        '--inner',
+        'Content-Type: text/html; charset=utf-8',
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64('<p>Pickup 14:00</p>'),
+        '--inner--',
+        '--outer',
+        'Content-Type: application/pdf; name="voucher.pdf"',
+        'Content-Disposition: attachment; filename="voucher.pdf"',
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64('%PDF-1.4 binary junk'),
+        '--outer--',
+        '',
+      ),
+    );
+    expect(parsed?.html).toBe('<p>Pickup 14:00</p>');
+    expect(parsed?.text).toBeNull();
+  });
+
+  it('skips a text part that is flagged as an attachment', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: a@example.com',
+        'Content-Type: multipart/mixed; boundary=b1',
+        '',
+        '--b1',
+        'Content-Type: text/plain; charset=utf-8',
+        'Content-Disposition: attachment; filename="notes.txt"',
+        '',
+        'attached notes',
+        '--b1--',
+        '',
+      ),
+    );
+    expect(parsed?.text).toBeNull();
+    expect(parsed?.html).toBeNull();
+  });
+
+  it('honours the part charset', () => {
+    const latin1 = Buffer.from('Hôtel Rivière, Zürich', 'latin1').toString('base64');
+    const parsed = parseEmail(
+      mail(
+        'From: hotel@example.com',
+        'Content-Type: text/plain; charset="iso-8859-1"',
+        'Content-Transfer-Encoding: base64',
+        '',
+        latin1,
+        '',
+      ),
+    );
+    expect(parsed?.text).toBe('Hôtel Rivière, Zürich');
+  });
+
+  it('falls back to utf8 for an unknown charset', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: hotel@example.com',
+        'Content-Type: text/plain; charset=x-made-up',
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64('Zürich Hbf'),
+        '',
+      ),
+    );
+    expect(parsed?.text).toBe('Zürich Hbf');
+  });
+
+  it('decodes RFC 2047 encoded-words in the subject', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: =?utf-8?q?Fl=C3=BCge?= <a@example.com>',
+        `Subject: =?utf-8?B?${b64('Buchungsbestätigung')}?= =?utf-8?Q?_f=C3=BCr_M=C3=BCnchen?=`,
+        'Content-Type: text/plain',
+        '',
+        'body',
+        '',
+      ),
+    );
+    expect(parsed?.headerLines).toContain('Subject: Buchungsbestätigung für München');
+    expect(parsed?.headerLines).toContain('From: Flüge <a@example.com>');
+  });
+
+  it('unfolds headers that span multiple lines', () => {
+    const parsed = parseEmail(
+      mail(
+        'From: a@example.com',
+        'Subject: Booking',
+        '\tconfirmation 12345',
+        'Content-Type: text/plain;',
+        ' charset=utf-8',
+        '',
+        'body',
+        '',
+      ),
+    );
+    expect(parsed?.headerLines).toContain('Subject: Booking confirmation 12345');
+    expect(parsed?.text).toBe('body\n');
+  });
+
+  it('walks into a forwarded message/rfc822 part', () => {
+    const inner = [
+      'From: airline@example.com',
+      'Subject: Original',
+      'Content-Type: text/html; charset=utf-8',
+      'Content-Transfer-Encoding: base64',
+      '',
+      b64('<p>Seat 12A</p>'),
+    ].join('\r\n');
+    const parsed = parseEmail(
+      mail(
+        'From: colleague@example.com',
+        'Subject: Fwd: Original',
+        'Content-Type: multipart/mixed; boundary=fwd',
+        '',
+        '--fwd',
+        'Content-Type: message/rfc822',
+        '',
+        inner,
+        '--fwd--',
+        '',
+      ),
+    );
+    expect(parsed?.html).toBe('<p>Seat 12A</p>');
+  });
+
+  it('returns empty bodies for a multipart without a usable boundary', () => {
+    const parsed = parseEmail(
+      mail('From: a@example.com', 'Content-Type: multipart/mixed', '', 'nothing to split here', ''),
+    );
+    expect(parsed?.html).toBeNull();
+    expect(parsed?.text).toBeNull();
+  });
+
+  it('treats a message without a content-type as plain text', () => {
+    const parsed = parseEmail(mail('From: a@example.com', 'Subject: Hi', '', 'Booking 4711', ''));
+    expect(parsed?.text).toBe('Booking 4711\n');
+  });
+});

--- a/server/tests/unit/nest/llm-parse/text-extract.test.ts
+++ b/server/tests/unit/nest/llm-parse/text-extract.test.ts
@@ -32,9 +32,198 @@ describe('text-extract', () => {
     expect(out).not.toContain('x{}');
   });
 
+  it('decodes html entities so the model reads the actual characters', async () => {
+    const html =
+      '<p>Zimmer f&uuml;r zwei &ndash; 120,00 &euro;</p><p>Gate &#88; / Terminal &#x58;</p>' +
+      '<p>&Uuml;berfahrt: Meier &amp; S&ouml;hne</p>';
+    const out = await extractText(Buffer.from(html, 'utf8'), 'a.html');
+    expect(out).toContain('Zimmer für zwei – 120,00 €');
+    expect(out).toContain('Gate X / Terminal X');
+    expect(out).toContain('Überfahrt: Meier & Söhne');
+    expect(out).not.toContain('&uuml;');
+    expect(out).not.toContain('&#88;');
+  });
+
+  it('turns non-breaking spaces into normal ones and leaves unknown entities alone', async () => {
+    const out = await extractText(
+      Buffer.from('<p>Sitz&nbsp;12A</p><p>Gleis&#160;7</p><p>&notanentity;</p>', 'utf8'),
+      'a.html',
+    );
+    expect(out).toContain('Sitz 12A');
+    expect(out).toContain('Gleis 7');
+    expect(out).toContain('&notanentity;');
+  });
+
+  it('resolves shouted entity names and keeps unusable numeric references', async () => {
+    const out = await extractText(Buffer.from('<p>Preis 12 &EURO; &#0; &#xD800; &#1114112;</p>', 'utf8'), 'a.html');
+    expect(out).toContain('Preis 12 €');
+    expect(out).toContain('&#0;');
+    expect(out).toContain('&#xD800;');
+    expect(out).toContain('&#1114112;');
+  });
+
+  it('decodes entities after the tags are gone, so escaped markup survives', async () => {
+    const out = await extractText(Buffer.from('<p>Regel: &lt;b&gt;fett&lt;/b&gt;</p>', 'utf8'), 'a.html');
+    expect(out).toContain('Regel: <b>fett</b>');
+  });
+
   it('extracts the embedded text layer from a pdf', async () => {
     const out = await extractText(Buffer.from('%PDF-1.4'), 'a.pdf');
     expect(out).toBe('Hotel X — confirmation ABC');
     expect(getText).toHaveBeenCalled();
+  });
+
+  describe('eml', () => {
+    const mail = (...lines: string[]) => Buffer.from(lines.join('\r\n'), 'latin1');
+    const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+    it('decodes a base64 html body instead of feeding the encoded blob to the model', async () => {
+      const body = b64('<html><body><h1>Flight AB123</h1><p>Seat 12A</p></body></html>');
+      const out = await extractText(
+        mail(
+          'From: Airline <noreply@airline.example>',
+          'Subject: Your booking',
+          'MIME-Version: 1.0',
+          'Content-Type: text/html; charset=utf-8',
+          'Content-Transfer-Encoding: base64',
+          '',
+          body,
+          '',
+        ),
+        'booking.eml',
+      );
+      expect(out).toContain('Flight AB123');
+      expect(out).toContain('Seat 12A');
+      expect(out).toContain('Subject: Your booking');
+      expect(out).not.toContain(body.slice(0, 24));
+      expect(out).not.toContain('<h1>');
+    });
+
+    it('decodes a quoted-printable html body', async () => {
+      const out = await extractText(
+        mail(
+          'From: hotel@example.com',
+          'Subject: Reservation',
+          'Content-Type: text/html; charset=utf-8',
+          'Content-Transfer-Encoding: quoted-printable',
+          '',
+          '<p>Zimmer f=C3=BCr zwei, 120,00 =E2=82=AC, Buchungsnummer=',
+          ' XYZ-42</p>',
+          '',
+        ),
+        'hotel.eml',
+      );
+      expect(out).toContain('Zimmer für zwei, 120,00 €, Buchungsnummer XYZ-42');
+      expect(out).not.toContain('=C3=BC');
+    });
+
+    it('prefers the html part of a multipart/alternative', async () => {
+      const out = await extractText(
+        mail(
+          'From: rail@example.com',
+          'Subject: Ticket',
+          'Content-Type: multipart/alternative; boundary="=_alt_1"',
+          '',
+          '--=_alt_1',
+          'Content-Type: text/plain; charset=utf-8',
+          '',
+          'plain fallback',
+          '--=_alt_1',
+          'Content-Type: text/html; charset=utf-8',
+          'Content-Transfer-Encoding: base64',
+          '',
+          b64('<p>Train IC 2043, coach 7</p>'),
+          '--=_alt_1--',
+          '',
+        ),
+        'ticket.eml',
+      );
+      expect(out).toContain('Train IC 2043, coach 7');
+      expect(out).not.toContain('plain fallback');
+    });
+
+    it('reads a plain-text mail', async () => {
+      const out = await extractText(
+        mail(
+          'From: ferry@example.com',
+          'Subject: Crossing',
+          'Content-Type: text/plain; charset=utf-8',
+          '',
+          'Booking 4711',
+          'Departure 08:30',
+          '',
+        ),
+        'ferry.eml',
+      );
+      expect(out).toContain('Booking 4711');
+      expect(out).toContain('Departure 08:30');
+    });
+
+    it('falls back to markup stripping when the .eml is not a MIME message', async () => {
+      const out = await extractText(Buffer.from('<html><body><p>Flight AB123</p></body></html>'), 'saved.eml');
+      expect(out).toBe('Flight AB123');
+    });
+
+    it('keeps the raw content when the mail carries no readable body part', async () => {
+      const attachment = b64('%PDF-1.4 ticket');
+      const out = await extractText(
+        mail(
+          'From: airline@example.com',
+          'Subject: Booking 4711',
+          'MIME-Version: 1.0',
+          'Content-Type: multipart/mixed; boundary="=_mix_1"',
+          '',
+          '--=_mix_1',
+          'Content-Type: application/pdf; name="ticket.pdf"',
+          'Content-Transfer-Encoding: base64',
+          'Content-Disposition: attachment; filename="ticket.pdf"',
+          '',
+          attachment,
+          '--=_mix_1--',
+          '',
+        ),
+        'attached.eml',
+      );
+      expect(out).toContain('Subject: Booking 4711');
+      expect(out).toContain(attachment);
+    });
+
+    it('uses the plain-text alternative when the html part is empty', async () => {
+      const out = await extractText(
+        mail(
+          'From: hotel@example.com',
+          'Subject: Reservation',
+          'Content-Type: multipart/alternative; boundary="=_alt_2"',
+          '',
+          '--=_alt_2',
+          'Content-Type: text/plain; charset=utf-8',
+          '',
+          'Zimmer 12, Anreise 04.08.',
+          '--=_alt_2',
+          'Content-Type: text/html; charset=utf-8',
+          '',
+          '<html><body></body></html>',
+          '--=_alt_2--',
+          '',
+        ),
+        'empty-html.eml',
+      );
+      expect(out).toContain('Zimmer 12, Anreise 04.08.');
+    });
+
+    it('decodes entities in an html mail body', async () => {
+      const out = await extractText(
+        mail(
+          'From: hotel@example.com',
+          'Subject: Reservierung',
+          'Content-Type: text/html; charset=utf-8',
+          '',
+          '<p>Zimmer f&uuml;r zwei &ndash; 120,00 &euro;</p>',
+          '',
+        ),
+        'entities.eml',
+      );
+      expect(out).toContain('Zimmer für zwei – 120,00 €');
+    });
   });
 });

--- a/server/tests/unit/nest/maps.controller.test.ts
+++ b/server/tests/unit/nest/maps.controller.test.ts
@@ -210,10 +210,18 @@ describe('MapsController (parity with the legacy /api/maps route)', () => {
     });
 
     it('maps a 4xx service error', async () => {
-      const photo = vi.fn().mockRejectedValue(withError(404, 'No photo available'));
+      const photo = vi.fn().mockRejectedValue(withError(429, 'Rate limited'));
       expect(await thrown(() => makeController({ photosDisabled: () => false, photo }).placePhoto(user, 'p1', '1', '2'))).toEqual({
-        status: 404, body: { error: 'No photo available' },
+        status: 429, body: { error: 'Rate limited' },
       });
+    });
+
+    // A place without a photo is an empty result, not a 404 — one 404 per photo-less
+    // place gets the user banned by any 404-rate IPS in front of TREK (#1727).
+    it('passes a photo-less place through as a 200 with photoUrl null', async () => {
+      const photo = vi.fn().mockResolvedValue({ photoUrl: null, attribution: null });
+      const res = await makeController({ photosDisabled: () => false, photo }).placePhoto(user, 'node:123', '1', '2');
+      expect(res).toEqual({ photoUrl: null, attribution: null });
     });
 
     it('logs and maps a 5xx service error', async () => {
@@ -244,17 +252,22 @@ describe('MapsController (parity with the legacy /api/maps route)', () => {
         json: vi.fn(),
         set: vi.fn(),
         type: vi.fn(),
+        end: vi.fn(),
       };
-      return res as unknown as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn>; type: ReturnType<typeof vi.fn> };
+      return res as unknown as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn>; type: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
     }
 
     beforeEach(() => createReadStream.mockReset());
 
-    it('404 when the photo is not cached', () => {
+    // Places persist this URL in image_url, so an evicted cache entry means one
+    // request per place on a trip render. 404 for each of them is the ban vector
+    // from #1727 — an uncached photo answers 204 with an empty body instead.
+    it('204 without a body when the photo is not cached', () => {
       const res = makeRes();
       makeController({ photoBytesPath: () => null }).placePhotoBytes('p1', res);
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Photo not cached' });
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.end).toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
       expect(createReadStream).not.toHaveBeenCalled();
     });
 
@@ -269,18 +282,22 @@ describe('MapsController (parity with the legacy /api/maps route)', () => {
       expect(stream.pipe).toHaveBeenCalledWith(res);
     });
 
-    it('falls back to 404 when the read stream errors', () => {
+    it('falls back to an empty 204 when the read stream errors', () => {
       let onError: () => void = () => {};
       const stream = { on: vi.fn((ev: string, cb: () => void) => { if (ev === 'error') onError = cb; return stream; }), pipe: vi.fn() };
       createReadStream.mockReturnValue(stream);
       const res = makeRes();
       makeController({ photoBytesPath: () => '/cache/p1.jpg' }).placePhotoBytes('p1', res);
       onError();
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Photo not cached' });
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.end).toHaveBeenCalled();
+      // The hit path already asked for a month of immutable caching — that header
+      // must not survive onto the empty answer, or the photo stays hidden once it
+      // is back in the cache.
+      expect(res.set).toHaveBeenLastCalledWith('Cache-Control', 'no-store');
     });
 
-    it('does not re-send a 404 when the stream errors after headers were flushed', () => {
+    it('does not re-send a 204 when the stream errors after headers were flushed', () => {
       let onError: () => void = () => {};
       const stream = { on: vi.fn((ev: string, cb: () => void) => { if (ev === 'error') onError = cb; return stream; }), pipe: vi.fn() };
       createReadStream.mockReturnValue(stream);
@@ -289,7 +306,7 @@ describe('MapsController (parity with the legacy /api/maps route)', () => {
       makeController({ photoBytesPath: () => '/cache/p1.jpg' }).placePhotoBytes('p1', res);
       onError();
       expect(res.status).not.toHaveBeenCalled();
-      expect(res.json).not.toHaveBeenCalled();
+      expect(res.end).not.toHaveBeenCalled();
     });
   });
 

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -79,6 +79,9 @@ vi.mock('../../../src/services/placeService', () => ({
   createPlace: vi.fn((tid: string, body: Record<string, unknown>) => ({ id: 10, trip_id: Number(tid), ...body })),
   updatePlace: vi.fn((_tid: string, pid: string) => (pid === '99' ? null : { id: Number(pid) })),
   deletePlace: vi.fn((_tid: string, pid: string) => pid !== '99'),
+  // Trip-scoped read the delete path uses to reject a foreign id before the
+  // journey hook runs — place 99 belongs to another trip.
+  getPlace: vi.fn((_tid: string, pid: string) => (pid === '99' ? null : { id: Number(pid) })),
   // trips.service (loaded for real since the trip fold) imports listPlaces for
   // its offline bundle — the mock must carry every named export it pulls.
   listPlaces: vi.fn(() => []),
@@ -111,6 +114,7 @@ const assignmentsStub = {
   dayExists: vi.fn((dayId: number) => dayId === 3),
   placeExists: vi.fn((placeId: number) => placeId === 7),
   getAssignmentForTrip: vi.fn((id: number) => (id === 99 ? undefined : { id, day_id: 3 })),
+  reconcile: vi.fn(),
 } as unknown as AssignmentsService;
 // Packing is a constructor-injected stub (same behaviors as the old path mock).
 const packingStub = {
@@ -235,6 +239,10 @@ vi.mock('../../../src/services/journeyService', () => ({
   // Consumed by the real assignments.service.ts module (loaded un-mocked as a
   // factory constructor dep); the instance is stubbed, so this is never called.
   reconcileTripSkeletons: vi.fn(),
+  // The skeleton hooks the place writes fire (#1705).
+  onPlaceCreated: vi.fn(),
+  onPlaceUpdated: vi.fn(),
+  onPlaceDeleted: vi.fn(),
   listJourneys: vi.fn((uid: number) => [{ id: 1, owner: uid }]),
   // journeyId 88 = no access (listEntries self-gates to null); else returns entries
   listEntries: vi.fn((journeyId: number, uid: number) => (journeyId === 88 ? null : [{ id: 10, journey_id: journeyId, author_id: uid }])),
@@ -288,6 +296,8 @@ const vacayStub = {
 import { PluginHostDepsFactory, type PluginCallRouter } from '../../../src/nest/plugins/host/plugin-host-deps.factory';
 import { getPluginDataDb, closePluginDataDb } from '../../../src/nest/plugins/host/plugin-host-state';
 import { db as mockDb } from '../../../src/db/database';
+import { onPlaceCreated, onPlaceUpdated, onPlaceDeleted } from '../../../src/services/journeyService';
+import { deletePlace as deletePlaceSvc } from '../../../src/services/placeService';
 import type { BudgetService } from '../../../src/nest/budget/budget.service';
 import type { ExchangeRatesService } from '../../../src/nest/budget/exchange-rates.service';
 import type { ReservationsService } from '../../../src/nest/reservations/reservations.service';
@@ -425,6 +435,47 @@ describe('host-deps factory — planner write + metadata deps', () => {
     expect((await call(h, 'places.delete', { tripId: 1, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
   });
 
+  // #1705: a place write from a plugin has to update a linked journey the same way
+  // the REST route does, otherwise the journey shows the old title (or an entry for
+  // a place that no longer exists) until it is reloaded.
+  it('places writes fire the journey hooks, delete ahead of the row, and skip a foreign id', async () => {
+    const h = host('db:write:places');
+    const created = vi.mocked(onPlaceCreated);
+    const updated = vi.mocked(onPlaceUpdated);
+    const deleted = vi.mocked(onPlaceDeleted);
+    const removePlace = vi.mocked(deletePlaceSvc);
+    [created, updated, deleted, removePlace].forEach((m) => m.mockClear());
+
+    expect((await call(h, 'places.create', { tripId: 1, input: { name: 'P' } })).ok).toBe(true);
+    expect(created).toHaveBeenCalledWith(1, 10);
+
+    expect((await call(h, 'places.update', { tripId: 1, placeId: 5, input: { name: 'Q' } })).ok).toBe(true);
+    expect(updated).toHaveBeenCalledWith(5);
+
+    expect((await call(h, 'places.delete', { tripId: 1, placeId: 5 })).ok).toBe(true);
+    expect(deleted).toHaveBeenCalledWith(5);
+    // source_place_id is ON DELETE SET NULL — after the row is gone the hook has
+    // nothing left to detach, so the order is part of the fix.
+    expect(deleted.mock.invocationCallOrder[0]).toBeLessThan(removePlace.mock.invocationCallOrder[0]);
+
+    // A place on another trip: refused before the hook can touch that trip's journeys.
+    deleted.mockClear();
+    updated.mockClear();
+    expect((await call(h, 'places.delete', { tripId: 1, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
+    expect((await call(h, 'places.update', { tripId: 1, placeId: 99, input: {} })).error.code).toBe('RESOURCE_FORBIDDEN');
+    expect(deleted).not.toHaveBeenCalled();
+    expect(updated).not.toHaveBeenCalled();
+  });
+
+  // A journey link that blows up must not turn a successful place write into an
+  // RPC error — every other caller of these hooks swallows them too.
+  it('places writes survive a throwing journey hook', async () => {
+    const h = host('db:write:places');
+    const updated = vi.mocked(onPlaceUpdated);
+    updated.mockImplementationOnce(() => { throw new Error('journey db locked'); });
+    expect((await call(h, 'places.update', { tripId: 1, placeId: 5, input: { name: 'Q' } })).ok).toBe(true);
+  });
+
   it('days + itinerary delegate; a day/place/assignment outside the trip is refused', async () => {
     const h = host('db:write:days', 'db:write:itinerary');
     expect((await call(h, 'days.create', { tripId: 1, input: { notes: 'n' } })).ok).toBe(true);
@@ -436,6 +487,28 @@ describe('host-deps factory — planner write + metadata deps', () => {
     expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 3, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
     expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 30 })).ok).toBe(true);
     expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  // #1705: a plugin itinerary write has to reach open sessions exactly like the REST
+  // route. The delete payload needs the dayId the client reducer evicts by, and both
+  // directions run the same journey-skeleton reconcile the controller/MCP tool run.
+  it('itinerary writes carry the dayId the client evicts by and re-mirror linked journeys', async () => {
+    const h = host('db:write:itinerary');
+    const reconcile = vi.mocked(assignmentsStub.reconcile);
+
+    reconcile.mockClear();
+    expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 })).ok).toBe(true);
+    expect(reconcile).toHaveBeenCalledWith(1);
+
+    reconcile.mockClear();
+    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 30 })).ok).toBe(true);
+    expect(broadcast).toHaveBeenCalledWith(1, 'assignment:deleted', { assignmentId: 30, dayId: 3 });
+    expect(reconcile).toHaveBeenCalledWith(1);
+
+    // A refused unassign deletes nothing, so it must not touch the journeys either.
+    reconcile.mockClear();
+    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
+    expect(reconcile).not.toHaveBeenCalled();
   });
 
   it('trips.update: archive/cover need their own permission; service errors map to RPC codes', async () => {

--- a/server/tests/unit/services/mapsService.test.ts
+++ b/server/tests/unit/services/mapsService.test.ts
@@ -8,9 +8,12 @@
  */
 import {
   parseOpeningHours,
+  normalizeOpeningPeriods,
+  normalizeSpecialDays,
   buildOsmDetails,
   getMapsKey,
   googleFtidFromMapsUrl,
+  isGooglePlaceId,
   buildUserAgent,
   resolveOverpassEndpoints,
   resolveOverpassTimeoutMs,
@@ -25,6 +28,7 @@ const {
   mockCheckSsrf,
   mockCacheGet,
   mockCacheGetErrored,
+  mockCacheMarkError,
   mockCachePut,
   mockCacheGetInFlight,
   mockCacheSetInFlight,
@@ -34,6 +38,7 @@ const {
   mockCheckSsrf: vi.fn(async () => ({ allowed: true })),
   mockCacheGet: vi.fn(() => null as any),
   mockCacheGetErrored: vi.fn(() => false),
+  mockCacheMarkError: vi.fn(),
   mockCachePut: vi.fn(async (placeId: string, _bytes: Buffer, attribution: string | null) => ({
     photoUrl: `/api/maps/place-photo/${encodeURIComponent(placeId)}/bytes`,
     filePath: `/tmp/${placeId}.jpg`,
@@ -83,7 +88,7 @@ vi.mock('../../../src/services/placePhotoCache', () => ({
   get: (placeId: string) => mockCacheGet(placeId),
   getErrored: (placeId: string) => mockCacheGetErrored(placeId),
   put: (placeId: string, bytes: Buffer, attribution: string | null) => mockCachePut(placeId, bytes, attribution),
-  markError: vi.fn(),
+  markError: (placeId: string, kind?: string) => mockCacheMarkError(placeId, kind),
   getInFlight: (placeId: string) => mockCacheGetInFlight(placeId),
   setInFlight: (placeId: string, p: Promise<any>) => mockCacheSetInFlight(placeId, p),
   serveFilePath: vi.fn(() => null),
@@ -100,6 +105,7 @@ afterEach(() => {
   mockCacheGet.mockReturnValue(null);
   mockCacheGetErrored.mockReset();
   mockCacheGetErrored.mockReturnValue(false);
+  mockCacheMarkError.mockReset();
   mockCachePut.mockReset();
   mockCachePut.mockImplementation(async (placeId: string, _bytes: Buffer, attribution: string | null) => ({
     photoUrl: `/api/maps/place-photo/${encodeURIComponent(placeId)}/bytes`,
@@ -157,6 +163,84 @@ describe('parseOpeningHours', () => {
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(100);
   });
+
+  it('MAPS-007b: emits machine-readable periods in Google day numbering (Sunday = 0)', () => {
+    const result = parseOpeningHours('Mo 09:00-18:00; Su 10:00-14:00');
+    expect(result.periods).toEqual([
+      { open: { day: 1, hour: 9, minute: 0 }, close: { day: 1, hour: 18, minute: 0 } },
+      { open: { day: 0, hour: 10, minute: 0 }, close: { day: 0, hour: 14, minute: 0 } },
+    ]);
+  });
+
+  it('MAPS-007c: a period past midnight closes on the following day', () => {
+    const result = parseOpeningHours('Sa 20:00-02:00');
+    expect(result.periods).toEqual([
+      { open: { day: 6, hour: 20, minute: 0 }, close: { day: 0, hour: 2, minute: 0 } },
+    ]);
+  });
+
+  it('MAPS-007d: the OSM 24:00 spelling becomes midnight of the next day', () => {
+    // Google's clock has no hour 24, so "00:00-24:00" is a full day, not a rejected range.
+    const result = parseOpeningHours('Mo 00:00-24:00');
+    expect(result.periods).toEqual([
+      { open: { day: 1, hour: 0, minute: 0 }, close: { day: 2, hour: 0, minute: 0 } },
+    ]);
+  });
+
+  it('MAPS-007e: unusable clock values produce no period', () => {
+    expect(parseOpeningHours('Mo 09:75-18:00').periods).toEqual([]);
+    expect(parseOpeningHours('Mo 09:00-24:30').periods).toEqual([]);
+    expect(parseOpeningHours('Mo closed').periods).toEqual([]);
+  });
+});
+
+// ── normalizeOpeningPeriods / normalizeSpecialDays ────────────────────────────
+
+describe('normalizeOpeningPeriods', () => {
+  it('MAPS-007f: keeps well-formed periods and fills the zeroes proto3 JSON omits', () => {
+    expect(
+      normalizeOpeningPeriods([{ open: { day: 3, hour: 9, minute: 30 }, close: { day: 3, hour: 17 } }]),
+    ).toEqual([{ open: { day: 3, hour: 9, minute: 30 }, close: { day: 3, hour: 17, minute: 0 } }]);
+    // Sunday midnight arrives as an empty object.
+    expect(normalizeOpeningPeriods([{ open: {} }])).toEqual([{ open: { day: 0, hour: 0, minute: 0 }, close: null }]);
+  });
+
+  it('MAPS-007g: a period without a close survives as the round-the-clock marker', () => {
+    expect(normalizeOpeningPeriods([{ open: { day: 0, hour: 0, minute: 0 } }])).toEqual([
+      { open: { day: 0, hour: 0, minute: 0 }, close: null },
+    ]);
+  });
+
+  it('MAPS-007h: drops out-of-range points and periods with an unusable close', () => {
+    expect(normalizeOpeningPeriods([{ open: { day: 7, hour: 9, minute: 0 } }])).toBeNull();
+    expect(normalizeOpeningPeriods([{ open: { day: 1, hour: 24, minute: 0 } }])).toBeNull();
+    // A broken close must not be mistaken for "never closes".
+    expect(
+      normalizeOpeningPeriods([{ open: { day: 1, hour: 9, minute: 0 }, close: { day: 1, hour: 9, minute: 90 } }]),
+    ).toBeNull();
+  });
+
+  it('MAPS-007i: returns null when there is nothing to normalise', () => {
+    expect(normalizeOpeningPeriods(undefined)).toBeNull();
+    expect(normalizeOpeningPeriods([])).toBeNull();
+  });
+});
+
+describe('normalizeSpecialDays', () => {
+  it('MAPS-007j: turns Google date parts into ISO dates without duplicates', () => {
+    expect(
+      normalizeSpecialDays([
+        { date: { year: 2026, month: 12, day: 25 } },
+        { date: { year: 2026, month: 1, day: 1 } },
+        { date: { year: 2026, month: 12, day: 25 } },
+      ]),
+    ).toEqual(['2026-12-25', '2026-01-01']);
+  });
+
+  it('MAPS-007k: skips incomplete or impossible dates and returns null when none are left', () => {
+    expect(normalizeSpecialDays([{}, { date: { year: 2026, month: 13, day: 1 } }, { date: { year: 2026, day: 5 } }])).toBeNull();
+    expect(normalizeSpecialDays(undefined)).toBeNull();
+  });
 });
 
 // ── buildOsmDetails ───────────────────────────────────────────────────────────
@@ -200,6 +284,19 @@ describe('buildOsmDetails', () => {
 
   it('MAPS-014: source is always openstreetmap', () => {
     expect(buildOsmDetails({}, 'node', '1').source).toBe('openstreetmap');
+  });
+
+  it('MAPS-012b: carries the structured periods next to the weekday lines', () => {
+    const result = buildOsmDetails({ opening_hours: 'Mo-Tu 09:00-18:00' }, 'node', '1');
+    expect(result.opening_periods).toEqual([
+      { open: { day: 1, hour: 9, minute: 0 }, close: { day: 1, hour: 18, minute: 0 } },
+      { open: { day: 2, hour: 9, minute: 0 }, close: { day: 2, hour: 18, minute: 0 } },
+    ]);
+  });
+
+  it('MAPS-012c: opening_periods is null when the day lines carry no usable times', () => {
+    expect(buildOsmDetails({}, 'node', '1').opening_periods).toBeNull();
+    expect(buildOsmDetails({ opening_hours: 'Mo closed' }, 'node', '1').opening_periods).toBeNull();
   });
 
   it('MAPS-014b: opening_hours is null when all days have unknown times (all "?")', () => {
@@ -1488,6 +1585,71 @@ describe('getPlaceDetails (fetch stubbed)', () => {
     expect((result.place as any).open_now).toBe(false);
   });
 
+  it('MAPS-041f2: hands the structured opening periods and special days to the client', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'ChIJPeriods',
+          regularOpeningHours: {
+            // Localised display text — the client shows it but must not parse it.
+            weekdayDescriptions: ['月曜日: 9:00～18:00'],
+            openNow: true,
+            periods: [{ open: { day: 1, hour: 9, minute: 0 }, close: { day: 1, hour: 18, minute: 0 } }],
+            specialDays: [{ date: { year: 2026, month: 12, day: 25 } }],
+          },
+        }),
+      }),
+    );
+    const { getPlaceDetails } = await import('../../../src/services/mapsService');
+    const place = (await getPlaceDetails(1, 'ChIJPeriods')).place as any;
+    expect(place.opening_periods).toEqual([
+      { open: { day: 1, hour: 9, minute: 0 }, close: { day: 1, hour: 18, minute: 0 } },
+    ]);
+    expect(place.opening_special_days).toEqual(['2026-12-25']);
+    expect(place.opening_hours).toEqual(['月曜日: 9:00～18:00']);
+  });
+
+  it('MAPS-041f3: opening_periods is null when Google sends no periods', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'ChIJNoPeriods',
+          regularOpeningHours: { weekdayDescriptions: ['Monday: 9:00 AM – 5:00 PM'], openNow: false },
+        }),
+      }),
+    );
+    const { getPlaceDetails } = await import('../../../src/services/mapsService');
+    const place = (await getPlaceDetails(1, 'ChIJNoPeriods')).place as any;
+    expect(place.opening_periods).toBeNull();
+    expect(place.opening_special_days).toBeNull();
+  });
+
+  it('MAPS-041f4: getPlaceDetailsExpanded carries the periods too', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+    // expanded=1 cache miss
+    mockDbGet.mockReturnValueOnce(undefined);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'ChIJExpandedPeriods',
+          // A place that never closes: one period, no close point.
+          regularOpeningHours: { openNow: true, periods: [{ open: { day: 0, hour: 0, minute: 0 } }] },
+        }),
+      }),
+    );
+    const { getPlaceDetailsExpanded } = await import('../../../src/services/mapsService');
+    const place = (await getPlaceDetailsExpanded(1, 'ChIJExpandedPeriods')).place as any;
+    expect(place.opening_periods).toEqual([{ open: { day: 0, hour: 0, minute: 0 }, close: null }]);
+  });
+
   it('MAPS-041g: getPlaceDetailsExpanded truncates reviews to first 5 entries', async () => {
     mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
     // expanded=1 cache miss
@@ -1508,6 +1670,33 @@ describe('getPlaceDetails (fetch stubbed)', () => {
     const { getPlaceDetailsExpanded } = await import('../../../src/services/mapsService');
     const result = await getPlaceDetailsExpanded(1, 'ChIJMany');
     expect((result.place as any).reviews).toHaveLength(5);
+  });
+
+  // The client sends whatever id the place carries, and the expanded lookup used to
+  // forward all of them — including OSM ids — to Google, which bills the 400
+  // INVALID_ARGUMENT it answers with (#1727).
+  it('MAPS-041h: getPlaceDetailsExpanded serves an OSM id from Overpass instead of Google', async () => {
+    mockDbGet.mockReturnValue({ maps_api_key: 'gkey' });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ elements: [{ tags: { website: 'https://nerja.example' } }] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { getPlaceDetailsExpanded } = await import('../../../src/services/mapsService');
+    const result = await getPlaceDetailsExpanded(1, 'node:5255005321');
+    expect((result.place as any).source).toBe('openstreetmap');
+    expect((result.place as any).website).toBe('https://nerja.example');
+    expect(fetchMock.mock.calls.map((call) => String(call[0])).some((url) => url.includes('places.googleapis.com')))
+      .toBe(false);
+  });
+
+  it('MAPS-041i: getPlaceDetailsExpanded answers a coordinate pseudo-id with no place at all', async () => {
+    mockDbGet.mockReturnValue({ maps_api_key: 'gkey' });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { getPlaceDetailsExpanded } = await import('../../../src/services/mapsService');
+    await expect(getPlaceDetailsExpanded(1, 'coords:48.8,2.3')).resolves.toEqual({ place: null });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1539,7 +1728,7 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     expect(mockCachePut).toHaveBeenCalledOnce();
   });
 
-  it('MAPS-043: throws 404 when Wikimedia returns nothing and no API key', async () => {
+  it('MAPS-043: resolves with photoUrl null when Wikimedia returns nothing and no API key', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -1548,7 +1737,10 @@ describe('getPlacePhoto (fetch stubbed)', () => {
       }),
     );
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
-    await expect(getPlacePhoto(999, 'coords:0.0,0.0', 0, 0)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(999, 'coords:0.0,0.0', 0, 0)).resolves.toEqual({
+      photoUrl: null,
+      attribution: null,
+    });
   });
 
   it('MAPS-043b: returns cached photo when disk cache returns a hit', async () => {
@@ -1567,27 +1759,42 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('MAPS-043c: throws 404 from error cache without making a network request', async () => {
+  it('MAPS-043c: serves the negative cache with photoUrl null and no network request', async () => {
     mockCacheGetErrored.mockReturnValue(true);
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const errorId = `coords:error-cache-${Date.now()}`;
-    await expect(getPlacePhoto(999, errorId, 0, 0)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(999, errorId, 0, 0)).resolves.toEqual({ photoUrl: null, attribution: null });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('MAPS-043d: throws 404 when lat/lng are NaN and no API key', async () => {
+  it('MAPS-043d: resolves with photoUrl null when lat/lng are NaN and no API key', async () => {
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const nanId = `coords:nan-test-${Date.now()}`;
-    await expect(getPlacePhoto(999, nanId, NaN, NaN)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(999, nanId, NaN, NaN)).resolves.toEqual({ photoUrl: null, attribution: null });
   });
 
-  it('MAPS-043e: falls through and throws 404 when Wikimedia fetch throws', async () => {
+  it('MAPS-043e: falls through to photoUrl null when the Wikimedia fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network fail')));
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const throwId = `coords:throw-test-${Date.now()}`;
-    await expect(getPlacePhoto(999, throwId, 48.8, 2.3, 'Place')).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(999, throwId, 48.8, 2.3, 'Place')).resolves.toEqual({
+      photoUrl: null,
+      attribution: null,
+    });
+  });
+
+  it('MAPS-043f: an in-flight lookup that found nothing resolves the waiter with photoUrl null', async () => {
+    mockCacheGetInFlight.mockReturnValue(Promise.resolve(null) as any);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { getPlacePhoto } = await import('../../../src/services/mapsService');
+    await expect(getPlacePhoto(999, 'ChIJInFlight', 48.8, 2.3)).resolves.toEqual({
+      photoUrl: null,
+      attribution: null,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('MAPS-044: returns proxy URL via Google path when API key present and photos exist', async () => {
@@ -1616,7 +1823,7 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     expect(mockCachePut).toHaveBeenCalledOnce();
   });
 
-  it('MAPS-044b: throws 404 when Google details fetch returns non-ok', async () => {
+  it('MAPS-044b: resolves with photoUrl null when Google details fetch returns non-ok', async () => {
     mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
     vi.stubGlobal(
       'fetch',
@@ -1628,10 +1835,50 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     );
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const errId = `ChIJErr-${Date.now()}`;
-    await expect(getPlacePhoto(1, errId, 48.8, 2.3)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(1, errId, 48.8, 2.3)).resolves.toEqual({ photoUrl: null, attribution: null });
+    // A rejected provider call says nothing about the place — remember it as a
+    // failed attempt (minutes), not as "this place has no photo" (a day).
+    expect(mockCacheMarkError).toHaveBeenCalledWith(errId, 'provider-error');
   });
 
-  it('MAPS-044c: throws 404 when Google place has no photos', async () => {
+  it('MAPS-044b2: remembers a place both providers came up empty for as a lasting miss', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // Google answers, the place simply has no photos.
+        .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ photos: [] }) })
+        // Wikimedia has no article near the coordinates either.
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ query: { pages: {} } }) }),
+    );
+    const { getPlacePhoto } = await import('../../../src/services/mapsService');
+    const emptyId = `ChIJEmpty-${Date.now()}`;
+    await expect(getPlacePhoto(1, emptyId, 48.8, 2.3)).resolves.toEqual({ photoUrl: null, attribution: null });
+    expect(mockCacheMarkError).toHaveBeenCalledWith(emptyId, 'no-photo');
+  });
+
+  it('MAPS-044b3: a failed Wikimedia image download counts as a failed attempt', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ query: { pages: { '1': { thumbnail: { source: 'https://wiki.org/photo.jpg' } } } } }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 503, arrayBuffer: async () => new ArrayBuffer(0) }),
+    );
+    const { getPlacePhoto } = await import('../../../src/services/mapsService');
+    const downId = `coords:down-${Date.now()}`;
+    await expect(getPlacePhoto(999, downId, 48.8, 2.3, 'Place')).resolves.toEqual({
+      photoUrl: null,
+      attribution: null,
+    });
+    expect(mockCacheMarkError).toHaveBeenCalledWith(downId, 'provider-error');
+  });
+
+  it('MAPS-044c: resolves with photoUrl null when the Google place has no photos', async () => {
     mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
     vi.stubGlobal(
       'fetch',
@@ -1642,10 +1889,10 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     );
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const noPhotoId = `ChIJNone-${Date.now()}`;
-    await expect(getPlacePhoto(1, noPhotoId, 48.8, 2.3)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(1, noPhotoId, 48.8, 2.3)).resolves.toEqual({ photoUrl: null, attribution: null });
   });
 
-  it('MAPS-044d: throws 404 when media endpoint returns non-ok status', async () => {
+  it('MAPS-044d: resolves with photoUrl null when the media endpoint returns non-ok status', async () => {
     mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
     const fetchMock = vi
       .fn()
@@ -1664,7 +1911,7 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { getPlacePhoto } = await import('../../../src/services/mapsService');
     const noUriId = `ChIJXYZ-${Date.now()}`;
-    await expect(getPlacePhoto(1, noUriId, 48.8, 2.3)).rejects.toMatchObject({ status: 404 });
+    await expect(getPlacePhoto(1, noUriId, 48.8, 2.3)).resolves.toEqual({ photoUrl: null, attribution: null });
   });
 
   it('MAPS-044e: returns proxy URL with null attribution when authorAttributions is empty', async () => {
@@ -1747,6 +1994,58 @@ describe('getPlacePhoto (fetch stubbed)', () => {
     expect(result.photoUrl).toBe(`/api/maps/place-photo/${encodeURIComponent(placeId)}/bytes`);
     expect(result.attribution).toBe('Wikipedia');
     expect(mockCachePut).toHaveBeenCalledOnce();
+  });
+
+  // OSM ids are what the client sends whenever a place has no google_place_id.
+  // Google rejects them with a billable 400 INVALID_ARGUMENT, so they must go
+  // straight to the Wikimedia fallback like coords: ids already do.
+  it.each(['node:5255005321', 'way:84527326', 'relation:345407'])(
+    'MAPS-044h: skips Google for the OSM id %s even when an API key is configured',
+    async (osmId) => {
+      mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ query: { pages: { '1': { thumbnail: { source: 'https://wiki.org/osm.jpg' } } } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: async () => new ArrayBuffer(90),
+        });
+      vi.stubGlobal('fetch', fetchMock);
+      const { getPlacePhoto } = await import('../../../src/services/mapsService');
+      const result = await getPlacePhoto(1, osmId, 36.7617, -3.8448, 'Cueva de Nerja');
+      expect(result.photoUrl).toBe(`/api/maps/place-photo/${encodeURIComponent(osmId)}/bytes`);
+      const requested = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(requested.some((url) => url.includes('places.googleapis.com'))).toBe(false);
+    },
+  );
+
+  it('MAPS-044i: an OSM id with no Wikimedia hit resolves with photoUrl null instead of a 404', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'gkey' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ query: { pages: {} } }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const { getPlacePhoto } = await import('../../../src/services/mapsService');
+    await expect(getPlacePhoto(1, 'node:2481346642', 36.76, -3.84, 'Nerja')).resolves.toEqual({
+      photoUrl: null,
+      attribution: null,
+    });
+    expect(fetchMock.mock.calls.map((call) => String(call[0])).some((url) => url.includes('places.googleapis.com')))
+      .toBe(false);
+  });
+});
+
+describe('isGooglePlaceId', () => {
+  it('MAPS-045: accepts Google place ids and rejects the ids Google cannot resolve', () => {
+    expect(isGooglePlaceId('ChIJLU7jZClu5kcR4PcOOO6p3I0')).toBe(true);
+    expect(isGooglePlaceId('coords:48.8,2.3')).toBe(false);
+    expect(isGooglePlaceId('node:5255005321')).toBe(false);
+    expect(isGooglePlaceId('way:84527326')).toBe(false);
+    expect(isGooglePlaceId('relation:345407')).toBe(false);
+    expect(isGooglePlaceId('https://lh3.googleusercontent.com/photo.jpg')).toBe(false);
+    // The collection views send the bare coordinate pair when a place has no ids.
+    expect(isGooglePlaceId('36.7617499,-3.8448432')).toBe(false);
   });
 });
 

--- a/server/tests/unit/services/placePhotoCache.test.ts
+++ b/server/tests/unit/services/placePhotoCache.test.ts
@@ -1,6 +1,7 @@
 /**
- * Unit tests for placePhotoCache — PPC-001 through PPC-010.
- * Covers the downscale guard in put(), removeIfUnreferenced(), and sweepOrphans().
+ * Unit tests for placePhotoCache — PPC-001 through PPC-012.
+ * Covers the downscale guard in put(), removeIfUnreferenced(), sweepOrphans(),
+ * and the two negative-cache windows.
  * Uses a real in-memory SQLite DB and a throwaway temp upload dir
  * (TREK_PLACE_PHOTO_DIR) so the real uploads tree is never touched.
  */
@@ -154,5 +155,60 @@ describe('placePhotoCache.sweepOrphans()', () => {
 
     expect(cache.sweepOrphans()).toBe(0);
     expect(fs.existsSync(filePathFor('ref-a'))).toBe(true);
+  });
+});
+
+describe('placePhotoCache negative cache', () => {
+  function ageError(placeId: string, ms: number): void {
+    testDb
+      .prepare('UPDATE google_place_photo_meta SET error_at = ? WHERE place_id = ?')
+      .run(Date.now() - ms, placeId);
+  }
+
+  it('PPC-009: a place with no photo stays remembered well past the old five-minute window', () => {
+    cache.markError('photo-less');
+
+    ageError('photo-less', 30 * 60 * 1000);
+    expect(cache.getErrored('photo-less')).toBe(true);
+
+    ageError('photo-less', 5 * 60 * 60 * 1000);
+    expect(cache.getErrored('photo-less')).toBe(true);
+  });
+
+  it('PPC-010: the miss expires once it is a day old', () => {
+    cache.markError('stale-miss');
+    ageError('stale-miss', 24 * 60 * 60 * 1000);
+
+    expect(cache.getErrored('stale-miss')).toBe(false);
+  });
+
+  // A failed provider call says nothing about the place, so it must not inherit the
+  // long window a real "this place has no photo" answer gets.
+  it('PPC-011: a failed provider call is forgotten after minutes and never persisted', () => {
+    vi.useFakeTimers();
+    try {
+      cache.markError('flaky', 'provider-error');
+      expect(cache.getErrored('flaky')).toBe(true);
+      // Nothing on disk — a restart retries instead of inheriting someone's outage.
+      expect(testDb.prepare('SELECT 1 FROM google_place_photo_meta WHERE place_id = ?').get('flaky')).toBeUndefined();
+
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      expect(cache.getErrored('flaky')).toBe(false);
+
+      // The long window belongs to the other case: same age, still remembered.
+      cache.markError('photo-less-too');
+      ageError('photo-less-too', 5 * 60 * 1000);
+      expect(cache.getErrored('photo-less-too')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('PPC-012: a cached photo clears an earlier failed attempt', async () => {
+    cache.markError('recovered', 'provider-error');
+    expect(cache.getErrored('recovered')).toBe(true);
+
+    await cache.put('recovered', await makeJpeg(40, 40), null);
+    expect(cache.getErrored('recovered')).toBe(false);
   });
 });

--- a/server/tests/unit/services/transitService.test.ts
+++ b/server/tests/unit/services/transitService.test.ts
@@ -142,6 +142,44 @@ describe('plan mapping', () => {
     expect(it.legs[0].distance).toBe(251);
   });
 
+  it('TRANSIT-SVC-011: prefers displayName over routeShortName for the line label', async () => {
+    // German long distance publishes "ICE 72" as displayName while routeShortName
+    // carries an internal line number (#1715).
+    fetchMock.mockResolvedValueOnce(
+      okJson({
+        itineraries: [
+          {
+            startTime: '2026-08-21T12:37:00Z',
+            endTime: '2026-08-21T13:38:00Z',
+            transfers: 1,
+            legs: [
+              {
+                mode: 'HIGHSPEED_RAIL',
+                duration: 1800,
+                routeShortName: '20',
+                displayName: 'ICE 72',
+                from: { name: 'Karlsruhe Hbf', lat: 49, lon: 8.4, departure: '2026-08-21T12:37:00Z' },
+                to: { name: 'Mannheim Hbf', lat: 49.4, lon: 8.4, arrival: '2026-08-21T13:07:00Z' },
+              },
+              {
+                mode: 'RAIL',
+                duration: 1860,
+                routeShortName: 'S9',
+                from: { name: 'Mannheim Hbf', lat: 49.4, lon: 8.4, departure: '2026-08-21T13:07:00Z' },
+                to: { name: 'Frankfurt Flughafen', lat: 50, lon: 8.5, arrival: '2026-08-21T13:38:00Z' },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const r = await plan({ from: '49.0090,8.4004', to: '50.0510,8.5706' });
+    const [longDistance, regional] = r.itineraries[0].legs;
+    expect(longDistance.line).toBe('ICE 72');
+    // Feeds that only supply routeShortName keep working.
+    expect(regional.line).toBe('S9');
+  });
+
   it('TRANSIT-SVC-008: forwards only whitelisted params and pins directModes=WALK', async () => {
     fetchMock.mockResolvedValueOnce(okJson({ itineraries: [] }));
     await plan({

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -266,7 +266,6 @@ const settings: TranslationStrings = {
   'settings.mfa.toastDisabled': 'تم تعطيل المصادقة الثنائية',
   'settings.mfa.demoBlocked': 'غير متاح في الوضع التجريبي',
   'settings.tabs.offline': 'Offline', // en-fallback
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', // en-fallback
   'settings.notificationPreferences.email': 'Email', // en-fallback
   'settings.notificationPreferences.webhook': 'Webhook', // en-fallback
   'settings.notificationPreferences.inapp': 'In-App', // en-fallback

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -24,7 +24,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Modelo de mapa',
   'settings.mapTemplatePlaceholder.select': 'Selecione o modelo...',
   'settings.mapDefaultHint': 'Deixe vazio para OpenStreetMap (padrão)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL do modelo de blocos do mapa',
   'settings.mapProvider': 'Provedor de mapa',
   'settings.mapProviderHint': 'Afeta os mapas do Planejador de Viagem e Diário. Atlas sempre usa Leaflet.',

--- a/shared/src/i18n/ca/settings.ts
+++ b/shared/src/i18n/ca/settings.ts
@@ -14,7 +14,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Plantilla del mapa',
   'settings.mapTemplatePlaceholder.select': 'Selecciona una plantilla...',
   'settings.mapDefaultHint': 'Deixa-ho buit per a OpenStreetMap (per defecte)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': "Plantilla d'URL per als mosaics del mapa",
   'settings.mapProvider': 'Proveïdor de mapa',
   'settings.mapProviderHint': 'Afecta els mapes de Trip Planner i Journey. Atles sempre utilitza Leaflet.',

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Šablona mapy',
   'settings.mapTemplatePlaceholder.select': 'Vyberte šablonu...',
   'settings.mapDefaultHint': 'Ponechte prázdné pro OpenStreetMap (výchozí)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL šablony pro mapové dlaždice',
   'settings.mapProvider': 'Poskytovatel mapy',
   'settings.mapProviderHint': 'Ovlivňuje mapy v Trip Planneru a Journey. Atlas vždy používá Leaflet.',

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -24,7 +24,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Karten-Vorlage',
   'settings.mapTemplatePlaceholder.select': 'Vorlage auswählen...',
   'settings.mapDefaultHint': 'Leer lassen für OpenStreetMap (Standard)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL-Template für die Kartenkacheln',
   'settings.mapProvider': 'Kartenanbieter',
   'settings.mapProviderHint': 'Gilt für Trip Planner und Journey. Atlas nutzt immer Leaflet.',

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -32,7 +32,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Map Template',
   'settings.mapTemplatePlaceholder.select': 'Select template...',
   'settings.mapDefaultHint': 'Leave empty for OpenStreetMap (default)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL template for map tiles',
   'settings.mapProvider': 'Map Provider',
   'settings.mapProviderHint': 'Affects Trip Planner and Journey maps. Atlas always uses Leaflet.',

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Plantilla del mapa',
   'settings.mapTemplatePlaceholder.select': 'Seleccionar plantilla...',
   'settings.mapDefaultHint': 'Déjalo vacío para OpenStreetMap (por defecto)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Plantilla de URL para los mosaicos del mapa',
   'settings.mapProvider': 'Proveedor de mapa',
   'settings.mapProviderHint': 'Afecta a los mapas de Trip Planner y Journey. Atlas siempre usa Leaflet.',

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Modèle de carte',
   'settings.mapTemplatePlaceholder.select': 'Sélectionner un modèle…',
   'settings.mapDefaultHint': 'Laissez vide pour OpenStreetMap (par défaut)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': "Modèle d'URL pour les tuiles de carte",
   'settings.mapProvider': 'Fournisseur de carte',
   'settings.mapProviderHint': 'Affecte les cartes Trip Planner et Journey. Atlas utilise toujours Leaflet.',

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -24,7 +24,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Πρότυπο Χάρτη',
   'settings.mapTemplatePlaceholder.select': 'Επιλέξτε πρότυπο...',
   'settings.mapDefaultHint': 'Αφήστε κενό για OpenStreetMap (προεπιλογή)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Πρότυπο URL για πλακίδια χάρτη',
   'settings.mapProvider': 'Πάροχος Χάρτη',
   'settings.mapProviderHint':

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Térkép sablon',
   'settings.mapTemplatePlaceholder.select': 'Sablon kiválasztása...',
   'settings.mapDefaultHint': 'Hagyd üresen az OpenStreetMap használatához (alapértelmezett)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL sablon a térképcsempékhez',
   'settings.mapProvider': 'Térkép szolgáltató',
   'settings.mapProviderHint': 'A Trip Planner és Journey térképekre érvényes. Az Atlas mindig Leafletet használ.',

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Template Peta',
   'settings.mapTemplatePlaceholder.select': 'Pilih template...',
   'settings.mapDefaultHint': 'Kosongkan untuk OpenStreetMap (default)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Template URL untuk tile peta',
   'settings.mapProvider': 'Penyedia peta',
   'settings.mapProviderHint': 'Berlaku untuk peta Trip Planner dan Journey. Atlas selalu menggunakan Leaflet.',

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Modello Mappa',
   'settings.mapTemplatePlaceholder.select': 'Seleziona modello...',
   'settings.mapDefaultHint': 'Lascia vuoto per OpenStreetMap (predefinito)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Modello URL per i tile della mappa',
   'settings.mapProvider': 'Provider mappa',
   'settings.mapProviderHint': 'Influisce sulle mappe Trip Planner e Journey. Atlas usa sempre Leaflet.',

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': '地図テンプレート',
   'settings.mapTemplatePlaceholder.select': 'テンプレートを選択…',
   'settings.mapDefaultHint': '空欄の場合は OpenStreetMap（既定）を使用',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': '地図タイルのURLテンプレート',
   'settings.mapProvider': '地図プロバイダー',
   'settings.mapProviderHint': '旅程プランナーと日記地図に影響します。Atlas は常に Leaflet を使用します。',

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': '지도 템플릿',
   'settings.mapTemplatePlaceholder.select': '템플릿 선택...',
   'settings.mapDefaultHint': '비워두면 OpenStreetMap (기본값) 사용',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': '지도 타일 URL 템플릿',
   'settings.mapProvider': '지도 공급자',
   'settings.mapProviderHint': '여행 플래너 및 Journey 지도에 영향을 줍니다. Atlas는 항상 Leaflet을 사용합니다.',

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -24,7 +24,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Kaartsjabloon',
   'settings.mapTemplatePlaceholder.select': 'Selecteer sjabloon...',
   'settings.mapDefaultHint': 'Laat leeg voor OpenStreetMap (standaard)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL-sjabloon voor kaarttegels',
   'settings.mapProvider': 'Kaartprovider',
   'settings.mapProviderHint': 'Geldt voor Trip Planner en Journey kaarten. Atlas gebruikt altijd Leaflet.',

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Szablon mapy',
   'settings.mapTemplatePlaceholder.select': 'Wybierz szablon...',
   'settings.mapDefaultHint': 'Pozostaw puste dla OpenStreetMap (domyślnie)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Szablon URL dla kafelków mapy',
   'settings.mapProvider': 'Dostawca mapy',
   'settings.mapProviderHint': 'Dotyczy map Trip Planner i Journey. Atlas zawsze używa Leaflet.',

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Шаблон карты',
   'settings.mapTemplatePlaceholder.select': 'Выберите шаблон...',
   'settings.mapDefaultHint': 'Оставьте пустым для OpenStreetMap (по умолчанию)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL-шаблон для тайлов карты',
   'settings.mapProvider': 'Провайдер карты',
   'settings.mapProviderHint': 'Применяется к Trip Planner и Journey. Atlas всегда использует Leaflet.',

--- a/shared/src/i18n/sv/settings.ts
+++ b/shared/src/i18n/sv/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Kartmall',
   'settings.mapTemplatePlaceholder.select': 'Välj mall...',
   'settings.mapDefaultHint': 'Lämna fältet tomt för OpenStreetMap (standard)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL-mall för kartrutor',
   'settings.mapProvider': 'Kartleverantör',
   'settings.mapProviderHint': 'Påverkar resplaneraren och resedagbokens kartor. Atlas använder alltid Leaflet.',

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Harita Şablonu',
   'settings.mapTemplatePlaceholder.select': 'Şablon seçin...',
   'settings.mapDefaultHint': 'OpenStreetMap için boş bırakın (varsayılan)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Harita kutucukları için URL şablonu',
   'settings.mapProvider': 'Harita Sağlayıcısı',
   'settings.mapProviderHint': 'Seyahat planlayıcı ve Journey haritalarını etkiler. Atlas her zaman Leaflet kullanır.',

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -24,7 +24,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Шаблон карти',
   'settings.mapTemplatePlaceholder.select': 'Виберіть шаблон...',
   'settings.mapDefaultHint': 'Залиште порожнім для OpenStreetMap (за замовчуванням)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'URL-шаблон для тайлів карти',
   'settings.mapProvider': 'Провайдер карти',
   'settings.mapProviderHint': 'Застосовується до Trip Planner та Journey. Atlas завжди використовує Leaflet.',

--- a/shared/src/i18n/vi/settings.ts
+++ b/shared/src/i18n/vi/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': 'Mẫu bản đồ',
   'settings.mapTemplatePlaceholder.select': 'Chọn mẫu...',
   'settings.mapDefaultHint': 'Để trống cho OpenStreetMap (mặc định)',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': 'Mẫu URL cho ô bản đồ',
   'settings.mapProvider': 'Nhà cung cấp bản đồ',
   'settings.mapProviderHint':

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': '地圖模板',
   'settings.mapTemplatePlaceholder.select': '選擇模板...',
   'settings.mapDefaultHint': '留空則使用 OpenStreetMap（預設）',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': '地圖瓦片 URL 模板',
   'settings.mapProvider': '地圖提供商',
   'settings.mapProviderHint': '影響行程規劃和旅程地圖。Atlas 始終使用 Leaflet。',

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -23,7 +23,6 @@ const settings: TranslationStrings = {
   'settings.mapTemplate': '地图模板',
   'settings.mapTemplatePlaceholder.select': '选择模板...',
   'settings.mapDefaultHint': '留空则使用 OpenStreetMap（默认）',
-  'settings.mapTemplatePlaceholder': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   'settings.mapHint': '地图瓦片 URL 模板',
   'settings.mapProvider': '地图提供商',
   'settings.mapProviderHint': '影响行程规划器和旅程地图。足迹始终使用 Leaflet。',

--- a/wiki/Map-Settings.md
+++ b/wiki/Map-Settings.md
@@ -30,7 +30,7 @@ When Leaflet is selected, pick a preset or enter a custom tile URL.
 
 | Name | URL |
 |------|-----|
-| OpenStreetMap | `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png` |
+| OpenStreetMap | `https://tile.openstreetmap.org/{z}/{x}/{y}.png` |
 | OpenStreetMap DE | `https://tile.openstreetmap.de/{z}/{x}/{y}.png` |
 | CartoDB Light | `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png` |
 | CartoDB Dark | `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png` |

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -295,7 +295,7 @@ If `ALLOWED_ORIGINS` is not set, TREK allows all origins (development default). 
 
 ## Place photos not loading / place thumbnail shows default map pin (Google Maps API key configured)
 
-**Cause:** When a Google Maps API key is set, TREK fetches photo references and image bytes from the Google Places API on the server side. If the server-side call is rejected or returns no photos, the `/place-photo/:id` endpoint returns 404 and the place falls back to the default map-pin thumbnail. The most common causes are:
+**Cause:** When a Google Maps API key is set, TREK fetches photo references and image bytes from the Google Places API on the server side. If the server-side call is rejected or returns no photos, the `/place-photo/:id` endpoint answers `200 { "photoUrl": null }` and the place falls back to the default map-pin thumbnail. The image proxy behind it, `/place-photo/:id/bytes`, answers `204 No Content` when it has nothing cached — neither endpoint returns 404, so a trip full of photo-less places cannot trip a 404 rate limit in a reverse proxy or IPS. The most common causes are:
 
 1. **HTTP referrer restriction on the API key.** Google Cloud Console lets you restrict a key to specific HTTP referrers. Because TREK calls Google from the server (not the browser), it sends a `Referer` header derived from `APP_URL`. If `APP_URL` is not set, the fallback is `http://localhost:<PORT>`, which will not match any domain whitelist in GCP.
 


### PR DESCRIPTION
Seven reported bugs, one branch. Each has a test that fails without its fix.

Closes #1733, #1727, #1724, #1725, #1705, #1715, #1680

## #1733 — map tiles fail on `d.tile.openstreetmap.org`

OSM stopped needing the a/b/c shards in 2022 and `d` has since lost its DNS record entirely. The map itself never asked for `d` — Leaflet's default is `abc` — but the offline tile prefetcher rotated over `['a','b','c','d']`, which is where the failing requests came from. Same list also meant the prefetch cached most tiles under a host the map never requests.

Presets and the prefetcher now use `tile.openstreetmap.org` directly. Because existing instances have the old URL saved in `user_settings`, changing the presets alone would not have helped them, so `normalizeTileUrl()` rewrites the value where it is read and where it is written back — a stored URL heals on the next save without a migration touching what someone typed themselves. The rule only matches the OSM hosts; CartoDB, `tile.openstreetmap.de`, mirrors and proxy URLs are left alone.

Two things that had to come along or the fix would have been a regression: the CSP in `globalMiddleware.ts` only allowed `https://*.tile.openstreetmap.org`, and a wildcard host never matches the apex domain, so the prefetcher's `fetch()` would have been blocked. And the service worker rule in `vite.config.js` still matched `[a-c].tile…` only, which would have quietly stopped filling the `map-tiles` cache.

## #1727 — photo 404s get self-hosters IP-banned

Reported with real impact: CrowdSec banned three users within five minutes, because opening one trip fires 30–60 `404`s from a single IP as the itinerary renders. "This place has no photo" is not an error, so it no longer answers 404.

Second half of the report: OSM places are sent to Google as `node:5255005321`, which can only ever return `400 INVALID_ARGUMENT` — a billed round-trip and ~1.3 s per place. `getPlacePhoto()` already guarded `coords:` this way; the `node:`/`way:`/`relation:` prefixes now get the same treatment, as does `getPlaceDetailsExpanded()`, which had no id guard at all.

The negative cache also distinguishes "this place has no photo" (long) from "the provider call failed" (short) instead of expiring both after five minutes and replaying the storm on the next visit.

## #1724 — `.eml` reached the LLM as base64

`text-extract.ts` treated `.eml` like ready-made HTML, but a real mail is multipart with `Content-Transfer-Encoding: base64` or `quoted-printable`. What the model actually received was the plaintext headers followed by a wall of base64, truncated at `MAX_EXTRACT_CHARS` before any content — which is why a sender name from the Subject line still showed up while the booking never did.

`.eml` is now parsed as MIME: the `text/html` part is preferred, `text/plain` is the fallback, transfer encoding and charset are decoded, and HTML entities are resolved before the text goes out. No new dependency — the repo had none for this, so it is a compact parser for exactly this case. If no text part is found the previous raw path still runs, so nothing that worked before stops working.

## #1725 — 24h setting ignored on reservation times

The rules for 12h/24h existed in three copies, and two of them ignored the setting. They are now one function. `splitReservationDateTime()` also truncated the meridiem instead of converting it, so `3:00 PM` became `3:00` — three in the morning. Values already stored that way normalise when a form renders the field, without changing the payload or the stored format.

## #1705 — plugin `itinerary.unassign` did not reach open sessions

`assign` broadcast, `unassign` did not, so the place stayed on the Plan tab until a manual refresh. It now emits the same event as the REST route. `createPlace`, `updatePlace` and `deletePlace` in the same file had the identical gap and are pulled onto the same footing.

## #1715 — wrong line identifier on long-distance trains

Transitous exposes `routeShortName`, which many operators (German long-distance among them) do not fill. `displayName` carries the identifier passengers actually see. It is preferred now, with `routeShortName` as the fallback.

## #1680 — open/closed ignored the place's timezone

The ring was evaluated against the viewer's clock, so a trip in Europe planned from Singapore showed the wrong state. It now evaluates in the timezone of the place, using Google's structured `regularOpeningHours.periods` rather than the localised `weekdayDescriptions` text — parsing display strings would have broken as soon as the account language was not English. Midnight-spanning hours, closed days and 24/7 are covered.

## Not in here

- **#1616** (tablet drag) — I could not reproduce the fix on real hardware, and the change I had would have stopped the text selection without making the drag work. Left open rather than shipped on a guess.
- **#1667** (Gemini Spark linking) — fails in Google's back-channel token exchange; not verifiable without testing against their linking service, and the debug logs jubnl asked for are still outstanding.
- **#1675** (SQLite corruption on network storage) — structural rather than a single defect. Deserves its own change, not a slot in a batch.

Some deliberate limits inside the fixes are noted in the commits, the main ones being: no DB migration for values already stored in the old shapes (#1725, #1733), and the field mask for Google Places is unchanged, so places cached before this lands keep their old open/closed data until the 7-day TTL expires (#1680).
