### PR TITLE
fix(atlas): translate unvisited country names via the locale resolver

### DIFF
--- a/client/src/pages/atlas/useAtlas.test.tsx
+++ b/client/src/pages/atlas/useAtlas.test.tsx
@@ -590,6 +590,28 @@ describe('useAtlas', () => {
       expect(atlas.confirmAction).toEqual({ type: 'choose', code: 'DE', name: 'Germany' });
     });
 
+    it('FE-HOOK-ATLAS-025b: an unvisited country is named by the locale resolver, not the English GeoJSON name (#1789)', async () => {
+      // GeoJSON only carries English names; marking an unvisited country must still use the
+      // account-language name, exactly as visited countries do.
+      await mountAtlas({
+        geo: {
+          type: 'FeatureCollection',
+          features: [
+            feature({ ISO_A2: 'FR', ADM0_A3: 'FRA', ISO_A3: 'FRA', NAME: 'France', ADMIN: 'France' }),
+            feature({ ISO_A2: 'DE', ADM0_A3: 'DEU', ISO_A3: 'DEU', NAME: 'GERMANY_EN_ONLY', ADMIN: 'GERMANY_EN_ONLY' }),
+          ],
+        },
+      });
+      await waitFor(() => expect(lf.geoJson.length).toBeGreaterThan(0));
+
+      const countryLayer = lf.geoJson[0] as MockGeoJson;
+      const de = countryLayer.entries.find((e) => (e.feature.properties as Record<string, string>).ISO_A2 === 'DE');
+
+      act(() => de!.layer.handlers.click({}));
+      expect(atlas.confirmAction).toEqual({ type: 'choose', code: 'DE', name: atlas.resolveName('DE') });
+      expect(atlas.confirmAction?.name).not.toBe('GERMANY_EN_ONLY');
+    });
+
     it('FE-HOOK-ATLAS-026: plugin tint layers are drawn in their own pane and redrawn on theme change', async () => {
       await mountAtlas({
         geo: geoCountries,

--- a/client/src/pages/atlas/useAtlas.ts
+++ b/client/src/pages/atlas/useAtlas.ts
@@ -417,7 +417,7 @@ export function useAtlas() {
           const countryCode = a3ToA2Entry ? a3ToA2Entry[0] : (isoA2 && isoA2 !== '-99' ? isoA2 : null)
           if (countryCode && countryCode !== '-99') {
             country_layer_by_a2_ref.current[countryCode] = layer
-            const name = feature.properties?.NAME || feature.properties?.ADMIN || resolveName(countryCode)
+            const name = resolveName(countryCode) || feature.properties?.NAME || feature.properties?.ADMIN || countryCode
             layer.bindTooltip(`<div style="font-size:12px;font-weight:600">${name}</div>`, {
               sticky: true, className: 'atlas-tooltip', direction: 'top', offset: [0, -10], opacity: 1
             })


### PR DESCRIPTION
## Description
In the Atlas map, unvisited countries were labelled with the bundled GeoJSON's
English `NAME`, while visited countries used the account-language resolver — so a
French account saw "Pologne" once a country was visited but "Poland" until then.

Root cause: `client/src/pages/atlas/useAtlas.ts:420`, the unvisited-country branch
built its label as `feature.properties?.NAME || ... || resolveName(countryCode)`,
which always short-circuited on the English GeoJSON name and never reached the
`Intl.DisplayNames` resolver. The visited branch (`:366`) and the country search
(`:136`) already resolve first.

Fix: prefer the locale resolver and fall back to the GeoJSON name only when
resolution fails — `resolveName(countryCode) || feature.properties?.NAME || ...`.
This lives in the page hook (`use<Atlas>()`), the correct layer, and because this
same value feeds `handleMarkCountry`, it also corrects the mark dialog title and the
name persisted when a whole country is added to the bucket list.

## Related Issue or Discussion
Closes #1789

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally   
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed