### PR TITLE
fix(planner): keep the file-upload callback above the place bail-out

### DIFF
--- a/client/src/components/Planner/PlaceInspector.test.tsx
+++ b/client/src/components/Planner/PlaceInspector.test.tsx
@@ -1280,4 +1280,18 @@ describe('PlaceInspector', () => {
     await waitFor(() => expect(onUploadImage).toHaveBeenCalledWith(place.id, file));
   });
 
+  it('FE-PLANNER-INSPECTOR-098: deselecting and reselecting a place survives a rerender', async () => {
+    // The component bails out with `if (!place) return null`. Any hook below that
+    // line runs only while a place is selected, so clearing the selection changes
+    // the hook count and React tears the whole tree down.
+    const { rerender } = render(<PlaceInspector {...defaultProps} />);
+    expect(screen.getByText('Eiffel Tower')).toBeTruthy();
+
+    rerender(<PlaceInspector {...defaultProps} place={null} />);
+    expect(screen.queryByText('Eiffel Tower')).toBeNull();
+
+    rerender(<PlaceInspector {...defaultProps} />);
+    expect(screen.getByText('Eiffel Tower')).toBeTruthy();
+  });
+
 });

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -231,6 +231,31 @@ export default function PlaceInspector({
     })
   }, [place, openSavePicker])
 
+  // Sits above the `if (!place)` bail-out below: a hook after an early return is
+  // only reached while a place is selected, so deselecting one mid-session
+  // changes the hook count and React tears the tree down.
+  const placeId = place?.id
+  const handleFileUpload = useCallback(async (e) => {
+    const selectedFiles = Array.from((e.target as HTMLInputElement).files || [])
+    if (!selectedFiles.length || !onFileUpload || !placeId) return
+    setIsUploading(true)
+    try {
+      for (const file of selectedFiles) {
+        const fd = new FormData()
+        fd.append('file', file)
+        fd.append('place_id', String(placeId))
+        await onFileUpload(fd)
+      }
+      setFilesExpanded(true)
+    } catch (err: unknown) {
+      console.error('Upload failed', err)
+      toast.error(translateApiError(t, err, 'files.uploadError'))
+    } finally {
+      setIsUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }, [onFileUpload, placeId, toast, t])
+
   const startNameEdit = () => {
     if (!onUpdatePlace) return
     setNameValue(place.name || '')
@@ -282,27 +307,6 @@ export default function PlaceInspector({
   const weekdayIndex = getWeekdayIndex(selectedDay?.date, placeTimeZone)
 
   const placeFiles = (files || []).filter(f => String(f.place_id) === String(place.id) || (f.linked_place_ids || []).includes(place.id))
-
-  const handleFileUpload = useCallback(async (e) => {
-    const selectedFiles = Array.from((e.target as HTMLInputElement).files || [])
-    if (!selectedFiles.length || !onFileUpload) return
-    setIsUploading(true)
-    try {
-      for (const file of selectedFiles) {
-        const fd = new FormData()
-        fd.append('file', file)
-        fd.append('place_id', String(place.id))
-        await onFileUpload(fd)
-      }
-      setFilesExpanded(true)
-    } catch (err: unknown) {
-      console.error('Upload failed', err)
-      toast.error(translateApiError(t, err, 'files.uploadError'))
-    } finally {
-      setIsUploading(false)
-      if (fileInputRef.current) fileInputRef.current.value = ''
-    }
-  }, [onFileUpload, place.id, toast, t])
 
   return (
     <div


### PR DESCRIPTION
`PlaceInspector` bails out with `if (!place) return null`, but the `useCallback` for
`handleFileUpload` sat below that line. So the callback is only registered while a place
is selected — closing the inspector, deleting the open place or switching trips changes
the hook count between renders and React throws *Rendered fewer hooks than expected*.

There is no error boundary anywhere in the client, so that error unmounts the entire
component tree: the user gets a white page and has to reload.

The fix moves the callback above the bail-out and reads the id through `place?.id`,
matching what `handleSaveToCollection` a few lines up already does.

`FE-PLANNER-INSPECTOR-098` covers it: render with a place, rerender with `place={null}`,
rerender with the place again. Against the old code it fails inside `renderWithHooks`.
