### PR TITLE
fix(costs): save a picked payer when nobody splits the expense

### DIFF
--- a/client/src/components/Budget/CostsPanel.test.tsx
+++ b/client/src/components/Budget/CostsPanel.test.tsx
@@ -222,6 +222,7 @@ describe('CostsPanel — settlements in the ledger', () => {
   })
 
   it('records a recorded-total expense with nobody to split with (#1286)', async () => {
+    seedStore(useAuthStore, { user: buildUser({ id: 1, username: 'alice' }), isAuthenticated: true })
     let posted: Record<string, unknown> | null = null
     server.use(
       http.get('/api/trips/1/budget', () => HttpResponse.json({ items: [] })),
@@ -239,11 +240,12 @@ describe('CostsPanel — settlements in the ledger', () => {
     await user.type(await screen.findByPlaceholderText('e.g. Dinner, souvenirs, gas…'), 'Hotel')
     await user.type(screen.getAllByPlaceholderText('0,00')[0], '120') // total only, paid on-site later
 
-    // Deselect everyone — the cost is recorded without a split (the bug: this was blocked).
-    // The participant toggles are buttons; the same names also appear as plain text in
-    // the Balances sidebar, so target the buttons specifically.
-    await user.click(screen.getByRole('button', { name: /alice/i }))
-    await user.click(screen.getByRole('button', { name: /bob/i }))
+    // Deselect everyone so the cost carries no split, and mark it as unpaid: a picked
+    // payer now always goes out (#1766), so "nobody paid" must be said explicitly.
+    await user.click(screen.getByRole('button', { name: 'Y You' }))
+    await user.click(screen.getByRole('button', { name: 'B bob' }))
+    await user.click(screen.getByRole('button', { name: 'You' })) // open the Who-paid select
+    pickOption('No one paid yet')
 
     const addBtns = screen.getAllByRole('button', { name: 'Add expense' })
     const submit = addBtns[addBtns.length - 1] // footer submit
@@ -254,6 +256,40 @@ describe('CostsPanel — settlements in the ledger', () => {
     expect(posted!.total_price).toBe(120)
     expect(posted!.member_ids).toEqual([])
     expect(posted!.payers).toEqual([])
+  })
+
+  it('keeps a picked payer when nobody splits the expense (#1766)', async () => {
+    seedStore(useAuthStore, { user: buildUser({ id: 1, username: 'alice' }), isAuthenticated: true })
+    let posted: Record<string, unknown> | null = null
+    server.use(
+      http.get('/api/trips/1/budget', () => HttpResponse.json({ items: [] })),
+      http.get('/api/trips/1/budget/settlement', () => HttpResponse.json({ balances: [], flows: [], settlements: [] })),
+      http.post('/api/trips/1/budget', async ({ request }) => {
+        posted = await request.json() as Record<string, unknown>
+        return HttpResponse.json({ item: { ...buildBudgetItem({ trip_id: 1, name: 'Flight' }), id: 11 } })
+      }),
+    )
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    render(<CostsPanel tripId={1} tripMembers={tripMembers} />)
+
+    await user.click(await screen.findByRole('button', { name: 'Add expense' }))
+    await user.type(await screen.findByPlaceholderText('e.g. Dinner, souvenirs, gas…'), 'Flight')
+    await user.type(screen.getAllByPlaceholderText('0,00')[0], '100')
+
+    // A personal expense: alice (the default "You" payer) fronted it, but nobody shares
+    // the split. The web used to drop the payer once no participants remained.
+    await user.click(screen.getByRole('button', { name: 'Y You' }))
+    await user.click(screen.getByRole('button', { name: 'B bob' }))
+
+    const addBtns = screen.getAllByRole('button', { name: 'Add expense' })
+    const submit = addBtns[addBtns.length - 1] // footer submit
+    expect(submit).not.toBeDisabled()
+    await user.click(submit)
+
+    await waitFor(() => expect(posted).toBeTruthy())
+    expect(posted!.member_ids).toEqual([])
+    expect(posted!.payers).toEqual([{ user_id: 1, amount: 100 }])
   })
 
   it('keeps "no one paid yet" when reopening a payer-less expense (#1533)', async () => {

--- a/client/src/components/Budget/CostsPanel.tsx
+++ b/client/src/components/Budget/CostsPanel.tsx
@@ -1228,11 +1228,14 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
   const save = async () => {
     if (!valid) return
     setSaving(true)
+    // A picked payer always goes out, even when nobody shares the expense: the
+    // server re-derives total_price from the payer sum (CostsPanel.helpers), so
+    // dropping the payer would store the entry with a total of 0.
     const payerList = multiPayer
       ? [...payerIds]
           .map(id => ({ user_id: id, amount: parseFloat(payerAmounts[id]) || 0 }))
           .filter(p => p.amount > 0)
-      : (payerId > 0 && participants.size > 0) ? [{ user_id: payerId, amount: totalNum }] : []
+      : payerId > 0 ? [{ user_id: payerId, amount: totalNum }] : []
     const memberList = [...participants].map(id => ({
       user_id: id,
       amount: splitMode === 'custom'


### PR DESCRIPTION
## Description
The Costs panel (web) dropped the selected payer whenever no split participants were
chosen: `CostsPanel.tsx:1235` gated the payer list on `participants.size > 0`, so a
personal expense that isn't split (a flight ticket paid by one person) was sent with
`payers: []` and lost its payment attribution — the server (`budget.service.ts:325`)
only writes payer rows when the array is non-empty.

The fix removes the `participants.size > 0` guard so a picked payer always goes out,
matching the mobile sheet (`MCostSheet.tsx:252`), which already does this. This is a
pure client payload-construction change; the server already handles a non-empty
`payers` array. "Nobody paid" remains expressible through the explicit "No one paid
yet" payer option (`payerId === 0`), and the #1286 regression test is updated to use
that option instead of relying on deselecting participants.

## Related Issue or Discussion
Closes #1766

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev` 
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally 
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed