### PR TITLE
Separate visited countries from planned ones in the atlas

### DIFF
--- a/client/src/mobile/screens/atlas/MAtlas.tsx
+++ b/client/src/mobile/screens/atlas/MAtlas.tsx
@@ -9,6 +9,8 @@ import MAtlasStatsCard from './MAtlasStatsCard'
 import MAtlasSearch from './MAtlasSearch'
 import MAtlasCountryPopup from './MAtlasCountryPopup'
 import MAtlasBucketSheet from './MAtlasBucketSheet'
+import MToggle from '../../components/MToggle'
+import { countryStatus } from '../../../pages/atlas/atlasModel'
 
 const removeBtnCls = 'mt-4 w-full rounded-full bg-[rgba(214,39,59,.12)] py-[11px] text-center text-[0.8125rem] font-bold text-[color:var(--m-st-danger)]' // theme-lint-disable — fixed status-danger tint
 
@@ -29,6 +31,9 @@ export default function MAtlas() {
     regionTooltipRef,
     stats,
     countries,
+    visitedCountries,
+    showPlanned,
+    togglePlanned,
     bucketList,
     selectedCountry,
     countryDetail,
@@ -36,6 +41,7 @@ export default function MAtlas() {
     select_country_from_search,
     atlas_country_options,
   } = atlas
+  const plannedCount = stats.totalCountriesPlanned || 0
   const [searchOpen, setSearchOpen] = useState(false)
   const [bucketOpen, setBucketOpen] = useState(false)
   const [detailOpen, setDetailOpen] = useState(false)
@@ -61,7 +67,12 @@ export default function MAtlas() {
   const suggestions = useMemo(() => {
     const seen = new Set<string>()
     const list: { code: string; label: string }[] = []
-    const visited = [...countries].sort((a, b) => (b.lastVisit || '').localeCompare(a.lastVisit || ''))
+    // Visited first, planned after — this list answers "where have I been", so a country
+    // you only booked a flight to shouldn't outrank one you actually saw.
+    const visited = [...countries].sort((a, b) => {
+      const rank = (c: typeof a) => (countryStatus(c) === 'visited' ? 0 : 1)
+      return rank(a) - rank(b) || (b.lastVisit || '').localeCompare(a.lastVisit || '')
+    })
     for (const c of visited) {
       if (seen.has(c.code)) continue
       seen.add(c.code)
@@ -98,14 +109,21 @@ export default function MAtlas() {
 
       {/* Full-width bucket-list button. The bottom nav makes a back button
           redundant on this main-nav screen, so the header spans the width. */}
-      <div className="absolute left-4 right-4 top-[var(--m-safe-top,12px)] z-[5]">
+      <div className="absolute left-4 right-4 top-[var(--m-safe-top,12px)] z-[5] flex items-center gap-2">
         <button
           type="button"
           onClick={() => setBucketOpen(true)}
-          className="flex h-[38px] w-full items-center justify-center rounded-full border border-[color:var(--m-gbr)] bg-[color:var(--m-sheet)] px-4 text-[0.78125rem] font-bold text-m-ink shadow-[0_5px_12px_-8px_rgba(0,0,0,.18)]"
+          className="flex h-[38px] flex-1 items-center justify-center rounded-full border border-[color:var(--m-gbr)] bg-[color:var(--m-sheet)] px-4 text-[0.78125rem] font-bold text-m-ink shadow-[0_5px_12px_-8px_rgba(0,0,0,.18)]"
         >
           {t('atlas.bucketTab')}
         </button>
+        {/* Only worth the space once there is something planned to reveal. */}
+        {plannedCount > 0 && (
+          <div className="flex h-[38px] shrink-0 items-center gap-2 rounded-full border border-[color:var(--m-gbr)] bg-[color:var(--m-sheet)] px-3 shadow-[0_5px_12px_-8px_rgba(0,0,0,.18)]">
+            <span className="text-[0.6875rem] font-bold text-m-ink">{t('atlas.planned')}</span>
+            <MToggle checked={showPlanned} onChange={() => togglePlanned()} ariaLabel={t('atlas.showPlanned')} />
+          </div>
+        )}
       </div>
 
       <MAtlasStatsCard stats={stats} />
@@ -115,7 +133,8 @@ export default function MAtlas() {
         onClose={() => setSearchOpen(false)}
         options={atlas_country_options}
         suggestions={suggestions}
-        isVisited={(code) => countries.some((c) => c.code === code)}
+        isVisited={(code) => visitedCountries.some((c) => c.code === code)}
+        isPlanned={(code) => countries.some((c) => c.code === code && countryStatus(c) !== 'visited')}
         isOnBucketList={(code) => bucketList.some((b) => b.country_code === code)}
         onSelect={(code) => {
           setSearchOpen(false)

--- a/client/src/mobile/screens/atlas/MAtlasCountryPopup.tsx
+++ b/client/src/mobile/screens/atlas/MAtlasCountryPopup.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, MapPin, Star } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import apiClient from '../../../api/client'
 import { continentForCountry } from '@trek/shared'
+import { withCountryMarkedVisited } from '../../../pages/atlas/atlasModel'
 import { getApiErrorMessage } from '../../../types'
 import { useToast } from '../../../components/shared/Toast'
 import MSheet from '../../components/MSheet'
@@ -78,16 +79,7 @@ export default function MAtlasCountryPopup({ atlas }: MAtlasCountryPopupProps) {
     const { code } = confirmAction
     try {
       await apiClient.post(`/addons/atlas/country/${code}/mark`)
-      setData((prev) => {
-        if (!prev || prev.countries.find((c) => c.code === code)) return prev
-        const cont = continentForCountry(code)
-        return {
-          ...prev,
-          countries: [...prev.countries, { code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null }],
-          stats: { ...prev.stats, totalCountries: prev.stats.totalCountries + 1 },
-          continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 },
-        }
-      })
+      setData((prev) => (prev ? withCountryMarkedVisited(prev, code) : prev))
     } catch (err) {
       toast.error(getApiErrorMessage(err, t('common.error')))
     }
@@ -103,18 +95,9 @@ export default function MAtlasCountryPopup({ atlas }: MAtlasCountryPopupProps) {
       setVisitedRegions((prev) => {
         const existing = prev[countryCode] || []
         if (existing.find((r) => r.code === regionCode)) return prev
-        return { ...prev, [countryCode]: [...existing, { code: regionCode, name: regionName, placeCount: 0, manuallyMarked: true }] }
+        return { ...prev, [countryCode]: [...existing, { code: regionCode, name: regionName, placeCount: 0, status: 'visited' as const, manuallyMarked: true }] }
       })
-      setData((prev) => {
-        if (!prev || prev.countries.find((c) => c.code === countryCode)) return prev
-        const cont = continentForCountry(countryCode)
-        return {
-          ...prev,
-          countries: [...prev.countries, { code: countryCode, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null }],
-          stats: { ...prev.stats, totalCountries: prev.stats.totalCountries + 1 },
-          continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 },
-        }
-      })
+      setData((prev) => (prev ? withCountryMarkedVisited(prev, countryCode) : prev))
     } catch (err) {
       toast.error(getApiErrorMessage(err, t('common.error')))
     }

--- a/client/src/mobile/screens/atlas/MAtlasSearch.tsx
+++ b/client/src/mobile/screens/atlas/MAtlasSearch.tsx
@@ -15,6 +15,8 @@ interface MAtlasSearchProps {
   /** Shown while the query is empty: recently visited + bucket countries. */
   suggestions: CountryOption[]
   isVisited: (code: string) => boolean
+  /** Countries that only appear via a trip which hasn't started yet (#1048). */
+  isPlanned: (code: string) => boolean
   isOnBucketList: (code: string) => boolean
   onSelect: (code: string) => void
 }
@@ -32,6 +34,7 @@ export default function MAtlasSearch({
   options,
   suggestions,
   isVisited,
+  isPlanned,
   isOnBucketList,
   onSelect,
 }: MAtlasSearchProps) {
@@ -91,6 +94,8 @@ export default function MAtlasSearch({
               <span className="min-w-0 flex-1 truncate text-[0.9375rem] font-extrabold text-m-ink">{r.label}</span>
               {isVisited(r.code) ? (
                 <span className={statusCls}>{t('mobileAtlas.visited')}</span>
+              ) : isPlanned(r.code) ? (
+                <span className={statusCls}>{t('mobileAtlas.planned')}</span>
               ) : isOnBucketList(r.code) ? (
                 <span className={statusCls}>{t('atlas.bucketTab')}</span>
               ) : null}

--- a/client/src/mobile/screens/atlas/MAtlasStatsCard.tsx
+++ b/client/src/mobile/screens/atlas/MAtlasStatsCard.tsx
@@ -19,13 +19,21 @@ export default function MAtlasStatsCard({ stats }: MAtlasStatsCardProps) {
     [stats.totalCities || 0, t('atlas.cities')],
     [stats.totalDays, t('atlas.days')],
   ]
+  // All five columns are spoken for, so the planned count rides along with the country
+  // number as a superscript rather than claiming a sixth column.
+  const planned = stats.totalCountriesPlanned || 0
 
   return (
     <div className="absolute bottom-[calc(var(--bottom-nav-h,84px)+16px)] left-4 right-4 z-[5]">
       <div className="flex w-full rounded-[22px] border border-[color:var(--m-shbr)] bg-[color:var(--m-sheet)] px-3 py-[14px] shadow-[0_18px_44px_-20px_rgba(0,0,0,.4)]">
-        {cols.map(([n, l]) => (
+        {cols.map(([n, l], i) => (
           <div key={l} className="flex-1 text-center">
-            <div className="text-[1.375rem] font-extrabold leading-none tabular-nums text-m-ink">{n}</div>
+            <div className="text-[1.375rem] font-extrabold leading-none tabular-nums text-m-ink">
+              {n}
+              {i === 0 && planned > 0 && (
+                <span className="align-super text-[0.6875rem] font-bold text-m-faint">+{planned}</span>
+              )}
+            </div>
             <div className="mt-1 font-geist text-[0.53125rem] font-bold uppercase tracking-[.06em] text-m-faint">{l}</div>
           </div>
         ))}

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -6,10 +6,11 @@ import CustomSelect from '../components/shared/CustomSelect'
 import EmptyState from '../components/shared/EmptyState'
 import { Globe, MapPin, Briefcase, Calendar, Flag, PanelLeftOpen, PanelLeftClose, X, Star, Plus, Trash2, Search } from 'lucide-react'
 import type { TranslationFn } from '../types'
-import { A2_TO_A3, countryCodeToFlag, type AtlasCountry, type AtlasStats, type AtlasData, type CountryDetail } from './atlas/atlasModel'
+import { A2_TO_A3, countryCodeToFlag, withCountryMarkedVisited, type AtlasCountry, type AtlasStats, type AtlasData, type CountryDetail } from './atlas/atlasModel'
 import { continentForCountry } from '@trek/shared'
 import { useAtlas } from './atlas/useAtlas'
 import AtlasCountrySearch from './atlas/AtlasCountrySearch'
+import AtlasLayerToggle from './atlas/AtlasLayerToggle'
 import { useToast } from '../components/shared/Toast'
 import { getApiErrorMessage } from '../types'
 import { useIsPhone } from '../mobile/useIsPhone'
@@ -29,6 +30,7 @@ function AtlasPageDesktop(): React.ReactElement {
     mapRef, regionTooltipRef, panelRef, glareRef, borderGlareRef,
     handlePanelMouseMove, handlePanelMouseLeave,
     data, setData, stats, countries, selectedCountry, countryDetail,
+    showPlanned, togglePlanned,
     loadCountryDetail, handleUnmarkCountry, select_country_from_search,
     visitedRegions, setVisitedRegions,
     atlas_country_search, set_atlas_country_search,
@@ -88,6 +90,12 @@ function AtlasPageDesktop(): React.ReactElement {
           setOpen={set_atlas_country_open}
           options={atlas_country_options}
           onSelect={select_country_from_search}
+        />
+        <AtlasLayerToggle
+          t={t}
+          showPlanned={showPlanned}
+          onToggle={togglePlanned}
+          plannedCount={stats.totalCountriesPlanned || 0}
         />
 
         {/* Mobile: Bottom bar */}
@@ -173,11 +181,7 @@ function AtlasPageDesktop(): React.ReactElement {
                 <button onClick={async () => {
                   try {
                     await apiClient.post(`/addons/atlas/country/${confirmAction.code}/mark`)
-                    setData(prev => {
-                      if (!prev || prev.countries.find(c => c.code === confirmAction.code)) return prev
-                      const cont = continentForCountry(confirmAction.code)
-                      return { ...prev, countries: [...prev.countries, { code: confirmAction.code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null }], stats: { ...prev.stats, totalCountries: prev.stats.totalCountries + 1 }, continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 } }
-                    })
+                    setData(prev => (prev ? withCountryMarkedVisited(prev, confirmAction.code) : prev))
                   } catch (err) {
                     toast.error(getApiErrorMessage(err, t('common.error')))
                   }
@@ -222,11 +226,7 @@ function AtlasPageDesktop(): React.ReactElement {
                       if (existing.find(r => r.code === rCode)) return prev
                       return { ...prev, [countryCode]: [...existing, { code: rCode, name: rName, placeCount: 0, manuallyMarked: true }] }
                     })
-                    setData(prev => {
-                      if (!prev || prev.countries.find(c => c.code === countryCode)) return prev
-                      const cont = continentForCountry(countryCode)
-                      return { ...prev, countries: [...prev.countries, { code: countryCode, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null }], stats: { ...prev.stats, totalCountries: prev.stats.totalCountries + 1 }, continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 } }
-                    })
+                    setData(prev => (prev ? withCountryMarkedVisited(prev, countryCode) : prev))
                   } catch (err) {
                     toast.error(getApiErrorMessage(err, t('common.error')))
                   }
@@ -463,7 +463,7 @@ function SidebarContent({ data, stats, countries, selectedCountry, countryDetail
   const { mostVisited, continents, lastTrip, nextTrip, streak, firstYear, tripsThisYear } = data || {}
   const contEntries = continents ? Object.entries(continents).sort((a, b) => b[1] - a[1]) : []
   const maxCont = contEntries.length > 0 ? contEntries[0][1] : 1
-  const CL = { 'Europe': t('atlas.europe'), 'Asia': t('atlas.asia'), 'North America': t('atlas.northAmerica'), 'South America': t('atlas.southAmerica'), 'Africa': t('atlas.africa'), 'Oceania': t('atlas.oceania') }
+  const CL = { 'Europe': t('atlas.europe'), 'Asia': t('atlas.asia'), 'North America': t('atlas.northAmerica'), 'South America': t('atlas.southAmerica'), 'Africa': t('atlas.africa'), 'Oceania': t('atlas.oceania'), 'Antarctica': t('atlas.antarctica') }
   const contColors = ['#818cf8', '#f472b6', '#34d399', '#fbbf24', '#fb923c', '#22d3ee']
 
   // Tab switcher
@@ -620,9 +620,16 @@ function SidebarContent({ data, stats, countries, selectedCountry, countryDetail
 
       {/* ═══ SECTION 1: Numbers ═══ */}
       {/* Countries hero */}
-      <div className="flex items-baseline gap-1.5 px-5 py-4 mx-2 my-2 rounded-xl" style={{ background: bg(0.08) }}>
-        <span className="text-5xl font-black tabular-nums leading-none" style={{ color: tp }}>{stats.totalCountries}</span>
-        <span className="text-sm font-medium" style={{ color: tm }}>{t('atlas.countries')}</span>
+      <div className="flex flex-col justify-center px-5 py-4 mx-2 my-2 rounded-xl" style={{ background: bg(0.08) }}>
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-5xl font-black tabular-nums leading-none" style={{ color: tp }}>{stats.totalCountries}</span>
+          <span className="text-sm font-medium" style={{ color: tm }}>{t('atlas.countries')}</span>
+        </div>
+        {(stats.totalCountriesPlanned || 0) > 0 && (
+          <span className="text-[9px] font-semibold mt-1.5 uppercase tracking-wide whitespace-nowrap" style={{ color: tf }}>
+            +{stats.totalCountriesPlanned} {t('atlas.planned')}
+          </span>
+        )}
       </div>
       {/* Other stats */}
       {[[stats.totalTrips, t('atlas.trips')], [stats.totalPlaces, t('atlas.places')], [stats.totalCities || 0, t('atlas.cities')], [stats.totalDays, t('atlas.days')]].map(([v, l], i) => (
@@ -637,7 +644,9 @@ function SidebarContent({ data, stats, countries, selectedCountry, countryDetail
 
       {/* ═══ SECTION 2: Continents ═══ */}
       <div className="flex items-center gap-4 px-3 py-4 shrink-0">
-        {['Europe', 'Asia', 'North America', 'South America', 'Africa', 'Oceania'].map((cont) => {
+        {/* Antarctica only joins the row once someone has actually been — CONTINENT_MAP has
+            always known AQ, but a permanent zero column would be dead space for everyone else. */}
+        {['Europe', 'Asia', 'North America', 'South America', 'Africa', 'Oceania', ...((continents?.['Antarctica'] || 0) > 0 ? ['Antarctica'] : [])].map((cont) => {
           const count = continents?.[cont] || 0
           const active = count > 0
           return (
@@ -693,8 +702,13 @@ function SidebarContent({ data, stats, countries, selectedCountry, countryDetail
           <div className="flex items-center gap-3 px-6 py-4">
             <span className="text-3xl">{countryCodeToFlag(selectedCountry)}</span>
             <div>
-              <p className="text-sm font-bold" style={{ color: tp }}>{resolveName(selectedCountry)}</p>
-              <p className="text-[10px] mb-1" style={{ color: tf }}>{countryDetail.places.length} {t('atlas.places')} · {countryDetail.trips.length} Trips</p>
+              <p className="text-sm font-bold" style={{ color: tp }}>
+                {resolveName(selectedCountry)}
+                {countryDetail.status && countryDetail.status !== 'visited' && (
+                  <span className="ml-2 text-[9px] font-semibold uppercase tracking-wide" style={{ color: tf }}>{t('atlas.planned')}</span>
+                )}
+              </p>
+              <p className="text-[10px] mb-1" style={{ color: tf }}>{countryDetail.places.length} {t('atlas.places')} · {countryDetail.trips.length} {t('atlas.tripPlural')}</p>
               <div className="flex flex-wrap gap-1">
                 {countryDetail.trips.slice(0, 3).map(trip => (
                   <button key={trip.id} onClick={() => onTripClick(trip.id)}

--- a/client/src/pages/AtlasPage.wiring.test.tsx
+++ b/client/src/pages/AtlasPage.wiring.test.tsx
@@ -8,7 +8,7 @@ import type { AtlasController } from '../mobile/screens/atlas/atlasController';
 import type { AtlasData, CountryDetail } from './atlas/atlasModel';
 import AtlasPage from './AtlasPage';
 
-// FE-PAGE-ATLASW-001 to FE-PAGE-ATLASW-026
+// FE-PAGE-ATLASW-001 to FE-PAGE-ATLASW-034
 //
 // AtlasPage is a wiring container around useAtlas: the hook is mocked here so the
 // confirm popup and the sidebar can be driven into every state directly, which the
@@ -450,7 +450,7 @@ describe('AtlasPage wiring', () => {
       render(<AtlasPage />);
 
       expect(screen.getByText('France')).toBeInTheDocument();
-      expect(screen.getByText('3 atlas.places · 4 Trips')).toBeInTheDocument();
+      expect(screen.getByText('3 atlas.places · 4 atlas.tripPlural')).toBeInTheDocument();
       // Only the first three trips are shown.
       expect(screen.queryByText('Brest')).not.toBeInTheDocument();
 
@@ -660,6 +660,53 @@ describe('AtlasPage wiring', () => {
 
       fireEvent.click(screen.getByText('common.back'));
       expect(atlas.setConfirmAction).toHaveBeenCalledWith({ type: 'choose', code: 'DE', name: 'Germany' });
+    });
+  });
+
+  describe('planned countries (#1048)', () => {
+    const withPlanned = (totalCountriesPlanned: number) =>
+      buildAtlasData({
+        stats: { totalTrips: 6, totalPlaces: 40, totalCountries: 9, totalDays: 55, totalCities: 12, totalCountriesPlanned },
+      });
+
+    it('FE-PAGE-ATLASW-032: the panel only mentions planned countries once there are some', () => {
+      setAtlas({ data: withPlanned(0) });
+      const { unmount } = render(<AtlasPage />);
+
+      expect(screen.queryByText(/atlas\.planned/)).not.toBeInTheDocument();
+      unmount();
+
+      setAtlas({ data: withPlanned(3) });
+      render(<AtlasPage />);
+
+      expect(screen.getByText('+3 atlas.planned')).toBeInTheDocument();
+    });
+
+    it('FE-PAGE-ATLASW-033: the layer toggle rides on the same count and flips the planned layer', () => {
+      setAtlas({ data: withPlanned(0) });
+      const { unmount } = render(<AtlasPage />);
+
+      expect(screen.queryByRole('button', { name: 'atlas.showPlanned' })).not.toBeInTheDocument();
+      unmount();
+
+      const atlas = setAtlas({ data: withPlanned(3) });
+      render(<AtlasPage />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'atlas.showPlanned' }));
+      expect(atlas.togglePlanned).toHaveBeenCalled();
+    });
+
+    it('FE-PAGE-ATLASW-034: the country detail badges a country you have not reached yet', () => {
+      setAtlas({ selectedCountry: 'FR', countryDetail: buildCountryDetail({ status: 'planned' }) });
+      const { unmount } = render(<AtlasPage />);
+
+      expect(screen.getByText('atlas.planned')).toBeInTheDocument();
+      unmount();
+
+      setAtlas({ selectedCountry: 'FR', countryDetail: buildCountryDetail({ status: 'visited' }) });
+      render(<AtlasPage />);
+
+      expect(screen.queryByText('atlas.planned')).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/atlas/AtlasLayerToggle.test.tsx
+++ b/client/src/pages/atlas/AtlasLayerToggle.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../tests/helpers/render';
+import type { TranslationFn } from '../../types';
+import AtlasLayerToggle from './AtlasLayerToggle';
+
+// FE-ATLAS-TOGGLE-001 to FE-ATLAS-TOGGLE-003
+
+const t = ((key: string) => key) as TranslationFn;
+
+describe('AtlasLayerToggle', () => {
+  it('FE-ATLAS-TOGGLE-001: stays out of the way while nothing is planned', () => {
+    const { container } = render(
+      <AtlasLayerToggle t={t} showPlanned={false} onToggle={vi.fn()} plannedCount={0} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('FE-ATLAS-TOGGLE-002: shows the label and how many countries the layer would add', () => {
+    render(<AtlasLayerToggle t={t} showPlanned={false} onToggle={vi.fn()} plannedCount={4} />);
+
+    expect(screen.getByText('atlas.showPlanned')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'atlas.showPlanned' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('FE-ATLAS-TOGGLE-003: reports the flip and reflects the current state', () => {
+    const onToggle = vi.fn();
+    const { rerender } = render(
+      <AtlasLayerToggle t={t} showPlanned={false} onToggle={onToggle} plannedCount={4} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'atlas.showPlanned' }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    rerender(<AtlasLayerToggle t={t} showPlanned onToggle={onToggle} plannedCount={4} />);
+    expect(screen.getByRole('button', { name: 'atlas.showPlanned' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/client/src/pages/atlas/AtlasLayerToggle.tsx
+++ b/client/src/pages/atlas/AtlasLayerToggle.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import ToggleSwitch from '../../components/Settings/ToggleSwitch'
+import type { TranslationFn } from '../../types'
+
+interface AtlasLayerToggleProps {
+  t: TranslationFn
+  showPlanned: boolean
+  onToggle: () => void
+  plannedCount: number
+}
+
+// Floating switch that reveals the countries you only plan to visit (#1048). Hidden
+// entirely when there is nothing planned — an always-present control for an empty set
+// is just clutter over the globe. Sits on the desktop map only; the mobile atlas has
+// its own compact toggle in MAtlas.
+export default function AtlasLayerToggle({ t, showPlanned, onToggle, plannedCount }: AtlasLayerToggleProps): React.ReactElement | null {
+  if (plannedCount <= 0) return null
+
+  return (
+    <div
+      className="absolute z-20 hidden md:flex"
+      style={{ top: 'calc(env(safe-area-inset-top, 0px) + 14px)', right: 18 }}
+    >
+      <div
+        className="flex items-center gap-3 rounded-full border border-edge"
+        style={{
+          padding: '8px 14px',
+          background: 'var(--bg-elevated)',
+          boxShadow: 'var(--shadow-popover)',
+          backdropFilter: 'blur(18px) saturate(180%)',
+          WebkitBackdropFilter: 'blur(18px) saturate(180%)',
+        }}
+      >
+        <span className="text-caption font-semibold text-content whitespace-nowrap">
+          {t('atlas.showPlanned')}
+        </span>
+        <span className="text-caption font-bold tabular-nums text-content-muted">{plannedCount}</span>
+        <ToggleSwitch on={showPlanned} onToggle={onToggle} label={t('atlas.showPlanned')} />
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/atlas/atlasModel.test.ts
+++ b/client/src/pages/atlas/atlasModel.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { A2_TO_A3, normalizeRegionName } from './atlasModel';
+import {
+  A2_TO_A3,
+  countryStatus,
+  isCountryVisible,
+  normalizeRegionName,
+  withCountryMarkedVisited,
+  type AtlasData,
+} from './atlasModel';
 
 describe('normalizeRegionName', () => {
   it('matches names that only differ by diacritics (Ile-de-France vs Île-de-France)', () => {
@@ -35,5 +42,116 @@ describe('A2_TO_A3 hardcoded entries (#1609)', () => {
     const isoA2 = feature.properties.ISO_A2;
     const countryCode = a3ToA2Entry ? a3ToA2Entry[0] : (isoA2 && isoA2 !== '-99' ? isoA2 : null);
     expect(countryCode).toBe('XK');
+  });
+});
+
+// Trip-date driven visit status (#1048). The three helpers below are the only place
+// the client decides what "been there" means, so every mark flow shares one answer.
+describe('countryStatus', () => {
+  it('treats a country without a status as visited (older server, no #1048 field)', () => {
+    expect(countryStatus({})).toBe('visited');
+  });
+
+  it('passes an explicit status through', () => {
+    expect(countryStatus({ status: 'visited' })).toBe('visited');
+    expect(countryStatus({ status: 'planned' })).toBe('planned');
+    expect(countryStatus({ status: 'idea' })).toBe('idea');
+  });
+});
+
+describe('isCountryVisible', () => {
+  it('always shows visited countries', () => {
+    expect(isCountryVisible({ status: 'visited' }, false)).toBe(true);
+    expect(isCountryVisible({ status: 'visited' }, true)).toBe(true);
+  });
+
+  it('hides planned and dateless countries until the layer is switched on', () => {
+    expect(isCountryVisible({ status: 'planned' }, false)).toBe(false);
+    expect(isCountryVisible({ status: 'idea' }, false)).toBe(false);
+    expect(isCountryVisible({ status: 'planned' }, true)).toBe(true);
+    expect(isCountryVisible({ status: 'idea' }, true)).toBe(true);
+  });
+
+  it('keeps a status-less country on the map with the toggle off', () => {
+    expect(isCountryVisible({}, false)).toBe(true);
+  });
+});
+
+describe('withCountryMarkedVisited', () => {
+  const base = (over: Partial<AtlasData> = {}): AtlasData => ({
+    countries: [{ code: 'FR', tripCount: 2, placeCount: 5, status: 'visited' }],
+    stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 1, totalDays: 14, totalCountriesPlanned: 0 },
+    continents: { Europe: 1 },
+    continentsPlanned: {},
+    ...over,
+  });
+
+  it('appends an unknown country as visited and counts it once', () => {
+    const next = withCountryMarkedVisited(base(), 'JP');
+
+    expect(next.countries).toHaveLength(2);
+    expect(next.countries[1]).toEqual({
+      code: 'JP', placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null, status: 'visited',
+    });
+    expect(next.stats.totalCountries).toBe(2);
+    expect(next.continents).toEqual({ Europe: 1, Asia: 1 });
+    // Nothing was planned, so the planned tallies stay untouched.
+    expect(next.stats.totalCountriesPlanned).toBe(0);
+    expect(next.continentsPlanned).toEqual({});
+  });
+
+  it('returns the very same object when the country is already visited', () => {
+    const prev = base();
+    expect(withCountryMarkedVisited(prev, 'FR')).toBe(prev);
+  });
+
+  it('promotes a planned country instead of adding a second entry', () => {
+    const prev = base({
+      countries: [
+        { code: 'FR', tripCount: 2, placeCount: 5, status: 'visited' },
+        { code: 'JP', tripCount: 1, placeCount: 0, status: 'planned' },
+      ],
+      stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 1, totalDays: 14, totalCountriesPlanned: 1 },
+      continents: { Europe: 1 },
+      continentsPlanned: { Asia: 1 },
+    });
+
+    const next = withCountryMarkedVisited(prev, 'JP');
+
+    expect(next.countries).toHaveLength(2);
+    expect(next.countries.find((c) => c.code === 'JP')?.status).toBe('visited');
+    expect(next.stats.totalCountries).toBe(2);
+    expect(next.stats.totalCountriesPlanned).toBe(0);
+    expect(next.continents).toEqual({ Europe: 1, Asia: 1 });
+    expect(next.continentsPlanned).toEqual({ Asia: 0 });
+  });
+
+  it('promotes a dateless country the same way', () => {
+    const prev = base({
+      countries: [{ code: 'JP', tripCount: 1, placeCount: 0, status: 'idea' }],
+      stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 0, totalDays: 14, totalCountriesPlanned: 1 },
+      continents: {},
+      continentsPlanned: { Asia: 1 },
+    });
+
+    const next = withCountryMarkedVisited(prev, 'JP');
+
+    expect(next.countries).toHaveLength(1);
+    expect(next.countries[0].status).toBe('visited');
+    expect(next.stats.totalCountries).toBe(1);
+    expect(next.stats.totalCountriesPlanned).toBe(0);
+  });
+
+  it('never lets the planned tallies fall below zero', () => {
+    const prev = base({
+      countries: [{ code: 'JP', tripCount: 1, placeCount: 0, status: 'planned' }],
+      stats: { totalTrips: 0, totalPlaces: 0, totalCountries: 0, totalDays: 0 },
+      continents: {},
+    });
+
+    const next = withCountryMarkedVisited(prev, 'JP');
+
+    expect(next.stats.totalCountriesPlanned).toBe(0);
+    expect(next.continentsPlanned).toEqual({ Asia: 0 });
   });
 });

--- a/client/src/pages/atlas/atlasModel.ts
+++ b/client/src/pages/atlas/atlasModel.ts
@@ -1,3 +1,5 @@
+import { continentForCountry, type VisitStatus } from '@trek/shared'
+
 /**
  * Shared types + pure helpers for the Atlas page. No React, no side effects.
  * A2_TO_A3 is deliberately a mutable module-level object: the geoData load
@@ -12,6 +14,8 @@ export interface AtlasCountry {
   placeCount: number
   firstVisit?: string | null
   lastVisit?: string | null
+  /** Optional so a client talking to an older server keeps painting everything as visited. */
+  status?: VisitStatus
 }
 
 export interface AtlasStats {
@@ -20,6 +24,8 @@ export interface AtlasStats {
   totalCountries: number
   totalDays: number
   totalCities?: number
+  totalCountriesPlanned?: number
+  totalCountriesIdea?: number
 }
 
 export interface AtlasData {
@@ -27,6 +33,7 @@ export interface AtlasData {
   stats: AtlasStats
   mostVisited?: AtlasCountry | null
   continents?: Record<string, number>
+  continentsPlanned?: Record<string, number>
   lastTrip?: { id: number; title: string; countryCode?: string } | null
   nextTrip?: { id: number; title: string; countryCode?: string } | null
   streak?: number
@@ -38,6 +45,48 @@ export interface CountryDetail {
   places: import('../../types').AtlasPlace[]
   trips: { id: number; title: string }[]
   manually_marked?: boolean
+  status?: VisitStatus
+}
+
+/** A country from a server that predates #1048 has no status — treat it as visited. */
+export function countryStatus(c: Pick<AtlasCountry, 'status'>): VisitStatus {
+  return c.status ?? 'visited'
+}
+
+/**
+ * Which countries belong on the map. Planned and dateless countries share one switch —
+ * splitting them into two would clutter the map for a distinction few users make.
+ */
+export function isCountryVisible(c: Pick<AtlasCountry, 'status'>, showPlanned: boolean): boolean {
+  return countryStatus(c) === 'visited' || showPlanned
+}
+
+/**
+ * Fold a manual "I have been here" mark into the loaded data without refetching — the
+ * map redraws from `data`, so a reload would flash the whole globe. A country that was
+ * merely planned moves over to the visited tally instead of being added twice.
+ * Shared by every mark flow (map click, search, mobile popup) so none of them can drift.
+ */
+export function withCountryMarkedVisited(prev: AtlasData, code: string): AtlasData {
+  const existing = prev.countries.find(c => c.code === code)
+  if (existing && countryStatus(existing) === 'visited') return prev
+  const cont = continentForCountry(code)
+  const wasPlanned = !!existing
+  return {
+    ...prev,
+    countries: existing
+      ? prev.countries.map(c => (c.code === code ? { ...c, status: 'visited' as const } : c))
+      : [...prev.countries, { code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null, status: 'visited' as const }],
+    stats: {
+      ...prev.stats,
+      totalCountries: prev.stats.totalCountries + 1,
+      ...(wasPlanned ? { totalCountriesPlanned: Math.max(0, (prev.stats.totalCountriesPlanned || 0) - 1) } : {}),
+    },
+    continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 },
+    ...(wasPlanned
+      ? { continentsPlanned: { ...prev.continentsPlanned, [cont]: Math.max(0, (prev.continentsPlanned?.[cont] || 0) - 1) } }
+      : {}),
+  }
 }
 
 export interface BucketItem {

--- a/client/src/pages/atlas/useAtlas.test.tsx
+++ b/client/src/pages/atlas/useAtlas.test.tsx
@@ -9,7 +9,7 @@ import { useSettingsStore } from '../../store/settingsStore';
 import { A2_TO_A3 } from './atlasModel';
 import { useAtlas } from './useAtlas';
 
-// FE-HOOK-ATLAS-001 to FE-HOOK-ATLAS-030
+// FE-HOOK-ATLAS-001 to FE-HOOK-ATLAS-035
 
 interface MockGeoJson {
   data: { features?: Record<string, unknown>[] };
@@ -133,6 +133,20 @@ const statsResponse = {
   tripsThisYear: 1,
 };
 
+// FR has already happened, DE is a trip that starts next month, JP has no dates at all.
+// totalCountries counts the visited ones only — that split is the whole point of #1048.
+const plannedStatsResponse = {
+  ...statsResponse,
+  countries: [
+    { code: 'FR', tripCount: 2, placeCount: 5, firstVisit: '2023-01-01', lastVisit: '2024-06-01', status: 'visited' },
+    { code: 'DE', tripCount: 1, placeCount: 0, firstVisit: '2099-05-01', lastVisit: '2099-05-08', status: 'planned' },
+    { code: 'JP', tripCount: 1, placeCount: 0, firstVisit: null, lastVisit: null, status: 'idea' },
+  ],
+  stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 1, totalDays: 14, totalCities: 3, totalCountriesPlanned: 1, totalCountriesIdea: 1 },
+  continents: { Europe: 1 },
+  continentsPlanned: { Europe: 1, Asia: 1 },
+};
+
 const feature = (props: Record<string, unknown>) => ({ type: 'Feature', properties: props, geometry: null });
 
 const geoCountries = {
@@ -171,6 +185,11 @@ function useAtlasHandlers(over: Partial<Record<string, unknown>> = {}) {
     http.get('/api/addons/atlas/regions/geo', () => HttpResponse.json(over.regionGeo ?? { features: [] })),
     http.get('/api/atlas-layers', () => HttpResponse.json({ layers: over.layers ?? [] })),
   );
+}
+
+/** The country layer is the only GeoJSON drawn without a dedicated pane. */
+function countryLayers(): MockGeoJson[] {
+  return (lf.geoJson as MockGeoJson[]).filter((g) => g.options.pane === undefined);
 }
 
 async function mountAtlas(over: Partial<Record<string, unknown>> = {}, props: { withPanel?: boolean } = {}) {
@@ -725,6 +744,101 @@ describe('useAtlas', () => {
       act(() => { lf.mapHandlers.moveend?.forEach((cb) => cb()); });
 
       expect((lf.geoJson as MockGeoJson[]).some((g) => g.options.pane === 'regionPane')).toBe(false);
+    });
+  });
+
+  describe('planned countries (#1048)', () => {
+    it('FE-HOOK-ATLAS-031: the planned layer starts off and only lists the visited countries', async () => {
+      await mountAtlas({ stats: plannedStatsResponse });
+
+      expect(atlas.showPlanned).toBe(false);
+      expect(atlas.visitedCountries.map((c) => c.code)).toEqual(['FR']);
+      expect(atlas.visibleCountries.map((c) => c.code)).toEqual(['FR']);
+      // countries stays the raw server list — the map picks from visibleCountries.
+      expect(atlas.countries.map((c) => c.code)).toEqual(['FR', 'DE', 'JP']);
+    });
+
+    it('FE-HOOK-ATLAS-032: a stored preference brings the planned countries back on mount', async () => {
+      localStorage.setItem('trek_atlas_show_planned', '1');
+      await mountAtlas({ stats: plannedStatsResponse });
+
+      expect(atlas.showPlanned).toBe(true);
+      expect(atlas.visibleCountries.map((c) => c.code)).toEqual(['FR', 'DE', 'JP']);
+      expect(atlas.visitedCountries.map((c) => c.code)).toEqual(['FR']);
+    });
+
+    it('FE-HOOK-ATLAS-032b: any other stored value keeps the layer off', async () => {
+      localStorage.setItem('trek_atlas_show_planned', '0');
+      await mountAtlas({ stats: plannedStatsResponse });
+
+      expect(atlas.showPlanned).toBe(false);
+    });
+
+    it('FE-HOOK-ATLAS-033: toggling reveals the planned countries and remembers the choice', async () => {
+      await mountAtlas({ stats: plannedStatsResponse });
+
+      act(() => atlas.togglePlanned());
+      expect(atlas.showPlanned).toBe(true);
+      expect(atlas.visibleCountries.map((c) => c.code)).toEqual(['FR', 'DE', 'JP']);
+      expect(localStorage.getItem('trek_atlas_show_planned')).toBe('1');
+
+      act(() => atlas.togglePlanned());
+      expect(atlas.showPlanned).toBe(false);
+      expect(atlas.visibleCountries.map((c) => c.code)).toEqual(['FR']);
+      expect(localStorage.getItem('trek_atlas_show_planned')).toBe('0');
+    });
+
+    it('FE-HOOK-ATLAS-034: a storage that refuses reads and writes still leaves a working toggle', async () => {
+      // Safari private mode: localStorage exists but throws. The toggle must not take
+      // the atlas down with it — it just forgets the choice between reloads.
+      const realGet = Storage.prototype.getItem;
+      const realSet = Storage.prototype.setItem;
+      const getSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function (this: Storage, key: string) {
+        if (key === 'trek_atlas_show_planned') throw new DOMException('denied', 'SecurityError');
+        return realGet.call(this, key);
+      });
+      const setSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (key === 'trek_atlas_show_planned') throw new DOMException('denied', 'SecurityError');
+        realSet.call(this, key, value);
+      });
+
+      try {
+        await mountAtlas({ stats: plannedStatsResponse });
+        expect(atlas.showPlanned).toBe(false);
+
+        act(() => atlas.togglePlanned());
+
+        expect(atlas.showPlanned).toBe(true);
+        expect(atlas.visibleCountries.map((c) => c.code)).toEqual(['FR', 'DE', 'JP']);
+      } finally {
+        getSpy.mockRestore();
+        setSpy.mockRestore();
+      }
+    });
+
+    it('FE-HOOK-ATLAS-035: planned countries are painted dashed and never eat a visited colour', async () => {
+      await mountAtlas({ stats: plannedStatsResponse, geo: geoCountries });
+      await waitFor(() => expect(countryLayers().length).toBeGreaterThan(0));
+      const before = countryLayers().length;
+
+      act(() => atlas.togglePlanned());
+      await waitFor(() => expect(countryLayers().length).toBeGreaterThan(before));
+
+      const layers = countryLayers();
+      const layer = layers[layers.length - 1];
+      const styleFor = (a2: string) => {
+        const i = (layer.data.features ?? []).findIndex(
+          (f) => (f.properties as Record<string, string>).ISO_A2 === a2,
+        );
+        return layer.styles[i] as { fillOpacity: number; dashArray?: string; fillColor: string };
+      };
+
+      expect(styleFor('FR').dashArray).toBeUndefined();
+      expect(styleFor('DE').dashArray).toBe('6 4');
+      // The palette is built from the visited list only, so France keeps the first colour
+      // whether or not the planned layer is on.
+      expect(styleFor('FR').fillColor).toBe('#6366f1');
+      expect(styleFor('DE').fillColor).not.toBe('#6366f1');
     });
   });
 });

--- a/client/src/pages/atlas/useAtlas.ts
+++ b/client/src/pages/atlas/useAtlas.ts
@@ -5,8 +5,10 @@ import { useSettingsStore } from '../../store/settingsStore'
 import apiClient, { mapsApi, pluginsApi, type PluginAtlasLayer } from '../../api/client'
 import L from 'leaflet'
 import type { GeoJsonFeatureCollection } from '../../types'
-import { A2_TO_A3, normalizeRegionName, type AtlasData, type CountryDetail, type BucketItem } from './atlasModel'
-import { continentForCountry } from '@trek/shared'
+import { A2_TO_A3, countryStatus, isCountryVisible, normalizeRegionName, withCountryMarkedVisited, type AtlasData, type CountryDetail, type BucketItem } from './atlasModel'
+import { continentForCountry, type VisitStatus } from '@trek/shared'
+
+const PLANNED_KEY = 'trek_atlas_show_planned'
 
 function useCountryNames(language: string): (code: string) => string {
   const [resolver, setResolver] = useState<(code: string) => string>(() => (code: string) => code)
@@ -67,12 +69,22 @@ export function useAtlas() {
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null)
   const [countryDetail, setCountryDetail] = useState<CountryDetail | null>(null)
   const [geoData, setGeoData] = useState<GeoJsonFeatureCollection | null>(null)
-  const [visitedRegions, setVisitedRegions] = useState<Record<string, { code: string; name: string; placeCount: number; manuallyMarked?: boolean }[]>>({})
+  const [visitedRegions, setVisitedRegions] = useState<Record<string, { code: string; name: string; placeCount: number; manuallyMarked?: boolean; status?: VisitStatus }[]>>({})
   const [pluginLayers, setPluginLayers] = useState<PluginAtlasLayer[]>([])
   const pluginLayerRef = useRef<L.GeoJSON | null>(null)
   const regionLayerRef = useRef<L.GeoJSON | null>(null)
   const regionGeoCache = useRef<Record<string, GeoJsonFeatureCollection>>({})
   const [showRegions, setShowRegions] = useState(false)
+  // Countries you only plan to visit stay off the map until asked for — the atlas is a
+  // record of where you have been, not of where you booked a flight to (#1048).
+  const [showPlanned, setShowPlanned] = useState<boolean>(() => {
+    try { return localStorage.getItem(PLANNED_KEY) === '1' } catch { return false }
+  })
+  const togglePlanned = () => setShowPlanned(v => {
+    const next = !v
+    try { localStorage.setItem(PLANNED_KEY, next ? '1' : '0') } catch { /* private mode — keep the toggle working anyway */ }
+    return next
+  })
   const [regionGeoLoaded, setRegionGeoLoaded] = useState(0)
   const regionTooltipRef = useRef<HTMLDivElement>(null)
   const loadCountryDetailRef = useRef<(code: string) => void>(() => {})
@@ -97,6 +109,11 @@ export function useAtlas() {
   const [atlas_country_search, set_atlas_country_search] = useState('')
   const [atlas_country_results, set_atlas_country_results] = useState<{ code: string; label: string }[]>([])
   const [atlas_country_open, set_atlas_country_open] = useState(false)
+
+  // visitedCountries drives the colour palette and every "how many" number;
+  // visibleCountries drives what the map paints and what stays clickable.
+  const visitedCountries = useMemo(() => (data?.countries ?? []).filter(c => countryStatus(c) === 'visited'), [data])
+  const visibleCountries = useMemo(() => (data?.countries ?? []).filter(c => isCountryVisible(c, showPlanned)), [data, showPlanned])
 
   const atlas_country_options = useMemo(() => {
     if (!geoData) return []
@@ -291,9 +308,10 @@ export function useAtlas() {
   useEffect(() => {
     if (!mapInstance.current || !geoData || !data) return
 
-    const visitedA3 = new Set(data.countries.map(c => A2_TO_A3[c.code]).filter(Boolean))
+    const visitedA3 = new Set(visibleCountries.map(c => A2_TO_A3[c.code]).filter(Boolean))
+    const plannedA3 = new Set(visibleCountries.filter(c => countryStatus(c) !== 'visited').map(c => A2_TO_A3[c.code]).filter(Boolean))
     const countryMap = {}
-    data.countries.forEach(c => { if (A2_TO_A3[c.code]) countryMap[A2_TO_A3[c.code]] = c })
+    visibleCountries.forEach(c => { if (A2_TO_A3[c.code]) countryMap[A2_TO_A3[c.code]] = c })
 
     // Preserve current map view
     const currentCenter = mapInstance.current.getCenter()
@@ -305,8 +323,10 @@ export function useAtlas() {
 
     // Generate deterministic color per country code
     const VISITED_COLORS = ['#6366f1','#ec4899','#14b8a6','#f97316','#8b5cf6','#ef4444','#3b82f6','#22c55e','#06b6d4','#f43f5e','#a855f7','#10b981','#0ea5e9','#e11d48','#0d9488','#7c3aed','#2563eb','#dc2626','#059669','#d946ef']
-    // Assign colors in order of visit (by index in countries array) so no two neighbors share a color easily
-    const visitedA3List = [...visitedA3]
+    // Assign colors in order of visit (by index in countries array) so no two neighbors share a color easily.
+    // Built from the visited countries only — if planned ones took part, flipping the toggle
+    // would shift every index and reshuffle the colours of the whole map.
+    const visitedA3List = [...new Set(visitedCountries.map(c => A2_TO_A3[c.code]).filter(Boolean))]
     const colorMap = {}
     visitedA3List.forEach((a3, i) => { colorMap[a3] = VISITED_COLORS[i % VISITED_COLORS.length] })
     const colorForCode = (a3) => colorMap[a3] || VISITED_COLORS[0]
@@ -319,6 +339,17 @@ export function useAtlas() {
       bubblingMouseEvents: false,
       style: (feature) => {
         const a3 = feature.properties?.ADM0_A3 || feature.properties?.ISO_A3 || feature.properties?.['ISO3166-1-Alpha-3'] || feature.id
+        // Planned countries read as an outline rather than a fill: dashed border, muted
+        // wash. Deliberately not one of the VISITED_COLORS, so "been there" stays distinct.
+        if (plannedA3.has(a3)) {
+          return {
+            fillColor: dark ? '#818cf8' : '#4f46e5',
+            fillOpacity: 0.38,
+            color: dark ? '#818cf8' : '#4f46e5',
+            weight: 1,
+            dashArray: '6 4',
+          }
+        }
         const visited = visitedA3.has(a3)
         return {
           fillColor: visited ? colorForCode(a3) : (dark ? '#1e1e2e' : '#e2e8f0'),
@@ -334,22 +365,31 @@ export function useAtlas() {
           country_layer_by_a2_ref.current[c.code] = layer
           const name = resolveName(c.code)
           const formatDate = (d) => { if (!d) return '—'; const dt = new Date(d); return dt.toLocaleDateString(getLocaleForLanguage(language), { month: 'short', year: 'numeric' }) }
-          const tooltipHtml = `
-            <div style="display:flex;flex-direction:column;gap:8px;min-width:160px">
-              <div style="font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;padding-bottom:6px;border-bottom:1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}">${name}</div>
-              <div style="display:flex;gap:14px">
-                <div><span style="font-size:16px;font-weight:800">${c.tripCount}</span> <span style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:0.05em">${c.tripCount === 1 ? t('atlas.tripSingular') : t('atlas.tripPlural')}</span></div>
-                <div><span style="font-size:16px;font-weight:800">${c.placeCount}</span> <span style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:0.05em">${c.placeCount === 1 ? t('atlas.placeVisited') : t('atlas.placesVisited')}</span></div>
-              </div>
-              <div style="display:flex;gap:2px;border-top:1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'};padding-top:8px">
-                <div style="flex:1;display:flex;flex-direction:column;gap:2px">
+          // "First trip / Last trip" is simply wrong for a country you haven't reached yet —
+          // a planned one gets a single departure date instead.
+          const planned = countryStatus(c) !== 'visited'
+          const datesHtml = planned
+            ? `<div style="flex:1;display:flex;flex-direction:column;gap:2px">
+                  <span style="font-size:9px;text-transform:uppercase;letter-spacing:0.08em;opacity:0.4">${t('atlas.plannedFor')}</span>
+                  <span style="font-size:12px;font-weight:700">${formatDate(c.firstVisit)}</span>
+                </div>`
+            : `<div style="flex:1;display:flex;flex-direction:column;gap:2px">
                   <span style="font-size:9px;text-transform:uppercase;letter-spacing:0.08em;opacity:0.4">${t('atlas.firstVisit')}</span>
                   <span style="font-size:12px;font-weight:700">${formatDate(c.firstVisit)}</span>
                 </div>
                 <div style="flex:1;display:flex;flex-direction:column;gap:2px">
                   <span style="font-size:9px;text-transform:uppercase;letter-spacing:0.08em;opacity:0.4">${t('atlas.lastVisitLabel')}</span>
                   <span style="font-size:12px;font-weight:700">${formatDate(c.lastVisit)}</span>
-                </div>
+                </div>`
+          const tooltipHtml = `
+            <div style="display:flex;flex-direction:column;gap:8px;min-width:160px">
+              <div style="font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;padding-bottom:6px;border-bottom:1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}">${name}${planned ? ` <span style="font-size:9px;font-weight:700;opacity:0.55;letter-spacing:0.06em">· ${t('atlas.planned')}</span>` : ''}</div>
+              <div style="display:flex;gap:14px">
+                <div><span style="font-size:16px;font-weight:800">${c.tripCount}</span> <span style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:0.05em">${c.tripCount === 1 ? t('atlas.tripSingular') : t('atlas.tripPlural')}</span></div>
+                <div><span style="font-size:16px;font-weight:800">${c.placeCount}</span> <span style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:0.05em">${c.placeCount === 1 ? t('atlas.placeVisited') : t('atlas.placesVisited')}</span></div>
+              </div>
+              <div style="display:flex;gap:2px;border-top:1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'};padding-top:8px">
+                ${datesHtml}
               </div>
             </div>`
           layer.bindTooltip(tooltipHtml, {
@@ -395,7 +435,7 @@ export function useAtlas() {
 
     // Restore map view after re-render
     mapInstance.current.setView(currentCenter, currentZoom, { animate: false })
-  }, [geoData, data, dark])
+  }, [geoData, data, dark, visibleCountries, visitedCountries])
 
   // Render plugin tint layers (atlasLayerProvider hook) — a dashed wash over the
   // countries a plugin flagged, in its own non-interactive pane above the country
@@ -452,29 +492,41 @@ export function useAtlas() {
 
     if (Object.keys(regionGeoCache.current).length === 0) return
 
-    // Build set of visited region codes and per-country name sets
+    // Build set of visited region codes and per-country name sets. Regions follow their
+    // country's status, so zooming into a planned country can't reveal "visited" regions.
     const visitedRegionCodes = new Set<string>()
+    const plannedRegionCodes = new Set<string>()
     const visitedRegionNamesByCountry = new Map<string, Set<string>>()
+    const plannedRegionNamesByCountry = new Map<string, Set<string>>()
     const regionPlaceCounts: Record<string, number> = {}
     for (const [countryCode, regions] of Object.entries(visitedRegions)) {
       const names = new Set<string>()
+      const plannedNames = new Set<string>()
       for (const r of regions) {
-        visitedRegionCodes.add(r.code)
-        names.add(normalizeRegionName(r.name))
+        const planned = (r.status ?? 'visited') !== 'visited'
+        if (planned && !showPlanned) continue
+        if (planned) {
+          plannedRegionCodes.add(r.code)
+          plannedNames.add(normalizeRegionName(r.name))
+        } else {
+          visitedRegionCodes.add(r.code)
+          names.add(normalizeRegionName(r.name))
+        }
         regionPlaceCounts[r.code] = r.placeCount
         regionPlaceCounts[`${countryCode}:${normalizeRegionName(r.name)}`] = r.placeCount
       }
       visitedRegionNamesByCountry.set(countryCode, names)
+      plannedRegionNamesByCountry.set(countryCode, plannedNames)
     }
 
     // Match feature by ISO code OR region name scoped to the feature's country. Names are
     // normalized (diacritics/dash variants folded) since the geocoder's cached region_name
     // and the bundled boundaries' name don't always agree on accenting (e.g. a cached
     // "Ile-de-France" must still match the bundle's "Île-de-France") (#atlas-region-match).
-    const isVisitedFeature = (f: any) => {
-      if (visitedRegionCodes.has(f.properties?.iso_3166_2)) return true
+    const matchesRegions = (f: any, codes: Set<string>, namesByCountry: Map<string, Set<string>>) => {
+      if (codes.has(f.properties?.iso_3166_2)) return true
       const countryA2 = (f.properties?.iso_a2 || '').toUpperCase()
-      const countryNames = visitedRegionNamesByCountry.get(countryA2)
+      const countryNames = namesByCountry.get(countryA2)
       if (!countryNames) return false
       const name = normalizeRegionName(f.properties?.name || '')
       if (countryNames.has(name)) return true
@@ -482,6 +534,8 @@ export function useAtlas() {
       if (nameEn && countryNames.has(nameEn)) return true
       return false
     }
+    const isVisitedFeature = (f: any) => matchesRegions(f, visitedRegionCodes, visitedRegionNamesByCountry)
+    const isPlannedFeature = (f: any) => matchesRegions(f, plannedRegionCodes, plannedRegionNamesByCountry)
 
     // Include ALL region features — visited ones get colored fill, unvisited get outline only
     const allFeatures: any[] = []
@@ -494,12 +548,14 @@ export function useAtlas() {
 
     // Use same colors as country layer
     const VISITED_COLORS = ['#6366f1','#ec4899','#14b8a6','#f97316','#8b5cf6','#ef4444','#3b82f6','#22c55e','#06b6d4','#f43f5e','#a855f7','#10b981','#0ea5e9','#e11d48','#0d9488','#7c3aed','#2563eb','#dc2626','#059669','#d946ef']
-    const countryA3Set = data ? data.countries.map(c => A2_TO_A3[c.code]).filter(Boolean) : []
+    // Same source as the country layer's palette (visited only), or the two layers would
+    // hand the same country different colours.
+    const countryA3Set = [...new Set(visitedCountries.map(c => A2_TO_A3[c.code]).filter(Boolean))]
     const countryColorMap: Record<string, string> = {}
     countryA3Set.forEach((a3, i) => { countryColorMap[a3] = VISITED_COLORS[i % VISITED_COLORS.length] })
     // Map country A2 code to country color
     const a2ColorMap: Record<string, string> = {}
-    if (data) data.countries.forEach(c => { if (A2_TO_A3[c.code] && countryColorMap[A2_TO_A3[c.code]]) a2ColorMap[c.code] = countryColorMap[A2_TO_A3[c.code]] })
+    visitedCountries.forEach(c => { if (A2_TO_A3[c.code] && countryColorMap[A2_TO_A3[c.code]]) a2ColorMap[c.code] = countryColorMap[A2_TO_A3[c.code]] })
 
     const mergedGeo = { type: 'FeatureCollection', features: allFeatures }
 
@@ -511,6 +567,15 @@ export function useAtlas() {
       pane: 'regionPane',
       style: (feature) => {
         const countryA2 = (feature?.properties?.iso_a2 || '').toUpperCase()
+        if (isPlannedFeature(feature)) {
+          return {
+            fillColor: dark ? '#818cf8' : '#4f46e5',
+            fillOpacity: 0.4,
+            color: dark ? '#818cf8' : '#4f46e5',
+            weight: 1,
+            dashArray: '6 4',
+          }
+        }
         const visited = isVisitedFeature(feature)
         return visited ? {
           fillColor: a2ColorMap[countryA2] || '#6366f1',
@@ -586,7 +651,9 @@ export function useAtlas() {
     if (mapInstance.current.getZoom() >= 6) {
       regionLayerRef.current.addTo(mapInstance.current)
     }
-  }, [regionGeoLoaded, visitedRegions, dark, t])
+    // visitedCountries belongs here: the region colours are derived from it, and without
+    // the dep this effect kept painting regions from a stale country list.
+  }, [regionGeoLoaded, visitedRegions, dark, t, visitedCountries, showPlanned])
 
   const handleMarkCountry = (code: string, name: string): void => {
     setConfirmAction({ type: 'choose', code, name })
@@ -637,16 +704,7 @@ export function useAtlas() {
     // Update local state immediately (no API reload = no map re-render flash)
     if (type === 'mark') {
       apiClient.post(`/addons/atlas/country/${code}/mark`).catch(() => {})
-      setData(prev => {
-        if (!prev || prev.countries.find(c => c.code === code)) return prev
-        const cont = continentForCountry(code)
-        return {
-          ...prev,
-          countries: [...prev.countries, { code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null }],
-          stats: { ...prev.stats, totalCountries: prev.stats.totalCountries + 1 },
-          continents: { ...prev.continents, [cont]: (prev.continents?.[cont] || 0) + 1 },
-        }
-      })
+      setData(prev => (prev ? withCountryMarkedVisited(prev, code) : prev))
     } else {
       apiClient.delete(`/addons/atlas/country/${code}/mark`).catch(() => {})
       setSelectedCountry(null)
@@ -756,6 +814,7 @@ export function useAtlas() {
     mapRef, regionTooltipRef, panelRef, glareRef, borderGlareRef,
     handlePanelMouseMove, handlePanelMouseLeave,
     data, setData, stats, countries, selectedCountry, countryDetail,
+    visitedCountries, visibleCountries, showPlanned, togglePlanned,
     loadCountryDetail, handleUnmarkCountry, select_country_from_search,
     visitedRegions, setVisitedRegions,
     atlas_country_search, set_atlas_country_search,

--- a/client/tests/helpers/atlas.ts
+++ b/client/tests/helpers/atlas.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import type { AtlasController } from '../../src/mobile/screens/atlas/atlasController';
+import type { VisitStatus } from '@trek/shared';
 import type { AtlasData, BucketItem, CountryDetail } from '../../src/pages/atlas/atlasModel';
 
 /**
@@ -12,17 +13,21 @@ import type { AtlasData, BucketItem, CountryDetail } from '../../src/pages/atlas
  * setter was called" and "this is the state it produced".
  */
 
-export type VisitedRegions = Record<string, { code: string; name: string; placeCount: number; manuallyMarked?: boolean }[]>;
+export type VisitedRegions = Record<
+  string,
+  { code: string; name: string; placeCount: number; manuallyMarked?: boolean; status?: VisitStatus }[]
+>;
 
 const echoT = (key: string, params?: Record<string, string | number>): string =>
   params ? `${key}:${Object.values(params).join(',')}` : key;
 
 export function buildAtlasData(over: Partial<AtlasData> = {}): AtlasData {
   return {
-    countries: [{ code: 'FR', tripCount: 2, placeCount: 5, firstVisit: '2023-01-01', lastVisit: '2024-06-01' }],
-    stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 1, totalDays: 14, totalCities: 3 },
+    countries: [{ code: 'FR', tripCount: 2, placeCount: 5, firstVisit: '2023-01-01', lastVisit: '2024-06-01', status: 'visited' }],
+    stats: { totalTrips: 3, totalPlaces: 10, totalCountries: 1, totalDays: 14, totalCities: 3, totalCountriesPlanned: 0, totalCountriesIdea: 0 },
     mostVisited: null,
     continents: { Europe: 1 },
+    continentsPlanned: {},
     lastTrip: { id: 7, title: 'Paris Trip', countryCode: 'FR' },
     nextTrip: null,
     streak: 2,
@@ -50,6 +55,7 @@ export function buildCountryDetail(over: Partial<CountryDetail> = {}): CountryDe
     places: [],
     trips: [],
     manually_marked: false,
+    status: 'visited',
     ...over,
   };
 }
@@ -99,6 +105,10 @@ export function buildAtlasController(over: Record<string, unknown> = {}): AtlasC
     data: buildAtlasData(),
     stats: buildAtlasData().stats,
     countries: buildAtlasData().countries,
+    visitedCountries: buildAtlasData().countries,
+    visibleCountries: buildAtlasData().countries,
+    showPlanned: false,
+    togglePlanned: vi.fn(() => undefined),
     selectedCountry: null,
     countryDetail: null,
     loadCountryDetail: vi.fn(async () => undefined),
@@ -144,6 +154,13 @@ export function buildAtlasController(over: Record<string, unknown> = {}): AtlasC
   const data = ctrl.data as AtlasData | null;
   if (!('stats' in over)) ctrl.stats = data?.stats ?? { totalTrips: 0, totalPlaces: 0, totalCountries: 0, totalDays: 0 };
   if (!('countries' in over)) ctrl.countries = data?.countries ?? [];
+  // The hook derives these from data + showPlanned; mirror that so a test that only
+  // sets `data` still gets a consistent controller.
+  const all = (ctrl.countries ?? []) as AtlasData['countries'];
+  if (!('visitedCountries' in over)) ctrl.visitedCountries = all.filter(c => (c.status ?? 'visited') === 'visited');
+  if (!('visibleCountries' in over)) {
+    ctrl.visibleCountries = ctrl.showPlanned ? all : all.filter(c => (c.status ?? 'visited') === 'visited');
+  }
 
   return ctrl as unknown as AtlasController;
 }

--- a/client/tests/unit/mobile/atlas/MAtlas.test.tsx
+++ b/client/tests/unit/mobile/atlas/MAtlas.test.tsx
@@ -5,7 +5,7 @@ import type { AtlasController } from '../../../../src/mobile/screens/atlas/atlas
 import type { CountryDetail } from '../../../../src/pages/atlas/atlasModel';
 import MAtlas from '../../../../src/mobile/screens/atlas/MAtlas';
 
-// FE-MOB-ATLASSCR-001 to FE-MOB-ATLASSCR-016
+// FE-MOB-ATLASSCR-001 to FE-MOB-ATLASSCR-019
 
 const mocks = vi.hoisted(() => ({ atlas: {} as AtlasController }));
 
@@ -219,5 +219,46 @@ describe('MAtlas', () => {
     await screen.findByPlaceholderText('Search a country...');
     const rows = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
     expect(rows.map((r) => r.textContent)).toEqual(['FranceVisited', 'JapanVisited']);
+  });
+
+  it('FE-MOB-ATLASSCR-017: the planned pill stays away while nothing is planned', () => {
+    render(<MAtlas />);
+
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByText('atlas.planned')).not.toBeInTheDocument();
+  });
+
+  it('FE-MOB-ATLASSCR-018: a planned country brings up the pill and its switch flips the layer', () => {
+    const atlas = setAtlas({
+      data: buildAtlasData({
+        stats: { totalTrips: 4, totalPlaces: 21, totalCountries: 7, totalDays: 30, totalCities: 9, totalCountriesPlanned: 2 },
+      }),
+    });
+    render(<MAtlas />);
+
+    expect(screen.getByText('atlas.planned')).toBeInTheDocument();
+    const toggle = screen.getByRole('switch', { name: 'atlas.showPlanned' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+    expect(atlas.togglePlanned).toHaveBeenCalled();
+  });
+
+  it('FE-MOB-ATLASSCR-019: suggestions rank the countries you have been to above the planned ones', async () => {
+    setAtlas({
+      data: buildAtlasData({
+        countries: [
+          { code: 'JP', tripCount: 1, placeCount: 0, lastVisit: '2099-08-01', status: 'planned' },
+          { code: 'FR', tripCount: 1, placeCount: 1, lastVisit: '2022-01-01', status: 'visited' },
+        ],
+        stats: { totalTrips: 2, totalPlaces: 1, totalCountries: 1, totalDays: 4, totalCountriesPlanned: 1 },
+      }),
+    });
+    render(<MAtlas />, { initialEntries: ['/atlas?search=1'] });
+
+    await screen.findByPlaceholderText('Search a country...');
+    const rows = screen.getAllByRole('button').filter((b) => b.querySelector('img'));
+    // Japan has the later date but is only planned, so France leads and keeps "Visited".
+    expect(rows.map((r) => r.textContent)).toEqual(['FranceVisited', 'JapanPlanned']);
   });
 });

--- a/client/tests/unit/mobile/atlas/MAtlasCountryPopup.test.tsx
+++ b/client/tests/unit/mobile/atlas/MAtlasCountryPopup.test.tsx
@@ -124,7 +124,7 @@ describe('MAtlasCountryPopup', () => {
 
     await waitFor(() => expect(atlas.setConfirmAction).toHaveBeenCalledWith(null));
     const regions = atlas.visitedRegions as VisitedRegions;
-    expect(regions.ES).toEqual([{ code: 'ES-GA', name: 'Galicia', placeCount: 0, manuallyMarked: true }]);
+    expect(regions.ES).toEqual([{ code: 'ES-GA', name: 'Galicia', placeCount: 0, status: 'visited', manuallyMarked: true }]);
     const data = atlas.data as AtlasData;
     expect(data.countries.map((c) => c.code)).toContain('ES');
     expect(data.stats.totalCountries).toBe(2);

--- a/client/tests/unit/mobile/atlas/MAtlasSearch.test.tsx
+++ b/client/tests/unit/mobile/atlas/MAtlasSearch.test.tsx
@@ -19,6 +19,7 @@ function renderSearch(overrides: Partial<React.ComponentProps<typeof MAtlasSearc
     options,
     suggestions: [{ code: 'JP', label: 'Japan' }],
     isVisited: () => false,
+    isPlanned: () => false,
     isOnBucketList: () => false,
     onSelect: () => {},
     ...overrides,
@@ -52,5 +53,24 @@ describe('MAtlasSearch', () => {
   it('FE-MOB-ATLAS-003: renders nothing while closed', () => {
     renderSearch({ open: false });
     expect(screen.queryByPlaceholderText('Search a country...')).not.toBeInTheDocument();
+  });
+
+  it('FE-MOB-ATLAS-004: a country you only plan to visit is labelled planned, not visited (#1048)', async () => {
+    renderSearch({ isPlanned: (code) => code === 'DE' });
+
+    await userEvent.type(screen.getByPlaceholderText('Search a country...'), 'germ');
+
+    expect(screen.getByText('Planned')).toBeInTheDocument();
+    expect(screen.queryByText('Visited')).not.toBeInTheDocument();
+  });
+
+  it('FE-MOB-ATLAS-005: having been there wins over the planned and bucket labels', async () => {
+    renderSearch({ isVisited: () => true, isPlanned: () => true, isOnBucketList: () => true });
+
+    await userEvent.type(screen.getByPlaceholderText('Search a country...'), 'germ');
+
+    expect(screen.getByText('Visited')).toBeInTheDocument();
+    expect(screen.queryByText('Planned')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bucket List')).not.toBeInTheDocument();
   });
 });

--- a/client/tests/unit/mobile/atlas/MAtlasStatsCard.test.tsx
+++ b/client/tests/unit/mobile/atlas/MAtlasStatsCard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '../../../helpers/render';
 import MAtlasStatsCard from '../../../../src/mobile/screens/atlas/MAtlasStatsCard';
 
-// FE-MOB-ATLAS-010 onwards
+// FE-MOB-ATLAS-010 to FE-MOB-ATLAS-012
 
 const stats = { totalCountries: 3, totalTrips: 2, totalPlaces: 125, totalCities: 31, totalDays: 26 };
 
@@ -16,5 +16,23 @@ describe('MAtlasStatsCard', () => {
     for (const value of ['3', '2', '125', '31', '26']) {
       expect(screen.getByText(value)).toBeInTheDocument();
     }
+    // No planned countries, no superscript — the column reads as a plain number.
+    expect(screen.getByText('Countries').parentElement).toHaveTextContent(/^3Countries$/);
+  });
+
+  it('FE-MOB-ATLAS-011: hangs the planned countries off the country total as a superscript (#1048)', () => {
+    render(<MAtlasStatsCard stats={{ ...stats, totalCountriesPlanned: 4 }} />);
+
+    expect(screen.getByText('+4')).toBeInTheDocument();
+    expect(screen.getByText('Countries').parentElement).toHaveTextContent(/^3\+4Countries$/);
+    // Only the first column carries it — the other four stay untouched.
+    expect(screen.getByText('Trips').parentElement).toHaveTextContent(/^2Trips$/);
+  });
+
+  it('FE-MOB-ATLAS-012: a zero planned count is left off entirely', () => {
+    render(<MAtlasStatsCard stats={{ ...stats, totalCountriesPlanned: 0 }} />);
+
+    expect(screen.queryByText('+0')).not.toBeInTheDocument();
+    expect(screen.getByText('Countries').parentElement).toHaveTextContent(/^3Countries$/);
   });
 });

--- a/server/src/nest/atlas/atlas.service.ts
+++ b/server/src/nest/atlas/atlas.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CONTINENT_MAP } from '@trek/shared';
+import { CONTINENT_MAP, strongerVisitStatus, todayUtc, tripVisitStatus, VisitStatus } from '@trek/shared';
 import { Trip, Place } from '../../types';
 import { DatabaseService } from '../database/database.service';
 import {
@@ -71,6 +71,15 @@ export class AtlasService {
     if (tripIds.length === 0) return [];
     const placeholders = tripIds.map(() => '?').join(',');
     return this.db.prepare(`SELECT * FROM places WHERE trip_id IN (${placeholders})`).all(...tripIds) as Place[];
+  }
+
+  /**
+   * Trip id → whether that trip counts as visited, planned or a dateless idea (#1048).
+   * Everything country-shaped downstream takes its status from here, so the map, the
+   * counters and the country detail sheet can never disagree about the same trip.
+   */
+  private tripStatusMap(trips: Trip[], today: string): Map<number, VisitStatus> {
+    return new Map(trips.map((t) => [t.id, tripVisitStatus(t.start_date, t.end_date, today)]));
   }
 
   // ── Country resolution (batch DB cache + sync fallback + background geocoding) ──
@@ -157,19 +166,26 @@ export class AtlasService {
     }
 
     const places = this.getPlacesForTrips(tripIds);
+    const now = todayUtc();
+    const tripStatus = this.tripStatusMap(trips, now);
 
     interface CountryEntry {
       code: string;
       places: { id: number; name: string; lat: number | null; lng: number | null }[];
       tripIds: Set<number>;
+      status: VisitStatus;
     }
     const placeCountries = this.resolvePlaceCountries(places);
     const countrySet = new Map<string, CountryEntry>();
     for (const place of places) {
       const code = placeCountries.get(place.id);
       if (code) {
-        if (!countrySet.has(code)) {
-          countrySet.set(code, { code, places: [], tripIds: new Set() });
+        const status = tripStatus.get(place.trip_id) ?? 'idea';
+        const entry = countrySet.get(code);
+        if (entry) {
+          entry.status = strongerVisitStatus(entry.status, status);
+        } else {
+          countrySet.set(code, { code, places: [], tripIds: new Set(), status });
         }
         countrySet
           .get(code)!
@@ -200,6 +216,7 @@ export class AtlasService {
         tripCount: c.tripIds.size,
         firstVisit: dates[0] || null,
         lastVisit: dates[dates.length - 1] || null,
+        status: c.status,
       };
     });
 
@@ -241,8 +258,20 @@ export class AtlasService {
     }[];
     for (const mc of manualCountries) {
       if (hidden.has(mc.country_code)) continue;
-      if (!countries.find((c) => c.code === mc.country_code)) {
-        countries.push({ code: mc.country_code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null });
+      const existing = countries.find((c) => c.code === mc.country_code);
+      if (existing) {
+        // Marking a country by hand is a statement of fact and outranks the dates of a
+        // trip that happens to go there later (#1048).
+        existing.status = 'visited';
+      } else {
+        countries.push({
+          code: mc.country_code,
+          placeCount: 0,
+          tripCount: 0,
+          firstVisit: null,
+          lastVisit: null,
+          status: 'visited',
+        });
       }
     }
 
@@ -254,29 +283,53 @@ export class AtlasService {
     const endpoints = this.db
       .prepare(
         `
-    SELECT DISTINCT e.lat, e.lng
+    SELECT DISTINCT r.trip_id, e.lat, e.lng
     FROM reservation_endpoints e
     JOIN reservations r ON e.reservation_id = r.id
     WHERE r.trip_id IN (${tripIds.map(() => '?').join(',')}) AND e.role IN ('from', 'to')
   `,
       )
-      .all(...tripIds) as { lat: number; lng: number }[];
+      .all(...tripIds) as { trip_id: number; lat: number; lng: number }[];
+
+    // Selecting trip_id makes the DISTINCT per trip, so the same airport comes back once
+    // per booking. Collapse to one entry per coordinate before resolving countries —
+    // getCountryFromCoords is a point-in-polygon scan and used to run once per point.
+    const endpointStatus = new Map<string, { lat: number; lng: number; status: VisitStatus }>();
     for (const e of endpoints) {
+      const status = tripStatus.get(e.trip_id) ?? 'idea';
+      const key = `${e.lat},${e.lng}`;
+      const seen = endpointStatus.get(key);
+      if (seen) seen.status = strongerVisitStatus(seen.status, status);
+      else endpointStatus.set(key, { lat: e.lat, lng: e.lng, status });
+    }
+    for (const e of endpointStatus.values()) {
       const code = getCountryFromCoords(e.lat, e.lng);
-      if (code && !hidden.has(code) && !countries.find((c) => c.code === code)) {
-        countries.push({ code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null });
-      }
+      if (!code || hidden.has(code)) continue;
+      const existing = countries.find((c) => c.code === code);
+      if (existing) existing.status = strongerVisitStatus(existing.status, e.status);
+      else
+        countries.push({ code, placeCount: 0, tripCount: 0, firstVisit: null, lastVisit: null, status: e.status });
     }
 
-    const mostVisited = countries.length > 0 ? countries.reduce((a, b) => (a.placeCount > b.placeCount ? a : b)) : null;
+    // Everything below counts actual visits only. countries[] still carries planned and
+    // dateless entries so the client can draw them once the user asks for them (#1048).
+    const visited = countries.filter((c) => c.status === 'visited');
+    const planned = countries.filter((c) => c.status === 'planned');
+
+    const mostVisited = visited.length > 0 ? visited.reduce((a, b) => (a.placeCount > b.placeCount ? a : b)) : null;
 
     const continents: Record<string, number> = {};
-    countries.forEach((c) => {
+    visited.forEach((c) => {
       const cont = CONTINENT_MAP[c.code] || 'Other';
       continents[cont] = (continents[cont] || 0) + 1;
     });
 
-    const now = new Date().toISOString().split('T')[0];
+    const continentsPlanned: Record<string, number> = {};
+    planned.forEach((c) => {
+      const cont = CONTINENT_MAP[c.code] || 'Other';
+      continentsPlanned[cont] = (continentsPlanned[cont] || 0) + 1;
+    });
+
     const pastTrips = trips
       .filter((t) => t.end_date && t.end_date <= now)
       .sort((a, b) => b.end_date!.localeCompare(a.end_date!));
@@ -330,12 +383,15 @@ export class AtlasService {
       stats: {
         totalTrips: trips.length,
         totalPlaces: places.length,
-        totalCountries: countries.length,
+        totalCountries: visited.length,
+        totalCountriesPlanned: planned.length,
+        totalCountriesIdea: countries.length - visited.length - planned.length,
         totalDays,
         totalCities,
       },
       mostVisited,
       continents,
+      continentsPlanned,
       lastTrip,
       nextTrip,
       streak,
@@ -355,7 +411,7 @@ export class AtlasService {
       const marked = !!this.db
         .prepare('SELECT 1 FROM visited_countries WHERE user_id = ? AND country_code = ?')
         .get(userId, code);
-      return { places: [], trips: [], manually_marked: marked };
+      return { places: [], trips: [], manually_marked: marked, status: marked ? 'visited' : 'idea' };
     }
 
     const places = this.getPlacesForTrips(tripIds);
@@ -392,7 +448,15 @@ export class AtlasService {
     const isManuallyMarked = !!this.db
       .prepare('SELECT 1 FROM visited_countries WHERE user_id = ? AND country_code = ?')
       .get(userId, code);
-    return { places: matchingPlaces, trips: matchingTrips, manually_marked: isManuallyMarked };
+
+    // Take the status from the same trip classification stats() uses rather than deriving
+    // it again here — the detail sheet and the map must agree on what this country is.
+    const tripStatus = this.tripStatusMap(trips, todayUtc());
+    let status: VisitStatus = 'idea';
+    for (const id of matchingTripIds) status = strongerVisitStatus(status, tripStatus.get(id) ?? 'idea');
+    if (isManuallyMarked) status = 'visited';
+
+    return { places: matchingPlaces, trips: matchingTrips, manually_marked: isManuallyMarked, status };
   }
 
   // ── Mark / unmark country ─────────────────────────────────────────────────
@@ -524,12 +588,20 @@ export class AtlasService {
 
   // ── Visited regions ───────────────────────────────────────────────────────
 
-  async visitedRegions(
-    userId: number,
-  ): Promise<{ regions: Record<string, { code: string; name: string; placeCount: number }[]> }> {
+  async visitedRegions(userId: number): Promise<{
+    regions: Record<
+      string,
+      { code: string; name: string; placeCount: number; status: VisitStatus; manuallyMarked?: boolean }[]
+    >;
+  }> {
     const trips = this.getUserTrips(userId);
     const tripIds = trips.map((t) => t.id);
     const places = this.getPlacesForTrips(tripIds);
+
+    // Regions carry the same status as their country, otherwise zooming into a merely
+    // planned country would reveal regions painted as visited (#1048).
+    const tripStatus = this.tripStatusMap(trips, todayUtc());
+    const placeTrip = new Map(places.map((p) => [p.id, p.trip_id]));
 
     // Check DB cache first
     const placeIds = places.filter((p) => p.lat && p.lng).map((p) => p.id);
@@ -567,22 +639,32 @@ export class AtlasService {
     }
 
     // Group by country → regions with place counts
-    const regionMap: Record<string, Map<string, { code: string; name: string; placeCount: number }>> = {};
-    for (const [, entry] of cachedMap) {
+    const regionMap: Record<
+      string,
+      Map<string, { code: string; name: string; placeCount: number; status: VisitStatus }>
+    > = {};
+    for (const [placeId, entry] of cachedMap) {
+      const tripId = placeTrip.get(placeId);
+      const status = (tripId !== undefined ? tripStatus.get(tripId) : undefined) ?? 'idea';
       if (!regionMap[entry.country_code]) regionMap[entry.country_code] = new Map();
       const existing = regionMap[entry.country_code].get(entry.region_code);
       if (existing) {
         existing.placeCount++;
+        existing.status = strongerVisitStatus(existing.status, status);
       } else {
         regionMap[entry.country_code].set(entry.region_code, {
           code: entry.region_code,
           name: entry.region_name,
           placeCount: 1,
+          status,
         });
       }
     }
 
-    const result: Record<string, { code: string; name: string; placeCount: number; manuallyMarked?: boolean }[]> = {};
+    const result: Record<
+      string,
+      { code: string; name: string; placeCount: number; status: VisitStatus; manuallyMarked?: boolean }[]
+    > = {};
     for (const [country, regions] of Object.entries(regionMap)) {
       result[country] = [...regions.values()];
     }
@@ -591,8 +673,17 @@ export class AtlasService {
     const manualRegions = this.listManuallyVisitedRegions(userId);
     for (const r of manualRegions) {
       if (!result[r.country_code]) result[r.country_code] = [];
-      if (!result[r.country_code].find((x) => x.code === r.region_code)) {
-        result[r.country_code].push({ code: r.region_code, name: r.region_name, placeCount: 0, manuallyMarked: true });
+      const existing = result[r.country_code].find((x) => x.code === r.region_code);
+      if (existing) {
+        existing.status = 'visited';
+      } else {
+        result[r.country_code].push({
+          code: r.region_code,
+          name: r.region_name,
+          placeCount: 0,
+          status: 'visited',
+          manuallyMarked: true,
+        });
       }
     }
 

--- a/server/src/nest/auth/auth.service.ts
+++ b/server/src/nest/auth/auth.service.ts
@@ -943,6 +943,9 @@ export class AuthService {
     );
     manualCountries.forEach(m => { if (m.country_code) countryCodes.add(m.country_code.toUpperCase()); });
 
+    // Only trips that have already started count as visited — a country you have merely
+    // booked a trip to isn't stamped in the passport yet, and one you jotted down without
+    // any dates even less so (#1048). date('now') is UTC, matching tripVisitStatus.
     const placeRegionCodes = this.db.all<{ country_code: string }>(`
     SELECT DISTINCT pr.country_code
     FROM place_regions pr
@@ -950,6 +953,8 @@ export class AuthService {
     JOIN trips t ON p.trip_id = t.id
     LEFT JOIN trip_members tm ON t.id = tm.trip_id
     WHERE (t.user_id = ? OR tm.user_id = ?) AND pr.country_code IS NOT NULL
+      AND COALESCE(t.start_date, t.end_date) IS NOT NULL
+      AND COALESCE(t.start_date, t.end_date) <= date('now')
   `, userId, userId);
     placeRegionCodes.forEach(r => { if (r.country_code) countryCodes.add(r.country_code.toUpperCase()); });
 
@@ -966,6 +971,8 @@ export class AuthService {
     JOIN trips t ON r.trip_id = t.id
     LEFT JOIN trip_members tm ON t.id = tm.trip_id
     WHERE (t.user_id = ? OR tm.user_id = ?) AND e.role IN ('from', 'to')
+      AND COALESCE(t.start_date, t.end_date) IS NOT NULL
+      AND COALESCE(t.start_date, t.end_date) <= date('now')
   `, userId, userId);
     for (const e of endpoints) {
       const code = getCountryFromCoords(e.lat, e.lng);

--- a/server/src/nest/collab/collab.service.ts
+++ b/server/src/nest/collab/collab.service.ts
@@ -500,6 +500,6 @@ export class CollabService {
       const params: Record<string, string> = { trip: tripInfo?.title || 'Untitled', actor: actor.email, tripId: String(tripId) };
       if (preview !== undefined) params.preview = preview;
       send({ event: 'collab_message', actorId: actor.id, scope: 'trip', targetId: Number(tripId), params }).catch(() => {});
-    });
+    }).catch(() => {});
   }
 }

--- a/server/src/nest/vacay/vacay.service.ts
+++ b/server/src/nest/vacay/vacay.service.ts
@@ -636,7 +636,7 @@ export class VacayService {
     // Notify invited user
     import('../notifications/notifications.bridge').then(({ send }) => {
       send({ event: 'vacay_invite', actorId: inviterId, scope: 'user', targetId: targetUserId, params: { actor: inviterEmail, planId: String(planId) } }).catch(() => {});
-    });
+    }).catch(() => {});
 
     return {};
   }
@@ -867,7 +867,7 @@ export class VacayService {
 
     import('../notifications/notifications.bridge').then(({ send }) => {
       send({ event: 'vacay_share', actorId: ownerId, scope: 'user', targetId: targetUserId, params: { actor: ownerEmail } }).catch(() => {});
-    });
+    }).catch(() => {});
 
     return {};
   }

--- a/server/tests/e2e/atlas.e2e.test.ts
+++ b/server/tests/e2e/atlas.e2e.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../src/websocket', () => ({ broadcastToUser: vi.fn(), broadcast: vi.
 
 import { createTables } from '../../src/db/schema';
 import { runMigrations } from '../../src/db/migrations';
-import { createUser } from '../helpers/factories';
+import { createUser, createTrip } from '../helpers/factories';
 import { AtlasModule } from '../../src/nest/atlas/atlas.module';
 import { DatabaseModule } from '../../src/nest/database/database.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
@@ -151,5 +151,37 @@ describe('Atlas e2e (real auth guard + real service + temp SQLite)', () => {
     const res = await request(server).delete('/api/addons/atlas/bucket-list/999').set('Cookie', sessionCookie(userId));
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ error: 'Item not found' });
+  });
+
+  // #1048 — the whole point of the feature over the real wire: a booked-but-not-taken
+  // trip must still reach the client (so the map can draw it) without counting as a
+  // visit. Runs on its own user so the trip-less pin above stays trip-less.
+  it('200 stats keeps a future trip out of the visited count but still ships it as planned', async () => {
+    const plannerId = createUser(db as never, { username: 'atlas-planner', email: 'atlas-planner@test.example' }).user.id;
+    // Offsets from today, not literal dates — a hardcoded future date expires.
+    const iso = (days: number) => new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+    const past = createTrip(db as never, plannerId, { title: 'Rome, last month', start_date: iso(-40), end_date: iso(-30) });
+    const future = createTrip(db as never, plannerId, { title: 'Tokyo, next month', start_date: iso(30), end_date: iso(40) });
+    // Address-only (no lat/lng), keeping the file's no-background-geocode property.
+    const insertPlace = db.prepare('INSERT INTO places (trip_id, name, address) VALUES (?, ?, ?)');
+    insertPlace.run(past.id, 'Colosseum', 'Piazza del Colosseo, Rome, Italy');
+    insertPlace.run(future.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    const res = await request(server).get('/api/addons/atlas/stats').set('Cookie', sessionCookie(plannerId));
+    expect(res.status).toBe(200);
+
+    const byCode = Object.fromEntries((res.body.countries as { code: string }[]).map((c) => [c.code, c]));
+    expect(byCode['IT']).toMatchObject({ status: 'visited' });
+    expect(byCode['JP']).toMatchObject({ status: 'planned' });
+    expect(res.body.stats.totalCountries).toBe(1);
+    expect(res.body.stats.totalCountriesPlanned).toBe(1);
+    expect(res.body.countries.length).toBeGreaterThan(res.body.stats.totalCountries);
+    expect(res.body.continents).toEqual({ Europe: 1 });
+    expect(res.body.continentsPlanned).toEqual({ Asia: 1 });
+
+    // The country sheet agrees with the map.
+    const jp = await request(server).get('/api/addons/atlas/country/jp').set('Cookie', sessionCookie(plannerId));
+    expect(jp.status).toBe(200);
+    expect(jp.body.status).toBe('planned');
   });
 });

--- a/server/tests/integration/atlas.test.ts
+++ b/server/tests/integration/atlas.test.ts
@@ -47,7 +47,7 @@ import { buildApp } from '../../src/bootstrap';
 import { createTables } from '../../src/db/schema';
 import { runMigrations } from '../../src/db/migrations';
 import { resetTestDb, resetRateLimits } from '../helpers/test-db';
-import { createUser } from '../helpers/factories';
+import { createUser, createTrip } from '../helpers/factories';
 import { authCookie } from '../helpers/auth';
 
 let nestApp: INestApplication;
@@ -102,6 +102,30 @@ describe('Atlas stats', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('countries');
     expect(res.body).toHaveProperty('stats');
+  });
+
+  it('ATLAS-014 — a future trip is returned as planned and excluded from totalCountries (#1048)', async () => {
+    const { user } = createUser(testDb);
+    // Offsets from today rather than literal dates, so this cannot expire.
+    const iso = (days: number) => new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+    const past = createTrip(testDb, user.id, { title: 'Rome, last month', start_date: iso(-40), end_date: iso(-30) });
+    const future = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: iso(30), end_date: iso(40) });
+    const insertPlace = testDb.prepare('INSERT INTO places (trip_id, name, address) VALUES (?, ?, ?)');
+    insertPlace.run(past.id, 'Colosseum', 'Piazza del Colosseo, Rome, Italy');
+    insertPlace.run(future.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    const res = await request(app)
+      .get('/api/addons/atlas/stats')
+      .set('Cookie', authCookie(user.id));
+
+    expect(res.status).toBe(200);
+    const countries = res.body.countries as { code: string; status: string }[];
+    expect(countries.find(c => c.code === 'IT')?.status).toBe('visited');
+    expect(countries.find(c => c.code === 'JP')?.status).toBe('planned');
+    expect(res.body.stats.totalCountries).toBe(1);
+    expect(res.body.stats.totalCountriesPlanned).toBe(1);
+    // The whole point: the map gets more countries than the passport counter shows.
+    expect(countries.length).toBeGreaterThan(res.body.stats.totalCountries);
   });
 
   it('ATLAS-002 — GET /api/atlas/country/:code returns places in country', async () => {

--- a/server/tests/unit/nest/atlas.service.test.ts
+++ b/server/tests/unit/nest/atlas.service.test.ts
@@ -106,7 +106,9 @@ describe('getStats', () => {
 
   it('ATLAS-UNIT-002: returns the country with the highest placeCount as mostVisited', async () => {
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { title: 'Euro Tour' });
+    // Dated in the past on purpose: since #1048 only a trip that has already started
+    // counts as visited, and mostVisited/totalCountries only look at visited countries.
+    const trip = createTrip(testDb, user.id, { title: 'Euro Tour', start_date: '2023-05-01', end_date: '2023-05-10' });
 
     // 3 places in France, 1 in Germany → France should win
     for (let i = 0; i < 3; i++) {
@@ -138,7 +140,8 @@ describe('getStats', () => {
 
   it('ATLAS-UNIT-004: single country yields mostVisited equal to that country', async () => {
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { title: 'Italy Trip' });
+    // Past dates — see ATLAS-UNIT-002; a dateless trip is an 'idea' and never mostVisited.
+    const trip = createTrip(testDb, user.id, { title: 'Italy Trip', start_date: '2023-05-01', end_date: '2023-05-10' });
     insertPlace(testDb, trip.id, 'Colosseum', 'Piazza del Colosseo, Rome, Italy');
 
     const stats = await atlas.stats(user.id);
@@ -1075,7 +1078,8 @@ describe('atlas quirk fixes', () => {
 
     const result = atlas.countryPlaces(user.id, 'JP');
 
-    expect(result).toEqual({ places: [], trips: [], manually_marked: true });
+    // status rides along since #1048 — a manual mark is a visit even with no trips.
+    expect(result).toEqual({ places: [], trips: [], manually_marked: true, status: 'visited' });
     expect(atlas.countryPlaces(user.id, 'FR').manually_marked).toBe(false);
   });
 
@@ -1144,5 +1148,254 @@ describe('atlas quirk fixes', () => {
       .prepare('SELECT 1 FROM visited_countries WHERE user_id = ? AND country_code = ?')
       .get(user.id, 'DE');
     expect(row).toBeUndefined();
+  });
+});
+
+// ── #1048: visited vs planned vs idea ────────────────────────────────────────
+//
+// Before this, every trip painted its countries as visited — a flight booked for
+// next summer coloured the map as if the traveller had already been there. The
+// trip's dates now decide, and countries[] carries that verdict as `status`.
+
+// Offsets from "now", never literal dates: a hardcoded 2026 date stops being the
+// future at some point and would silently flip these assertions to green-for-the-
+// wrong-reason (or red) months after the fact.
+function isoOffsetDays(days: number): string {
+  return new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+}
+const PAST_START = isoOffsetDays(-40);
+const PAST_END = isoOffsetDays(-30);
+const FUTURE_START = isoOffsetDays(30);
+const FUTURE_END = isoOffsetDays(40);
+
+describe('getStats — visited vs planned vs idea (#1048)', () => {
+  it('ATLAS-UNIT-029: a country from a trip that already happened is visited', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Rome, last month', start_date: PAST_START, end_date: PAST_END });
+    insertPlace(testDb, trip.id, 'Colosseum', 'Piazza del Colosseo, Rome, Italy');
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.countries).toEqual([expect.objectContaining({ code: 'IT', status: 'visited' })]);
+    expect(stats.stats.totalCountries).toBe(1);
+    expect(stats.stats.totalCountriesPlanned).toBe(0);
+    expect(stats.stats.totalCountriesIdea).toBe(0);
+  });
+
+  it('ATLAS-UNIT-030: a country from a future trip is planned — listed, but not counted as visited', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Japan, next month', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, trip.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    const stats = await atlas.stats(user.id);
+
+    // Still in countries[] — the client needs it to draw the dashed outline — but it
+    // must not inflate the "countries visited" counter.
+    expect(stats.countries.find((c: any) => c.code === 'JP')).toMatchObject({ status: 'planned' });
+    expect(stats.stats.totalCountries).toBe(0);
+    expect(stats.stats.totalCountriesPlanned).toBe(1);
+    expect(stats.countries.length).toBeGreaterThan(stats.stats.totalCountries);
+  });
+
+  it('ATLAS-UNIT-031: a trip that has started but not ended counts as visited — you are there now', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, {
+      title: 'Currently in Berlin',
+      start_date: isoOffsetDays(-2),
+      end_date: isoOffsetDays(5),
+    });
+    insertPlace(testDb, trip.id, 'Brandenburger Tor', 'Pariser Platz, Berlin, Germany');
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.countries.find((c: any) => c.code === 'DE')).toMatchObject({ status: 'visited' });
+    expect(stats.stats.totalCountries).toBe(1);
+  });
+
+  it('ATLAS-UNIT-032: a trip starting today is already visited (the <= boundary)', async () => {
+    const { user } = createUser(testDb);
+    const today = isoOffsetDays(0);
+    const trip = createTrip(testDb, user.id, { title: 'Flying out today', start_date: today, end_date: isoOffsetDays(6) });
+    insertPlace(testDb, trip.id, 'Louvre', '75001 Paris, France');
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.countries.find((c: any) => c.code === 'FR')).toMatchObject({ status: 'visited' });
+    expect(stats.stats.totalCountriesPlanned).toBe(0);
+  });
+
+  it('ATLAS-UNIT-033: a trip with no dates at all is an idea, not a plan', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Someday: Japan' });
+    insertPlace(testDb, trip.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.countries.find((c: any) => c.code === 'JP')).toMatchObject({ status: 'idea' });
+    expect(stats.stats.totalCountries).toBe(0);
+    expect(stats.stats.totalCountriesPlanned).toBe(0);
+    expect(stats.stats.totalCountriesIdea).toBe(1);
+  });
+
+  it('ATLAS-UNIT-034: a country with both a past and a future trip takes the stronger status', async () => {
+    const { user } = createUser(testDb);
+    const past = createTrip(testDb, user.id, { title: 'Munich 2023', start_date: PAST_START, end_date: PAST_END });
+    const future = createTrip(testDb, user.id, { title: 'Munich again', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, past.id, 'Marienplatz', 'Marienplatz, Munich, Germany');
+    insertPlace(testDb, future.id, 'Englischer Garten', 'Englischer Garten, Munich, Germany');
+
+    const stats = await atlas.stats(user.id);
+
+    const de = stats.countries.find((c: any) => c.code === 'DE');
+    expect(de).toMatchObject({ status: 'visited', tripCount: 2, placeCount: 2 });
+    expect(stats.stats.totalCountries).toBe(1);
+    expect(stats.stats.totalCountriesPlanned).toBe(0);
+  });
+
+  it('ATLAS-UNIT-035: marking a country by hand outranks a future trip going there', async () => {
+    // "I have been to Japan" is a statement of fact; a booking for next month cannot
+    // downgrade it back to a plan.
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Japan, next month', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, trip.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+    testDb.prepare('INSERT INTO visited_countries (user_id, country_code) VALUES (?, ?)').run(user.id, 'JP');
+
+    const stats = await atlas.stats(user.id);
+
+    const jp = stats.countries.filter((c: any) => c.code === 'JP');
+    expect(jp).toHaveLength(1); // upgraded in place, not appended a second time
+    expect(jp[0]).toMatchObject({ status: 'visited', placeCount: 1 });
+    expect(stats.stats.totalCountries).toBe(1);
+    expect(stats.stats.totalCountriesPlanned).toBe(0);
+  });
+
+  it('ATLAS-UNIT-036: removing a country hides it even while it is only planned (#1490 tombstone)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: FUTURE_START, end_date: FUTURE_END });
+    const reservation = createReservation(testDb, trip.id, { type: 'flight' });
+    insertReservationEndpoint(testDb, reservation.id, 'from', 0, 50.9014, 4.4844); // Brussels
+    insertReservationEndpoint(testDb, reservation.id, 'to', 1, 35.6762, 139.6503); // Tokyo
+
+    const before = await atlas.stats(user.id);
+    expect(before.countries.find((c: any) => c.code === 'JP')).toMatchObject({ status: 'planned' });
+
+    atlas.unmarkCountry(user.id, 'JP');
+
+    const after = await atlas.stats(user.id);
+    expect(after.countries.map((c: any) => c.code)).not.toContain('JP');
+    expect(after.countries.map((c: any) => c.code)).toContain('BE');
+    expect(after.stats.totalCountriesPlanned).toBe(1);
+  });
+
+  it('ATLAS-UNIT-037: continents counts visited only; the planned ones live in continentsPlanned', async () => {
+    const { user } = createUser(testDb);
+    const past = createTrip(testDb, user.id, { title: 'Paris 2023', start_date: PAST_START, end_date: PAST_END });
+    const future = createTrip(testDb, user.id, { title: 'Tokyo soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, past.id, 'Louvre', '75001 Paris, France');
+    insertPlace(testDb, future.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.continents).toEqual({ Europe: 1 });
+    expect(stats.continentsPlanned).toEqual({ Asia: 1 });
+  });
+
+  it('ATLAS-UNIT-038: mostVisited ignores planned countries even when they have more places', async () => {
+    const { user } = createUser(testDb);
+    const past = createTrip(testDb, user.id, { title: 'Rome 2023', start_date: PAST_START, end_date: PAST_END });
+    const future = createTrip(testDb, user.id, { title: 'Japan soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, past.id, 'Colosseum', 'Piazza del Colosseo, Rome, Italy');
+    for (let i = 0; i < 3; i++) insertPlace(testDb, future.id, `Tokyo Place ${i}`, `Street ${i}, Tokyo, Japan`);
+
+    const stats = await atlas.stats(user.id);
+
+    // JP has 3 places to IT's 1, but you have not been there yet.
+    expect(stats.mostVisited).not.toBeNull();
+    expect(stats.mostVisited!.code).toBe('IT');
+    expect(stats.mostVisited!.placeCount).toBe(1);
+  });
+
+  it('ATLAS-UNIT-039: countries reached only by a future flight leg are planned, not visited (#1366 path)', async () => {
+    // Endpoint-derived countries go through their own dedupe-per-coordinate branch,
+    // so they need their own guard that the trip's dates still decide.
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: FUTURE_START, end_date: FUTURE_END });
+    const reservation = createReservation(testDb, trip.id, { type: 'flight' });
+    insertReservationEndpoint(testDb, reservation.id, 'from', 0, 50.9014, 4.4844); // Brussels
+    insertReservationEndpoint(testDb, reservation.id, 'to', 1, 35.6762, 139.6503); // Tokyo
+
+    const stats = await atlas.stats(user.id);
+
+    expect(stats.countries.find((c: any) => c.code === 'BE')).toMatchObject({ status: 'planned' });
+    expect(stats.countries.find((c: any) => c.code === 'JP')).toMatchObject({ status: 'planned' });
+    expect(stats.stats.totalCountries).toBe(0);
+    expect(stats.stats.totalCountriesPlanned).toBe(2);
+  });
+});
+
+describe('getCountryPlaces — status (#1048)', () => {
+  it('ATLAS-UNIT-040: the country sheet reports the same status the map paints', async () => {
+    const { user } = createUser(testDb);
+    const past = createTrip(testDb, user.id, { title: 'Paris 2023', start_date: PAST_START, end_date: PAST_END });
+    const future = createTrip(testDb, user.id, { title: 'Tokyo soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, past.id, 'Louvre', '75001 Paris, France');
+    insertPlace(testDb, future.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+
+    expect(atlas.countryPlaces(user.id, 'FR').status).toBe('visited');
+    expect(atlas.countryPlaces(user.id, 'JP').status).toBe('planned');
+    // A country with no trip and no manual mark has nothing behind it at all.
+    expect(atlas.countryPlaces(user.id, 'BR').status).toBe('idea');
+  });
+
+  it('ATLAS-UNIT-041: a manual mark makes the sheet visited even for a future-only country', async () => {
+    const { user } = createUser(testDb);
+    const future = createTrip(testDb, user.id, { title: 'Tokyo soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    insertPlace(testDb, future.id, 'Senso-ji', 'Asakusa, Tokyo, Japan');
+    atlas.markCountry(user.id, 'JP');
+
+    const result = atlas.countryPlaces(user.id, 'JP');
+
+    expect(result.manually_marked).toBe(true);
+    expect(result.status).toBe('visited');
+    expect(result.places).toHaveLength(1);
+  });
+});
+
+describe('getVisitedRegions — status (#1048)', () => {
+  it('ATLAS-UNIT-042: a region inherits its trip status; a manually marked one is visited', async () => {
+    const { user } = createUser(testDb);
+    const future = createTrip(testDb, user.id, { title: 'Paris soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    const place = insertPlaceWithCoords(testDb, future.id, 'Paris Hotel', 48.85, 2.35);
+    // Pre-seed the region cache so nothing geocodes in the background (see ATLAS-UNIT-020).
+    testDb
+      .prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+      .run(place.id, 'FR', 'FR-75', 'Île-de-France');
+    testDb
+      .prepare('INSERT INTO visited_regions (user_id, region_code, region_name, country_code) VALUES (?, ?, ?, ?)')
+      .run(user.id, 'DE-BY', 'Bayern', 'DE');
+
+    const result = await atlas.visitedRegions(user.id);
+
+    // Zooming into a merely planned country must not reveal regions painted as visited.
+    expect(result.regions['FR']).toEqual([expect.objectContaining({ code: 'FR-75', status: 'planned' })]);
+    expect(result.regions['DE']).toEqual([expect.objectContaining({ code: 'DE-BY', status: 'visited' })]);
+  });
+
+  it('ATLAS-UNIT-043: marking a planned region by hand upgrades it to visited', async () => {
+    const { user } = createUser(testDb);
+    const future = createTrip(testDb, user.id, { title: 'Paris soon', start_date: FUTURE_START, end_date: FUTURE_END });
+    const place = insertPlaceWithCoords(testDb, future.id, 'Paris Hotel', 48.85, 2.35);
+    testDb
+      .prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+      .run(place.id, 'FR', 'FR-75', 'Île-de-France');
+
+    expect((await atlas.visitedRegions(user.id)).regions['FR'][0].status).toBe('planned');
+
+    atlas.markRegion(user.id, 'FR-75', 'Île-de-France', 'FR');
+
+    const after = await atlas.visitedRegions(user.id);
+    // Still one entry — the manual mark upgrades the derived region rather than duplicating it.
+    expect(after.regions['FR']).toHaveLength(1);
+    expect(after.regions['FR'][0].status).toBe('visited');
   });
 });

--- a/server/tests/unit/nest/auth.service.test.ts
+++ b/server/tests/unit/nest/auth.service.test.ts
@@ -72,7 +72,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vites
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createAdmin, createInviteToken, createTrip, createReservation } from '../../helpers/factories';
+import { createUser, createAdmin, createInviteToken, createTrip, createPlace, createReservation } from '../../helpers/factories';
 import { AuthService } from '../../../src/nest/auth/auth.service';
 import * as authBridge from '../../../src/nest/auth/auth.bridge';
 import { AtlasService } from '../../../src/nest/atlas/atlas.service';
@@ -751,9 +751,15 @@ describe('getTravelStats', () => {
     ).run(reservationId, role, sequence, `Endpoint ${sequence}`, lat, lng);
   }
 
+  // Every trip below is dated in the past: since #1048 the passport card only counts
+  // countries from trips that have already started, so a dateless fixture would make
+  // these role-filter/tombstone assertions vacuous.
+  const PAST_START = '2023-05-01';
+  const PAST_END = '2023-05-10';
+
   it('AUTH-DB-047: #1486 counts the from/to countries of a flight', () => {
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { title: 'Tokyo Trip' });
+    const trip = createTrip(testDb, user.id, { title: 'Tokyo Trip', start_date: PAST_START, end_date: PAST_END });
     const res = createReservation(testDb, trip.id, { type: 'flight' });
     endpoint(res.id, 'from', 0, 50.9014, 4.4844);   // Brussels
     endpoint(res.id, 'to', 1, 35.6762, 139.6503);   // Tokyo
@@ -767,7 +773,7 @@ describe('getTravelStats', () => {
     // The Atlas query grew a role filter for #1486 but this copy of it did not, so the
     // dashboard passport card still counted a plane change as a visited country.
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { title: 'Connection Trip' });
+    const trip = createTrip(testDb, user.id, { title: 'Connection Trip', start_date: PAST_START, end_date: PAST_END });
     const res = createReservation(testDb, trip.id, { type: 'flight' });
     endpoint(res.id, 'from', 0, 50.9014, 4.4844);     // Brussels
     endpoint(res.id, 'stop', 1, 35.6762, 139.6503);   // Tokyo — never leaves the airport
@@ -781,7 +787,7 @@ describe('getTravelStats', () => {
 
   it('AUTH-DB-049: #1490 a country removed in Atlas is not counted on the dashboard either', () => {
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { title: 'Tokyo Trip' });
+    const trip = createTrip(testDb, user.id, { title: 'Tokyo Trip', start_date: PAST_START, end_date: PAST_END });
     const res = createReservation(testDb, trip.id, { type: 'flight' });
     endpoint(res.id, 'from', 0, 50.9014, 4.4844);
     endpoint(res.id, 'to', 1, 35.6762, 139.6503);
@@ -793,6 +799,68 @@ describe('getTravelStats', () => {
     const after = svc.getTravelStats(user.id);
     expect(after.countries).not.toContain('JP');
     expect(after.countries).toContain('BE');
+  });
+
+  // ── #1048: the passport card only stamps trips that have happened ──────────
+  // Relative offsets, not literal dates — a hardcoded "future" date expires.
+  const iso = (days: number) => new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
+
+  function placeInRegion(tripId: number, countryCode: string, regionCode: string) {
+    const place = createPlace(testDb, tripId, { name: `Place in ${countryCode}` });
+    testDb
+      .prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+      .run(place.id, countryCode, regionCode, regionCode);
+  }
+
+  it('AUTH-DB-094: #1048 a place in a future trip does not stamp its country; a past trip does', () => {
+    const { user } = createUser(testDb);
+    const past = createTrip(testDb, user.id, { title: 'Paris, last month', start_date: iso(-40), end_date: iso(-30) });
+    const future = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: iso(30), end_date: iso(40) });
+    placeInRegion(past.id, 'FR', 'FR-75');
+    placeInRegion(future.id, 'JP', 'JP-13');
+
+    const stats = svc.getTravelStats(user.id);
+
+    expect(stats.countries).toContain('FR');
+    expect(stats.countries).not.toContain('JP');
+  });
+
+  it('AUTH-DB-095: #1048 a trip with no dates at all stamps nothing', () => {
+    const { user } = createUser(testDb);
+    const dateless = createTrip(testDb, user.id, { title: 'Someday: Japan' });
+    placeInRegion(dateless.id, 'JP', 'JP-13');
+    const res = createReservation(testDb, dateless.id, { type: 'flight' });
+    endpoint(res.id, 'from', 0, 50.9014, 4.4844); // Brussels
+
+    const stats = svc.getTravelStats(user.id);
+
+    expect(stats.countries).toEqual([]);
+  });
+
+  it('AUTH-DB-096: #1048 a flight booked for a future trip does not stamp its endpoints', () => {
+    const { user } = createUser(testDb);
+    const future = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: iso(30), end_date: iso(40) });
+    const res = createReservation(testDb, future.id, { type: 'flight' });
+    endpoint(res.id, 'from', 0, 50.9014, 4.4844);   // Brussels
+    endpoint(res.id, 'to', 1, 35.6762, 139.6503);   // Tokyo
+
+    const stats = svc.getTravelStats(user.id);
+
+    expect(stats.countries).not.toContain('BE');
+    expect(stats.countries).not.toContain('JP');
+  });
+
+  it('AUTH-DB-097: #1048 a manually marked country stays stamped regardless of trip dates', () => {
+    // The manual list is the user's own word, not derived from a trip — the date
+    // filter must not reach it.
+    const { user } = createUser(testDb);
+    const future = createTrip(testDb, user.id, { title: 'Tokyo, next month', start_date: iso(30), end_date: iso(40) });
+    placeInRegion(future.id, 'JP', 'JP-13');
+    testDb.prepare('INSERT INTO visited_countries (user_id, country_code) VALUES (?, ?)').run(user.id, 'JP');
+
+    const stats = svc.getTravelStats(user.id);
+
+    expect(stats.countries).toContain('JP');
   });
 });
 

--- a/shared/src/atlas/atlas.schema.spec.ts
+++ b/shared/src/atlas/atlas.schema.spec.ts
@@ -1,6 +1,29 @@
-import { markRegionRequestSchema, createBucketItemRequestSchema, regionGeoSchema } from './atlas.schema';
+import {
+  markRegionRequestSchema,
+  createBucketItemRequestSchema,
+  regionGeoSchema,
+  visitStatusSchema,
+  todayUtc,
+  tripVisitStatus,
+  VISIT_STATUS_RANK,
+  strongerVisitStatus,
+} from './atlas.schema';
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+/**
+ * The date helpers below read the wall clock, so every test that exercises the
+ * default `today` pins it first — otherwise the suite flips its answers when it
+ * happens to run across midnight UTC.
+ */
+function freezeClock(iso: string): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('markRegionRequestSchema', () => {
   it('requires both name and country_code', () => {
@@ -34,5 +57,113 @@ describe('regionGeoSchema', () => {
       }).success,
     ).toBe(true);
     expect(regionGeoSchema.safeParse({ type: 'Other', features: [] }).success).toBe(false);
+  });
+});
+
+describe('visitStatusSchema', () => {
+  it('accepts the three buckets and nothing else', () => {
+    expect(visitStatusSchema.safeParse('visited').success).toBe(true);
+    expect(visitStatusSchema.safeParse('planned').success).toBe(true);
+    expect(visitStatusSchema.safeParse('idea').success).toBe(true);
+    expect(visitStatusSchema.safeParse('wishlist').success).toBe(false);
+    expect(visitStatusSchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('tripVisitStatus', () => {
+  // Passed explicitly wherever the clock is not the thing under test.
+  const TODAY = '2026-08-03';
+
+  it('counts a trip that already ended as visited', () => {
+    expect(tripVisitStatus('2026-01-10', '2026-01-20', TODAY)).toBe('visited');
+  });
+
+  it('counts a running trip as visited — you are there right now', () => {
+    expect(tripVisitStatus('2026-08-01', '2026-08-10', TODAY)).toBe('visited');
+  });
+
+  it('counts a trip that has not started yet as planned', () => {
+    expect(tripVisitStatus('2026-09-01', '2026-09-10', TODAY)).toBe('planned');
+  });
+
+  it('flips to visited on the start day itself', () => {
+    expect(tripVisitStatus(TODAY, '2026-08-09', TODAY)).toBe('visited');
+    expect(tripVisitStatus(TODAY, TODAY, TODAY)).toBe('visited');
+    // ...and the very next day is still only planned
+    expect(tripVisitStatus('2026-08-04', '2026-08-09', TODAY)).toBe('planned');
+  });
+
+  it('works off start_date alone', () => {
+    expect(tripVisitStatus('2026-01-10', null, TODAY)).toBe('visited');
+    expect(tripVisitStatus('2026-12-01', null, TODAY)).toBe('planned');
+  });
+
+  it('falls back to end_date as the effective start', () => {
+    expect(tripVisitStatus(null, '2026-01-20', TODAY)).toBe('visited');
+    expect(tripVisitStatus(null, '2026-12-20', TODAY)).toBe('planned');
+  });
+
+  it('treats a trip without any date as an idea, not a plan', () => {
+    expect(tripVisitStatus(null, null, TODAY)).toBe('idea');
+  });
+
+  it('treats null, undefined and empty strings alike', () => {
+    expect(tripVisitStatus(undefined, undefined, TODAY)).toBe('idea');
+    expect(tripVisitStatus(null, undefined, TODAY)).toBe('idea');
+    expect(tripVisitStatus(undefined, null, TODAY)).toBe('idea');
+    expect(tripVisitStatus('', '', TODAY)).toBe('idea');
+    expect(tripVisitStatus(undefined, '2026-01-20', TODAY)).toBe(tripVisitStatus(null, '2026-01-20', TODAY));
+    expect(tripVisitStatus('', '2026-01-20', TODAY)).toBe('visited');
+  });
+
+  it('defaults to the UTC clock, right up to the last second of the day', () => {
+    freezeClock('2026-08-03T23:59:59.999Z');
+    expect(tripVisitStatus('2026-08-03', null)).toBe('visited');
+    expect(tripVisitStatus('2026-08-04', null)).toBe('planned');
+  });
+});
+
+describe('strongerVisitStatus', () => {
+  it('ranks visited above planned above idea', () => {
+    expect(VISIT_STATUS_RANK.visited).toBeLessThan(VISIT_STATUS_RANK.planned);
+    expect(VISIT_STATUS_RANK.planned).toBeLessThan(VISIT_STATUS_RANK.idea);
+  });
+
+  it('picks the stronger status regardless of argument order', () => {
+    expect(strongerVisitStatus('visited', 'planned')).toBe('visited');
+    expect(strongerVisitStatus('planned', 'visited')).toBe('visited');
+    expect(strongerVisitStatus('visited', 'idea')).toBe('visited');
+    expect(strongerVisitStatus('idea', 'visited')).toBe('visited');
+    expect(strongerVisitStatus('planned', 'idea')).toBe('planned');
+    expect(strongerVisitStatus('idea', 'planned')).toBe('planned');
+  });
+
+  it('returns the shared status on a tie', () => {
+    expect(strongerVisitStatus('visited', 'visited')).toBe('visited');
+    expect(strongerVisitStatus('planned', 'planned')).toBe('planned');
+    expect(strongerVisitStatus('idea', 'idea')).toBe('idea');
+  });
+});
+
+describe('todayUtc', () => {
+  it('formats as YYYY-MM-DD', () => {
+    freezeClock('2026-08-03T12:00:00.000Z');
+    expect(todayUtc()).toBe('2026-08-03');
+    expect(todayUtc()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    freezeClock('2026-01-05T08:30:00.000Z');
+    expect(todayUtc()).toBe('2026-01-05');
+  });
+
+  it('does not tip into the next day late in the evening UTC', () => {
+    freezeClock('2026-08-03T23:59:59.999Z');
+    expect(todayUtc()).toBe('2026-08-03');
+  });
+
+  it('rolls over at midnight UTC', () => {
+    freezeClock('2026-08-04T00:00:00.000Z');
+    expect(todayUtc()).toBe('2026-08-04');
   });
 });

--- a/shared/src/atlas/atlas.schema.ts
+++ b/shared/src/atlas/atlas.schema.ts
@@ -57,6 +57,50 @@ export const regionGeoSchema = z.object({
 export type RegionGeo = z.infer<typeof regionGeoSchema>;
 
 /**
+ * How a country/region ended up on the atlas map. Before this, every trip counted as a
+ * visit, so a booked-but-not-taken trip painted the map as if you had already been there.
+ * Requested in discussion #1048 — note that's a discussion, not an issue:
+ * https://github.com/liketrek/TREK/discussions/1048
+ *
+ *  - visited: at least one source is a trip that has already started, or a manual mark
+ *  - planned: every source is a trip starting in the future
+ *  - idea:    every source is a trip with no dates at all
+ */
+export const visitStatusSchema = z.enum(['visited', 'planned', 'idea']);
+export type VisitStatus = z.infer<typeof visitStatusSchema>;
+
+/** Today as 'YYYY-MM-DD' in UTC — the comparison base the rest of TREK uses. */
+export function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Bucket a trip by its dates. A trip that has started but not ended still counts as
+ * visited — you are there right now. A trip with neither date is an idea, not a plan,
+ * and must stay out of the visit stats.
+ */
+export function tripVisitStatus(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+  today: string = todayUtc(),
+): VisitStatus {
+  const effectiveStart = startDate || endDate || null;
+  if (!effectiveStart) return 'idea';
+  return effectiveStart <= today ? 'visited' : 'planned';
+}
+
+/** visited beats planned beats idea — a country takes its strongest source. */
+export const VISIT_STATUS_RANK: Record<VisitStatus, number> = {
+  visited: 0,
+  planned: 1,
+  idea: 2,
+};
+
+export function strongerVisitStatus(a: VisitStatus, b: VisitStatus): VisitStatus {
+  return VISIT_STATUS_RANK[a] <= VISIT_STATUS_RANK[b] ? a : b;
+}
+
+/**
  * ISO 3166-1 alpha-2 country code → continent. Single source of truth for the
  * Atlas continent breakdown, used by the server (stats aggregation) and the
  * client (keeping the per-continent counts in sync on optimistic mark/unmark).

--- a/shared/src/i18n/ar/atlas.ts
+++ b/shared/src/i18n/ar/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'رحلات',
   'atlas.placeVisited': 'مكان تمت زيارته',
   'atlas.placesVisited': 'أماكن تمت زيارتها',
+  'atlas.planned': 'مُخطط',
+  'atlas.showPlanned': 'إظهار الدول المخطط زيارتها',
+  'atlas.plannedFor': 'مخطط لـ',
+  'atlas.antarctica': 'أنتاركتيكا',
 };
 export default atlas;

--- a/shared/src/i18n/ar/mobileAtlas.ts
+++ b/shared/src/i18n/ar/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'تمت الزيارة',
+  'mobileAtlas.planned': 'مُخطط',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/br/atlas.ts
+++ b/shared/src/i18n/br/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Viagens',
   'atlas.placeVisited': 'Lugar visitado',
   'atlas.placesVisited': 'Lugares visitados',
+  'atlas.planned': 'Planejado',
+  'atlas.showPlanned': 'Mostrar países planejados',
+  'atlas.plannedFor': 'Planejado para',
+  'atlas.antarctica': 'Antártida',
 };
 export default atlas;

--- a/shared/src/i18n/br/mobileAtlas.ts
+++ b/shared/src/i18n/br/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visitado',
+  'mobileAtlas.planned': 'Planejado',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/ca/atlas.ts
+++ b/shared/src/i18n/ca/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Mes',
   'atlas.addToBucketHint': 'Desa-ho com a lloc que vols visitar',
   'atlas.bucketWhen': 'Quan planeges visitar-lo?',
+  'atlas.planned': 'Planificat',
+  'atlas.showPlanned': 'Mostra els països planificats',
+  'atlas.plannedFor': 'Planificat per a',
+  'atlas.antarctica': 'Antàrtida',
 };
 export default atlas;

--- a/shared/src/i18n/ca/mobileAtlas.ts
+++ b/shared/src/i18n/ca/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visitat',
+  'mobileAtlas.planned': 'Planificat',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/cs/atlas.ts
+++ b/shared/src/i18n/cs/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.placeVisited': 'Navštívené místo',
   'atlas.placesVisited': 'Navštívená místa',
   'atlas.searchCountry': 'Hledat zemi...',
+  'atlas.planned': 'Plánováno',
+  'atlas.showPlanned': 'Zobrazit plánované země',
+  'atlas.plannedFor': 'Plánováno na',
+  'atlas.antarctica': 'Antarktida',
 };
 export default atlas;

--- a/shared/src/i18n/cs/mobileAtlas.ts
+++ b/shared/src/i18n/cs/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Navštíveno',
+  'mobileAtlas.planned': 'Plánováno',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/de/atlas.ts
+++ b/shared/src/i18n/de/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Reisen',
   'atlas.placeVisited': 'Ort besucht',
   'atlas.placesVisited': 'Orte besucht',
+  'atlas.planned': 'Geplant',
+  'atlas.showPlanned': 'Geplante Länder anzeigen',
+  'atlas.plannedFor': 'Geplant für',
+  'atlas.antarctica': 'Antarktis',
 };
 export default atlas;

--- a/shared/src/i18n/de/mobileAtlas.ts
+++ b/shared/src/i18n/de/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Besucht',
+  'mobileAtlas.planned': 'Geplant',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/en/atlas.ts
+++ b/shared/src/i18n/en/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Trips',
   'atlas.placeVisited': 'Place visited',
   'atlas.placesVisited': 'Places visited',
+  'atlas.planned': 'Planned',
+  'atlas.showPlanned': 'Show planned countries',
+  'atlas.plannedFor': 'Planned for',
+  'atlas.antarctica': 'Antarctica',
 };
 export default atlas;

--- a/shared/src/i18n/en/mobileAtlas.ts
+++ b/shared/src/i18n/en/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visited',
+  'mobileAtlas.planned': 'Planned',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/es/atlas.ts
+++ b/shared/src/i18n/es/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Mes',
   'atlas.addToBucketHint': 'Guardar como lugar que quieres visitar',
   'atlas.bucketWhen': '¿Cuándo planeas visitarlo?',
+  'atlas.planned': 'Planeado',
+  'atlas.showPlanned': 'Mostrar países planeados',
+  'atlas.plannedFor': 'Planeado para',
+  'atlas.antarctica': 'Antártida',
 };
 export default atlas;

--- a/shared/src/i18n/es/mobileAtlas.ts
+++ b/shared/src/i18n/es/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visitado',
+  'mobileAtlas.planned': 'Planeado',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/fr/atlas.ts
+++ b/shared/src/i18n/fr/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Mois',
   'atlas.addToBucketHint': 'Sauvegarder comme lieu à visiter',
   'atlas.bucketWhen': "Quand prévoyez-vous d'y aller ?",
+  'atlas.planned': 'Prévu',
+  'atlas.showPlanned': 'Afficher les pays prévus',
+  'atlas.plannedFor': 'Prévu pour',
+  'atlas.antarctica': 'Antarctique',
 };
 export default atlas;

--- a/shared/src/i18n/fr/mobileAtlas.ts
+++ b/shared/src/i18n/fr/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visité',
+  'mobileAtlas.planned': 'Prévu',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/gr/atlas.ts
+++ b/shared/src/i18n/gr/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Ταξίδια',
   'atlas.placeVisited': 'Μέρος που επισκεφθήκατε',
   'atlas.placesVisited': 'Μέρη που επισκεφθήκατε',
+  'atlas.planned': 'Προγραμματισμένο',
+  'atlas.showPlanned': 'Εμφάνιση προγραμματισμένων χωρών',
+  'atlas.plannedFor': 'Προγραμματισμένο για',
+  'atlas.antarctica': 'Ανταρκτική',
 };
 export default atlas;

--- a/shared/src/i18n/gr/mobileAtlas.ts
+++ b/shared/src/i18n/gr/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Επισκέφθηκα',
+  'mobileAtlas.planned': 'Προγραμματισμένο',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/hu/atlas.ts
+++ b/shared/src/i18n/hu/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Utazások',
   'atlas.placeVisited': 'Meglátogatott hely',
   'atlas.placesVisited': 'Meglátogatott helyek',
+  'atlas.planned': 'Tervezett',
+  'atlas.showPlanned': 'Tervezett országok megjelenítése',
+  'atlas.plannedFor': 'Tervezve erre',
+  'atlas.antarctica': 'Antarktisz',
 };
 export default atlas;

--- a/shared/src/i18n/hu/mobileAtlas.ts
+++ b/shared/src/i18n/hu/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Meglátogatva',
+  'mobileAtlas.planned': 'Tervezett',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/id/atlas.ts
+++ b/shared/src/i18n/id/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Perjalanan',
   'atlas.placeVisited': 'Tempat dikunjungi',
   'atlas.placesVisited': 'Tempat dikunjungi',
+  'atlas.planned': 'Direncanakan',
+  'atlas.showPlanned': 'Tampilkan negara yang direncanakan',
+  'atlas.plannedFor': 'Direncanakan untuk',
+  'atlas.antarctica': 'Antarktika',
 };
 export default atlas;

--- a/shared/src/i18n/id/mobileAtlas.ts
+++ b/shared/src/i18n/id/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Dikunjungi',
+  'mobileAtlas.planned': 'Direncanakan',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/it/atlas.ts
+++ b/shared/src/i18n/it/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.placeVisited': 'Luogo visitato',
   'atlas.placesVisited': 'Luoghi visitati',
   'atlas.searchCountry': 'Cerca un paese...',
+  'atlas.planned': 'In programma',
+  'atlas.showPlanned': 'Mostra i paesi in programma',
+  'atlas.plannedFor': 'In programma per',
+  'atlas.antarctica': 'Antartide',
 };
 export default atlas;

--- a/shared/src/i18n/it/mobileAtlas.ts
+++ b/shared/src/i18n/it/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Visitato',
+  'mobileAtlas.planned': 'In programma',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/ja/atlas.ts
+++ b/shared/src/i18n/ja/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': '旅行',
   'atlas.placeVisited': '訪問した場所',
   'atlas.placesVisited': '訪問した場所',
+  'atlas.planned': '予定',
+  'atlas.showPlanned': '予定の国を表示',
+  'atlas.plannedFor': '予定日',
+  'atlas.antarctica': '南極',
 };
 export default atlas;

--- a/shared/src/i18n/ja/mobileAtlas.ts
+++ b/shared/src/i18n/ja/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': '訪問済み',
+  'mobileAtlas.planned': '予定',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/ko/atlas.ts
+++ b/shared/src/i18n/ko/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': '여행',
   'atlas.placeVisited': '방문한 장소',
   'atlas.placesVisited': '방문한 장소',
+  'atlas.planned': '예정',
+  'atlas.showPlanned': '예정된 국가 표시',
+  'atlas.plannedFor': '예정일',
+  'atlas.antarctica': '남극',
 };
 export default atlas;

--- a/shared/src/i18n/ko/mobileAtlas.ts
+++ b/shared/src/i18n/ko/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': '방문함',
+  'mobileAtlas.planned': '예정',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/nl/atlas.ts
+++ b/shared/src/i18n/nl/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Maand',
   'atlas.addToBucketHint': 'Opslaan als plek die je wilt bezoeken',
   'atlas.bucketWhen': 'Wanneer ben je van plan te gaan?',
+  'atlas.planned': 'Gepland',
+  'atlas.showPlanned': 'Geplande landen tonen',
+  'atlas.plannedFor': 'Gepland voor',
+  'atlas.antarctica': 'Antarctica',
 };
 export default atlas;

--- a/shared/src/i18n/nl/mobileAtlas.ts
+++ b/shared/src/i18n/nl/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Bezocht',
+  'mobileAtlas.planned': 'Gepland',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/pl/atlas.ts
+++ b/shared/src/i18n/pl/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.placeVisited': 'Odwiedzone miejsce',
   'atlas.placesVisited': 'Odwiedzone miejsca',
   'atlas.searchCountry': 'Szukaj kraju...',
+  'atlas.planned': 'Zaplanowane',
+  'atlas.showPlanned': 'Pokaż zaplanowane kraje',
+  'atlas.plannedFor': 'Zaplanowano na',
+  'atlas.antarctica': 'Antarktyda',
 };
 export default atlas;

--- a/shared/src/i18n/pl/mobileAtlas.ts
+++ b/shared/src/i18n/pl/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Odwiedzone',
+  'mobileAtlas.planned': 'Zaplanowane',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/ru/atlas.ts
+++ b/shared/src/i18n/ru/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Месяц',
   'atlas.addToBucketHint': 'Сохранить как место для посещения',
   'atlas.bucketWhen': 'Когда вы планируете поехать?',
+  'atlas.planned': 'Запланировано',
+  'atlas.showPlanned': 'Показать запланированные страны',
+  'atlas.plannedFor': 'Запланировано на',
+  'atlas.antarctica': 'Антарктида',
 };
 export default atlas;

--- a/shared/src/i18n/ru/mobileAtlas.ts
+++ b/shared/src/i18n/ru/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Посещено',
+  'mobileAtlas.planned': 'Запланировано',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/sv/atlas.ts
+++ b/shared/src/i18n/sv/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Resor',
   'atlas.placeVisited': 'Plats besökt',
   'atlas.placesVisited': 'Platser besökta',
+  'atlas.planned': 'Planerat',
+  'atlas.showPlanned': 'Visa planerade länder',
+  'atlas.plannedFor': 'Planerat till',
+  'atlas.antarctica': 'Antarktis',
 };
 export default atlas;

--- a/shared/src/i18n/sv/mobileAtlas.ts
+++ b/shared/src/i18n/sv/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Besökt',
+  'mobileAtlas.planned': 'Planerat',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/tr/atlas.ts
+++ b/shared/src/i18n/tr/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Geziler',
   'atlas.placeVisited': 'Ziyaret edilen yer',
   'atlas.placesVisited': 'Ziyaret edilen yerler',
+  'atlas.planned': 'Planlandı',
+  'atlas.showPlanned': 'Planlanan ülkeleri göster',
+  'atlas.plannedFor': 'Planlanan tarih',
+  'atlas.antarctica': 'Antarktika',
 };
 export default atlas;

--- a/shared/src/i18n/tr/mobileAtlas.ts
+++ b/shared/src/i18n/tr/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Ziyaret edildi',
+  'mobileAtlas.planned': 'Planlandı',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/uk/atlas.ts
+++ b/shared/src/i18n/uk/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': 'Місяць',
   'atlas.addToBucketHint': 'Зберегти як місце для відвідування',
   'atlas.bucketWhen': 'Коли ви плануєте поїхати?',
+  'atlas.planned': 'Заплановано',
+  'atlas.showPlanned': 'Показати заплановані країни',
+  'atlas.plannedFor': 'Заплановано на',
+  'atlas.antarctica': 'Антарктида',
 };
 export default atlas;

--- a/shared/src/i18n/uk/mobileAtlas.ts
+++ b/shared/src/i18n/uk/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Відвідано',
+  'mobileAtlas.planned': 'Заплановано',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/vi/atlas.ts
+++ b/shared/src/i18n/vi/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.tripPlural': 'Chuyến đi',
   'atlas.placeVisited': 'Nơi đã ghé thăm',
   'atlas.placesVisited': 'Địa điểm đã ghé thăm',
+  'atlas.planned': 'Đã lên kế hoạch',
+  'atlas.showPlanned': 'Hiện các quốc gia đã lên kế hoạch',
+  'atlas.plannedFor': 'Dự kiến',
+  'atlas.antarctica': 'Nam Cực',
 };
 export default atlas;

--- a/shared/src/i18n/vi/mobileAtlas.ts
+++ b/shared/src/i18n/vi/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': 'Đã đến',
+  'mobileAtlas.planned': 'Đã lên kế hoạch',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/zh-TW/atlas.ts
+++ b/shared/src/i18n/zh-TW/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': '月份',
   'atlas.addToBucketHint': '儲存為想去的地方',
   'atlas.bucketWhen': '你計劃什麼時候去？',
+  'atlas.planned': '計劃中',
+  'atlas.showPlanned': '顯示計劃中的國家',
+  'atlas.plannedFor': '計劃於',
+  'atlas.antarctica': '南極洲',
 };
 export default atlas;

--- a/shared/src/i18n/zh-TW/mobileAtlas.ts
+++ b/shared/src/i18n/zh-TW/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': '已造訪',
+  'mobileAtlas.planned': '計劃中',
 };
 
 export default mobileAtlas;

--- a/shared/src/i18n/zh/atlas.ts
+++ b/shared/src/i18n/zh/atlas.ts
@@ -54,5 +54,9 @@ const atlas: TranslationStrings = {
   'atlas.month': '月份',
   'atlas.addToBucketHint': '保存为想去的地方',
   'atlas.bucketWhen': '你计划什么时候去？',
+  'atlas.planned': '计划中',
+  'atlas.showPlanned': '显示计划中的国家',
+  'atlas.plannedFor': '计划于',
+  'atlas.antarctica': '南极洲',
 };
 export default atlas;

--- a/shared/src/i18n/zh/mobileAtlas.ts
+++ b/shared/src/i18n/zh/mobileAtlas.ts
@@ -2,6 +2,7 @@ import type { TranslationStrings } from '../types';
 
 const mobileAtlas: TranslationStrings = {
   'mobileAtlas.visited': '已到访',
+  'mobileAtlas.planned': '计划中',
 };
 
 export default mobileAtlas;

--- a/wiki/Atlas.md
+++ b/wiki/Atlas.md
@@ -14,6 +14,14 @@ Atlas gives you a visual overview of your travel footprint. Visited countries ar
 
 When the admin has enabled the Atlas addon, an **Atlas** entry appears in the main navigation. Your visited countries are populated automatically from your existing trips.
 
+## Visited and planned countries
+
+A country only counts as visited once the trip that takes you there has started. A trip currently under way counts too — you are there. Countries from trips that begin in the future are **planned**, and trips saved without any dates are treated as ideas that stay out of your statistics entirely.
+
+Planned countries are hidden from the map by default. Use the **Show planned countries** switch above the map to bring them in; they appear with a dashed outline so they never look like somewhere you have already been. The switch only appears when you actually have upcoming trips, and it remembers your choice.
+
+Countries you mark by hand always count as visited, whatever the dates of any trip going there.
+
 ## Marking countries as visited
 
 Click any country on the map to open an action popup where you can mark it as visited or add it to your bucket list. Use the search bar at the top of the map to find and fly to a country — pressing Enter or selecting a result from the dropdown opens the same action popup.
@@ -34,12 +42,12 @@ The bucket list is separate from "visited". Use it to track countries or places 
 
 Your Atlas statistics panel shows:
 
-- **Countries visited** — total number of distinct countries.
+- **Countries visited** — total number of distinct countries you have actually been to. Countries from upcoming trips are counted separately and shown next to this number.
 - **Trips** — total number of trips across all time.
 - **Places** — total number of individual places logged in trips.
 - **Cities** — total number of distinct cities visited.
 - **Travel days** — total days spent travelling.
-- **Continent breakdown** — number of countries visited per continent (Europe, Asia, North America, South America, Africa, Oceania).
+- **Continent breakdown** — number of countries visited per continent (Europe, Asia, North America, South America, Africa, Oceania). Antarctica joins the row once you have been.
 - **Travel streak** — number of consecutive years in which you have taken at least one trip.
 - **Trips this year** — number of trips in the current calendar year.
 


### PR DESCRIPTION
Closes the request from [discussion #1048](https://github.com/liketrek/TREK/discussions/1048).

The atlas counted every trip as a visit. A country you had booked a flight to was painted
exactly like one you came back from, and a trip you jotted down with no dates at all
counted just the same. As MikeDabrowski put it, seeing upcoming trips as already visited
is "super weird" — he had patched the query locally to only look at past trips.

## How a country is classified

A trip is bucketed by its dates, comparing `start_date ?? end_date` against today in UTC —
the same basis the dashboard and journey lifecycles already use:

| Trip | Status |
| --- | --- |
| Dates in the past, or **currently running** | `visited` |
| Starts in the future | `planned` |
| No dates at all | `idea` |

A country takes the strongest status of its sources, so somewhere you have been and are
going back to stays visited. Marking a country by hand always wins — that is a statement
of fact, not a date. Regions inherit their country's status, otherwise zooming into a
planned country would reveal regions painted as visited.

Running trips count as visited on purpose: you are there right now, and it matches how
`getTripStatus` already treats an ongoing trip as not-upcoming.

## What changes for a user

The big number on the atlas now counts only places you have actually been, with the
planned count beside it. Planned countries are **off the map by default** and come back
through a switch above the globe, drawn dashed so they can't be mistaken for visits. The
switch only shows up when there is something planned, and it remembers its state.

The dashboard passport card derives its countries independently of the atlas, so it had to
follow the same rule — otherwise the two surfaces would have disagreed again, which is the
drift #1490 closed. For anyone with upcoming trips, both numbers go down after this.

## Compatibility

No migration: the status is derived entirely from columns that already exist. The API is
additive — `countries[]` stays a superset of what it returned before, every entry just
gains a `status`. A client that doesn't know the field paints the map exactly as it did.
The only changed value is `totalCountries`, which is the point of the request.

## Picked up along the way

- The region layer read `data` without listing it as a dependency, so region colours
  already went stale on their own — adding the switch would have made it visible.
- Five copies of the optimistic "mark as visited" update are now one helper, which also
  promotes a planned country rather than adding it a second time.
- Antarctica has been in `CONTINENT_MAP` all along but had no translation and never
  appeared; it now joins the continent row once someone has been.
- A hardcoded `Trips` in the country detail is translated.
