### PR TITLE
fix(admin): stop a stale base URL from hijacking the Anthropic endpoint

### DIFF
--- a/client/src/components/Admin/AddonManager.test.tsx
+++ b/client/src/components/Admin/AddonManager.test.tsx
@@ -560,6 +560,34 @@ describe('AddonManager', () => {
     });
   });
 
+  it('FE-ADMIN-ADDON-029: switching to Anthropic clears a stale base URL before saving', async () => {
+    const user = userEvent.setup();
+    const bodies: unknown[] = [];
+    server.use(
+      addonsRoute([llmAddon({ provider: 'local', model: '', baseUrl: 'http://ollama.lan:11434/v1', apiKey: '', multimodal: false })]),
+      modelsRoute([]),
+      http.put('/api/admin/addons/llm_parsing', async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    render(<><ToastContainer /><AddonManager /></>);
+
+    await screen.findByText('Installed on the server');
+
+    await user.click(screen.getByRole('button', { name: /Local · OpenAI-compatible/ }));
+    await user.click(screen.getByRole('button', { name: 'Anthropic' }));
+    await user.type(screen.getByPlaceholderText('claude-opus-4-8'), 'claude-haiku-4-5-20251001');
+    await user.type(screen.getByPlaceholderText('sk-…'), 'sk-ant-live');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Saved');
+    // The stale local base URL must not ride along to Anthropic — it would hijack the endpoint.
+    expect(bodies[0]).toEqual({
+      config: { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', baseUrl: '', apiKey: 'sk-ant-live', multimodal: false },
+    });
+  });
+
   it('FE-ADMIN-ADDON-027: an error frame in the pull stream aborts the pull and is reported', async () => {
     const user = userEvent.setup();
     server.use(

--- a/client/src/components/Admin/AddonManager.tsx
+++ b/client/src/components/Admin/AddonManager.tsx
@@ -399,7 +399,7 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
     setSaving(true)
     try {
       // Send the masked sentinel unchanged so the server keeps the stored key.
-      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: baseUrl.trim(), apiKey, multimodal: cfg.multimodal === true } })
+      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: provider === 'anthropic' ? '' : baseUrl.trim(), apiKey, multimodal: cfg.multimodal === true } })
       toast.success('Saved')
     } catch {
       toast.error('Failed to save')


### PR DESCRIPTION
## Description
`LlmParsingConfig.save()` in `client/src/components/Admin/AddonManager.tsx:402` sent
`baseUrl` unconditionally. The Base URL field is only rendered for non-Anthropic
providers (line 435), so switching a configured Local/OpenAI provider to Anthropic
hides the input but leaves the old URL in state — and it was still saved. The server's
`AnthropicClient.extract()` honours any `baseUrl`, so every Anthropic request was then
misrouted to that stale host instead of `api.anthropic.com`, surfacing as bogus
"Anthropic" 404s / nginx HTML errors.

Fix: gate the saved value on the provider — `baseUrl: provider === 'anthropic' ? '' :
baseUrl.trim()` — mirroring the field's own render condition and the already-correct
per-user path (`LlmConnectionSection.tsx`, `showBaseUrl`). This belongs in the admin UI
save payload, not the server: `llm-config.resolver.ts` already maps an empty string to
`undefined`, so `''` falls back to the default endpoint with no server-side change.

## Related Issue or Discussion
Closes #1748

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally 
- [x] I have added/updated tests that prove my fix is effective 
- [ ] I have updated documentation if needed