### PR TITLE
Snapshot scheduled backups, make the SQLite journal mode configurable

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -43,6 +43,9 @@ DEMO_MODE=false # Demo mode - resets data hourly
 
 # BACKUP_UPLOAD_LIMIT_MB=500 # Max size (MB) of a backup archive you can upload when restoring. Raise it if your backup exceeds 500 MB. If you sit behind a reverse proxy, raise its upload limit too (e.g. nginx client_max_body_size).
 
+# TREK_DB_JOURNAL_MODE=WAL # SQLite journal mode (DELETE, TRUNCATE, PERSIST, MEMORY, WAL, OFF). WAL is fastest and the right choice on local disk. Set DELETE if the data directory lives on network storage (Azure App Service, an SMB/NFS volume on a NAS) — WAL coordinates writers through a shared-memory file that those filesystems do not implement reliably. The mode is stored inside the database file, so it survives a restart; changing this applies on the next boot.
+# TREK_DB_SYNCHRONOUS=NORMAL # How hard SQLite flushes to disk (OFF, NORMAL, FULL, EXTRA). Defaults to NORMAL under WAL and FULL under any other journal mode — leave it alone unless you know why you want otherwise. Both variables fall back to their default (with a warning in the log) if the value is not a mode SQLite knows.
+
 # MCP_RATE_LIMIT=300 # Max MCP API requests per user per minute (default: 300)
 # MCP_MAX_SESSION_PER_USER=20 # Max concurrent MCP sessions per user (default: 20)
 

--- a/server/reset-admin.js
+++ b/server/reset-admin.js
@@ -7,7 +7,8 @@
  *
  * Defaults to admin@trek.local with a generated password (printed below). The
  * account is flagged must_change_password, so you are prompted to set a new one
- * on first login. Honours TREK_DB_FILE the same way the server does.
+ * on first login. Honours TREK_DB_FILE, TREK_DB_JOURNAL_MODE and
+ * TREK_DB_SYNCHRONOUS the same way the server does.
  */
 const path = require('path');
 const crypto = require('crypto');
@@ -21,8 +22,36 @@ const email = process.env.RESET_ADMIN_EMAIL || 'admin@trek.local';
 const password = process.env.RESET_ADMIN_PASSWORD || crypto.randomBytes(12).toString('base64url');
 const generated = !process.env.RESET_ADMIN_PASSWORD;
 
+// journal_mode is stored in the database file header, not per connection, so
+// opening the file here decides the mode for the server too. Plain JS outside
+// the Nest context can't reach src/app-config, hence the direct read — the
+// defaults must match parsers.resolveDurability() (WAL + NORMAL, FULL once a
+// rollback journal is in play). Run this via `docker exec` and the container's
+// environment applies, same as for the server.
+const journalModes = ['DELETE', 'TRUNCATE', 'PERSIST', 'MEMORY', 'WAL', 'OFF'];
+const syncLevels = ['OFF', 'NORMAL', 'FULL', 'EXTRA'];
+
+const wantedJournal = (process.env.TREK_DB_JOURNAL_MODE || '').trim().toUpperCase();
+const journalMode = journalModes.includes(wantedJournal) ? wantedJournal : 'WAL';
+if (wantedJournal && journalMode !== wantedJournal) {
+  console.warn(`TREK_DB_JOURNAL_MODE="${process.env.TREK_DB_JOURNAL_MODE}" is not a SQLite journal mode — using ${journalMode}.`);
+}
+
+const wantedSync = (process.env.TREK_DB_SYNCHRONOUS || '').trim().toUpperCase();
+const defaultSync = journalMode === 'WAL' ? 'NORMAL' : 'FULL';
+const synchronous = syncLevels.includes(wantedSync) ? wantedSync : defaultSync;
+if (wantedSync && synchronous !== wantedSync) {
+  console.warn(`TREK_DB_SYNCHRONOUS="${process.env.TREK_DB_SYNCHRONOUS}" is not a SQLite synchronous level — using ${synchronous}.`);
+}
+
 const dbPath = process.env.TREK_DB_FILE || path.join(__dirname, 'data/travel.db');
 const db = new Database(dbPath);
+// Spelled out rather than left to better-sqlite3's default, so switching the
+// journal mode below waits for a busy server instead of failing on the spot.
+// Five seconds, same as src/db/database.ts.
+db.exec('PRAGMA busy_timeout = 5000');
+db.exec(`PRAGMA journal_mode = ${journalMode}`);
+db.exec(`PRAGMA synchronous = ${synchronous}`);
 
 const hash = bcrypt.hashSync(password, BCRYPT_COST);
 const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);

--- a/server/scripts/migrate-encryption.ts
+++ b/server/scripts/migrate-encryption.ts
@@ -181,11 +181,47 @@ async function main() {
 
   // Backup
   const backupPath = `${dbPath}.backup-${Date.now()}`;
-  fs.copyFileSync(dbPath, backupPath);
-  console.log(`\nBackup created: ${backupPath}`);
 
   const db = new Database(dbPath);
-  db.pragma('journal_mode = WAL');
+  db.pragma('busy_timeout = 5000');
+
+  // The rollback copy has to be a consistent snapshot, not a plain file copy:
+  // this script is documented as running against a live server, so in WAL mode
+  // the committed tail sits in the -wal sidecar a copy would leave behind.
+  // VACUUM INTO snapshots even while the server writes; the checkpoint plus
+  // copy is only the fallback for when it cannot (disk, lock).
+  try {
+    db.exec(`VACUUM INTO '${backupPath.replace(/'/g, "''")}'`);
+  } catch {
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    fs.copyFileSync(dbPath, backupPath);
+  }
+  console.log(`\nBackup created: ${backupPath}`);
+
+  // journal_mode lives in the file header, so hardcoding WAL here would quietly
+  // undo a deliberate DELETE/TRUNCATE setup (network storage) on the first key
+  // rotation. This script ships without src/ in the image and cannot import
+  // src/app-config, so it reads the same variables directly — keep the defaults
+  // in step with parsers.resolveDurability().
+  const journalModes = ['DELETE', 'TRUNCATE', 'PERSIST', 'MEMORY', 'WAL', 'OFF'];
+  const syncLevels = ['OFF', 'NORMAL', 'FULL', 'EXTRA'];
+
+  const wantedJournal = (process.env.TREK_DB_JOURNAL_MODE ?? '').trim().toUpperCase();
+  const journalMode = journalModes.includes(wantedJournal) ? wantedJournal : 'WAL';
+  if (wantedJournal && journalMode !== wantedJournal) {
+    console.warn(`TREK_DB_JOURNAL_MODE="${process.env.TREK_DB_JOURNAL_MODE}" is not a SQLite journal mode — using ${journalMode}.`);
+  }
+
+  const wantedSync = (process.env.TREK_DB_SYNCHRONOUS ?? '').trim().toUpperCase();
+  const defaultSync = journalMode === 'WAL' ? 'NORMAL' : 'FULL';
+  const synchronous = syncLevels.includes(wantedSync) ? wantedSync : defaultSync;
+  if (wantedSync && synchronous !== wantedSync) {
+    console.warn(`TREK_DB_SYNCHRONOUS="${process.env.TREK_DB_SYNCHRONOUS}" is not a SQLite synchronous level — using ${synchronous}.`);
+  }
+
+  db.pragma(`journal_mode = ${journalMode}`);
+  db.pragma(`synchronous = ${synchronous}`);
+  console.log(`Journal mode: ${db.pragma('journal_mode', { simple: true })}\n`);
 
   const result: MigrationResult = { migrated: 0, alreadyMigrated: 0, skipped: 0, errors: [] };
 

--- a/server/src/app-config/README.md
+++ b/server/src/app-config/README.md
@@ -63,7 +63,7 @@ PORT, HOST, TRUST_PROXY, SESSION_DURATION(_REMEMBER), MCP_SESSION_TTL,
 MCP_MAX_SESSION_PER_USER, MCP_SSE_KEEPALIVE, TREK_PLUGIN_RPC_*/LOG_*/MAX_RSS_MB,
 TREK_PLUGIN_REGISTRY_URL, TREK_WIKI_DIR*, TREK_PLACE_PHOTO_DIR, BACKUP_*,
 TRANSIT_API_URL, LOG_LEVEL*, ALLOW_INTERNAL_NETWORK*, DEFAULT_LANGUAGE,
-TREK_DB_FILE, ENCRYPTION_KEY.
+TREK_DB_FILE, TREK_DB_JOURNAL_MODE, TREK_DB_SYNCHRONOUS, ENCRYPTION_KEY.
 (* frozen today because the consuming module captures it at import; tests that
 override these set them at file top, before the SUT import.)
 
@@ -85,7 +85,13 @@ ADMIN_PASSWORD, IDEMPOTENCY_TTL_SECONDS, MCP_RATE_LIMIT (request-path check).
   `plugins/host/plugin-audit.ts`.
 - `src/config.ts` ENCRYPTION_KEY/JWT_SECRET resolution — key material with file
   persistence and runtime rotation, not env config.
-- Standalone scripts (`reset-admin.js`, `scripts/*`) and `tests/**`.
+- Standalone scripts (`reset-admin.js`, `scripts/*`) and `tests/**`. Note that
+  `reset-admin.js` and `scripts/migrate-encryption.ts` open the database file
+  read-write and therefore re-implement `TREK_DB_JOURNAL_MODE` /
+  `TREK_DB_SYNCHRONOUS` inline (the journal mode lives in the file header, so
+  they must agree with the server). Neither can import this layer — the image
+  ships `dist/`, not `src/` — so the defaults in `parsers.resolveDurability()`
+  and in those two files move together.
 
 The exemption list is enforced by the `no-restricted-syntax` ban on
 `process.env` in `eslint.config.mjs` — keep the two lists in sync.

--- a/server/src/app-config/derive.ts
+++ b/server/src/app-config/derive.ts
@@ -23,6 +23,7 @@ import {
   parseDurationMs,
   positiveIntOr,
   positiveNumberOr,
+  resolveDurability,
   resolveKeepaliveMs,
   resolveSessionTtlMs,
   stripTrailingSlashes,
@@ -205,8 +206,15 @@ export function deriveBackup(raw: RawEnv) {
 }
 
 export function deriveDb(raw: RawEnv) {
+  const durability = resolveDurability(raw.TREK_DB_JOURNAL_MODE, raw.TREK_DB_SYNCHRONOUS);
   return {
     trekDbFile: raw.TREK_DB_FILE,
+    /** Resolved journal_mode — WAL unless the operator asked for something else (network storage needs DELETE/TRUNCATE). */
+    journalMode: durability.journalMode,
+    /** Resolved synchronous level — NORMAL under WAL (what SQLite already does), FULL under a rollback journal. */
+    synchronous: durability.synchronous,
+    /** Complaints about unusable values; derivation stays side-effect free, so db/durability.ts logs them when it opens the file. */
+    durabilityWarnings: durability.warnings,
   };
 }
 

--- a/server/src/app-config/env.schema.ts
+++ b/server/src/app-config/env.schema.ts
@@ -116,6 +116,12 @@ export const envSchema = z.object({
 
   // Data / paths
   TREK_DB_FILE: anyString,
+  // The two SQLite pragmas are deliberately unvalidated: a typo here must fall
+  // back and warn rather than abort boot, because reset-admin.js — the way out
+  // of a locked-out instance — reads the same variables and is not covered by
+  // this schema at all. Resolution lives in parsers.resolveDurability().
+  TREK_DB_JOURNAL_MODE: anyString,
+  TREK_DB_SYNCHRONOUS: anyString,
   TREK_WIKI_DIR: anyString,
   TREK_PLACE_PHOTO_DIR: anyString,
   BACKUP_UPLOAD_LIMIT_MB: positiveNumber,

--- a/server/src/app-config/parsers.ts
+++ b/server/src/app-config/parsers.ts
@@ -106,3 +106,68 @@ export function resolveKeepaliveMs(raw: string | undefined): number {
   const parsed = Number.parseInt(raw ?? '');
   return Number.isFinite(parsed) && parsed >= 0 ? parsed * 1000 : 25_000;
 }
+
+/** SQLite's journal_mode vocabulary. WAL is the default and the right choice on local disk; DELETE and TRUNCATE are the ones that survive network storage (Azure App Service, SMB/NFS volumes), where WAL's shared-memory coordination is not reliable. */
+const JOURNAL_MODES = ['DELETE', 'TRUNCATE', 'PERSIST', 'MEMORY', 'WAL', 'OFF'];
+
+/** PRAGMA synchronous levels, in the order SQLite numbers them (0-3). */
+const SYNCHRONOUS_LEVELS = ['OFF', 'NORMAL', 'FULL', 'EXTRA'];
+
+export const DEFAULT_JOURNAL_MODE = 'WAL';
+
+export interface Durability {
+  journalMode: string;
+  synchronous: string;
+  /** Rejected input, phrased for the log. Resolution never throws — a typo in a pragma must not lock an operator out of their instance — so the process that opens the file prints these instead. */
+  warnings: string[];
+}
+
+/**
+ * TREK_DB_JOURNAL_MODE / TREK_DB_SYNCHRONOUS → the pragmas to apply.
+ *
+ * journal_mode is persisted in the database file header, so it outlives the
+ * process that set it and every entry point opening the file read-write has to
+ * agree on it (see src/db/durability.ts). Defaults reproduce what an existing
+ * install runs today: WAL, and the synchronous=NORMAL that SQLite itself picks
+ * for a WAL database. Anything other than WAL keeps a rollback journal, where
+ * NORMAL means a power cut can lose the last transactions — those default to
+ * FULL, otherwise moving off WAL for safety would only trade one risk for
+ * another.
+ */
+export function resolveDurability(rawJournalMode: string | undefined, rawSynchronous: string | undefined): Durability {
+  const warnings: string[] = [];
+
+  let journalMode = DEFAULT_JOURNAL_MODE;
+  const wanted = rawJournalMode?.trim().toUpperCase();
+  if (wanted) {
+    if (JOURNAL_MODES.includes(wanted)) {
+      journalMode = wanted;
+    } else {
+      warnings.push(
+        `TREK_DB_JOURNAL_MODE="${rawJournalMode}" is not a SQLite journal mode ` +
+          `(${JOURNAL_MODES.join(', ')}) — using ${DEFAULT_JOURNAL_MODE}.`,
+      );
+    }
+  }
+
+  const defaultSynchronous = journalMode === DEFAULT_JOURNAL_MODE ? 'NORMAL' : 'FULL';
+  let synchronous = defaultSynchronous;
+  const wantedSync = rawSynchronous?.trim().toUpperCase();
+  if (wantedSync) {
+    if (SYNCHRONOUS_LEVELS.includes(wantedSync)) {
+      synchronous = wantedSync;
+    } else {
+      warnings.push(
+        `TREK_DB_SYNCHRONOUS="${rawSynchronous}" is not a SQLite synchronous level ` +
+          `(${SYNCHRONOUS_LEVELS.join(', ')}) — using ${defaultSynchronous}.`,
+      );
+    }
+  }
+
+  return { journalMode, synchronous, warnings };
+}
+
+/** `PRAGMA synchronous` reads back as a number — name it, so the boot log says FULL instead of 2. Unrecognized values pass through unchanged. */
+export function synchronousName(level: unknown): string {
+  return SYNCHRONOUS_LEVELS[Number(level)] ?? String(level);
+}

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { readEnv } from '../app-config';
+import { applyDurabilityPragmas } from './durability';
 import { createTables } from './schema';
 import { runMigrations } from './migrations';
 import { runSeeds } from './seeds';
@@ -39,9 +40,16 @@ function initDb(): void {
   }
 
   _db = new Database(dbPath);
-  _db.exec('PRAGMA journal_mode = WAL');
+  // Ahead of the journal switch now: changing journal_mode needs an exclusive
+  // lock, which a sibling process (reset-admin, the rotation script) may hold.
   _db.exec('PRAGMA busy_timeout = 5000');
+  const durability = applyDurabilityPragmas(_db);
   _db.exec('PRAGMA foreign_keys = ON');
+  // Reported so an operator can see whether their setting took — the test DB is
+  // :memory: and has no journal file, so there is nothing to report there.
+  if (dbPath !== ':memory:') {
+    console.log(`[DB] journal_mode=${durability.journalMode}, synchronous=${durability.synchronous}`);
+  }
 
   createTables(_db);
   runMigrations(_db);

--- a/server/src/db/durability.ts
+++ b/server/src/db/durability.ts
@@ -1,0 +1,36 @@
+import type Database from 'better-sqlite3';
+import { readEnv } from '../app-config';
+import { synchronousName } from '../app-config/parsers';
+
+export interface ActiveDurability {
+  journalMode: string;
+  synchronous: string;
+}
+
+/**
+ * Applies the configured journal_mode / synchronous pragmas to a freshly opened
+ * connection and reports back what SQLite actually settled on.
+ *
+ * journal_mode is stored in the database file header, so it is not a per-process
+ * setting: whichever process opened the file last decides the mode for all of
+ * them. reset-admin.js and scripts/migrate-encryption.ts open the same file and
+ * therefore read the same two variables — they cannot import this module (they
+ * are standalone scripts and src/ is not in the image), so keep the three in
+ * sync when the defaults change.
+ *
+ * The returned values are read back from the engine rather than echoed from the
+ * config, so a mode SQLite refused shows up as what it really is — an in-memory
+ * database stays MEMORY however hard you ask for WAL.
+ */
+export function applyDurabilityPragmas(db: Database.Database): ActiveDurability {
+  const { journalMode, synchronous, durabilityWarnings } = readEnv().db;
+  durabilityWarnings.forEach(warning => console.warn(`[DB] ${warning}`));
+
+  db.exec(`PRAGMA journal_mode = ${journalMode}`);
+  db.exec(`PRAGMA synchronous = ${synchronous}`);
+
+  return {
+    journalMode: String(db.pragma('journal_mode', { simple: true })).toUpperCase(),
+    synchronous: synchronousName(db.pragma('synchronous', { simple: true })),
+  };
+}

--- a/server/src/scheduler.ts
+++ b/server/src/scheduler.ts
@@ -1,5 +1,4 @@
 import cron, { type ScheduledTask } from 'node-cron';
-import archiver from 'archiver';
 import { readEnv } from './app-config';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -7,7 +6,6 @@ import { logInfo, logError } from './nest/audit/audit-log.logger';
 
 const dataDir = path.join(__dirname, '../data');
 const backupsDir = path.join(dataDir, 'backups');
-const uploadsDir = path.join(__dirname, '../uploads');
 const settingsFile = path.join(dataDir, 'backup-settings.json');
 
 const VALID_INTERVALS = ['hourly', 'daily', 'weekly', 'monthly'];
@@ -60,31 +58,20 @@ function saveSettings(settings: BackupSettings): void {
 }
 
 async function runBackup(): Promise<void> {
-  if (!fs.existsSync(backupsDir)) fs.mkdirSync(backupsDir, { recursive: true });
-
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const filename = `auto-backup-${timestamp}.zip`;
-  const outputPath = path.join(backupsDir, filename);
-
   try {
-    // Flush WAL to main DB file before archiving
-    try { const { db } = require('./db/database'); db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch (e) {}
-
-    await new Promise<void>((resolve, reject) => {
-      const output = fs.createWriteStream(outputPath);
-      const archive = archiver('zip', { zlib: { level: 9 } });
-      output.on('close', resolve);
-      archive.on('error', reject);
-      archive.pipe(output);
-      const dbPath = path.join(dataDir, 'travel.db');
-      if (fs.existsSync(dbPath)) archive.file(dbPath, { name: 'travel.db' });
-      if (fs.existsSync(uploadsDir)) archive.directory(uploadsDir, 'uploads');
-      archive.finalize();
-    });
+    // Same archive the admin panel builds, only under the auto-backup name: it
+    // snapshots travel.db with VACUUM INTO instead of archiving the live file
+    // (the archiver reads its entries during finalize, so a WAL auto-checkpoint
+    // landing in between tears the copy), and it carries .encryption_key and the
+    // plugin trees — without the key a scheduled backup cannot be decrypted on
+    // another install. Imported lazily because backupService imports this module
+    // for the schedule settings.
+    const { createBackup } = await import('./services/backupService');
+    const { filename } = await createBackup('auto-backup');
     logInfo(`Auto-Backup created: ${filename}`);
   } catch (err: unknown) {
+    // createBackup removes its own half-written zip before rethrowing.
     logError(`Auto-Backup: ${err instanceof Error ? err.message : err}`);
-    if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
     return;
   }
 

--- a/server/src/services/backupService.ts
+++ b/server/src/services/backupService.ts
@@ -143,14 +143,25 @@ export function listBackups(): BackupInfo[] {
 // Create backup
 // ---------------------------------------------------------------------------
 
-export async function createBackup(): Promise<BackupInfo> {
+/**
+ * Writes a full backup zip and returns its BackupInfo.
+ *
+ * `prefix` picks the filename scheme. The scheduler passes 'auto-backup' because
+ * everything downstream tells the two apart by name: cleanupOldBackups() prunes
+ * only auto-backup-*.zip, and the admin panel badges them as automatic. Manual
+ * backups keep the default.
+ */
+export async function createBackup(prefix: 'backup' | 'auto-backup' = 'backup'): Promise<BackupInfo> {
   ensureBackupsDir();
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const filename = `backup-${timestamp}.zip`;
+  const filename = `${prefix}-${timestamp}.zip`;
   const outputPath = path.join(backupsDir, filename);
-  const pdataSnap = path.join(backupsDir, `.plugins-snap-${timestamp}`);
-  const dbSnap = path.join(backupsDir, `.travel-snap-${timestamp}.db`);
+  // The scratch names carry the prefix too: a scheduled run and a manual one that
+  // start in the same second would otherwise share a snapshot path, and the first
+  // to finish would delete the other's staging copy mid-archive.
+  const pdataSnap = path.join(backupsDir, `.plugins-snap-${prefix}-${timestamp}`);
+  const dbSnap = path.join(backupsDir, `.travel-snap-${prefix}-${timestamp}.db`);
 
   try {
     try { db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch (e) {}

--- a/server/tests/unit/auto-backup.test.ts
+++ b/server/tests/unit/auto-backup.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Scheduled backup run.
+ *
+ * The auto-backup used to archive the live travel.db: the archiver reads its
+ * entries while streaming, so a WAL auto-checkpoint writing pages back mid-run
+ * left a torn copy in the zip — without the -wal that would make it recoverable.
+ * It also shipped without .encryption_key, so the archive could not be decrypted
+ * on another install. The run now goes through backupService.createBackup(),
+ * which snapshots the DB with VACUUM INTO and bundles the key.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => '{}'),
+  writeFileSync: vi.fn(),
+  readdirSync: vi.fn(() => [] as unknown as string[]),
+  statSync: vi.fn(() => ({ size: 0, birthtime: new Date(0), mtimeMs: 0 })),
+  unlinkSync: vi.fn(),
+  createWriteStream: vi.fn(),
+  createReadStream: vi.fn(),
+  rmSync: vi.fn(),
+  copyFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  cpSync: vi.fn(),
+  realpathSync: vi.fn((p: string) => p),
+}));
+
+const archiveMock = vi.hoisted(() => ({
+  pipe: vi.fn(),
+  file: vi.fn(),
+  directory: vi.fn(),
+  glob: vi.fn(),
+  finalize: vi.fn(),
+  on: vi.fn(),
+}));
+
+const archiverMock = vi.hoisted(() => vi.fn());
+
+const dbMock = vi.hoisted(() => ({
+  db: { exec: vi.fn(), prepare: vi.fn() },
+  closeDb: vi.fn(),
+  reinitialize: vi.fn(),
+}));
+
+const logMock = vi.hoisted(() => ({ logInfo: vi.fn(), logError: vi.fn() }));
+
+const cronMock = vi.hoisted(() => ({ schedule: vi.fn(), validate: vi.fn(() => true) }));
+
+vi.mock('node-cron', () => ({ default: cronMock, ...cronMock }));
+vi.mock('fs', () => ({ default: fsMock, ...fsMock }));
+vi.mock('node:fs', () => ({ default: fsMock, ...fsMock }));
+vi.mock('archiver', () => ({ default: archiverMock }));
+vi.mock('unzipper', () => ({ default: { Extract: vi.fn(), Open: { file: vi.fn() } } }));
+vi.mock('../../src/db/database', () => dbMock);
+vi.mock('../../src/nest/audit/audit-log.logger', () => logMock);
+vi.mock('../../src/config', () => ({
+  JWT_SECRET: 'test-secret',
+  ENCRYPTION_KEY: 'a'.repeat(64),
+  updateJwtSecret: () => {},
+}));
+
+import path from 'node:path';
+import { start } from '../../src/scheduler';
+
+const liveDb = path.join(__dirname, '../../data', 'travel.db');
+
+/** Wires up the archiver so finalize() resolves the run, and returns its events. */
+function stubArchiver(): Record<string, (arg?: unknown) => void> {
+  const outputEvents: Record<string, (arg?: unknown) => void> = {};
+  const archiveEvents: Record<string, (arg?: unknown) => void> = {};
+  fsMock.createWriteStream.mockReturnValue({
+    on: vi.fn((event: string, cb: () => void) => { outputEvents[event] = cb; }),
+  } as never);
+  archiveMock.on.mockImplementation((event: string, cb: (arg?: unknown) => void) => { archiveEvents[event] = cb; });
+  archiveMock.finalize.mockImplementation(() => { outputEvents['close']?.(); });
+  archiverMock.mockReturnValue(archiveMock);
+  return archiveEvents;
+}
+
+/** Starts the scheduler with auto-backup enabled and hands back the cron callback. */
+function scheduledRun(): () => Promise<void> {
+  fsMock.readFileSync.mockReturnValue(JSON.stringify({ enabled: true, interval: 'daily', keep_days: 7 }));
+  start();
+  return cronMock.schedule.mock.calls.at(-1)?.[1] as () => Promise<void>;
+}
+
+describe('auto-backup run', () => {
+  const envKey = process.env.ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No ENCRYPTION_KEY in the env means the key file is the source of truth and
+    // has to travel with the backup.
+    delete process.env.ENCRYPTION_KEY;
+    fsMock.statSync.mockReturnValue({ size: 4096, birthtime: new Date('2026-04-27T02:00:00Z'), mtimeMs: Date.now() } as never);
+  });
+
+  afterEach(() => {
+    process.env.ENCRYPTION_KEY = envKey;
+  });
+
+  it('archives a VACUUM INTO snapshot, never the live travel.db', async () => {
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('travel.db') || String(p).endsWith('backup-settings.json'));
+    stubArchiver();
+
+    await scheduledRun()();
+
+    expect(dbMock.db.exec).toHaveBeenCalledWith(expect.stringContaining('VACUUM INTO'));
+    const dbEntry = archiveMock.file.mock.calls.find(([, opts]) => opts?.name === 'travel.db');
+    expect(dbEntry).toBeDefined();
+    expect(dbEntry?.[0]).toContain('.travel-snap-auto-backup-');
+    expect(dbEntry?.[0]).not.toBe(liveDb);
+  });
+
+  it('bundles the at-rest encryption key', async () => {
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('.encryption_key') || String(p).endsWith('backup-settings.json'));
+    stubArchiver();
+
+    await scheduledRun()();
+
+    expect(archiveMock.file).toHaveBeenCalledWith(
+      expect.stringContaining('.encryption_key'),
+      { name: '.encryption_key' },
+    );
+  });
+
+  it('keeps the auto-backup-*.zip naming so retention still prunes it', async () => {
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('backup-settings.json'));
+    fsMock.readdirSync.mockReturnValue(['auto-backup-2020-01-01T02-00-00.zip'] as unknown as string[]);
+    stubArchiver();
+
+    await scheduledRun()();
+
+    expect(logMock.logInfo).toHaveBeenCalledWith(expect.stringMatching(/^Auto-Backup created: auto-backup-[\dT-]+\.zip$/));
+    // cleanupOldBackups(keep_days) still runs after the archive and only sees
+    // files it can match by prefix
+    expect(fsMock.unlinkSync).toHaveBeenCalledWith(expect.stringContaining('auto-backup-2020-01-01T02-00-00.zip'));
+  });
+
+  it('logs the failure, drops the partial zip and skips retention', async () => {
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('.zip') || String(p).endsWith('backup-settings.json'));
+    const archiveEvents = stubArchiver();
+    archiveMock.finalize.mockImplementation(() => { archiveEvents['error']?.(new Error('disk full')); });
+
+    await scheduledRun()();
+
+    expect(logMock.logError).toHaveBeenCalledWith('Auto-Backup: disk full');
+    expect(logMock.logInfo).not.toHaveBeenCalledWith(expect.stringContaining('Auto-Backup created'));
+    expect(fsMock.unlinkSync).toHaveBeenCalledWith(expect.stringContaining('auto-backup-'));
+    // the snapshot scratch file is cleaned up too, and retention never runs
+    expect(fsMock.rmSync).toHaveBeenCalledWith(expect.stringContaining('.travel-snap-auto-backup-'), { force: true });
+    expect(fsMock.readdirSync).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/db/durability.test.ts
+++ b/server/tests/unit/db/durability.test.ts
@@ -1,0 +1,241 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveDurability } from '../../../src/app-config/parsers';
+import { applyDurabilityPragmas } from '../../../src/db/durability';
+
+// journal_mode is written into the database file header, so it outlives the
+// connection that set it. Anything asserting a mode here therefore reopens the
+// file: that is the property operators on SMB/NFS volumes actually depend on.
+
+const SERVER_ROOT = path.resolve(__dirname, '../../..');
+
+let tmpDir: string;
+let dbPath: string;
+
+function readModes(file: string): { journalMode: string; synchronous: number } {
+  const db = new Database(file);
+  try {
+    return {
+      journalMode: String(db.pragma('journal_mode', { simple: true })).toUpperCase(),
+      synchronous: Number(db.pragma('synchronous', { simple: true })),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trek-durability-'));
+  dbPath = path.join(tmpDir, 'travel.db');
+  delete process.env.TREK_DB_JOURNAL_MODE;
+  delete process.env.TREK_DB_SYNCHRONOUS;
+});
+
+afterEach(() => {
+  delete process.env.TREK_DB_JOURNAL_MODE;
+  delete process.env.TREK_DB_SYNCHRONOUS;
+  vi.restoreAllMocks();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('resolveDurability', () => {
+  it('defaults to WAL with the synchronous level a WAL database already runs at', () => {
+    expect(resolveDurability(undefined, undefined)).toEqual({
+      journalMode: 'WAL',
+      synchronous: 'NORMAL',
+      warnings: [],
+    });
+    expect(resolveDurability('', '')).toEqual({ journalMode: 'WAL', synchronous: 'NORMAL', warnings: [] });
+  });
+
+  it('accepts every SQLite journal mode, case- and padding-insensitively', () => {
+    expect(resolveDurability('delete', undefined).journalMode).toBe('DELETE');
+    expect(resolveDurability('  Truncate  ', undefined).journalMode).toBe('TRUNCATE');
+    expect(resolveDurability('PERSIST', undefined).journalMode).toBe('PERSIST');
+    expect(resolveDurability('memory', undefined).journalMode).toBe('MEMORY');
+    expect(resolveDurability('off', undefined).journalMode).toBe('OFF');
+  });
+
+  it('raises the default to FULL once a rollback journal is in play', () => {
+    // NORMAL is only safe under WAL; on DELETE/TRUNCATE it lets a power cut eat
+    // committed transactions, which would defeat the point of leaving WAL.
+    expect(resolveDurability('DELETE', undefined).synchronous).toBe('FULL');
+    expect(resolveDurability('TRUNCATE', undefined).synchronous).toBe('FULL');
+    expect(resolveDurability('WAL', undefined).synchronous).toBe('NORMAL');
+  });
+
+  it('lets synchronous be set independently of the journal mode', () => {
+    expect(resolveDurability('WAL', 'full').synchronous).toBe('FULL');
+    expect(resolveDurability('DELETE', 'normal').synchronous).toBe('NORMAL');
+    expect(resolveDurability(undefined, 'EXTRA').synchronous).toBe('EXTRA');
+    expect(resolveDurability(undefined, 'off').synchronous).toBe('OFF');
+  });
+
+  it('falls back and reports instead of rejecting an unusable value', () => {
+    const result = resolveDurability('WALL', 'sort-of');
+    expect(result.journalMode).toBe('WAL');
+    expect(result.synchronous).toBe('NORMAL');
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toContain('TREK_DB_JOURNAL_MODE="WALL"');
+    expect(result.warnings[1]).toContain('TREK_DB_SYNCHRONOUS="sort-of"');
+  });
+
+  it('keeps the per-mode synchronous default when only that value is bogus', () => {
+    const result = resolveDurability('DELETE', 'maybe');
+    expect(result.journalMode).toBe('DELETE');
+    expect(result.synchronous).toBe('FULL');
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe('applyDurabilityPragmas', () => {
+  it('leaves an unconfigured install on WAL', () => {
+    const db = new Database(dbPath);
+    const active = applyDurabilityPragmas(db);
+    db.exec('CREATE TABLE t (a)');
+    db.close();
+
+    expect(active).toEqual({ journalMode: 'WAL', synchronous: 'NORMAL' });
+    expect(readModes(dbPath).journalMode).toBe('WAL');
+  });
+
+  it('switches the file to the configured mode and persists it', () => {
+    process.env.TREK_DB_JOURNAL_MODE = 'DELETE';
+
+    const wal = new Database(dbPath);
+    wal.exec('PRAGMA journal_mode = WAL');
+    wal.exec('CREATE TABLE t (a)');
+    wal.close();
+    expect(readModes(dbPath).journalMode).toBe('WAL');
+
+    const db = new Database(dbPath);
+    const active = applyDurabilityPragmas(db);
+    db.close();
+
+    expect(active.journalMode).toBe('DELETE');
+    // FULL (2) — a rollback journal without it is no safer than the WAL setup
+    // the operator moved away from.
+    expect(active.synchronous).toBe('FULL');
+    expect(readModes(dbPath)).toEqual({ journalMode: 'DELETE', synchronous: 2 });
+  });
+
+  it('applies an explicit synchronous level on top of the journal mode', () => {
+    process.env.TREK_DB_SYNCHRONOUS = 'FULL';
+
+    const db = new Database(dbPath);
+    const active = applyDurabilityPragmas(db);
+    expect(active).toEqual({ journalMode: 'WAL', synchronous: 'FULL' });
+    expect(Number(db.pragma('synchronous', { simple: true }))).toBe(2);
+    db.close();
+  });
+
+  it('warns and stays on the default when the mode is misspelled', () => {
+    process.env.TREK_DB_JOURNAL_MODE = 'DELET';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const db = new Database(dbPath);
+    const active = applyDurabilityPragmas(db);
+    db.close();
+
+    expect(active.journalMode).toBe('WAL');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('TREK_DB_JOURNAL_MODE="DELET"');
+  });
+
+  it('warns and keeps the mode default when synchronous is misspelled', () => {
+    process.env.TREK_DB_SYNCHRONOUS = 'VERY';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const db = new Database(dbPath);
+    const active = applyDurabilityPragmas(db);
+    db.close();
+
+    expect(active.synchronous).toBe('NORMAL');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('TREK_DB_SYNCHRONOUS="VERY"');
+  });
+
+  it('reports what the engine settled on, not what was asked for', () => {
+    process.env.TREK_DB_JOURNAL_MODE = 'WAL';
+    const db = new Database(':memory:');
+    expect(applyDurabilityPragmas(db).journalMode).toBe('MEMORY');
+    db.close();
+  });
+});
+
+// The other two processes that open travel.db read-write. They cannot import
+// the module above (standalone scripts, and src/ is not in the container
+// image), so they are exercised as processes — a copy of the resolution that
+// drifts flips the header back and silently un-does the operator's choice.
+describe('standalone scripts honour the same configuration', () => {
+  function seedWalDb(): void {
+    const db = new Database(dbPath);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE,
+        email TEXT UNIQUE,
+        password_hash TEXT,
+        role TEXT,
+        must_change_password INTEGER DEFAULT 0,
+        mfa_secret TEXT,
+        maps_api_key TEXT,
+        openweather_api_key TEXT,
+        immich_api_key TEXT,
+        synology_password TEXT,
+        synology_sid TEXT,
+        synology_did TEXT
+      );
+      CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT);
+      CREATE TABLE settings (user_id INTEGER, key TEXT, value TEXT);
+      CREATE TABLE trip_album_links (id INTEGER PRIMARY KEY, passphrase TEXT);
+      CREATE TABLE trek_photos (id INTEGER PRIMARY KEY, passphrase TEXT);
+    `);
+    db.close();
+    expect(readModes(dbPath).journalMode).toBe('WAL');
+  }
+
+  it('reset-admin.js applies TREK_DB_JOURNAL_MODE instead of leaving WAL behind', () => {
+    seedWalDb();
+
+    execFileSync(process.execPath, ['reset-admin.js'], {
+      cwd: SERVER_ROOT,
+      env: {
+        ...process.env,
+        TREK_DB_FILE: dbPath,
+        TREK_DB_JOURNAL_MODE: 'DELETE',
+        RESET_ADMIN_EMAIL: 'locked-out@example.com',
+        RESET_ADMIN_PASSWORD: 'Recovery12345!',
+      },
+      stdio: 'pipe',
+    });
+
+    expect(readModes(dbPath)).toEqual({ journalMode: 'DELETE', synchronous: 2 });
+
+    const db = new Database(dbPath);
+    const admin = db.prepare('SELECT role FROM users WHERE email = ?').get('locked-out@example.com') as
+      | { role: string }
+      | undefined;
+    db.close();
+    expect(admin?.role).toBe('admin');
+  }, 60000);
+
+  it('migrate-encryption.ts no longer forces the database back to WAL', () => {
+    seedWalDb();
+
+    execFileSync(process.execPath, ['--import', 'tsx', 'scripts/migrate-encryption.ts'], {
+      cwd: SERVER_ROOT,
+      env: { ...process.env, DB_PATH: dbPath, TREK_DB_JOURNAL_MODE: 'DELETE' },
+      input: 'old-key\nnew-key\nyes\n',
+      stdio: 'pipe',
+    });
+
+    expect(readModes(dbPath)).toEqual({ journalMode: 'DELETE', synchronous: 2 });
+  }, 120000);
+});

--- a/server/tests/unit/services/backupService.test.ts
+++ b/server/tests/unit/services/backupService.test.ts
@@ -609,6 +609,34 @@ describe('BACKUP-036 createBackup', () => {
       expect.anything(),
     );
   });
+
+  it('BACKUP-036i — the auto-backup prefix names both the zip and its scratch snapshots', async () => {
+    // The scheduler passes 'auto-backup' so retention and the admin panel can
+    // still tell scheduled archives apart by filename.
+    fsMock.existsSync.mockImplementation((p: string) => String(p).endsWith('travel.db'));
+    fsMock.mkdirSync.mockReturnValue(undefined);
+
+    const writableEvents: Record<string, Function> = {};
+    fsMock.createWriteStream.mockReturnValue({
+      on: vi.fn((event: string, cb: Function) => { writableEvents[event] = cb; }),
+    } as never);
+    archiverInstanceMock.on.mockImplementation((_e: string, _cb: Function) => {});
+    archiverInstanceMock.pipe.mockReturnValue(undefined);
+    archiverInstanceMock.finalize.mockImplementation(() => {
+      if (writableEvents['close']) writableEvents['close']();
+    });
+    archiverMock.mockReturnValue(archiverInstanceMock);
+
+    fsMock.statSync.mockReturnValue({ size: 1024, birthtime: new Date('2026-04-06T12:00:00Z') });
+
+    const result = await createBackup('auto-backup');
+
+    expect(result.filename).toMatch(/^auto-backup-.*\.zip$/);
+    expect(archiverInstanceMock.file).toHaveBeenCalledWith(
+      expect.stringContaining('.travel-snap-auto-backup-'),
+      { name: 'travel.db' },
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/wiki/Backups.md
+++ b/wiki/Backups.md
@@ -19,7 +19,7 @@ A backup is a ZIP archive with these entries:
 | `plugins-data/` | Each installed plugin's own database + files (present only if plugins are installed) |
 | `plugins-code/` | The installed plugin code, so a restore is self-contained (dev-linked plugins are skipped) |
 
-**Not included:** the encryption key. Store your `ENCRYPTION_KEY` separately from the backup ZIP — for example, in a password manager. See [Encryption-Key-Rotation](Encryption-Key-Rotation).
+**Also included:** the at-rest encryption key, unless you supply it through the `ENCRYPTION_KEY` environment variable — in that case the file is not the source of truth and is left out. Bundling it is what makes a backup restorable onto a different install, and it makes the ZIP as sensitive as the key itself: store and transfer it accordingly. See [Encryption-Key-Rotation](Encryption-Key-Rotation).
 
 ## Manual backup
 
@@ -64,7 +64,7 @@ Enable scheduled backups in the **Auto-Backup** section of the Backup tab.
 
 Auto-backup files are named `auto-backup-<timestamp>.zip` (manual backups use `backup-<timestamp>.zip`).
 
-After each auto-backup run, **all** backup files (manual and auto) older than `keep_days` are pruned. Set `keep_days` to `0` to disable pruning entirely.
+After each auto-backup run, **auto-backup files** older than `keep_days` are pruned. Manual backups are never pruned — delete those yourself when you no longer need them. Set `keep_days` to `0` to disable pruning entirely.
 
 ## Before updating TREK
 

--- a/wiki/Environment-Variables.md
+++ b/wiki/Environment-Variables.md
@@ -256,6 +256,30 @@ To get a key: create a free account at [unsplash.com/developers](https://unsplas
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
 | `TREK_PLACE_PHOTO_DIR`   | Directory where cached Google place photos are stored. Created recursively on boot. Set this to point photo storage at a dedicated mounted volume.                                                                                                     | `uploads/photos/google` |
 | `BACKUP_UPLOAD_LIMIT_MB` | Maximum **compressed** size (in MB) of a restore-backup archive that may be uploaded. Raise it if your backups (which include the `uploads/` directory) exceed the default. Non-positive or invalid values log a warning and fall back to the default. | `500`                   |
+| `TREK_DB_JOURNAL_MODE`   | SQLite [journal mode](https://sqlite.org/pragma.html#pragma_journal_mode): `DELETE`, `TRUNCATE`, `PERSIST`, `MEMORY`, `WAL` or `OFF`. Set `DELETE` when the data directory lives on network storage — see below. Values SQLite doesn't know log a warning and fall back. | `WAL`                   |
+| `TREK_DB_SYNCHRONOUS`    | SQLite [synchronous](https://sqlite.org/pragma.html#pragma_synchronous) level: `OFF`, `NORMAL`, `FULL` or `EXTRA`. The default follows the journal mode — `NORMAL` under WAL (what SQLite itself uses there), `FULL` otherwise, because a rollback journal at `NORMAL` can lose committed transactions on a power cut. | `NORMAL` / `FULL`       |
+
+### Running the database on network storage
+
+WAL is the right mode on a local disk and stays the default. It coordinates readers and writers through a shared-memory
+file (`travel.db-shm`) and memory mapping, and [SQLite's own documentation](https://sqlite.org/wal.html#noshm) says that
+combination is not safe on filesystems that don't implement those primitives properly. In practice that means Azure App
+Service (Linux), and SMB/NFS volumes mounted from a NAS or a PaaS host. If your `data/` directory is one of those, set:
+
+```
+TREK_DB_JOURNAL_MODE=DELETE
+```
+
+The journal mode is written into the database file header, not held per connection, so it survives restarts and applies
+from the next boot onward. The startup log prints what is actually in effect:
+
+```
+[DB] journal_mode=DELETE, synchronous=FULL
+```
+
+The maintenance tools that open the same file — `reset-admin.js` and `scripts/migrate-encryption.ts` — read the same two
+variables, so run them with the same environment (`docker exec` into the container does this for you). Otherwise the
+next key rotation or admin reset would quietly switch the file back to WAL.
 
 ---
 


### PR DESCRIPTION
Two things came out of looking into #1675. Neither is the cause the report proposes, and one of them nobody had noticed.

Closes #1675

## Scheduled backups could be silently corrupt

`runBackup()` archived `travel.db` directly. The archiver reads its entries lazily during `finalize()`, so a WAL checkpoint writing pages back mid-stream tears the archived copy — and the `-wal` that would make it recoverable isn't in the zip. The manual path in `backupService.ts` was moved to `VACUUM INTO` for exactly this reason, with a comment describing the failure; the scheduler was never brought along. That's the path running unattended every night on every instance, and you find out when you need the backup.

It calls the same `createBackup()` now rather than keeping a second, drifted copy of the archive logic. That also closes two gaps the scheduled path had: it now bundles the at-rest encryption key and the plugin data, so a scheduled backup is restorable onto another install for the first time.

`migrate-encryption.ts` had the same defect in its pre-rotation safety copy — a plain `copyFileSync` of a live WAL database, and it's the operator's only rollback if a key rotation goes wrong. It takes a snapshot too.

## The journal mode is configurable

WAL was hardcoded with no way out. On network-backed storage — Azure App Service Linux, SMB/NFS volumes on NAS and PaaS boxes — SQLite documents WAL as unsafe, because coordination runs through the `-shm` file and mmap. That needs no concurrency at all; a single process is enough.

`TREK_DB_JOURNAL_MODE` and `TREK_DB_SYNCHRONOUS` now set both pragmas, defaulting to today's behaviour so nothing changes for existing deployments. The mode is persistent in the file header, so all three processes that open `travel.db` read the same configuration: the server, `reset-admin.js`, and `migrate-encryption.ts` — which used to hard-set WAL and would have silently reverted a deliberate `DELETE` setup on the first key rotation. `synchronous` was never set anywhere, so WAL ran on `NORMAL`; switching to `DELETE` without `FULL` would only have traded one unsafe configuration for another.

An invalid value falls back and warns rather than refusing to start, and the mode that actually took effect is read back and logged, so an operator can tell whether the setting landed.

## What this does not do

The report asks for write serialization or backpressure on the shared connection. That would not help: better-sqlite3 is synchronous, every statement blocks the single Node thread, and there are no worker threads or cluster mode — writes from request handling are already serialized by construction. The rate limiter in `plugin-supervisor.ts` cited as precedent guards against event-loop starvation from an unthrottled plugin loop, which its own comment says; it isn't about database serialization.

Two shipped paths do open `travel.db` from a second process — `reset-admin.js` and `migrate-encryption.ts`, both documented as running via `docker exec` against a live container. Multi-writer WAL on a network filesystem is unsafe, so those matter, and both now honour the configured mode. Note also that the Helm chart pins `replicas: 1` with a `Recreate` strategy for this reason; there is no equivalent guard for Docker, Compose or App Service, where overlapping container recycling can put two processes on one database file. That's worth its own change rather than being folded in here.

The long-term ask — moving to Drizzle or Kysely with Postgres support — is an architecture decision, not something to slip into a bug fix.

Docs: `wiki/Environment-Variables.md` documents the two variables. `wiki/Backups.md` had two statements that were already wrong before this branch and are now corrected — the encryption key *is* in the backup, and retention prunes only auto-backups, never manual ones.
