### PR TITLE
Drag and drop places on tablets (#1616)

### DIFF
--- a/client/src/components/Planner/DayPlanSidebar.test.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.test.tsx
@@ -3836,4 +3836,29 @@ describe('reordering the day plan with a finger (#1616)', () => {
       teardown()
     }
   })
+
+  // The reorder popup renders inside the sidebar, so it inherits the opt-in and
+  // its day rows become draggable by finger too. Pinned so it stays deliberate.
+  it('FE-PLANNER-DAYPLAN-191: a long press reorders days in the reorder popup', async () => {
+    const onReorderDays = vi.fn().mockResolvedValue(undefined)
+    const days = [
+      buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' }),
+      buildDay({ id: 11, date: '2025-06-02', title: 'Day 2' }),
+      buildDay({ id: 12, date: '2025-06-03', title: 'Day 3' }),
+    ]
+    render(<DayPlanSidebar {...makeDefaultProps({ days, onReorderDays, onAddDay: vi.fn() })} />)
+    fireEvent.click(screen.getByLabelText('Reorder days'))
+    const teardown = installTouchDragBridge()
+    try {
+      const rows = document.querySelectorAll('[draggable="true"]')
+      const from = [...rows].find(r => r.textContent?.includes('Day 1'))!
+      const to = [...rows].find(r => r.textContent?.includes('Day 3'))!
+      expect(from.closest('[data-touch-drag]')).not.toBeNull()
+      await longPress(from)
+      dragTo(to)
+      await waitFor(() => expect(onReorderDays).toHaveBeenCalled())
+    } finally {
+      teardown()
+    }
+  })
 })

--- a/client/src/components/Planner/DayPlanSidebar.test.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.test.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '../../store/authStore'
 import { useTripStore, type TripStoreState } from '../../store/tripStore'
 import { useSettingsStore } from '../../store/settingsStore'
 import { usePluginStore } from '../../store/pluginStore'
+import { installTouchDragBridge } from '../../utils/touchDragBridge'
 import { resetAllStores, seedStore } from '../../../tests/helpers/store'
 import {
   buildUser, buildTrip, buildDay, buildPlace, buildCategory, buildAssignment, buildDayNote, buildReservation,
@@ -2953,16 +2954,29 @@ describe('DayPlanSidebar', () => {
     expect(document.querySelectorAll('.dp-row')).toHaveLength(0)
   })
 
-  it('FE-PLANNER-DAYPLAN-155: on a touch device place rows lose their drag handle', () => {
-    const place = buildPlace({ id: 1, name: 'Touch place' })
+  it('FE-PLANNER-DAYPLAN-155: below lg place rows lose their drag handle', () => {
+    const place = buildPlace({ id: 1, name: 'Narrow place' })
     const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
     const a = buildAssignment({ id: 11, day_id: 10, order_index: 0, place })
-    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], places: [place], assignments: { '10': [a] }, isTouch: true })} />)
-    const row = screen.getByText('Touch place').closest('.dp-row') as HTMLElement
+    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], places: [place], assignments: { '10': [a] }, isMobile: true })} />)
+    const row = screen.getByText('Narrow place').closest('.dp-row') as HTMLElement
     expect(row.getAttribute('draggable')).toBe('false')
     expect(row.querySelector('.dp-grip')).toBeNull()
     fireEvent.dragStart(row, { dataTransfer: emptyDataTransfer })
     expect(row.style.opacity).toBe('1')
+  })
+
+  // #1616: a tablet is a coarse pointer at a desktop width. It gets the same rows
+  // the mouse does — the long press in touchDragBridge is what starts the drag.
+  it('FE-PLANNER-DAYPLAN-155b: at desktop width place rows keep grip and drag', () => {
+    const place = buildPlace({ id: 1, name: 'Tablet place' })
+    const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
+    const a = buildAssignment({ id: 11, day_id: 10, order_index: 0, place })
+    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], places: [place], assignments: { '10': [a] }, isMobile: false })} />)
+    const row = screen.getByText('Tablet place').closest('.dp-row') as HTMLElement
+    expect(row.getAttribute('draggable')).toBe('true')
+    expect(row.querySelector('.dp-grip')).not.toBeNull()
+    expect(row.closest('[data-touch-drag]')).not.toBeNull()
   })
 
   // ── Booking rows ─────────────────────────────────────────────────────────
@@ -3655,10 +3669,10 @@ describe('DayPlanSidebar', () => {
     await waitFor(() => expect(updateDayNote).toHaveBeenCalledWith(1, 10, 70, { sort_order: expect.any(Number) }))
   })
 
-  it('FE-PLANNER-DAYPLAN-188: on a touch device note rows lose their grip and cannot be dragged', () => {
+  it('FE-PLANNER-DAYPLAN-188: below lg note rows lose their grip and cannot be dragged', () => {
     const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
     mockDayNotesState.dayNotes = { '10': [buildDayNote({ id: 70, day_id: 10, text: 'A note' })] }
-    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], isTouch: true })} />)
+    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], isMobile: true })} />)
     const row = cardRow(screen.getByText('A note'))
     expect(row.getAttribute('draggable')).toBe('false')
     expect(row.querySelector('.dp-grip')).toBeNull()
@@ -3756,5 +3770,70 @@ describe('DayPlanSidebar remaining branches', () => {
     const body = document.body.textContent ?? ''
     expect(body.indexOf('Departing Inn')).toBeGreaterThan(-1)
     expect(body.indexOf('Departing Inn')).toBeLessThan(body.indexOf('Arriving Inn'))
+  })
+})
+
+// #1616 — the reporter's iPad sees both panes but could not pick a row up at all.
+// This drives the real bridge rather than a synthetic dragstart, so it fails if the
+// long press, the hit test or the opt-in container ever stop lining up.
+describe('reordering the day plan with a finger (#1616)', () => {
+  /** Presses a row for longer than the bridge's long press. */
+  async function longPress(row: Element) {
+    fireEvent.touchStart(row, { touches: [{ identifier: 1, clientX: 20, clientY: 40 }] })
+    await new Promise(resolve => setTimeout(resolve, 400))
+  }
+
+  function dragTo(target: Element) {
+    document.elementFromPoint = () => target as Element
+    fireEvent.touchMove(document, { touches: [{ identifier: 1, clientX: 20, clientY: 180 }] })
+    const end = new Event('touchend', { bubbles: true, cancelable: true })
+    Object.defineProperty(end, 'touches', { value: [] })
+    fireEvent(document, end)
+  }
+
+  it('FE-PLANNER-DAYPLAN-189: a long press drags one place row onto another and reorders the day', async () => {
+    const onReorder = vi.fn().mockResolvedValue(undefined)
+    const place1 = buildPlace({ id: 1, name: 'First Place' })
+    const place2 = buildPlace({ id: 2, name: 'Second Place' })
+    const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
+    const a1 = buildAssignment({ id: 11, day_id: 10, order_index: 0, place: place1 })
+    const a2 = buildAssignment({ id: 12, day_id: 10, order_index: 1, place: place2 })
+    render(<DayPlanSidebar {...makeDefaultProps({
+      days: [day], places: [place1, place2], assignments: { '10': [a1, a2] }, onReorder,
+    })} />)
+    const teardown = installTouchDragBridge()
+    try {
+      const from = screen.getByText('First Place').closest('[draggable="true"]')!
+      const to = screen.getByText('Second Place').closest('[draggable="true"]')!
+      await longPress(from)
+      dragTo(to)
+      await waitFor(() => expect(onReorder).toHaveBeenCalledWith(10, expect.any(Array)))
+    } finally {
+      teardown()
+    }
+  })
+
+  it('FE-PLANNER-DAYPLAN-190: a swipe across the same row scrolls instead of reordering', async () => {
+    const onReorder = vi.fn().mockResolvedValue(undefined)
+    const place1 = buildPlace({ id: 1, name: 'First Place' })
+    const place2 = buildPlace({ id: 2, name: 'Second Place' })
+    const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
+    const a1 = buildAssignment({ id: 11, day_id: 10, order_index: 0, place: place1 })
+    const a2 = buildAssignment({ id: 12, day_id: 10, order_index: 1, place: place2 })
+    render(<DayPlanSidebar {...makeDefaultProps({
+      days: [day], places: [place1, place2], assignments: { '10': [a1, a2] }, onReorder,
+    })} />)
+    const teardown = installTouchDragBridge()
+    try {
+      const from = screen.getByText('First Place').closest('[draggable="true"]')!
+      fireEvent.touchStart(from, { touches: [{ identifier: 1, clientX: 20, clientY: 40 }] })
+      // The finger travels before the press lands, so the browser keeps the gesture.
+      const moved = fireEvent.touchMove(document, { touches: [{ identifier: 1, clientX: 20, clientY: 140 }] })
+      expect(moved).toBe(true)
+      await new Promise(resolve => setTimeout(resolve, 400))
+      expect(onReorder).not.toHaveBeenCalled()
+    } finally {
+      teardown()
+    }
   })
 })

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -104,11 +104,6 @@ interface DayPlanSidebarProps {
   /** Mobile: show the route tools footer (Route toggle / Optimize / travel profile) on expanded days, since selecting a day closes the sheet */
   showRouteToolsWhenExpanded?: boolean
   isMobile?: boolean
-  /** Coarse primary pointer. Drag & drop reorder is disabled here (it hijacks the
-   *  touch-scroll gesture, #1432); the grip handle is hidden and the arrow reorder
-   *  buttons take over instead. Distinct from isMobile, which is width-based — a
-   *  tablet is a wide touch device and needs both. */
-  isTouch?: boolean
 }
 
 /**
@@ -156,9 +151,11 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
   onScrollTopChange,
   showRouteToolsWhenExpanded = false,
   isMobile = false,
-  isTouch = false,
   } = props
-  const dragDisabled = isMobile || isTouch
+  // Below lg the plan and the places sit in separate tabs, so there is nothing
+  // to drag between. A coarse pointer is no longer a reason of its own: tablets
+  // reach the same drag through a long press (#1616).
+  const dragDisabled = isMobile
   const toast = useToast()
   const { t, language, locale } = useTranslation()
   const ctxMenu = useContextMenu()
@@ -1254,7 +1251,7 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
     ])
   }
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', position: 'relative', fontFamily: "var(--font-system)" }}>
+    <div data-touch-drag={dragDisabled ? undefined : ''} style={{ display: 'flex', flexDirection: 'column', height: '100%', position: 'relative', fontFamily: "var(--font-system)" }}>
       {/* Toolbar */}
       <DayPlanSidebarToolbar
         tripId={tripId}

--- a/client/src/components/Planner/DayReorderPopup.tsx
+++ b/client/src/components/Planner/DayReorderPopup.tsx
@@ -85,7 +85,10 @@ export function DayReorderPopup({ isOpen, days, t, locale, onReorder, onAddDay, 
         {t('dayplan.reorderHint')}
       </p>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {/* The popup is a modal, so it portals out of the planner and has to opt
+          into the long-press drag itself (#1616). Without this a finger only
+          selects the row text. */}
+      <div data-touch-drag style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         {ordered.map((day, index) => (
           <div
             key={day.id}

--- a/client/src/components/Planner/PlacesSidebar.test.tsx
+++ b/client/src/components/Planner/PlacesSidebar.test.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../../store/authStore';
 import { useTripStore } from '../../store/tripStore';
 import { usePermissionsStore } from '../../store/permissionsStore';
 import { placesApi } from '../../api/client';
+import { installTouchDragBridge } from '../../utils/touchDragBridge';
 import { resetAllStores, seedStore } from '../../../tests/helpers/store';
 import { buildUser, buildTrip, buildPlace, buildCategory, buildDay, buildAssignment } from '../../../tests/helpers/factories';
 import { server } from '../../../tests/helpers/msw/server';
@@ -620,34 +621,36 @@ describe('Google Maps list import', () => {
 
 });
 
-// #1432: a tablet is a touch device at a desktop width. Before the fix, isTouch didn't
-// exist and drag was gated on width alone, so on an iPad the rows stayed draggable and a
-// scroll swipe started an HTML5 drag, which raised the drop-to-import overlay instead of
-// scrolling. These cases pin the desktop-width + coarse-pointer combination.
-describe('touch device at desktop width (#1432)', () => {
-  const touchProps = { ...defaultProps, isMobile: false, isTouch: true };
+// #1616: a tablet is a coarse pointer at a desktop width, and it sees both panes, so
+// it has somewhere to drag a place to. A coarse pointer used to switch the drag off by
+// itself, which left the reporter's iPad selecting text instead of picking up a row.
+// Width is the only gate now: below lg the places live in their own tab.
+describe('touch device at desktop width (#1616)', () => {
+  const tabletProps = { ...defaultProps, isMobile: false };
 
-  it('FE-PLANNER-SIDEBAR-044: place rows are not draggable', () => {
+  it('FE-PLANNER-SIDEBAR-044: place rows are draggable and opt into the touch bridge', () => {
     const place = buildPlace({ id: 7, name: 'Tablet Place' });
-    render(<PlacesSidebar {...touchProps} places={[place]} />);
+    const { container } = render(<PlacesSidebar {...tabletProps} places={[place]} />);
     const placeRow = screen.getByText('Tablet Place').closest('div[draggable]')!;
-    expect(placeRow.getAttribute('draggable')).toBe('false');
-  });
-
-  it('FE-PLANNER-SIDEBAR-045: dragging over the sidebar does not raise the drop-to-import overlay', () => {
-    const place = buildPlace({ id: 7, name: 'Tablet Place' });
-    const { container } = render(<PlacesSidebar {...touchProps} places={[place]} />);
-    fireEvent.dragEnter(container.firstChild as HTMLElement);
-    expect(screen.queryByText('Drop to import')).not.toBeInTheDocument();
-  });
-
-  it('FE-PLANNER-SIDEBAR-046: a mouse-driven desktop keeps drag and the drop-to-import overlay', () => {
-    const place = buildPlace({ id: 7, name: 'Desktop Place' });
-    const { container } = render(<PlacesSidebar {...defaultProps} isTouch={false} places={[place]} />);
-    const placeRow = screen.getByText('Desktop Place').closest('div[draggable]')!;
     expect(placeRow.getAttribute('draggable')).toBe('true');
+    expect((container.firstChild as HTMLElement).hasAttribute('data-touch-drag')).toBe(true);
+  });
+
+  it('FE-PLANNER-SIDEBAR-045: dragging over the sidebar raises the drop-to-import overlay', () => {
+    const place = buildPlace({ id: 7, name: 'Tablet Place' });
+    const { container } = render(<PlacesSidebar {...tabletProps} places={[place]} />);
     fireEvent.dragEnter(container.firstChild as HTMLElement);
     expect(screen.getByText('Drop to import')).toBeInTheDocument();
+  });
+
+  it('FE-PLANNER-SIDEBAR-046: below lg the rows stay undraggable and the bridge stays out', () => {
+    const place = buildPlace({ id: 7, name: 'Narrow Place' });
+    const { container } = render(<PlacesSidebar {...defaultProps} isMobile places={[place]} />);
+    const placeRow = screen.getByText('Narrow Place').closest('div[draggable]')!;
+    expect(placeRow.getAttribute('draggable')).toBe('false');
+    expect((container.firstChild as HTMLElement).hasAttribute('data-touch-drag')).toBe(false);
+    fireEvent.dragEnter(container.firstChild as HTMLElement);
+    expect(screen.queryByText('Drop to import')).not.toBeInTheDocument();
   });
 });
 
@@ -668,5 +671,42 @@ describe('track colour legend (#776)', () => {
     const row = screen.getByText('Plain Place').closest('div[draggable]')!;
     const strokes = Array.from(row.querySelectorAll('span')).filter(el => (el as HTMLElement).style.borderRadius === '999px');
     expect(strokes).toHaveLength(0);
+  });
+});
+
+// #1616 — the other half of the reporter's gesture: the pickup. A tablet cannot
+// start an HTML5 drag with a finger, so the bridge's long press has to do it, and
+// the row has to hand over the placeId the day plan reads back on drop.
+describe('picking a place up with a finger (#1616)', () => {
+  it('FE-PLANNER-SIDEBAR-047: a long press on a place row starts a drag carrying its id', async () => {
+    const place = buildPlace({ id: 42, name: 'Tablet Place' });
+    render(<PlacesSidebar {...defaultProps} isMobile={false} places={[place]} />);
+    const teardown = installTouchDragBridge();
+    try {
+      const row = screen.getByText('Tablet Place').closest('[draggable="true"]')!;
+      fireEvent.touchStart(row, { touches: [{ identifier: 1, clientX: 20, clientY: 40 }] });
+      await new Promise(resolve => setTimeout(resolve, 400));
+      expect(window.__dragData).toEqual({ placeId: '42' });
+    } finally {
+      teardown();
+      window.__dragData = null;
+    }
+  });
+
+  it('FE-PLANNER-SIDEBAR-048: a swipe down the list scrolls instead of picking the row up', async () => {
+    const place = buildPlace({ id: 42, name: 'Tablet Place' });
+    render(<PlacesSidebar {...defaultProps} isMobile={false} places={[place]} />);
+    const teardown = installTouchDragBridge();
+    try {
+      const row = screen.getByText('Tablet Place').closest('[draggable="true"]')!;
+      fireEvent.touchStart(row, { touches: [{ identifier: 1, clientX: 20, clientY: 40 }] });
+      const moved = fireEvent.touchMove(document, { touches: [{ identifier: 1, clientX: 20, clientY: 140 }] });
+      await new Promise(resolve => setTimeout(resolve, 400));
+      expect(moved).toBe(true);
+      expect(window.__dragData).toBeFalsy();
+    } finally {
+      teardown();
+      window.__dragData = null;
+    }
   });
 });

--- a/client/src/components/Planner/PlacesSidebar.tsx
+++ b/client/src/components/Planner/PlacesSidebar.tsx
@@ -17,13 +17,17 @@ const PlacesSidebar = React.memo(function PlacesSidebar(props: PlacesSidebarProp
     sidebarDragOver, handleSidebarDragEnter, handleSidebarDragOver, handleSidebarDragLeave, handleSidebarDrop,
     selectMode, filtered, t, dayPickerPlace, listImportOpen,
     fileImportOpen, setFileImportOpen, sidebarDropFile, setSidebarDropFile, tripId, pushUndo,
-    ctxMenu, isMobile, isTouch, pendingDeleteIds, setPendingDeleteIds, onBulkDeleteConfirm,
+    ctxMenu, isMobile, pendingDeleteIds, setPendingDeleteIds, onBulkDeleteConfirm,
     categories, selectedIds, exitSelectMode, onBulkChangeCategory, categoryPickerOpen, setCategoryPickerOpen,
     collectionsEnabled, saveToListOpen, setSaveToListOpen,
   } = S
-  const dragDisabled = isMobile || isTouch
+  // Below lg the places sit in their own tab with no plan beside them to drag
+  // into. A coarse pointer no longer disables the drag on its own — tablets
+  // reach it through a long press (#1616).
+  const dragDisabled = isMobile
   return (
     <div
+      data-touch-drag={dragDisabled ? undefined : ''}
       onDragEnter={dragDisabled ? undefined : handleSidebarDragEnter}
       onDragOver={dragDisabled ? undefined : handleSidebarDragOver}
       onDragLeave={dragDisabled ? undefined : handleSidebarDragLeave}

--- a/client/src/components/Planner/PlacesSidebarList.tsx
+++ b/client/src/components/Planner/PlacesSidebarList.tsx
@@ -7,7 +7,7 @@ export function PlacesList(S: SidebarState) {
   const {
     filtered, scrollContainerRef, onScrollTopChange, filter, t, canEditPlaces, onAddPlace,
     categories, selectedPlaceId, plannedIds, inDaySet, selectedIds, selectMode, selectedDayId,
-    isMobile, isTouch, onPlaceClick, openContextMenu, onAssignToDay, toggleSelected, setDayPickerPlace, registerPlaceRow, tripId,
+    isMobile, onPlaceClick, openContextMenu, onAssignToDay, toggleSelected, setDayPickerPlace, registerPlaceRow, tripId,
   } = S
   // Plugin-contributed columns/actions for the places view, keyed by place id (#plugins).
   const contribFor = usePluginViewContributions('places', tripId)
@@ -43,7 +43,6 @@ export function PlacesList(S: SidebarState) {
                 selectedDayId={selectedDayId}
                 canEditPlaces={canEditPlaces}
                 isMobile={isMobile}
-                isTouch={Boolean(isTouch)}
                 t={t}
                 onPlaceClick={onPlaceClick}
                 onContextMenu={openContextMenu}

--- a/client/src/components/Planner/PlacesSidebarRow.tsx
+++ b/client/src/components/Planner/PlacesSidebarRow.tsx
@@ -16,8 +16,6 @@ interface MemoPlaceRowProps {
   selectedDayId: number | null
   canEditPlaces: boolean
   isMobile: boolean
-  /** Primary pointer is coarse — HTML5 drag would swallow the scroll gesture (#1432). */
-  isTouch: boolean
   t: (key: string, params?: Record<string, any>) => string
   onPlaceClick: (id: number | null) => void
   onContextMenu: (e: React.MouseEvent, place: Place) => void
@@ -29,11 +27,12 @@ interface MemoPlaceRowProps {
 
 export const MemoPlaceRow = React.memo(function MemoPlaceRow({
   place, category: cat, isSelected, isPlanned, inDay, isChecked,
-  selectMode, selectedDayId, canEditPlaces, isMobile, isTouch, t,
+  selectMode, selectedDayId, canEditPlaces, isMobile, t,
   onPlaceClick, onContextMenu, onAssignToDay, toggleSelected, setDayPickerPlace, registerPlaceRow,
 }: MemoPlaceRowProps) {
   const hasGeometry = Boolean(place.route_geometry)
-  const dragDisabled = isMobile || isTouch
+  // Touch is reached through a long press instead of being locked out (#1616).
+  const dragDisabled = isMobile
   return (
     <div
       key={place.id}

--- a/client/src/components/Planner/usePlacesSidebar.ts
+++ b/client/src/components/Planner/usePlacesSidebar.ts
@@ -31,8 +31,6 @@ export interface PlacesSidebarProps {
   onBulkChangeCategory?: (ids: number[], categoryId: number | null) => void
   days: Day[]
   isMobile: boolean
-  /** Primary pointer is coarse — HTML5 drag would swallow the scroll gesture (#1432). */
-  isTouch?: boolean
   pushUndo?: (label: string, undoFn: () => Promise<void> | void) => void
   initialScrollTop?: number
   onScrollTopChange?: (top: number) => void

--- a/client/src/hooks/useTouchDragBridge.test.ts
+++ b/client/src/hooks/useTouchDragBridge.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
+import { useTouchDragBridge } from './useTouchDragBridge'
+
+describe('useTouchDragBridge (#1616)', () => {
+  let source: HTMLElement
+  let started: number
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = '<div data-touch-drag><div id="source" draggable="true">Place</div></div>'
+    source = document.getElementById('source')!
+    started = 0
+    document.addEventListener('dragstart', () => { started++ })
+    document.elementFromPoint = () => source
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  /** Presses the row for longer than the bridge's long press. */
+  function longPress() {
+    fireEvent.touchStart(source, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] })
+    vi.advanceTimersByTime(400)
+  }
+
+  it('FE-TOUCHDRAGHOOK-001: while enabled a long press starts a drag', () => {
+    renderHook(() => useTouchDragBridge(true))
+    longPress()
+    expect(started).toBe(1)
+  })
+
+  it('FE-TOUCHDRAGHOOK-002: a mouse-driven desktop is left to the browser', () => {
+    renderHook(() => useTouchDragBridge(false))
+    longPress()
+    expect(started).toBe(0)
+  })
+
+  it('FE-TOUCHDRAGHOOK-003: leaving the planner stops the bridge watching', () => {
+    const { unmount } = renderHook(() => useTouchDragBridge(true))
+    unmount()
+    longPress()
+    expect(started).toBe(0)
+  })
+
+  it('FE-TOUCHDRAGHOOK-004: turning it off mid-session stops the bridge watching', () => {
+    const { rerender } = renderHook(({ on }) => useTouchDragBridge(on), {
+      initialProps: { on: true },
+    })
+    rerender({ on: false })
+    longPress()
+    expect(started).toBe(0)
+  })
+})

--- a/client/src/hooks/useTouchDragBridge.ts
+++ b/client/src/hooks/useTouchDragBridge.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { installTouchDragBridge } from '../utils/touchDragBridge'
+
+/**
+ * Arms the planner's long-press touch drag while `enabled` (#1616).
+ *
+ * Deliberately not armed on hybrid laptops: their primary pointer is fine, so
+ * `drag-drop-touch` is loaded there instead (see utils/touchDragPolyfill) and
+ * two bridges would fight over the same gesture. The two conditions cannot
+ * both hold — a pointer is either coarse or fine.
+ */
+export function useTouchDragBridge(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return
+    return installTouchDragBridge()
+  }, [enabled])
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1165,6 +1165,18 @@ img[alt="TREK"] {
   .dp-day-header[data-selected="true"] .dp-day-actions { opacity: 1; }
 }
 
+/* Planner rows a finger can pick up (#1616). A long press is what arms the drag,
+   and that is the same gesture the browser answers with a text selection and a
+   callout — "the action is interpreted as a text selection" in the report. Only
+   on coarse pointers, and only inside the two panes that opt into the bridge. */
+@media (pointer: coarse) {
+  [data-touch-drag] [draggable='true'] {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}
+
 /* ── TREK range slider — thin filled track + soft round thumb ─────────────── */
 .trek-range {
   -webkit-appearance: none;

--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -52,6 +52,7 @@ import { useTripPlanner } from './tripPlanner/useTripPlanner'
 import { usePoiExplore } from '../components/Map/usePoiExplore'
 import PoiCategoryPill from '../components/Map/PoiCategoryPill'
 import { useIsPhone } from '../mobile/useIsPhone'
+import { useTouchDragBridge } from '../hooks/useTouchDragBridge'
 import MTripShell from '../mobile/screens/trip/MTripShell'
 
 function ListsContainer({ tripId, packingItems, todoItems }: { tripId: number; packingItems: PackingItem[]; todoItems: TodoItem[] }) {
@@ -227,6 +228,11 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
     mapTileUrl, fontStyle, splashDone,
   } = useTripPlanner()
 
+  // Tablets run this very layout but cannot start an HTML5 drag with a finger,
+  // so a long press stands in for one (#1616). Only where the pointer is
+  // coarse — a hybrid laptop loads drag-drop-touch instead.
+  useTouchDragBridge(isTouch && !isMobile)
+
   const poi = usePoiExplore()
   const [glMap, setGlMap] = useState<CompassMap | null>(null)
   const poiPillEnabled = useSettingsStore(s => s.settings.map_poi_pill_enabled) !== false
@@ -379,7 +385,6 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
               }}>
                 <DayPlanSidebar
                   isMobile={isMobile}
-                  isTouch={isTouch}
                   tripId={tripId}
                   trip={trip}
                   days={days}
@@ -491,7 +496,6 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
                     pushUndo={pushUndo}
                     days={days}
                     isMobile={false}
-                    isTouch={isTouch}
                   />
                 </div>
               </div>

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -298,7 +298,7 @@ export function useTripPlanner() {
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
-  // Layout is width-driven (isMobile); drag affordances are pointer-driven (isTouch).
+  // Layout is width-driven (isMobile); the drag bridge is pointer-driven (isTouch).
   // Conflating them is what left a tablet's places list undraggable-but-unscrollable (#1432).
   const isTouch = useIsTouch()
 

--- a/client/src/utils/touchDragBridge.test.ts
+++ b/client/src/utils/touchDragBridge.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fireEvent } from '@testing-library/react'
+import { installTouchDragBridge } from './touchDragBridge'
+
+/** Longer than the bridge's long press, short enough to stay readable. */
+const PRESS = 400
+
+type Point = { clientX: number; clientY: number; identifier?: number }
+
+function touchStart(el: Element, points: Point[]) {
+  fireEvent.touchStart(el, { touches: points.map(p => ({ identifier: 1, ...p })) })
+}
+function touchMove(points: Point[]) {
+  return fireEvent.touchMove(document, { touches: points.map(p => ({ identifier: 1, ...p })) })
+}
+function touchEnd(type: 'touchend' | 'touchcancel' = 'touchend', remaining: Point[] = []) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'touches', { value: remaining.map(p => ({ identifier: 1, ...p })) })
+  document.dispatchEvent(event)
+}
+
+describe('touchDragBridge (#1616)', () => {
+  let teardown: () => void
+  let source: HTMLElement
+  let dropZone: HTMLElement
+  let outside: HTMLElement
+  let seen: string[]
+
+  /** Records every drag event that reaches the document. */
+  const record = (e: Event) => { seen.push(`${e.type}@${(e.target as HTMLElement).id}`) }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = `
+      <div data-touch-drag id="places"><div id="source" draggable="true">Place</div></div>
+      <div data-touch-drag id="plan"><div id="zone">Day 1</div><div id="zone2">Day 2</div></div>
+      <div id="loose" draggable="true">Outside any pane</div>
+    `
+    source = document.getElementById('source')!
+    dropZone = document.getElementById('zone')!
+    outside = document.getElementById('loose')!
+    seen = []
+    for (const type of ['dragstart', 'dragenter', 'dragover', 'dragleave', 'drop', 'dragend']) {
+      document.addEventListener(type, record)
+    }
+    // jsdom has no layout, so the element under the finger has to be declared.
+    document.elementFromPoint = () => dropZone
+    teardown = installTouchDragBridge()
+  })
+
+  afterEach(() => {
+    teardown()
+    for (const type of ['dragstart', 'dragenter', 'dragover', 'dragleave', 'drop', 'dragend']) {
+      document.removeEventListener(type, record)
+    }
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  /** Presses on the source long enough for the bridge to claim the gesture. */
+  function longPress(el: Element = source) {
+    touchStart(el, [{ clientX: 10, clientY: 10 }])
+    vi.advanceTimersByTime(PRESS)
+  }
+
+  it('FE-TOUCHDRAG-001: a swipe before the press lands scrolls instead of dragging', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }])
+    const notPrevented = touchMove([{ clientX: 10, clientY: 60 }])
+    vi.advanceTimersByTime(PRESS)
+    expect(seen).toEqual([])
+    // Not calling preventDefault is what leaves the scroll to the browser (#1432).
+    expect(notPrevented).toBe(true)
+  })
+
+  it('FE-TOUCHDRAG-002: a long press starts the drag and tracks the element under the finger', () => {
+    longPress()
+    expect(seen).toContain('dragstart@source')
+    touchMove([{ clientX: 200, clientY: 200 }])
+    expect(seen).toContain('dragenter@zone')
+    expect(seen).toContain('dragover@zone')
+  })
+
+  it('FE-TOUCHDRAG-003: once armed the move is consumed so the pane does not scroll', () => {
+    longPress()
+    expect(touchMove([{ clientX: 200, clientY: 200 }])).toBe(false)
+  })
+
+  it('FE-TOUCHDRAG-004: releasing over a zone that accepted the drag drops on it', () => {
+    dropZone.addEventListener('dragover', e => e.preventDefault())
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    touchEnd()
+    expect(seen).toContain('drop@zone')
+    expect(seen).toContain('dragend@source')
+  })
+
+  it('FE-TOUCHDRAG-005: a zone that never accepts the drag gets no drop', () => {
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    touchEnd()
+    expect(seen).not.toContain('drop@zone')
+    expect(seen).toContain('dragleave@zone')
+    expect(seen).toContain('dragend@source')
+  })
+
+  it('FE-TOUCHDRAG-006: leaving a zone for another one hands over enter and leave', () => {
+    const other = document.getElementById('zone2')!
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    document.elementFromPoint = () => other
+    touchMove([{ clientX: 200, clientY: 260 }])
+    expect(seen).toContain('dragleave@zone')
+    expect(seen).toContain('dragenter@zone2')
+  })
+
+  it('FE-TOUCHDRAG-007: touchcancel ends the drag without dropping', () => {
+    dropZone.addEventListener('dragover', e => e.preventDefault())
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    touchEnd('touchcancel')
+    expect(seen).not.toContain('drop@zone')
+    expect(seen).toContain('dragend@source')
+  })
+
+  it('FE-TOUCHDRAG-008: a row outside an opted-in pane is left alone', () => {
+    longPress(outside)
+    expect(seen).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-009: a browser-driven drag stands the bridge down (iPadOS)', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }])
+    fireEvent.dragStart(source)
+    seen = []
+    vi.advanceTimersByTime(PRESS)
+    // Silent: the browser's own sequence is the only one the handlers should see.
+    expect(seen).toEqual([])
+    touchEnd()
+    expect(seen).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-010: a second finger cancels the pending press', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }])
+    touchStart(source, [{ clientX: 10, clientY: 10 }, { clientX: 90, clientY: 90, identifier: 2 }])
+    vi.advanceTimersByTime(PRESS)
+    expect(seen).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-011: the long-press context menu is suppressed while a drag is pending', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }])
+    expect(fireEvent.contextMenu(source)).toBe(false)
+  })
+
+  it('FE-TOUCHDRAG-012: the context menu is left alone when no drag is pending', () => {
+    expect(fireEvent.contextMenu(source)).toBe(true)
+  })
+
+  it('FE-TOUCHDRAG-013: a source that vetoes its own dragstart gets the gesture back', () => {
+    source.addEventListener('dragstart', e => e.preventDefault())
+    longPress()
+    expect(seen).toContain('dragend@source')
+    // The veto ends the session, so the next move is the browser's again.
+    expect(touchMove([{ clientX: 200, clientY: 200 }])).toBe(true)
+  })
+
+  it('FE-TOUCHDRAG-014: the click that follows a drag is swallowed', () => {
+    const onClick = vi.fn()
+    source.addEventListener('click', onClick)
+    longPress()
+    touchEnd()
+    fireEvent.click(source)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('FE-TOUCHDRAG-015: a drag carries data between the source and the drop zone', () => {
+    let carried = ''
+    source.addEventListener('dragstart', e => (e as DragEvent).dataTransfer?.setData('placeId', '42'))
+    dropZone.addEventListener('dragover', e => e.preventDefault())
+    dropZone.addEventListener('drop', e => { carried = (e as DragEvent).dataTransfer?.getData('placeId') ?? '' })
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    touchEnd()
+    expect(carried).toBe('42')
+  })
+
+  it('FE-TOUCHDRAG-016: teardown stops watching for new gestures', () => {
+    teardown()
+    longPress()
+    expect(seen).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-017: a drag near the bottom edge scrolls the pane it is over', () => {
+    const pane = document.getElementById('plan')!
+    Object.defineProperty(pane, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(pane, 'clientHeight', { value: 400, configurable: true })
+    pane.style.overflowY = 'auto'
+    pane.getBoundingClientRect = () => ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) })
+    longPress()
+    touchMove([{ clientX: 200, clientY: 390 }])
+    const before = pane.scrollTop
+    vi.advanceTimersByTime(64)
+    expect(pane.scrollTop).toBeGreaterThan(before)
+  })
+
+  it('FE-TOUCHDRAG-018: a drag near the top edge scrolls the pane back up', () => {
+    const pane = document.getElementById('plan')!
+    Object.defineProperty(pane, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(pane, 'clientHeight', { value: 400, configurable: true })
+    pane.style.overflowY = 'scroll'
+    pane.getBoundingClientRect = () => ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) })
+    pane.scrollTop = 500
+    longPress()
+    touchMove([{ clientX: 200, clientY: 10 }])
+    vi.advanceTimersByTime(64)
+    expect(pane.scrollTop).toBeLessThan(500)
+  })
+
+  it('FE-TOUCHDRAG-019: staying on the same zone keeps asking it, without re-entering', () => {
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    const enters = seen.filter(e => e === 'dragenter@zone').length
+    touchMove([{ clientX: 200, clientY: 210 }])
+    expect(seen.filter(e => e === 'dragenter@zone')).toHaveLength(enters)
+    expect(seen.filter(e => e === 'dragover@zone').length).toBeGreaterThan(1)
+  })
+
+  it('FE-TOUCHDRAG-020: dragging over empty space leaves the last zone and finds no target', () => {
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    document.elementFromPoint = () => null
+    touchMove([{ clientX: 999, clientY: 999 }])
+    expect(seen).toContain('dragleave@zone')
+    touchEnd()
+    expect(seen).not.toContain('drop@zone')
+  })
+
+  it('FE-TOUCHDRAG-021: another finger moving is not mistaken for the dragging one', () => {
+    longPress()
+    const before = seen.length
+    touchMove([{ clientX: 400, clientY: 400, identifier: 9 }])
+    expect(seen).toHaveLength(before)
+  })
+
+  it('FE-TOUCHDRAG-022: lifting one of two fingers does not end the drag', () => {
+    dropZone.addEventListener('dragover', e => e.preventDefault())
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    touchEnd('touchend', [{ clientX: 200, clientY: 200 }])
+    expect(seen).not.toContain('dragend@source')
+    touchEnd()
+    expect(seen).toContain('drop@zone')
+  })
+
+  it('FE-TOUCHDRAG-023: the carried data behaves like a DataTransfer', () => {
+    let types: readonly string[] = []
+    let cleared = ''
+    let missing = 'unset'
+    source.addEventListener('dragstart', e => {
+      const dt = (e as DragEvent).dataTransfer!
+      dt.setData('placeId', '7')
+      types = dt.types
+      missing = dt.getData('nothing')
+      dt.clearData('placeId')
+      cleared = dt.getData('placeId')
+    })
+    longPress()
+    expect(types).toEqual(['placeId'])
+    expect(missing).toBe('')
+    expect(cleared).toBe('')
+  })
+
+  it('FE-TOUCHDRAG-024: clearing every format empties the carried data', () => {
+    let left: readonly string[] = ['stale']
+    source.addEventListener('dragstart', e => {
+      const dt = (e as DragEvent).dataTransfer!
+      dt.setData('placeId', '7')
+      dt.clearData()
+      left = dt.types
+    })
+    longPress()
+    expect(left).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-025: a finger that only jitters still completes the press', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }])
+    // Holding a row steady is never perfectly steady; a few pixels is not a scroll.
+    touchMove([{ clientX: 13, clientY: 14 }])
+    vi.advanceTimersByTime(PRESS)
+    expect(seen).toContain('dragstart@source')
+  })
+
+  it('FE-TOUCHDRAG-026: a drag in the middle of a pane leaves the scroll alone', () => {
+    const pane = document.getElementById('plan')!
+    Object.defineProperty(pane, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(pane, 'clientHeight', { value: 400, configurable: true })
+    pane.style.overflowY = 'auto'
+    pane.getBoundingClientRect = () => ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) })
+    pane.scrollTop = 200
+    longPress()
+    touchMove([{ clientX: 200, clientY: 200 }])
+    vi.advanceTimersByTime(64)
+    expect(pane.scrollTop).toBe(200)
+  })
+
+  it('FE-TOUCHDRAG-027: a two-finger gesture never becomes a drag', () => {
+    touchStart(source, [{ clientX: 10, clientY: 10 }, { clientX: 90, clientY: 90, identifier: 2 }])
+    vi.advanceTimersByTime(PRESS)
+    expect(seen).toEqual([])
+  })
+
+  it('FE-TOUCHDRAG-028: holding at the edge re-tests what the scroll brought under the finger', () => {
+    const pane = document.getElementById('plan')!
+    const other = document.getElementById('zone2')!
+    other.addEventListener('dragover', e => e.preventDefault())
+    Object.defineProperty(pane, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(pane, 'clientHeight', { value: 400, configurable: true })
+    pane.style.overflowY = 'auto'
+    pane.getBoundingClientRect = () => ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) })
+    longPress()
+    touchMove([{ clientX: 200, clientY: 390 }])
+    // The finger stays put; the scroll is what changes the row beneath it.
+    document.elementFromPoint = () => other
+    vi.advanceTimersByTime(32)
+    touchEnd()
+    expect(seen).toContain('dragenter@zone2')
+    expect(seen).toContain('drop@zone2')
+  })
+})

--- a/client/src/utils/touchDragBridge.ts
+++ b/client/src/utils/touchDragBridge.ts
@@ -1,0 +1,302 @@
+/**
+ * Long-press touch drag for the three-column planner (#1616).
+ *
+ * Tablets run the desktop planner but have a coarse primary pointer, and a
+ * finger never starts an HTML5 drag on Android (#1265). The old answer was
+ * `drag-drop-touch`, a document-wide polyfill that turned every touch over a
+ * draggable element into a drag: the places list stopped scrolling (#1432) and
+ * the dblclick it synthesised zoomed the map (#1440). That polyfill is now
+ * confined to hybrid laptops (see touchDragPolyfill.ts) and drag was switched
+ * off outright wherever the pointer is coarse — which took tablets with it.
+ *
+ * This bridge takes the narrow path instead. It only watches touches that begin
+ * on a draggable row inside an opted-in `[data-touch-drag]` container, it waits
+ * out a long press before claiming the gesture — a swipe inside that window is
+ * a scroll and is left alone — and it synthesises nothing but the drag events
+ * themselves. Once armed it replays the real sequence (dragstart →
+ * dragenter/dragover/dragleave → drop → dragend) on the element under the
+ * finger, so every drop handler already in the planner keeps working unchanged.
+ *
+ * If the browser starts a drag of its own first — iPadOS does — the bridge
+ * stands down the moment it sees a dragstart it did not fire itself.
+ */
+
+/** How long a finger must rest on a row before the gesture becomes a drag. */
+const LONG_PRESS_MS = 320
+/** Moving further than this before the press lands means the user is scrolling. */
+const MOVE_TOLERANCE = 10
+/** Distance from a scroll container's edge at which dragging scrolls it. */
+const EDGE_ZONE = 56
+/** Pixels per frame the edge scroll moves at full strength. */
+const EDGE_SPEED = 14
+
+interface Session {
+  source: HTMLElement
+  touchId: number
+  startX: number
+  startY: number
+  x: number
+  y: number
+  armed: boolean
+  pressTimer: number
+  ghost: HTMLElement | null
+  ghostDX: number
+  ghostDY: number
+  target: Element | null
+  canDrop: boolean
+  scroller: Element | null
+  frame: number
+  transfer: DataTransfer
+}
+
+let session: Session | null = null
+
+/** Events this module dispatched, so a browser-driven drag stays recognisable. */
+const ours = new WeakSet<Event>()
+
+/**
+ * A stand-in for the browsers that refuse `new DataTransfer()`. Only the parts
+ * the planner's handlers reach for are implemented.
+ */
+function createTransfer(): DataTransfer {
+  try {
+    return new DataTransfer()
+  } catch {
+    const store = new Map<string, string>()
+    return {
+      dropEffect: 'move',
+      effectAllowed: 'all',
+      files: [] as unknown as FileList,
+      items: [] as unknown as DataTransferItemList,
+      get types() { return Array.from(store.keys()) },
+      setData: (format: string, data: string) => { store.set(format, String(data)) },
+      getData: (format: string) => store.get(format) ?? '',
+      clearData: (format?: string) => { if (format) store.delete(format); else store.clear() },
+      setDragImage: () => {},
+    } as unknown as DataTransfer
+  }
+}
+
+/** Dispatches one drag event and reports whether the target accepted it. */
+function fire(type: string, target: EventTarget, s: Session): boolean {
+  let event: Event
+  try {
+    event = new DragEvent(type, {
+      bubbles: true, cancelable: true, composed: true,
+      clientX: s.x, clientY: s.y, dataTransfer: s.transfer,
+    })
+  } catch {
+    event = new Event(type, { bubbles: true, cancelable: true, composed: true })
+  }
+  // Safari builds the event but drops the dataTransfer, and the Event fallback
+  // never had one. An own property shadows the prototype's read-only getter.
+  if ((event as DragEvent).dataTransfer !== s.transfer) {
+    Object.defineProperty(event, 'dataTransfer', { value: s.transfer, configurable: true })
+  }
+  for (const [key, value] of [['clientX', s.x], ['clientY', s.y]] as const) {
+    if ((event as DragEvent)[key] !== value) {
+      Object.defineProperty(event, key, { value, configurable: true })
+    }
+  }
+  ours.add(event)
+  // preventDefault on dragover is how a drop zone says yes, and dispatchEvent
+  // reports that as false.
+  return !target.dispatchEvent(event)
+}
+
+/** The nearest ancestor that actually scrolls vertically, if there is one. */
+function scrollerFor(element: Element | null): Element | null {
+  for (let node = element; node && node !== document.body; node = node.parentElement) {
+    const overflow = getComputedStyle(node).overflowY
+    if ((overflow === 'auto' || overflow === 'scroll') && node.scrollHeight > node.clientHeight) return node
+  }
+  return null
+}
+
+function buildGhost(s: Session): void {
+  const box = s.source.getBoundingClientRect()
+  const ghost = s.source.cloneNode(true) as HTMLElement
+  ghost.removeAttribute('id')
+  ghost.setAttribute('aria-hidden', 'true')
+  Object.assign(ghost.style, {
+    position: 'fixed', left: '0', top: '0', margin: '0',
+    width: `${box.width}px`, height: `${box.height}px`,
+    pointerEvents: 'none', opacity: '0.92', zIndex: '10000',
+    borderRadius: '8px', background: 'var(--bg-elevated, var(--bg-panel, #fff))',
+    boxShadow: '0 10px 28px rgba(0,0,0,0.3)',
+    transform: `translate3d(${box.left}px, ${box.top}px, 0)`,
+  })
+  s.ghostDX = box.left - s.x
+  s.ghostDY = box.top - s.y
+  document.body.appendChild(ghost)
+  s.ghost = ghost
+}
+
+function moveGhost(s: Session): void {
+  if (!s.ghost) return
+  s.ghost.style.transform = `translate3d(${s.x + s.ghostDX}px, ${s.y + s.ghostDY}px, 0)`
+}
+
+/** Keeps a long list reachable by scrolling once the finger nears an edge. */
+function edgeScroll(): void {
+  const s = session
+  if (!s || !s.armed) return
+  s.frame = requestAnimationFrame(edgeScroll)
+  if (!s.scroller) return
+  const box = s.scroller.getBoundingClientRect()
+  const fromTop = s.y - box.top
+  const fromBottom = box.bottom - s.y
+  const before = s.scroller.scrollTop
+  if (fromTop < EDGE_ZONE) {
+    s.scroller.scrollTop -= EDGE_SPEED * Math.max(0.2, 1 - fromTop / EDGE_ZONE)
+  } else if (fromBottom < EDGE_ZONE) {
+    s.scroller.scrollTop += EDGE_SPEED * Math.max(0.2, 1 - fromBottom / EDGE_ZONE)
+  }
+  // The rows moved under a finger that did not, so whatever sits beneath it has
+  // changed. Without this, holding at the edge drops onto a stale row.
+  if (s.scroller.scrollTop !== before) retarget(s)
+}
+
+function arm(): void {
+  const s = session
+  if (!s) return
+  s.armed = true
+  buildGhost(s)
+  // A source that vetoes its own dragstart gets the gesture handed back.
+  if (fire('dragstart', s.source, s)) { endSession(false); return }
+  s.frame = requestAnimationFrame(edgeScroll)
+}
+
+/** Reports the element under the finger, with the ghost kept out of the way. */
+function targetAt(s: Session): Element | null {
+  return document.elementFromPoint(s.x, s.y)
+}
+
+function retarget(s: Session): void {
+  const next = targetAt(s)
+  if (next === s.target) {
+    if (next) s.canDrop = fire('dragover', next, s)
+    return
+  }
+  if (s.target) fire('dragleave', s.target, s)
+  s.target = next
+  s.canDrop = false
+  if (next) {
+    fire('dragenter', next, s)
+    s.canDrop = fire('dragover', next, s)
+    s.scroller = scrollerFor(next)
+  }
+}
+
+/** Swallows the click the browser sends after a drag so the row is not opened. */
+function swallowNextClick(): void {
+  const stop = (e: Event) => { e.stopPropagation(); e.preventDefault() }
+  document.addEventListener('click', stop, { capture: true, once: true })
+  setTimeout(() => document.removeEventListener('click', stop, { capture: true }), 400)
+}
+
+/**
+ * Ends the gesture. `silent` drops the session without replaying the tail of the
+ * sequence — for when the browser has taken the drag over and its own events are
+ * the ones the handlers should see.
+ */
+function endSession(drop: boolean, silent = false): void {
+  const s = session
+  if (!s) return
+  session = null
+  clearTimeout(s.pressTimer)
+  cancelAnimationFrame(s.frame)
+  s.ghost?.remove()
+  detachGestureListeners()
+  if (!s.armed || silent) return
+  if (drop && s.target && s.canDrop) fire('drop', s.target, s)
+  else if (s.target) fire('dragleave', s.target, s)
+  fire('dragend', s.source, s)
+  swallowNextClick()
+}
+
+function onTouchMove(e: TouchEvent): void {
+  const s = session
+  if (!s) return
+  const touch = Array.from(e.touches).find(t => t.identifier === s.touchId)
+  if (!touch) return
+  s.x = touch.clientX
+  s.y = touch.clientY
+  if (!s.armed) {
+    if (Math.hypot(s.x - s.startX, s.y - s.startY) > MOVE_TOLERANCE) endSession(false)
+    return
+  }
+  // Armed: the gesture is a drag, so the page must not scroll under it.
+  e.preventDefault()
+  moveGhost(s)
+  retarget(s)
+}
+
+function onTouchEnd(e: TouchEvent): void {
+  const s = session
+  if (!s) return
+  if (Array.from(e.touches).some(t => t.identifier === s.touchId)) return
+  endSession(e.type === 'touchend')
+}
+
+function onNativeDragStart(e: Event): void {
+  // iPadOS starts a drag of its own from the same long press. Let it have the
+  // gesture rather than running two sequences over one finger.
+  if (!ours.has(e)) endSession(false, true)
+}
+
+function onContextMenu(e: Event): void {
+  // Android raises this on the same long press that arms the drag.
+  if (session) e.preventDefault()
+}
+
+function attachGestureListeners(): void {
+  document.addEventListener('touchmove', onTouchMove, { passive: false })
+  document.addEventListener('touchend', onTouchEnd)
+  document.addEventListener('touchcancel', onTouchEnd)
+  document.addEventListener('contextmenu', onContextMenu)
+  document.addEventListener('dragstart', onNativeDragStart, true)
+}
+
+function detachGestureListeners(): void {
+  document.removeEventListener('touchmove', onTouchMove)
+  document.removeEventListener('touchend', onTouchEnd)
+  document.removeEventListener('touchcancel', onTouchEnd)
+  document.removeEventListener('contextmenu', onContextMenu)
+  document.removeEventListener('dragstart', onNativeDragStart, true)
+}
+
+function onTouchStart(e: TouchEvent): void {
+  if (session) { endSession(false); return }
+  if (e.touches.length !== 1) return
+  const start = e.target as Element | null
+  const source = start?.closest?.('[draggable="true"]') as HTMLElement | null
+  if (!source || !source.closest('[data-touch-drag]')) return
+  const touch = e.touches[0]
+  session = {
+    source,
+    touchId: touch.identifier,
+    startX: touch.clientX, startY: touch.clientY,
+    x: touch.clientX, y: touch.clientY,
+    armed: false,
+    pressTimer: window.setTimeout(arm, LONG_PRESS_MS),
+    ghost: null, ghostDX: 0, ghostDY: 0,
+    target: null, canDrop: false,
+    scroller: scrollerFor(source),
+    frame: 0,
+    transfer: createTransfer(),
+  }
+  attachGestureListeners()
+}
+
+/**
+ * Starts watching for long-press drags. Returns the teardown, which also ends
+ * any drag still in flight.
+ */
+export function installTouchDragBridge(): () => void {
+  document.addEventListener('touchstart', onTouchStart, { passive: true })
+  return () => {
+    document.removeEventListener('touchstart', onTouchStart)
+    endSession(false)
+  }
+}

--- a/client/src/utils/touchDragPolyfill.ts
+++ b/client/src/utils/touchDragPolyfill.ts
@@ -6,11 +6,11 @@
  * dblclick fires the default double-click-zoom, so two quick one-finger pans zoomed
  * instead of panning (#1440).
  *
- * Reorder DnD is disabled wherever the primary pointer is coarse (#1432), so the only
- * device class left with a job for the polyfill is the hybrid laptop: a mouse as the
- * primary pointer, with a touchscreen also available. Loading it anywhere else — notably
- * on tablets, which a width check misclassifies as desktop — re-arms the very gesture
- * hijack #1432 removed, and drags the #1440 phantom-dblclick along with it.
+ * The hybrid laptop is the only device class left with a job for it: a mouse as the
+ * primary pointer, with a touchscreen also available. Loading it anywhere else re-arms
+ * the very gesture hijack #1432 removed, and drags the #1440 phantom-dblclick along
+ * with it. Coarse-pointer devices get touchDragBridge instead, which waits out a long
+ * press before it claims a gesture and so leaves scrolling alone (#1616).
  */
 export function maybeInstallTouchDragPolyfill(): Promise<unknown> | void {
   if (typeof window === 'undefined') return


### PR DESCRIPTION
Closes #1616

Dragging a place from the right pane into the schedule does nothing on a tablet — the row gets selected as text instead. Reported on an iPad (iOS 18.7.8) and confirmed on a Samsung tablet.

## Why it happened

`dragDisabled` was `isMobile || isTouch`, and the coarse-pointer half of that was only ever switching tablets off: phones render the mobile shell below `md` and never reach this layout at all. The reporter sees both panes, so they are on the three-column planner where `isMobile` is false and `isTouch` was the only thing in the way.

That check was also guarding against something that had already been fixed elsewhere. What swallowed the scroll gesture in #1432 was the document-wide `drag-drop-touch` polyfill, and that has since been confined to hybrid laptops. Removing the touch check does not bring #1432 back — but a finger still cannot start an HTML5 drag on Android (#1265), so something has to stand in for it.

## What this does

Adds `touchDragBridge`, a narrow replacement for the old polyfill. It only watches touches that begin on a draggable row inside a container that opted in via `data-touch-drag`, and it waits out a 320 ms press before claiming the gesture — moving more than 10 px inside that window is a scroll and is left to the browser. Once armed it replays the real sequence (`dragstart` → `dragenter`/`dragover`/`dragleave` → `drop` → `dragend`) on the element under the finger, so every drop handler in the planner keeps working untouched. It synthesises no `dblclick`, so #1440 stays fixed, and it never listens outside the two panes, so the map is unaffected. If the browser starts a drag of its own — iPadOS does — the bridge stands down silently and lets it have the gesture.

Width is still the gate that means something: below `lg` the plan and the places are separate tabs, so there is nothing to drag between and the day picker remains the way to assign a place.

Also in here:

- Rows in an opted-in pane get `-webkit-touch-callout` and `user-select` off under `@media (pointer: coarse)`. Without it the press that starts the drag raises the selection first — that is the "interpreted as a text selection" in the report.
- Dragging near the top or bottom edge scrolls the pane and re-tests what ended up under the finger, so a long day plan stays reachable.
- The day reorder popup is a modal and portals out of the sidebar, so it opts in separately. Its rows already had a bare `draggable` and no `user-select`, which on a tablet meant a long press selected the label and nothing moved.
- The `isTouch` prop had no other use and is gone from the sidebar chain, along with a doc comment claiming arrow reorder buttons take over on touch — there are none.

## Verification

Beyond the unit and component tests, the bridge was driven in a real Chromium with real touch input (CDP `Input.dispatchTouchEvent`), because jsdom always falls back out of the native `DataTransfer` and `DragEvent` paths and would leave them untested. A swipe scrolls the list and starts no drag; a long press carries a place onto the day under the finger with its `placeId` intact; a long press inside the plan reorders and carries its `assignmentId`; the drop handler receives a real `DragEvent` with a real `DataTransfer`; no text selection is left behind.

Not covered: a physical iPad. The Chromium run covers the Android half of the report, iOS Safari is untested.
