### PR TITLE
Keep weight when copying a packing item, and let people set a bag limit

### DIFF
--- a/client/src/components/Packing/PackingListPanel.test.tsx
+++ b/client/src/components/Packing/PackingListPanel.test.tsx
@@ -1320,6 +1320,60 @@ describe('PackingListPanel', () => {
     await waitFor(() => expect(updateBody).toMatchObject({ name: 'Luggage' }));
   });
 
+  // #207: the column, the contract and the API have existed since v2.9.0 — there was
+  // simply no way to type a limit in, so users encoded it in the bag name instead.
+  it('FE-COMP-PACKING-065b: a bag without a limit offers to set one, in kg', async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/addons', () => HttpResponse.json({ bagTracking: true, addons: [] })),
+      http.get('/api/trips/:id/packing/bags', () =>
+        HttpResponse.json({ bags: [{ id: 12, name: 'Cabin bag', color: '#10b981', weight_limit_grams: null, members: [] }] })
+      ),
+      http.put('/api/trips/1/packing/bags/12', async ({ request }) => {
+        updateBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ bag: { id: 12, name: 'Cabin bag', color: '#10b981', weight_limit_grams: 8000, members: [] } });
+      })
+    );
+    render(<PackingListPanel tripId={1} items={[buildPackingItem({ name: 'Jacket', category: 'Clothing' })]} />);
+
+    await waitFor(() => expect(screen.getAllByText('Set limit').length).toBeGreaterThan(0));
+    await user.click(screen.getAllByText('Set limit')[0]);
+
+    const limitInput = await screen.findByLabelText('Weight limit');
+    await user.type(limitInput, '8');
+    await user.keyboard('{Enter}');
+
+    // Entered in kilograms, stored in grams.
+    await waitFor(() => expect(updateBody).toMatchObject({ weight_limit_grams: 8000 }));
+  });
+
+  it('FE-COMP-PACKING-065c: an existing limit is shown next to the packed weight and can be cleared', async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/addons', () => HttpResponse.json({ bagTracking: true, addons: [] })),
+      http.get('/api/trips/:id/packing/bags', () =>
+        HttpResponse.json({ bags: [{ id: 13, name: 'Hold bag', color: '#6366f1', weight_limit_grams: 20000, members: [] }] })
+      ),
+      http.put('/api/trips/1/packing/bags/13', async ({ request }) => {
+        updateBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ bag: { id: 13, name: 'Hold bag', color: '#6366f1', weight_limit_grams: null, members: [] } });
+      })
+    );
+    render(<PackingListPanel tripId={1} items={[buildPackingItem({ name: 'Boots', category: 'Clothing' })]} />);
+
+    await waitFor(() => expect(screen.getAllByText(/\/ 20\.0 kg/).length).toBeGreaterThan(0));
+
+    await user.click(screen.getAllByText(/\/ 20\.0 kg/)[0]);
+    const limitInput = await screen.findByLabelText('Weight limit');
+    await user.clear(limitInput);
+    await user.keyboard('{Enter}');
+
+    // An emptied field clears the limit rather than writing 0.
+    await waitFor(() => expect(updateBody).toMatchObject({ weight_limit_grams: null }));
+  });
+
   it('FE-COMP-PACKING-066: BagCard Plus button opens user picker with trip members', async () => {
     const user = userEvent.setup();
     server.use(

--- a/client/src/components/Packing/PackingListPanelBagCard.tsx
+++ b/client/src/components/Packing/PackingListPanelBagCard.tsx
@@ -21,6 +21,27 @@ export function BagCard({ bag, bagItems, totalWeight, pct, tripId, tripMembers, 
     setEditingName(false)
   }
 
+  // Limits are entered in kg — that is how airlines state them — and stored in grams.
+  const limitToInput = (grams?: number | null) => (grams ? String(grams / 1000) : '')
+  const [editingLimit, setEditingLimit] = useState(false)
+  const [limitVal, setLimitVal] = useState(limitToInput(bag.weight_limit_grams))
+  useEffect(() => setLimitVal(limitToInput(bag.weight_limit_grams)), [bag.weight_limit_grams])
+
+  const saveLimit = () => {
+    setEditingLimit(false)
+    const raw = limitVal.trim().replace(',', '.')
+    if (raw === '') {
+      // Clearing the field removes the limit and puts the bar back on relative scaling.
+      if (bag.weight_limit_grams != null) onUpdate(bag.id, { weight_limit_grams: null })
+      return
+    }
+    const kg = Number(raw)
+    // Anything unparseable or negative leaves the stored limit alone rather than wiping it.
+    if (!Number.isFinite(kg) || kg <= 0) { setLimitVal(limitToInput(bag.weight_limit_grams)); return }
+    const grams = Math.round(kg * 1000)
+    if (grams !== bag.weight_limit_grams) onUpdate(bag.id, { weight_limit_grams: grams })
+  }
+
   const memberIds = (bag.members || []).map(m => m.user_id)
   const toggleMember = (userId: number) => {
     const next = memberIds.includes(userId) ? memberIds.filter(id => id !== userId) : [...memberIds, userId]
@@ -40,8 +61,29 @@ export function BagCard({ bag, bagItems, totalWeight, pct, tripId, tripMembers, 
         ) : (
           <span onClick={() => canEdit && setEditingName(true)} style={{ flex: 1, fontSize: sz.name, fontWeight: 600, color: compact ? 'var(--text-secondary)' : 'var(--text-primary)', cursor: canEdit ? 'text' : 'default' }}>{bag.name}</span>
         )}
-        <span style={{ fontSize: sz.weight, color: 'var(--text-faint)', fontWeight: 500 }}>
+        <span style={{ fontSize: sz.weight, color: 'var(--text-faint)', fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 3 }}>
           {totalWeight >= 1000 ? `${(totalWeight / 1000).toFixed(1)} kg` : `${totalWeight} g`}
+          {editingLimit && canEdit ? (
+            <>
+              <span>/</span>
+              <input autoFocus value={limitVal} onChange={e => setLimitVal(e.target.value)}
+                onBlur={saveLimit}
+                onKeyDown={e => { if (e.key === 'Enter') saveLimit(); if (e.key === 'Escape') { setLimitVal(limitToInput(bag.weight_limit_grams)); setEditingLimit(false) } }}
+                inputMode="decimal" aria-label={t('packing.bagLimit')} placeholder={t('packing.bagLimit')}
+                style={{ width: 42, fontSize: sz.weight, padding: '1px 3px', borderRadius: 4, border: '1px solid var(--border-primary)', outline: 'none', fontFamily: 'inherit', color: 'var(--text-primary)', background: 'transparent' }} />
+              <span>kg</span>
+            </>
+          ) : bag.weight_limit_grams ? (
+            <span onClick={() => canEdit && setEditingLimit(true)} title={t('packing.bagLimit')}
+              style={{ cursor: canEdit ? 'text' : 'default' }}>
+              / {(bag.weight_limit_grams / 1000).toFixed(1)} kg
+            </span>
+          ) : canEdit ? (
+            <button onClick={() => setEditingLimit(true)} title={t('packing.bagLimit')}
+              style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--text-faint)', fontSize: sz.count, fontFamily: 'inherit', textDecoration: 'underline dotted' }}>
+              {t('packing.setBagLimit')}
+            </button>
+          ) : null}
         </span>
         {canEdit && <button onClick={onDelete} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: 'var(--text-faint)', display: 'flex' }}><X size={sz.icon} /></button>}
       </div>

--- a/client/src/components/Packing/PackingListPanelBagModal.tsx
+++ b/client/src/components/Packing/PackingListPanelBagModal.tsx
@@ -1,6 +1,6 @@
 import { X, Plus } from 'lucide-react'
 import type { PackingState } from './usePackingListPanel'
-import { itemWeight } from './packingListPanel.helpers'
+import { bagFillPct, itemWeight } from './packingListPanel.helpers'
 import { BagCard } from './PackingListPanelBagCard'
 
 export function BagModal(S: PackingState) {
@@ -8,6 +8,8 @@ export function BagModal(S: PackingState) {
     setShowBagModal, t, bags, items, tripId, tripMembers, canEdit, handleDeleteBag, handleUpdateBag, handleSetBagMembers,
     showAddBag, setShowAddBag, newBagName, setNewBagName, handleCreateBag,
   } = S
+  // Reference for bags without a limit of their own — computed once instead of per bag.
+  const heaviestBagWeight = Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + itemWeight(i), 0)), 1)
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: 20, paddingTop: 140, paddingBottom: 'calc(20px + var(--bottom-nav-h))', overflowY: 'auto' }}
       onClick={() => setShowBagModal(false)}>
@@ -21,8 +23,7 @@ export function BagModal(S: PackingState) {
         {bags.map(bag => {
           const bagItems = items.filter(i => i.bag_id === bag.id)
           const totalWeight = bagItems.reduce((sum, i) => sum + itemWeight(i), 0)
-          const maxWeight = Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + itemWeight(i), 0)), 1)
-          const pct = Math.min(100, Math.round((totalWeight / maxWeight) * 100))
+          const pct = bagFillPct(totalWeight, bag.weight_limit_grams, heaviestBagWeight)
           return (
             <BagCard key={bag.id} bag={bag} bagItems={bagItems} totalWeight={totalWeight} pct={pct} tripId={tripId} tripMembers={tripMembers} canEdit={canEdit} onDelete={() => handleDeleteBag(bag.id)} onUpdate={handleUpdateBag} onSetMembers={handleSetBagMembers} t={t} />
           )

--- a/client/src/components/Packing/PackingListPanelBagSidebar.tsx
+++ b/client/src/components/Packing/PackingListPanelBagSidebar.tsx
@@ -1,6 +1,6 @@
 import { Plus } from 'lucide-react'
 import type { PackingState } from './usePackingListPanel'
-import { itemWeight } from './packingListPanel.helpers'
+import { bagFillPct, itemWeight } from './packingListPanel.helpers'
 import { BagCard } from './PackingListPanelBagCard'
 
 export function BagSidebar(S: PackingState) {
@@ -8,6 +8,8 @@ export function BagSidebar(S: PackingState) {
     t, bags, items, tripId, tripMembers, canEdit, handleDeleteBag, handleUpdateBag, handleSetBagMembers,
     showAddBag, setShowAddBag, newBagName, setNewBagName, handleCreateBag,
   } = S
+  // Reference for bags without a limit of their own — computed once instead of per bag.
+  const heaviestBagWeight = Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + itemWeight(i), 0)), 1)
   return (
     <div className="hidden xl:block" style={{ width: 260, marginLeft: 16, borderLeft: '1px solid var(--border-secondary)', overflowY: 'auto', padding: 16, flexShrink: 0 }}>
       <div style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-faint)', marginBottom: 12 }}>
@@ -17,8 +19,7 @@ export function BagSidebar(S: PackingState) {
       {bags.map(bag => {
         const bagItems = items.filter(i => i.bag_id === bag.id)
         const totalWeight = bagItems.reduce((sum, i) => sum + itemWeight(i), 0)
-        const maxWeight = bag.weight_limit_grams || Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + itemWeight(i), 0)), 1)
-        const pct = Math.min(100, Math.round((totalWeight / maxWeight) * 100))
+        const pct = bagFillPct(totalWeight, bag.weight_limit_grams, heaviestBagWeight)
         return (
           <BagCard key={bag.id} bag={bag} bagItems={bagItems} totalWeight={totalWeight} pct={pct} tripId={tripId} tripMembers={tripMembers} canEdit={canEdit} onDelete={() => handleDeleteBag(bag.id)} onUpdate={handleUpdateBag} onSetMembers={handleSetBagMembers} t={t} compact />
         )

--- a/client/src/components/Packing/packingListPanel.helpers.test.ts
+++ b/client/src/components/Packing/packingListPanel.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { katColor, itemWeight, parseCsvLine, parseImportLines } from './packingListPanel.helpers'
+import { katColor, itemWeight, bagFillPct, parseCsvLine, parseImportLines } from './packingListPanel.helpers'
 import { KAT_COLORS } from './packingListPanel.constants'
 
 describe('packingListPanel.helpers', () => {
@@ -43,6 +43,27 @@ describe('packingListPanel.helpers', () => {
     it('treats null weight/quantity as their defaults', () => {
       expect(itemWeight({ weight_grams: null, quantity: null })).toBe(0)
       expect(itemWeight({ weight_grams: 100, quantity: null })).toBe(100)
+    })
+  })
+
+  describe('bagFillPct', () => {
+    it('measures against the bag limit when there is one', () => {
+      expect(bagFillPct(5000, 20000, 99999)).toBe(25)
+      expect(bagFillPct(20000, 20000, 1)).toBe(100)
+    })
+
+    it('never reports more than full', () => {
+      expect(bagFillPct(30000, 20000, 1)).toBe(100)
+    })
+
+    it('falls back to the heaviest bag when no limit is set', () => {
+      expect(bagFillPct(2500, null, 5000)).toBe(50)
+      expect(bagFillPct(2500, undefined, 5000)).toBe(50)
+      expect(bagFillPct(0, 0, 5000)).toBe(0)
+    })
+
+    it('does not divide by zero on an empty trip', () => {
+      expect(bagFillPct(0, null, 0)).toBe(0)
     })
   })
 

--- a/client/src/components/Packing/packingListPanel.helpers.ts
+++ b/client/src/components/Packing/packingListPanel.helpers.ts
@@ -14,6 +14,15 @@ export function katColor(kat: string, allCategories?: string[]): string {
 export const itemWeight = (i: { weight_grams?: number | null; quantity?: number | null }): number =>
   (i.weight_grams || 0) * (i.quantity || 1)
 
+/**
+ * How full a bag's bar reads. A bag with a weight limit is measured against that limit —
+ * that is the number an airline cares about. Without one there is nothing absolute to
+ * measure against, so bags are shown relative to the heaviest one and stay comparable.
+ * Lives here because three surfaces draw this bar and one of them used to forget the limit.
+ */
+export const bagFillPct = (bagWeight: number, limitGrams: number | null | undefined, heaviestBagWeight: number): number =>
+  Math.min(100, Math.round((bagWeight / (limitGrams || Math.max(heaviestBagWeight, 1))) * 100))
+
 // Parse CSV line respecting quoted values (e.g. "Shirt, blue" stays as one field)
 export const parseCsvLine = (line: string): string[] => {
   const parts: string[] = []

--- a/client/src/mobile/screens/trip/tabs/MBagsSheet.tsx
+++ b/client/src/mobile/screens/trip/tabs/MBagsSheet.tsx
@@ -7,6 +7,7 @@ import { avatarSrc } from '../../../../utils/avatarSrc'
 import type { PackingBag, PackingItem, TripMember } from '../../../../types'
 import type { TripPlanner } from '../MTripShell'
 import { formatWeight, packingItemWeight } from './listsModel'
+import { bagFillPct } from '../../../../components/Packing/packingListPanel.helpers'
 
 export interface MBagsSheetProps {
   planner: TripPlanner
@@ -37,6 +38,8 @@ export default function MBagsSheet({
   const unassigned = items.filter(i => !i.bag_id)
   const unassignedWeight = unassigned.reduce((s, i) => s + packingItemWeight(i), 0)
   const totalWeight = items.reduce((s, i) => s + packingItemWeight(i), 0)
+  // Reference for bags without a limit of their own — computed once instead of per bag.
+  const heaviestBagWeight = Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + packingItemWeight(i), 0)), 1)
 
   const submitNewBag = () => {
     if (!newBagName.trim()) return
@@ -53,9 +56,7 @@ export default function MBagsSheet({
         {bags.map(bag => {
           const bagItems = items.filter(i => i.bag_id === bag.id)
           const bagWeight = bagItems.reduce((s, i) => s + packingItemWeight(i), 0)
-          const maxWeight = bag.weight_limit_grams
-            || Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + packingItemWeight(i), 0)), 1)
-          const pct = Math.min(100, Math.round((bagWeight / maxWeight) * 100))
+          const pct = bagFillPct(bagWeight, bag.weight_limit_grams, heaviestBagWeight)
           return (
             <BagRow
               key={bag.id}
@@ -159,6 +160,24 @@ function BagRow({ planner, bag, itemCount, weight, pct, tripMembers, canEdit, on
     setEditingName(false)
   }
 
+  // Limits are entered in kg — that is how airlines state them — and stored in grams.
+  const limitToInput = (grams?: number | null) => (grams ? String(grams / 1000) : '')
+  const [editingLimit, setEditingLimit] = useState(false)
+  const [limitVal, setLimitVal] = useState(limitToInput(bag.weight_limit_grams))
+
+  const saveLimit = () => {
+    setEditingLimit(false)
+    const raw = limitVal.trim().replace(',', '.')
+    if (raw === '') {
+      if (bag.weight_limit_grams != null) onUpdate({ weight_limit_grams: null })
+      return
+    }
+    const kg = Number(raw)
+    if (!Number.isFinite(kg) || kg <= 0) { setLimitVal(limitToInput(bag.weight_limit_grams)); return }
+    const grams = Math.round(kg * 1000)
+    if (grams !== bag.weight_limit_grams) onUpdate({ weight_limit_grams: grams })
+  }
+
   return (
     <div className="mb-4">
       <div className="mb-1 flex items-center gap-[8px]">
@@ -178,7 +197,34 @@ function BagRow({ planner, bag, itemCount, weight, pct, tripMembers, canEdit, on
             {bag.name}
           </button>
         )}
-        <span className="font-geist text-[0.71875rem] font-medium text-m-faint">{formatWeight(weight)}</span>
+        <span className="flex flex-none items-center gap-1 font-geist text-[0.71875rem] font-medium text-m-faint">
+          {formatWeight(weight)}
+          {editingLimit && canEdit ? (
+            <>
+              <span>/</span>
+              <input
+                type="text"
+                autoFocus
+                inputMode="decimal"
+                value={limitVal}
+                aria-label={t('packing.bagLimit')}
+                onChange={e => setLimitVal(e.target.value)}
+                onBlur={saveLimit}
+                onKeyDown={e => { if (e.key === 'Enter') saveLimit(); if (e.key === 'Escape') { setLimitVal(limitToInput(bag.weight_limit_grams)); setEditingLimit(false) } }}
+                className="w-9 border-b border-[color:var(--m-rowbr)] bg-transparent text-right text-m-ink outline-none"
+              />
+              <span>kg</span>
+            </>
+          ) : bag.weight_limit_grams ? (
+            <button type="button" onClick={() => canEdit && setEditingLimit(true)} aria-label={t('packing.bagLimit')}>
+              / {(bag.weight_limit_grams / 1000).toFixed(1)} kg
+            </button>
+          ) : canEdit ? (
+            <button type="button" onClick={() => setEditingLimit(true)} className="underline decoration-dotted">
+              {t('packing.setBagLimit')}
+            </button>
+          ) : null}
+        </span>
         {canEdit && (
           <button type="button" onClick={onDelete} aria-label={t('common.delete')} className="flex flex-none items-center text-m-faint">
             <X size={14} strokeWidth={2} />

--- a/client/tests/unit/mobile/trip/MBagsSheet.test.tsx
+++ b/client/tests/unit/mobile/trip/MBagsSheet.test.tsx
@@ -247,4 +247,33 @@ describe('MBagsSheet', () => {
 
     expect(onClose).toHaveBeenCalled()
   })
+
+  // #207: the limit was storable and readable but had nowhere to be typed in.
+  it('FE-MOB-BAGS-020: a limit typed in kg is stored in grams', () => {
+    const { onUpdateBag } = setup({ bags: [bag({ id: 1, name: 'Backpack' })] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'packing.setBagLimit' }))
+    const input = screen.getByLabelText('packing.bagLimit')
+    fireEvent.change(input, { target: { value: '7.5' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onUpdateBag).toHaveBeenCalledWith(1, { weight_limit_grams: 7500 })
+  })
+
+  it('FE-MOB-BAGS-021: emptying the field clears the limit instead of storing zero', () => {
+    const { onUpdateBag } = setup({ bags: [bag({ id: 1, name: 'Backpack', weight_limit_grams: 20000 })] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'packing.bagLimit' }))
+    const input = screen.getByLabelText('packing.bagLimit')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onUpdateBag).toHaveBeenCalledWith(1, { weight_limit_grams: null })
+  })
+
+  it('FE-MOB-BAGS-022: read-only mode offers no way to set a limit', () => {
+    setup({ canEdit: false, bags: [bag({ id: 1, name: 'Backpack' })] })
+
+    expect(screen.queryByRole('button', { name: 'packing.setBagLimit' })).toBeNull()
+  })
 })

--- a/server/src/nest/packing/packing.service.ts
+++ b/server/src/nest/packing/packing.service.ts
@@ -170,7 +170,7 @@ export class PackingService {
 
   createItem(
     tripId: string | number,
-    data: { name: string; category?: string; checked?: boolean; quantity?: number; is_private?: boolean; visibility?: PackingVisibility; recipient_ids?: number[] },
+    data: { name: string; category?: string; checked?: boolean; quantity?: number; weight_grams?: number | null; bag_id?: number | null; is_private?: boolean; visibility?: PackingVisibility; recipient_ids?: number[] },
     ownerId?: number,
   ) {
     const maxOrder = this.db.get<{ max: number | null }>('SELECT MAX(sort_order) as max FROM packing_items WHERE trip_id = ?', tripId)!;
@@ -180,8 +180,8 @@ export class PackingService {
 
     const itemId = this.db.transaction(() => {
       const result = this.db.run(
-        'INSERT INTO packing_items (trip_id, name, checked, category, sort_order, quantity, is_private, owner_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)',
-        tripId, data.name, data.checked ? 1 : 0, data.category || 'Other', sortOrder, qty, isPrivate, ownerId ?? null
+        'INSERT INTO packing_items (trip_id, name, checked, category, sort_order, quantity, weight_grams, bag_id, is_private, owner_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)',
+        tripId, data.name, data.checked ? 1 : 0, data.category || 'Other', sortOrder, qty, data.weight_grams ?? null, data.bag_id ?? null, isPrivate, ownerId ?? null
       );
       const id = Number(result.lastInsertRowid);
       // "Shared with specific people" — record the recipients it covers.
@@ -253,7 +253,7 @@ export class PackingService {
 
   /** Loads an item scoped to its trip (the trip-access check happens in the controller). */
   private getItemInTrip(tripId: string | number, id: string | number) {
-    return this.db.get<{ id: number; owner_id: number | null; is_private: number; name: string; category: string | null; quantity: number }>(
+    return this.db.get<{ id: number; owner_id: number | null; is_private: number; name: string; category: string | null; quantity: number; weight_grams: number | null; bag_id: number | null }>(
       'SELECT * FROM packing_items WHERE id = ? AND trip_id = ?', id, tripId
     );
   }
@@ -305,11 +305,37 @@ export class PackingService {
     return this.enrichItems([this.db.get('SELECT * FROM packing_items WHERE id = ?', id)])[0];
   }
 
-  /** Clone a (Common) item onto the caller's Personal list as a private starting point. */
+  /**
+   * A copy keeps the original's bag only when that bag is the caller's to pack: one nobody
+   * owns, or one they belong to. Inheriting someone else's bag would drop the copy into
+   * their luggage and inflate their weight (#207).
+   */
+  private bagForCloner(tripId: string | number, bagId: number | null, userId: number): number | null {
+    if (bagId == null) return null;
+    const bag = this.db.get<{ user_id: number | null }>('SELECT user_id FROM packing_bags WHERE id = ? AND trip_id = ?', bagId, tripId);
+    if (!bag) return null;
+    if (bag.user_id === userId) return bagId;
+    const members = this.db.all<{ user_id: number }>('SELECT user_id FROM packing_bag_members WHERE bag_id = ?', bagId);
+    if (bag.user_id == null && members.length === 0) return bagId; // shared bag, nobody's in particular
+    return members.some(m => m.user_id === userId) ? bagId : null;
+  }
+
+  /**
+   * Clone a (Common) item onto the caller's Personal list as a private starting point.
+   * Weight comes along — it is a property of the thing, and re-entering it by hand for
+   * every traveller was the whole complaint in #207.
+   */
   cloneItem(tripId: string | number, id: string | number, userId: number) {
     const item = this.getItemInTrip(tripId, id);
     if (!item) return null;
-    return this.createItem(tripId, { name: item.name, category: item.category || undefined, quantity: item.quantity, visibility: 'personal' }, userId);
+    return this.createItem(tripId, {
+      name: item.name,
+      category: item.category || undefined,
+      quantity: item.quantity,
+      weight_grams: item.weight_grams,
+      bag_id: this.bagForCloner(tripId, item.bag_id, userId),
+      visibility: 'personal',
+    }, userId);
   }
 
   deleteItem(tripId: string | number, id: string | number) {

--- a/server/tests/unit/nest/packing.service.test.ts
+++ b/server/tests/unit/nest/packing.service.test.ts
@@ -60,7 +60,7 @@ vi.mock('../../../src/nest/notifications/notifications.bridge', () => ({ send })
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createAdmin, createTrip } from '../../helpers/factories';
+import { createUser, createAdmin, createTrip, addTripMember } from '../../helpers/factories';
 import { DatabaseService } from '../../../src/nest/database/database.service';
 import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
 import { PackingService } from '../../../src/nest/packing/packing.service';
@@ -583,6 +583,61 @@ describe('three-tier packing sharing (#858)', () => {
     // The clone is the cloner's alone.
     expect(names(svc.listItems(trip.id, owner.id) as any[])).toEqual(['Travel adapter']);     // owner sees only the common one
     expect(names(svc.listItems(trip.id, cloner.id) as any[])).toEqual(['Travel adapter', 'Travel adapter']); // common + own clone
+  });
+
+  // #207: "one person curates the list, everyone copies it" meant re-entering every
+  // weight by hand, because a copy arrived empty.
+  it('PACK-SVC-073: cloneItem carries the weight over', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: cloner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    const common = svc.createItem(trip.id, { name: 'Tent', visibility: 'common', weight_grams: 2400, quantity: 2 }, owner.id) as any;
+
+    const clone = svc.cloneItem(trip.id, common.id, cloner.id) as any;
+
+    expect(clone.weight_grams).toBe(2400);
+    expect(clone.quantity).toBe(2);
+  });
+
+  it('PACK-SVC-074: cloneItem keeps a bag nobody owns', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: cloner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    const bag = svc.createBag(trip.id, { name: 'Car boot' }) as any;
+    const common = svc.createItem(trip.id, { name: 'Cool box', visibility: 'common', weight_grams: 3000, bag_id: bag.id }, owner.id) as any;
+
+    const clone = svc.cloneItem(trip.id, common.id, cloner.id) as any;
+
+    expect(clone.bag_id).toBe(bag.id);
+  });
+
+  it('PACK-SVC-075: cloneItem drops a bag that belongs to someone else', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: cloner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, cloner.id);
+    const bag = svc.createBag(trip.id, { name: 'Owner backpack' }) as any;
+    svc.setBagMembers(trip.id, bag.id, [owner.id]);
+    const common = svc.createItem(trip.id, { name: 'Rope', visibility: 'common', weight_grams: 900, bag_id: bag.id }, owner.id) as any;
+
+    const clone = svc.cloneItem(trip.id, common.id, cloner.id) as any;
+
+    // Weight still comes along — only the foreign bag is dropped, so the copy cannot
+    // land in someone else's luggage and inflate their total.
+    expect(clone.weight_grams).toBe(900);
+    expect(clone.bag_id).toBeNull();
+  });
+
+  it('PACK-SVC-076: cloneItem keeps a bag the cloner is a member of', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: cloner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, cloner.id);
+    const bag = svc.createBag(trip.id, { name: 'Shared duffel' }) as any;
+    svc.setBagMembers(trip.id, bag.id, [owner.id, cloner.id]);
+    const common = svc.createItem(trip.id, { name: 'Stove', visibility: 'common', bag_id: bag.id }, owner.id) as any;
+
+    expect((svc.cloneItem(trip.id, common.id, cloner.id) as any).bag_id).toBe(bag.id);
   });
 });
 

--- a/shared/src/i18n/ar/packing.ts
+++ b/shared/src/i18n/ar/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'يمكنني إحضاره أيضًا',
   'packing.alsoBringingStop': 'لن أحضره',
   'packing.cloneToMine': 'نسخ إلى قائمتي',
+  'packing.bagLimit': 'حد الوزن',
+  'packing.setBagLimit': 'تعيين حد',
 };
 export default packing;

--- a/shared/src/i18n/br/packing.ts
+++ b/shared/src/i18n/br/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Eu também posso levar',
   'packing.alsoBringingStop': 'Não vou levar',
   'packing.cloneToMine': 'Copiar para minha lista',
+  'packing.bagLimit': 'Limite de peso',
+  'packing.setBagLimit': 'Definir limite',
 };
 export default packing;

--- a/shared/src/i18n/ca/packing.ts
+++ b/shared/src/i18n/ca/packing.ts
@@ -208,5 +208,7 @@ const packing: TranslationStrings = {
   'packing.itemName': 'Nom',
   'packing.itemQuantity': 'Quantitat',
   'packing.itemWeight': 'Pes (g)',
+  'packing.bagLimit': 'Límit de pes',
+  'packing.setBagLimit': 'Defineix un límit',
 };
 export default packing;

--- a/shared/src/i18n/cs/packing.ts
+++ b/shared/src/i18n/cs/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Můžu to vzít taky',
   'packing.alsoBringingStop': 'Neberu to',
   'packing.cloneToMine': 'Kopírovat do mého seznamu',
+  'packing.bagLimit': 'Hmotnostní limit',
+  'packing.setBagLimit': 'Nastavit limit',
 };
 export default packing;

--- a/shared/src/i18n/de/packing.ts
+++ b/shared/src/i18n/de/packing.ts
@@ -208,5 +208,7 @@ const packing: TranslationStrings = {
       category: 'Gesundheit',
     },
   ],
+  'packing.bagLimit': 'Gewichtslimit',
+  'packing.setBagLimit': 'Limit setzen',
 };
 export default packing;

--- a/shared/src/i18n/en/packing.ts
+++ b/shared/src/i18n/en/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
       category: 'Health',
     },
   ],
+  'packing.bagLimit': 'Weight limit',
+  'packing.setBagLimit': 'Set limit',
 };
 export default packing;

--- a/shared/src/i18n/es/packing.ts
+++ b/shared/src/i18n/es/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Yo también puedo llevarlo',
   'packing.alsoBringingStop': 'No lo llevo',
   'packing.cloneToMine': 'Copiar a mi lista',
+  'packing.bagLimit': 'Límite de peso',
+  'packing.setBagLimit': 'Definir límite',
 };
 export default packing;

--- a/shared/src/i18n/fr/packing.ts
+++ b/shared/src/i18n/fr/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': "Je peux l'apporter aussi",
   'packing.alsoBringingStop': "Je ne l'apporte pas",
   'packing.cloneToMine': 'Copier dans ma liste',
+  'packing.bagLimit': 'Limite de poids',
+  'packing.setBagLimit': 'Définir une limite',
 };
 export default packing;

--- a/shared/src/i18n/gr/packing.ts
+++ b/shared/src/i18n/gr/packing.ts
@@ -118,5 +118,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Μπορώ να το φέρω κι εγώ',
   'packing.alsoBringingStop': 'Δεν το φέρνω',
   'packing.cloneToMine': 'Αντιγραφή στη λίστα μου',
+  'packing.bagLimit': 'Όριο βάρους',
+  'packing.setBagLimit': 'Ορισμός ορίου',
 };
 export default packing;

--- a/shared/src/i18n/hu/packing.ts
+++ b/shared/src/i18n/hu/packing.ts
@@ -208,5 +208,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Én is tudom hozni',
   'packing.alsoBringingStop': 'Mégsem hozom',
   'packing.cloneToMine': 'Másolás a listámra',
+  'packing.bagLimit': 'Súlykorlát',
+  'packing.setBagLimit': 'Korlát beállítása',
 };
 export default packing;

--- a/shared/src/i18n/id/packing.ts
+++ b/shared/src/i18n/id/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Saya juga bisa membawanya',
   'packing.alsoBringingStop': 'Saya tidak membawanya',
   'packing.cloneToMine': 'Salin ke daftar saya',
+  'packing.bagLimit': 'Batas berat',
+  'packing.setBagLimit': 'Atur batas',
 };
 export default packing;

--- a/shared/src/i18n/it/packing.ts
+++ b/shared/src/i18n/it/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': "Posso portarlo anch'io",
   'packing.alsoBringingStop': 'Non lo porto',
   'packing.cloneToMine': 'Copia nella mia lista',
+  'packing.bagLimit': 'Limite di peso',
+  'packing.setBagLimit': 'Imposta limite',
 };
 export default packing;

--- a/shared/src/i18n/ja/packing.ts
+++ b/shared/src/i18n/ja/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': '私も持っていけます',
   'packing.alsoBringingStop': 'やっぱり持っていきません',
   'packing.cloneToMine': 'マイリストにコピー',
+  'packing.bagLimit': '重量制限',
+  'packing.setBagLimit': '制限を設定',
 };
 export default packing;

--- a/shared/src/i18n/ko/packing.ts
+++ b/shared/src/i18n/ko/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': '저도 가져갈 수 있어요',
   'packing.alsoBringingStop': '안 가져갈게요',
   'packing.cloneToMine': '내 목록으로 복사',
+  'packing.bagLimit': '무게 제한',
+  'packing.setBagLimit': '제한 설정',
 };
 export default packing;

--- a/shared/src/i18n/nl/packing.ts
+++ b/shared/src/i18n/nl/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Ik kan het ook meenemen',
   'packing.alsoBringingStop': 'Ik neem het niet mee',
   'packing.cloneToMine': 'Kopiëren naar mijn lijst',
+  'packing.bagLimit': 'Gewichtslimiet',
+  'packing.setBagLimit': 'Limiet instellen',
 };
 export default packing;

--- a/shared/src/i18n/pl/packing.ts
+++ b/shared/src/i18n/pl/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Ja też mogę to wziąć',
   'packing.alsoBringingStop': 'Jednak nie biorę',
   'packing.cloneToMine': 'Kopiuj do mojej listy',
+  'packing.bagLimit': 'Limit wagi',
+  'packing.setBagLimit': 'Ustaw limit',
 };
 export default packing;

--- a/shared/src/i18n/ru/packing.ts
+++ b/shared/src/i18n/ru/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Я тоже могу принести',
   'packing.alsoBringingStop': 'Я не принесу',
   'packing.cloneToMine': 'Копировать в мой список',
+  'packing.bagLimit': 'Ограничение веса',
+  'packing.setBagLimit': 'Задать лимит',
 };
 export default packing;

--- a/shared/src/i18n/sv/packing.ts
+++ b/shared/src/i18n/sv/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Jag kan ta med det också',
   'packing.alsoBringingStop': 'Jag tar inte med det',
   'packing.cloneToMine': 'Kopiera till min lista',
+  'packing.bagLimit': 'Viktgräns',
+  'packing.setBagLimit': 'Ange gräns',
 };
 export default packing;

--- a/shared/src/i18n/tr/packing.ts
+++ b/shared/src/i18n/tr/packing.ts
@@ -117,5 +117,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Ben de getirebilirim',
   'packing.alsoBringingStop': 'Getirmiyorum',
   'packing.cloneToMine': 'Listeme kopyala',
+  'packing.bagLimit': 'Ağırlık limiti',
+  'packing.setBagLimit': 'Limit belirle',
 };
 export default packing;

--- a/shared/src/i18n/uk/packing.ts
+++ b/shared/src/i18n/uk/packing.ts
@@ -206,5 +206,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Я теж можу принести',
   'packing.alsoBringingStop': 'Я не принесу',
   'packing.cloneToMine': 'Копіювати до мого списку',
+  'packing.bagLimit': 'Обмеження ваги',
+  'packing.setBagLimit': 'Задати ліміт',
 };
 export default packing;

--- a/shared/src/i18n/vi/packing.ts
+++ b/shared/src/i18n/vi/packing.ts
@@ -207,5 +207,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': 'Tôi cũng có thể mang',
   'packing.alsoBringingStop': 'Tôi không mang',
   'packing.cloneToMine': 'Sao chép vào danh sách của tôi',
+  'packing.bagLimit': 'Giới hạn cân nặng',
+  'packing.setBagLimit': 'Đặt giới hạn',
 };
 export default packing;

--- a/shared/src/i18n/zh-TW/packing.ts
+++ b/shared/src/i18n/zh-TW/packing.ts
@@ -205,5 +205,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': '我也可以帶',
   'packing.alsoBringingStop': '我不帶了',
   'packing.cloneToMine': '複製到我的清單',
+  'packing.bagLimit': '重量限制',
+  'packing.setBagLimit': '設定限制',
 };
 export default packing;

--- a/shared/src/i18n/zh/packing.ts
+++ b/shared/src/i18n/zh/packing.ts
@@ -205,5 +205,7 @@ const packing: TranslationStrings = {
   'packing.alsoBring': '我也可以带',
   'packing.alsoBringingStop': '我不带了',
   'packing.cloneToMine': '复制到我的清单',
+  'packing.bagLimit': '重量限制',
+  'packing.setBagLimit': '设置限制',
 };
 export default packing;


### PR DESCRIPTION
Two of the three things reported in [discussion #207](https://github.com/liketrek/TREK/discussions/207#discussioncomment-17874392). Both were verified against the code before writing anything.

## A copy keeps its weight

`createItem` never accepted `weight_grams` or `bag_id` — not in the signature, not in the INSERT — so `cloneItem` had nothing to hand on. Every "copy to my list" arrived empty. The reported workflow ("one person curates the list, everyone copies it and adjusts") therefore meant re-entering every weight by hand for each traveller.

The bag needed more thought than the weight. Bags belong to a *trip*, but they can be assigned to a person via `packing_bags.user_id` and `packing_bag_members`. Copying the original's bag unconditionally would drop your item into someone else's luggage and inflate their total — the very effect #1767 complains about. So a copy keeps the bag only when nobody owns it, or when the copier is one of its members. The weight always comes along.

Templates still drop weight and quantity — `packing_template_items` has no columns for them. That needs a migration and a contract change, so it is not in here.

## A bag weight limit can finally be entered

The column, the Zod contract, the `PUT` route and its e2e test have existed since v2.9.0. What never existed was a field to type a limit into — the only way to record one was to write it into the bag name, where nothing can act on it. My note in this thread on 2026-04-05 said bag weight tracking "was already available"; that was true of the data layer and not of the product, and the report is right to push back.

Desktop bag card and mobile bag row now take a limit in kilograms — how airlines state them — and store it in grams. An emptied field clears the limit rather than storing a zero.

While adding it I found the fill-bar formula in three places, and the copy in the bag modal had been written without the limit. A limit set on a window narrower than `xl` therefore did nothing at all. The formula now lives once in `packingListPanel.helpers` as `bagFillPct`, next to `itemWeight`.

## Not touched

- The tare weight of the bag itself, which is what the original "Bag weight" checkbox in the first post actually asked for. There is no column for it.
- #1767. The symptom is real, but the fix suggested there (`owner_id === currentUserId`) would break the shared total: `createItem` stamps `owner_id` on every item including Common ones, so filtering by it would shrink the group total to "only what I entered myself", even on trips with no sharing at all.

No migration, no new endpoint. Everything is additive; a bag without a limit behaves exactly as before.
