### PR TITLE
chore(client): tighten the precache ceiling and correct the offline docs

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -24,11 +24,17 @@ export default defineConfig(({ mode }) => ({
         suppressWarnings: true,
       },
       workbox: {
-        // Anything above this is dropped from the precache manifest without failing
-        // the build, so the PWA would just be broken offline. Keep the ceiling close
-        // to the real bundle so growth shows up as a build warning instead. Revisit
-        // once route-level splitting lands and the entry chunk shrinks.
-        maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
+        // Anything above this is dropped from the precache manifest. The build does
+        // not fail over it, it only prints "won't be precached", so the ceiling has
+        // to sit close to the real bundle or an accidental heavyweight goes
+        // offline-broken unnoticed. Largest precached entry after route splitting is
+        // the heic-to chunk at 3.0 MB; the entry chunk is down to 1.2 MB.
+        maximumFileSizeToCacheInBytes: 3.5 * 1024 * 1024,
+        // Every route chunk is precached alongside the shell, deliberately: for an
+        // offline-first travel planner a route the user never opened before losing
+        // signal still has to work. The trade is that route splitting buys first
+        // paint and not install size — 107 entries / 17,795 KiB before the split,
+        // 178 / 17,826 KiB after.
         globPatterns: ['**/*.{js,css,html,svg,png,woff,woff2,ttf}'],
         // build:analyze drops a treemap next to the app; it must never end up in a
         // precache manifest if someone ships that build by accident.

--- a/wiki/Offline-Mode-and-PWA.md
+++ b/wiki/Offline-Mode-and-PWA.md
@@ -26,12 +26,15 @@ TREK uses Workbox service-worker caching plus an IndexedDB database (Dexie) for 
 
 | Content | Cache name | Strategy | Duration | Max entries |
 |---------|------------|----------|----------|-------------|
-| CartoDB / OpenStreetMap map tiles | `map-tiles` | CacheFirst | 30 days | 1 000 |
-| API responses (trips, places, bookings, etc.) | `api-data` | NetworkFirst (5 s timeout) | 24 hours | 200 |
+| CartoDB / OpenStreetMap map tiles | `map-tiles` | CacheFirst | 30 days | 12 288 |
+| Mapbox GL style, glyphs, sprites and vector tiles | `mapbox-tiles` | StaleWhileRevalidate | 30 days | 3 000 |
+| OpenFreeMap MapLibre style and tiles | `openfreemap-tiles` | StaleWhileRevalidate | 30 days | 3 000 |
 | Cover images and avatars (`/uploads/covers`, `/uploads/avatars`) | `user-uploads` | CacheFirst | 7 days | 300 |
-| App shell (HTML / JS / CSS) | precache | Precached | Until next deploy | — |
+| App shell and every page of the app (HTML / JS / CSS) | precache | Precached | Until next deploy | — |
 
-> **Note:** The API cache excludes sensitive endpoints — `/api/auth`, `/api/admin`, `/api/backup`, and `/api/settings` are always fetched from the network.
+> **Note:** API responses are **never** stored in the service-worker cache. Workbox keys its entries by URL and cannot vary them on the session cookie, so on a shared device one account's cached data could be served to the next. Offline reads come from the per-user IndexedDB cache described below instead.
+
+> **Note:** The precache covers every page, not just the one you happen to open first. A page you have never visited still works after you lose connectivity — at the cost of a larger initial install.
 
 **IndexedDB (Dexie) — structured trip data**
 


### PR DESCRIPTION
Follow-up to #1812.

The 6 MB ceiling was set against the pre-split bundle, where the entry chunk alone was 5.2 MB. It is now 1.2 MB and the largest precached entry is the `heic-to` chunk at 3.0 MB, so the old limit had nothing left to catch. Lowered to 3.5 MB.

Verified rather than assumed: a file above the ceiling is dropped from the manifest and the build still succeeds, printing only `assets/… won't be precached`. The PWA is then quietly broken offline for that file, which is why the ceiling has to stay close to the real bundle. The precache is unchanged by this PR — 188 entries either way.

Every route chunk stays precached, deliberately: for an offline-first travel planner a route the user never opened before losing signal still has to work. That is why route splitting bought first paint and not install size, and the comment now says so instead of leaving the next reader to rediscover it.

### The wiki table was wrong

`wiki/Offline-Mode-and-PWA.md` described an `api-data` cache holding API responses for 24 hours under NetworkFirst. That cache does not exist: API requests are `NetworkOnly`, because Workbox keys entries by URL and cannot vary them on the session cookie, so on a shared device one account's data could be served to the next. Documenting a cache that was deliberately removed is the wrong way round for a privacy decision.

Also corrected: map tiles were listed at 1 000 entries, the real cap is 12 288 and has to stay in step with `MAX_TILES` in `tilePrefetcher.ts`. The two GL tile caches were missing altogether.

### Worth a separate decision

`heic-to` is now the single largest precached entry at 3.0 MB — HEIC conversion for photo upload. Photo uploads require connectivity anyway (the wiki says so under Limitations), so that chunk can never be used offline. Excluding it would cut roughly a sixth off the install with nothing lost offline, but that is a product call rather than cleanup, so it is not in this PR.