### PR TITLE
fix(navbar): prevent centred tab pill overlapping actions on tablet

### DIFF
--- a/client/src/components/Layout/Navbar.tsx
+++ b/client/src/components/Layout/Navbar.tsx
@@ -156,6 +156,7 @@ export default function Navbar({ tripTitle, tripId, onBack, showBack, onShare }:
             const isActive = location.pathname === tab.path
             return (
               <Link key={tab.id} to={tab.path}
+                title={tab.label} aria-label={tab.label}
                 className="flex items-center gap-1.5 transition-colors"
                 style={{
                   padding: '5px 16px', borderRadius: 9, fontSize: 'calc(13.5px * var(--fs-scale-body, 1))', fontWeight: 500,
@@ -166,7 +167,7 @@ export default function Navbar({ tripTitle, tripId, onBack, showBack, onShare }:
                 onMouseEnter={e => { if (!isActive) e.currentTarget.style.color = 'var(--text-primary)' }}
                 onMouseLeave={e => { if (!isActive) e.currentTarget.style.color = 'var(--text-muted)' }}>
                 <tab.Icon className="w-4 h-4" />
-                <span>{tab.label}</span>
+                <span className="hidden lg:inline">{tab.label}</span>
               </Link>
             )
           })}


### PR DESCRIPTION
## Description
On tablet-width viewports (~768–1024px) the navbar's centred tab pill overlapped the right-hand action cluster (notification bell + user menu). The pill is absolutely centred (`left:50%; translateX(-50%)`), so once the tab text labels made it wide enough its right edge slid underneath the bell and the user menu.

The tab text labels are now hidden below the `lg` breakpoint:
- **Tablet (768–1024px):** icon-only tabs → the pill stays narrow and clears the right-hand actions.
- **Desktop (≥1024px):** icon + label, exactly as before.

The tab links gain `title` / `aria-label` so they stay accessible without a visible label (hover tooltip + screen-reader name).

Two-line diff in a single file: `client/src/components/Layout/Navbar.tsx`.

## Related Issue or Discussion
Closes #1746

## Type of Change
- [x] Bug fix

## Tests
- `Navbar.test.tsx` — 35/35 pass (the addon/plugin link tests resolve the link by its accessible name, which the new `aria-label` preserves).
- Client builds clean; verified on a running instance.

## Screenshots
<img width="567" height="62" alt="before-tablet-overlap" src="https://github.com/user-attachments/assets/fe877452-0ab1-4d76-8a19-b58e29460309" />
<img width="704" height="1076" alt="after-tablet" src="https://github.com/user-attachments/assets/8ee6b168-db55-4a29-91cb-e9128404258b" />
<img width="664" height="1072" alt="after-phone" src="https://github.com/user-attachments/assets/0ff8f74f-eecd-4ca9-89f9-5d7ddc82d78c" />
<img width="1916" height="1072" alt="after-desktop" src="https://github.com/user-attachments/assets/5d2d972a-19eb-40e8-9a47-4e1afd5756c5" />

