### PR TITLE
fix(auth): redirect authenticated users away from /login and /register

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -291,6 +291,34 @@ describe('Public routes', () => {
   })
 })
 
+// ── PublicRoute — redirect already-authenticated visitors ─────────────────────
+
+describe('PublicRoute — already authenticated', () => {
+  it('FE-COMP-APP-012a: /login redirects to /dashboard when already authenticated', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    renderApp('/login')
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    expect(screen.queryByText('Login')).not.toBeInTheDocument()
+  })
+
+  it('FE-COMP-APP-012b: /register redirects to /dashboard when already authenticated', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    renderApp('/register')
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    expect(screen.queryByText('Login')).not.toBeInTheDocument()
+  })
+
+  it('FE-COMP-APP-012c: /login with a ?redirect= target is left to useLogin (OAuth consent handoff), not bounced', async () => {
+    // The consent page parks its URL in ?redirect= when it needs a login; that
+    // flow must reach the form even for an authenticated visitor, so the guard
+    // stays out of the way whenever a redirect target is present.
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    renderApp('/login?redirect=' + encodeURIComponent('/oauth/consent?client_id=x'))
+    await waitFor(() => expect(screen.getByText('Login')).toBeInTheDocument())
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+  })
+})
+
 // ── App — on-mount effects ─────────────────────────────────────────────────────
 
 describe('App — on-mount effects', () => {

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -294,17 +294,29 @@ describe('Public routes', () => {
 // ── PublicRoute — redirect already-authenticated visitors ─────────────────────
 
 describe('PublicRoute — already authenticated', () => {
-  it('FE-COMP-APP-012a: /login redirects to /dashboard when already authenticated', async () => {
+  /**
+   * The bounce goes to START_DESTINATION_ROUTE, so RootRedirect resolves where
+   * it actually lands — which needs settings, exactly like the cases above.
+   */
+  function seedAuthedOnDashboard() {
     seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({
+      isLoaded: true,
+      settings: buildSettings({ start_page: 'dashboard' }),
+    })
+  }
+
+  it('FE-COMP-APP-012a: /login sends an authenticated visitor to the start destination', async () => {
+    seedAuthedOnDashboard()
     renderApp('/login')
-    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    await waitFor(() => expect(currentPath()).toBe('/dashboard'))
     expect(screen.queryByText('Login')).not.toBeInTheDocument()
   })
 
-  it('FE-COMP-APP-012b: /register redirects to /dashboard when already authenticated', async () => {
-    seedAuth({ isAuthenticated: true, user: buildUser() })
+  it('FE-COMP-APP-012b: /register does the same', async () => {
+    seedAuthedOnDashboard()
     renderApp('/register')
-    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    await waitFor(() => expect(currentPath()).toBe('/dashboard'))
     expect(screen.queryByText('Login')).not.toBeInTheDocument()
   })
 
@@ -312,10 +324,21 @@ describe('PublicRoute — already authenticated', () => {
     // The consent page parks its URL in ?redirect= when it needs a login; that
     // flow must reach the form even for an authenticated visitor, so the guard
     // stays out of the way whenever a redirect target is present.
-    seedAuth({ isAuthenticated: true, user: buildUser() })
-    renderApp('/login?redirect=' + encodeURIComponent('/oauth/consent?client_id=x'))
+    seedAuthedOnDashboard()
+    const target = '/login?redirect=' + encodeURIComponent('/oauth/consent?client_id=x')
+    renderApp(target)
     await waitFor(() => expect(screen.getByText('Login')).toBeInTheDocument())
-    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+    expect(currentPath()).toBe(target)
+  })
+
+  it('FE-COMP-APP-012d: /register?invite= reaches the form so the token can be validated', async () => {
+    // An invite link is the one way someone joins a trip they were invited to
+    // from an account they are already signed into; bouncing it would swallow
+    // the token silently.
+    seedAuthedOnDashboard()
+    renderApp('/register?invite=abc123')
+    await waitFor(() => expect(screen.getByText('Login')).toBeInTheDocument())
+    expect(currentPath()).toBe('/register?invite=abc123')
   })
 })
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, ReactNode, Suspense } from 'react'
+import React, { useEffect, useState, useRef, ReactNode, Suspense } from 'react'
 import { Routes, Route, Navigate, useLocation } from 'react-router'
 import { useAuthStore } from './store/authStore'
 import { useSettingsStore } from './store/settingsStore'
@@ -155,8 +155,21 @@ function ProtectedRoute({ children, adminRequired = false, addonId }: ProtectedR
  * never sees them — including /login, where someone lands when everything else
  * failed, and the two anonymous share pages.
  */
-function PublicRoute({ children }: { children: React.ReactNode }) {
+function PublicRoute({ children, redirectAuthed = false }: { children: React.ReactNode; redirectAuthed?: boolean }) {
   const location = useLocation()
+  // redirectAuthed (only /login and /register) bounces a visitor who is already
+  // authenticated when they land here — manual URL, browser back button (#1810)
+  // — to the dashboard. Only when there is no ?redirect= target: the OAuth
+  // consent login handoff (useOAuthAuthorize.handleLoginRedirect) parks the
+  // consent URL in ?redirect= and must reach useLogin untouched — bouncing on it
+  // would drop the flow, or loop if the server still reports login_required.
+  // Capture the flag at mount so a fresh login is left alone: it flips
+  // isAuthenticated to true while the takeoff animation still plays here, before
+  // useLogin navigates away.
+  const wasAuthenticated = useRef(useAuthStore.getState().isAuthenticated)
+  if (redirectAuthed && wasAuthenticated.current && !new URLSearchParams(location.search).has('redirect')) {
+    return <Navigate to="/dashboard" replace />
+  }
   return (
     <ErrorBoundary key={location.pathname} boundaryId="public-route" level="route">
       {children}
@@ -372,10 +385,10 @@ export default function App() {
       <Suspense fallback={<RouteFallback />}>
         <Routes>
           <Route path="/" element={<RootRedirect />} />
-          <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+          <Route path="/login" element={<PublicRoute redirectAuthed><LoginPage /></PublicRoute>} />
           <Route path="/shared/:token" element={<PublicRoute><SharedTripPage /></PublicRoute>} />
           <Route path="/public/journey/:token" element={<PublicRoute><JourneyPublicPage /></PublicRoute>} />
-          <Route path="/register" element={<PublicRoute><LoginPage /></PublicRoute>} />
+          <Route path="/register" element={<PublicRoute redirectAuthed><LoginPage /></PublicRoute>} />
           <Route path="/forgot-password" element={<PublicRoute><ForgotPasswordPage /></PublicRoute>} />
           <Route path="/reset-password" element={<PublicRoute><ResetPasswordPage /></PublicRoute>} />
           {/* OAuth 2.1 consent page — intentionally outside ProtectedRoute */}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,7 @@ import { lazyWithRetry } from './utils/lazyWithRetry'
 import { useIsPhone } from './mobile/useIsPhone'
 import { TranslationProvider, useTranslation } from './i18n'
 import { authApi, tripsApi } from './api/client'
-import { readStartDestination, tripStartPath, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB, SETTINGS_WAIT_MS } from './utils/startDestination'
+import { readStartDestination, tripStartPath, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB, SETTINGS_WAIT_MS, START_DESTINATION_ROUTE } from './utils/startDestination'
 import { usePermissionsStore, PermissionLevel } from './store/permissionsStore'
 import { useInAppNotificationListener } from './hooks/useInAppNotificationListener.ts'
 import { registerSyncTriggers, unregisterSyncTriggers } from './sync/syncTriggers'
@@ -158,17 +158,21 @@ function ProtectedRoute({ children, adminRequired = false, addonId }: ProtectedR
 function PublicRoute({ children, redirectAuthed = false }: { children: React.ReactNode; redirectAuthed?: boolean }) {
   const location = useLocation()
   // redirectAuthed (only /login and /register) bounces a visitor who is already
-  // authenticated when they land here — manual URL, browser back button (#1810)
-  // — to the dashboard. Only when there is no ?redirect= target: the OAuth
-  // consent login handoff (useOAuthAuthorize.handleLoginRedirect) parks the
-  // consent URL in ?redirect= and must reach useLogin untouched — bouncing on it
-  // would drop the flow, or loop if the server still reports login_required.
+  // authenticated when they land here — manual URL, browser back button (#1810).
+  // Only on a bare URL, because every parameter this page takes is a flow that
+  // has to reach useLogin intact: ?redirect= carries the OAuth consent handoff
+  // (bouncing drops it, or loops if the server still reports login_required),
+  // ?invite= puts the form into register mode against a validated token, and
+  // ?oidc_code= / ?oidc_error= complete an external login. A visitor with any of
+  // those in the URL asked for this page on purpose.
   // Capture the flag at mount so a fresh login is left alone: it flips
   // isAuthenticated to true while the takeoff animation still plays here, before
   // useLogin navigates away.
+  // The target is START_DESTINATION_ROUTE, not /dashboard, so the bounce honours
+  // the start-page preference the same way useLogin does.
   const wasAuthenticated = useRef(useAuthStore.getState().isAuthenticated)
-  if (redirectAuthed && wasAuthenticated.current && !new URLSearchParams(location.search).has('redirect')) {
-    return <Navigate to="/dashboard" replace />
+  if (redirectAuthed && wasAuthenticated.current && !location.search) {
+    return <Navigate to={START_DESTINATION_ROUTE} replace />
   }
   return (
     <ErrorBoundary key={location.pathname} boundaryId="public-route" level="route">


### PR DESCRIPTION
## Description
`/login` and `/register` (both render `LoginPage`) had no guard for already-authenticated
visitors — `client/src/App.tsx:220,223` rendered the page unconditionally, and the only
redirect logic (`ProtectedRoute`, `RootRedirect`, `useLogin`) ran the other direction or
only on a login action. So a logged-in user typing `/login` or using the back button saw
the login form instead of being redirected.

Adds a `GuestRoute` guard mirroring the existing `RootRedirect`/`ProtectedRoute` pattern and
wraps both auth routes with it; it redirects an already-authenticated visitor to `/dashboard`
(honoring `?redirect=` with the same open-redirect guard `useLogin` uses). The flag is
captured at mount via `useRef`, so a fresh login — which flips `isAuthenticated` true while
the takeoff animation still plays on `/login` before `useLogin` navigates — is left alone.
Routing is the right layer for this, alongside the other guards, rather than inside `useLogin`.

## Related Issue or Discussion
Closes #1810

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev` 
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally 
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed