### PR TITLE
feat: open TREK on your active trip, on the tab you pick

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, waitFor, act } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, useLocation } from 'react-router'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from '../tests/helpers/msw/server'
@@ -30,10 +30,19 @@ vi.mock('./hooks/useInAppNotificationListener.ts', () => ({
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
+/** Reports the router's current location, so a test can assert where App sent it. */
+function LocationProbe() {
+  const loc = useLocation()
+  return <span data-testid="loc">{loc.pathname + loc.search}</span>
+}
+
+const currentPath = () => screen.getByTestId('loc').textContent
+
 function renderApp(initialPath = '/') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <App />
+      <LocationProbe />
     </MemoryRouter>
   )
 }
@@ -164,6 +173,22 @@ describe('ProtectedRoute — unauthenticated', () => {
     seedAuth({ isAuthenticated: false })
     renderApp('/dashboard')
     await waitFor(() => expect(screen.getByText('Login')).toBeInTheDocument())
+  })
+
+  // A session that ran out should return you to the page you were on. Pressing
+  // "log out" should not: clearing isAuthenticated re-renders this route for the
+  // page still on screen, and the ?redirect= it stamped there beat the user's
+  // startup destination on every login after the first.
+  it('FE-COMP-APP-034: keeps the return ticket when the session merely ended', async () => {
+    seedAuth({ isAuthenticated: false, loggingOut: false })
+    renderApp('/trips/1/files')
+    await waitFor(() => expect(currentPath()).toBe('/login?redirect=%2Ftrips%2F1%2Ffiles'))
+  })
+
+  it('FE-COMP-APP-035: drops it on a deliberate sign-out, so the startup destination decides', async () => {
+    seedAuth({ isAuthenticated: false, loggingOut: true })
+    renderApp('/dashboard')
+    await waitFor(() => expect(currentPath()).toBe('/login'))
   })
 
   it('FE-COMP-APP-005: /trips/42 redirects to /login when not authenticated', async () => {

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { http, HttpResponse } from 'msw'
@@ -8,6 +8,7 @@ import { useAuthStore } from './store/authStore'
 import { useSettingsStore } from './store/settingsStore'
 import { resetAllStores } from '../tests/helpers/store'
 import { buildUser, buildSettings } from '../tests/helpers/factories'
+import { SETTINGS_WAIT_MS } from './utils/startDestination'
 import App from './App'
 
 // ── Mock page components ───────────────────────────────────────────────────────
@@ -395,5 +396,44 @@ describe('Version cache-busting', () => {
     seedAuth()
     renderApp('/')
     await waitFor(() => expect(reload).toHaveBeenCalled())
+  })
+})
+
+// Regression: a device that has never mirrored the preference must not treat
+// "nothing mirrored" as "user wants the dashboard".
+describe('RootRedirect — preference not mirrored on this device', () => {
+  it('FE-COMP-APP-031: honours the server setting when localStorage is empty', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    // Cold start: settings are still in flight when RootRedirect first runs.
+    useSettingsStore.setState({ isLoaded: false })
+    server.use(http.get('/api/trips/active', () => HttpResponse.json({ trip: { id: 42, title: 'Japan' } })))
+
+    renderApp('/')
+
+    // ...and land a moment later, exactly as loadSettings() does.
+    await act(async () => {
+      useSettingsStore.setState({
+        isLoaded: true,
+        settings: buildSettings({ start_page: 'active_trip', start_trip_tab: 'finanzplan' }),
+      })
+    })
+
+    await waitFor(() => expect(screen.getByText('TripPlanner')).toBeInTheDocument())
+  })
+
+  // loadSettings leaves isLoaded false on a failed request so it can retry, so
+  // the wait above needs a floor or a launch with no backend never resolves.
+  it('FE-COMP-APP-032: gives up on the settings after the timeout and opens the dashboard', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({ isLoaded: false })
+
+    renderApp('/')
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+
+    await act(async () => { vi.advanceTimersByTime(SETTINGS_WAIT_MS + 100) })
+
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    vi.useRealTimers()
   })
 })

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -421,6 +421,20 @@ describe('RootRedirect — preference not mirrored on this device', () => {
     await waitFor(() => expect(screen.getByText('TripPlanner')).toBeInTheDocument())
   })
 
+  // Waiting for someone else's effect to fetch the settings made the decision
+  // ride on where that request landed in the queue — behind ~380 others on a
+  // cold start, which is how the redirect silently lost the race and fell
+  // through to the dashboard. It now asks for them itself.
+  it('FE-COMP-APP-033: asks for the settings itself instead of waiting to be told', async () => {
+    const loadSettings = vi.fn().mockResolvedValue(undefined)
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({ isLoaded: false, loadSettings })
+
+    renderApp('/')
+
+    await waitFor(() => expect(loadSettings).toHaveBeenCalled())
+  })
+
   // loadSettings leaves isLoaded false on a failed request so it can retry, so
   // the wait above needs a floor or a launch with no backend never resolves.
   it('FE-COMP-APP-032: gives up on the settings after the timeout and opens the dashboard', async () => {

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -81,6 +81,81 @@ describe('RootRedirect', () => {
   })
 })
 
+// ── RootRedirect — startup destination ────────────────────────────────────────
+
+describe('RootRedirect — startup destination', () => {
+  /** Serves GET /api/trips/active and reports whether it was asked at all. */
+  function stubActiveTrip(trip: { id: number; title: string } | null) {
+    const calls: string[] = []
+    server.use(
+      http.get('/api/trips/active', ({ request }) => {
+        calls.push(request.url)
+        return HttpResponse.json({ trip })
+      }),
+    )
+    return calls
+  }
+
+  it('FE-COMP-APP-026: opens the active trip on the chosen tab', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({
+      isLoaded: true,
+      settings: buildSettings({ start_page: 'active_trip', start_trip_tab: 'finanzplan' }),
+    })
+    stubActiveTrip({ id: 42, title: 'Japan' })
+
+    renderApp('/')
+    await waitFor(() => expect(screen.getByText('TripPlanner')).toBeInTheDocument())
+  })
+
+  it('FE-COMP-APP-027: falls back to the dashboard when the user has no trip', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({
+      isLoaded: true,
+      settings: buildSettings({ start_page: 'active_trip', start_trip_tab: 'finanzplan' }),
+    })
+    stubActiveTrip(null)
+
+    renderApp('/')
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+  })
+
+  it('FE-COMP-APP-028: falls back to the dashboard when the lookup fails', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({
+      isLoaded: true,
+      settings: buildSettings({ start_page: 'active_trip' }),
+    })
+    server.use(http.get('/api/trips/active', () => HttpResponse.error()))
+
+    renderApp('/')
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+  })
+
+  // The whole point of the localStorage mirror: the default launch must not pay
+  // for a lookup it doesn't need.
+  it('FE-COMP-APP-029: never asks for the active trip when starting on the dashboard', async () => {
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({ isLoaded: true, settings: buildSettings({ start_page: 'dashboard' }) })
+    const calls = stubActiveTrip({ id: 42, title: 'Japan' })
+
+    renderApp('/')
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument())
+    expect(calls).toHaveLength(0)
+  })
+
+  it('FE-COMP-APP-030: reads the preference from localStorage before settings have loaded', async () => {
+    localStorage.setItem('trek_start_page', 'active_trip')
+    localStorage.setItem('trek_start_trip_tab', 'finanzplan')
+    seedAuth({ isAuthenticated: true, user: buildUser() })
+    useSettingsStore.setState({ isLoaded: false })
+    stubActiveTrip({ id: 42, title: 'Japan' })
+
+    renderApp('/')
+    await waitFor(() => expect(screen.getByText('TripPlanner')).toBeInTheDocument())
+  })
+})
+
 // ── ProtectedRoute — unauthenticated ──────────────────────────────────────────
 
 describe('ProtectedRoute — unauthenticated', () => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -190,6 +190,7 @@ function RootRedirect() {
   const { isAuthenticated, isLoading } = useAuthStore()
   const settingsLoaded = useSettingsStore((s) => s.isLoaded)
   const settings = useSettingsStore((s) => s.settings)
+  const loadSettings = useSettingsStore((s) => s.loadSettings)
   const [target, setTarget] = useState<string | null>(null)
   // Bounds the wait below: loadSettings deliberately leaves isLoaded false on a
   // failed request so it can retry, which would otherwise strand a launch that
@@ -205,7 +206,14 @@ function RootRedirect() {
   useEffect(() => {
     if (isLoading || !isAuthenticated || target) return
     const mirrored = readStartDestination()
-    if (!mirrored && !settingsLoaded && !settingsGaveUp) return
+    if (!mirrored && !settingsLoaded && !settingsGaveUp) {
+      // Ask for the settings instead of waiting for whoever else might. The
+      // store de-dupes concurrent loads, so this is free when one is already in
+      // flight — and it stops the decision from riding on where that request
+      // happens to land in the queue behind everything else a launch fires off.
+      loadSettings()
+      return
+    }
     // Loaded settings are the truth; the mirror is what we knew last time.
     const { page, tab } = settingsLoaded
       ? { page: settings.start_page ?? DEFAULT_START_PAGE, tab: settings.start_trip_tab ?? DEFAULT_START_TRIP_TAB }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,7 @@ import { lazyWithRetry } from './utils/lazyWithRetry'
 import { useIsPhone } from './mobile/useIsPhone'
 import { TranslationProvider, useTranslation } from './i18n'
 import { authApi, tripsApi } from './api/client'
-import { readStartDestination, tripStartPath, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB } from './utils/startDestination'
+import { readStartDestination, tripStartPath, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB, SETTINGS_WAIT_MS } from './utils/startDestination'
 import { usePermissionsStore, PermissionLevel } from './store/permissionsStore'
 import { useInAppNotificationListener } from './hooks/useInAppNotificationListener.ts'
 import { registerSyncTriggers, unregisterSyncTriggers } from './sync/syncTriggers'
@@ -179,31 +179,44 @@ function ViewportRoute({ phone: Phone, desktop: Desktop }: {
  * here rather than on /dashboard — landing on the dashboard directly has to keep
  * working, or there would be no way back to it.
  *
- * The preference is read from the localStorage mirror, so the default path stays
- * exactly as fast as before: no settings request to wait for. Only someone who
- * asked for 'active_trip' pays for the one lookup that finds their trip, and a
- * failure there just falls back to the dashboard.
+ * Once this device has seen the preference it comes from the localStorage
+ * mirror, so the common launch waits for nothing. A device that has never seen
+ * it waits for the settings instead of assuming the default — the preference
+ * lives on the server, and guessing here would ignore it on every browser that
+ * didn't set it. Only 'active_trip' costs the one lookup that finds the trip,
+ * and any failure along the way lands on the dashboard.
  */
 function RootRedirect() {
   const { isAuthenticated, isLoading } = useAuthStore()
   const settingsLoaded = useSettingsStore((s) => s.isLoaded)
   const settings = useSettingsStore((s) => s.settings)
   const [target, setTarget] = useState<string | null>(null)
+  // Bounds the wait below: loadSettings deliberately leaves isLoaded false on a
+  // failed request so it can retry, which would otherwise strand a launch that
+  // started offline on the spinner.
+  const [settingsGaveUp, setSettingsGaveUp] = useState(false)
+
+  useEffect(() => {
+    if (settingsLoaded) return
+    const timer = setTimeout(() => setSettingsGaveUp(true), SETTINGS_WAIT_MS)
+    return () => clearTimeout(timer)
+  }, [settingsLoaded])
 
   useEffect(() => {
     if (isLoading || !isAuthenticated || target) return
-    // Straight after login the real settings are already in the store, so use
-    // them; on a cold start they aren't, and waiting would defeat the point.
+    const mirrored = readStartDestination()
+    if (!mirrored && !settingsLoaded && !settingsGaveUp) return
+    // Loaded settings are the truth; the mirror is what we knew last time.
     const { page, tab } = settingsLoaded
       ? { page: settings.start_page ?? DEFAULT_START_PAGE, tab: settings.start_trip_tab ?? DEFAULT_START_TRIP_TAB }
-      : readStartDestination()
+      : (mirrored ?? { page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
     if (page !== 'active_trip') { setTarget('/dashboard'); return }
     let cancelled = false
     tripsApi.active()
       .then(({ trip }) => { if (!cancelled) setTarget(trip ? tripStartPath(trip.id, tab) : '/dashboard') })
       .catch(() => { if (!cancelled) setTarget('/dashboard') })
     return () => { cancelled = true }
-  }, [isLoading, isAuthenticated, settingsLoaded, target])
+  }, [isLoading, isAuthenticated, settingsLoaded, settingsGaveUp, settings, target])
 
   if (isLoading || (isAuthenticated && !target)) {
     return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, ReactNode, Suspense } from 'react'
+import React, { useEffect, useState, ReactNode, Suspense } from 'react'
 import { Routes, Route, Navigate, useLocation } from 'react-router'
 import { useAuthStore } from './store/authStore'
 import { useSettingsStore } from './store/settingsStore'
@@ -19,7 +19,8 @@ import ErrorBoundary from './components/shared/ErrorBoundary'
 import { lazyWithRetry } from './utils/lazyWithRetry'
 import { useIsPhone } from './mobile/useIsPhone'
 import { TranslationProvider, useTranslation } from './i18n'
-import { authApi } from './api/client'
+import { authApi, tripsApi } from './api/client'
+import { readStartDestination, tripStartPath, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB } from './utils/startDestination'
 import { usePermissionsStore, PermissionLevel } from './store/permissionsStore'
 import { useInAppNotificationListener } from './hooks/useInAppNotificationListener.ts'
 import { registerSyncTriggers, unregisterSyncTriggers } from './sync/syncTriggers'
@@ -172,10 +173,39 @@ function ViewportRoute({ phone: Phone, desktop: Desktop }: {
   return isPhone ? <Phone /> : <Desktop />
 }
 
+/**
+ * The entry point every shortcut, bookmark and the installed PWA share
+ * (manifest start_url is '/'), which is why the startup destination is decided
+ * here rather than on /dashboard — landing on the dashboard directly has to keep
+ * working, or there would be no way back to it.
+ *
+ * The preference is read from the localStorage mirror, so the default path stays
+ * exactly as fast as before: no settings request to wait for. Only someone who
+ * asked for 'active_trip' pays for the one lookup that finds their trip, and a
+ * failure there just falls back to the dashboard.
+ */
 function RootRedirect() {
   const { isAuthenticated, isLoading } = useAuthStore()
+  const settingsLoaded = useSettingsStore((s) => s.isLoaded)
+  const settings = useSettingsStore((s) => s.settings)
+  const [target, setTarget] = useState<string | null>(null)
 
-  if (isLoading) {
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || target) return
+    // Straight after login the real settings are already in the store, so use
+    // them; on a cold start they aren't, and waiting would defeat the point.
+    const { page, tab } = settingsLoaded
+      ? { page: settings.start_page ?? DEFAULT_START_PAGE, tab: settings.start_trip_tab ?? DEFAULT_START_TRIP_TAB }
+      : readStartDestination()
+    if (page !== 'active_trip') { setTarget('/dashboard'); return }
+    let cancelled = false
+    tripsApi.active()
+      .then(({ trip }) => { if (!cancelled) setTarget(trip ? tripStartPath(trip.id, tab) : '/dashboard') })
+      .catch(() => { if (!cancelled) setTarget('/dashboard') })
+    return () => { cancelled = true }
+  }, [isLoading, isAuthenticated, settingsLoaded, target])
+
+  if (isLoading || (isAuthenticated && !target)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-slate-50">
         <div className="w-10 h-10 border-4 border-slate-200 border-t-slate-900 rounded-full animate-spin"></div>
@@ -183,7 +213,7 @@ function RootRedirect() {
     )
   }
 
-  return <Navigate to={isAuthenticated ? '/dashboard' : '/login'} replace />
+  return <Navigate to={isAuthenticated ? (target ?? '/dashboard') : '/login'} replace />
 }
 
 /**

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -82,6 +82,7 @@ function ProtectedRoute({ children, adminRequired = false, addonId }: ProtectedR
   const user = useAuthStore((s) => s.user)
   const isLoading = useAuthStore((s) => s.isLoading)
   const appRequireMfa = useAuthStore((s) => s.appRequireMfa)
+  const loggingOut = useAuthStore((s) => s.loggingOut)
   const addonStore = useAddonStore()
   const { t } = useTranslation()
   const location = useLocation()
@@ -99,6 +100,10 @@ function ProtectedRoute({ children, adminRequired = false, addonId }: ProtectedR
   }
 
   if (!isAuthenticated) {
+    // A session that ended on its own should come back to where it left off; a
+    // deliberate sign-out is a fresh start and gets no return ticket, so the
+    // startup destination decides where the next login lands.
+    if (loggingOut) return <Navigate to="/login" replace />
     const redirectParam = encodeURIComponent(location.pathname + location.search + location.hash)
     return <Navigate to={`/login?redirect=${redirectParam}`} replace />
   }

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -19,7 +19,7 @@ import {
   type TripAddMemberRequest, type TripTransferOwnershipRequest,
   type TripCreateGuestRequest, type TripRenameGuestRequest, type AssignmentReorderRequest,
   type PackingReorderRequest, type PackingCreateBagRequest, type TodoReorderRequest,
-  type TripCreateRequest, type TripUpdateRequest, type TripCopyRequest,
+  type TripCreateRequest, type TripUpdateRequest, type TripCopyRequest, type ActiveTripResponse,
   type DayCreateRequest, type DayUpdateRequest, type DayReorderRequest,
   type PlaceCreateRequest, type PlaceUpdateRequest,
   type ReservationCreateRequest, type ReservationUpdateRequest,
@@ -372,6 +372,9 @@ export const tripsApi = {
   list: (params?: Record<string, unknown>) => apiClient.get('/trips', { params }).then(r => r.data),
   create: (data: TripCreateRequest) => apiClient.post('/trips', data).then(r => r.data),
   get: (id: number | string) => apiClient.get(`/trips/${id}`).then(r => r.data),
+  // The startup redirect's one lookup — deliberately not list(), which would pull
+  // every trip with its counts just to read one id.
+  active: (): Promise<ActiveTripResponse> => apiClient.get('/trips/active').then(r => r.data),
   update: (id: number | string, data: TripUpdateRequest) => apiClient.put(`/trips/${id}`, data).then(r => r.data),
   delete: (id: number | string) => apiClient.delete(`/trips/${id}`).then(r => r.data),
   uploadCover: (id: number | string, formData: FormData) => postMultipart(`/trips/${id}/cover`, formData),

--- a/client/src/components/Settings/DisplaySettingsTab.test.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-DISPLAY-001 to FE-COMP-DISPLAY-048
+// FE-COMP-DISPLAY-001 to FE-COMP-DISPLAY-052
 import { render, screen, within, fireEvent } from '../../../tests/helpers/render';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -393,5 +393,54 @@ describe('DisplaySettingsTab – Map and privacy toggles', () => {
     await user.click(screen.getByRole('button', { name: /24h/ }));
 
     expect(screen.getAllByText('Nope').length).toBeGreaterThan(0);
+  });
+});
+
+describe('DisplaySettingsTab – startup destination', () => {
+  it('FE-COMP-DISPLAY-049: defaults to the dashboard and hides the tab picker', () => {
+    seedStore(useSettingsStore, { settings: buildSettings() });
+    render(<DisplaySettingsTab />);
+    const block = optionBlock(/^Start page$/);
+
+    expect(within(block).getByText('Dashboard').closest('button')!.style.border).toContain('var(--text-primary)');
+    // Nothing to pick a tab for while TREK opens on the dashboard.
+    expect(screen.queryByText('Start tab')).not.toBeInTheDocument();
+  });
+
+  it('FE-COMP-DISPLAY-050: choosing the active trip saves it and reveals the tab picker', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, { settings: buildSettings(), updateSetting });
+    render(<DisplaySettingsTab />);
+
+    await user.click(within(optionBlock(/^Start page$/)).getByText('Active trip'));
+
+    expect(updateSetting).toHaveBeenCalledWith('start_page', 'active_trip');
+  });
+
+  it('FE-COMP-DISPLAY-051: with the active trip chosen, the tab picker stores the planner tab id', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, {
+      settings: buildSettings({ start_page: 'active_trip', start_trip_tab: 'plan' }),
+      updateSetting,
+    });
+    render(<DisplaySettingsTab />);
+
+    await user.click(screen.getByRole('button', { name: 'Plan' }));
+    await user.click(await screen.findByText('Costs'));
+
+    // The German legacy id, not the English label the user sees.
+    expect(updateSetting).toHaveBeenCalledWith('start_trip_tab', 'finanzplan');
+  });
+
+  it('FE-COMP-DISPLAY-052: a rejected start-page change surfaces the error', async () => {
+    const user = userEvent.setup();
+    seedFailing('Start locked');
+    render(<><ToastContainer /><DisplaySettingsTab /></>);
+
+    await user.click(within(optionBlock(/^Start page$/)).getByText('Active trip'));
+
+    await screen.findByText('Start locked');
   });
 });

--- a/client/src/components/Settings/DisplaySettingsTab.tsx
+++ b/client/src/components/Settings/DisplaySettingsTab.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Languages, Map, ChevronDown, Check } from 'lucide-react'
+import { Languages, Map, ChevronDown, Check, Rocket } from 'lucide-react'
 import { SUPPORTED_LANGUAGES, useTranslation } from '../../i18n'
 import { useSettingsStore, DEFAULT_SETTINGS } from '../../store/settingsStore'
 import { useToast } from '../shared/Toast'
 import CustomSelect from '../shared/CustomSelect'
 import { SYMBOLS, currenciesWith } from '../Budget/BudgetPanel.constants'
 import Section from './Section'
+import { TRIP_TAB_IDS, TRIP_TAB_LABEL_KEYS } from '../../constants/tripTabs'
+import { DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB } from '../../utils/startDestination'
 import type { DistanceUnit } from '../../types'
 
 export default function DisplaySettingsTab(): React.ReactElement {
@@ -34,8 +36,60 @@ export default function DisplaySettingsTab(): React.ReactElement {
     setDistanceUnit(settings.distance_unit || DEFAULT_SETTINGS.distance_unit)
   }, [settings.distance_unit])
 
+  const startPage = settings.start_page === 'active_trip' ? 'active_trip' : DEFAULT_START_PAGE
+  const startTripTab = settings.start_trip_tab || DEFAULT_START_TRIP_TAB
+
   return (
     <>
+      <Section title={t('settings.general.startup')} icon={Rocket}>
+      {/* Where opening TREK lands */}
+      <div>
+        <label className="block text-sm font-medium mb-2 text-content-secondary">{t('settings.startPage')}</label>
+        <div className="flex gap-3">
+          {([
+            { value: 'dashboard', label: t('settings.startPageDashboard') },
+            { value: 'active_trip', label: t('settings.startPageActiveTrip') },
+          ] as const).map(opt => (
+            <button
+              key={opt.value}
+              onClick={async () => {
+                try { await updateSetting('start_page', opt.value) }
+                catch (e: unknown) { toast.error(e instanceof Error ? e.message : t('common.error')) }
+              }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '10px 20px', borderRadius: 10, cursor: 'pointer',
+                fontFamily: 'inherit', fontSize: 'calc(14px * var(--fs-scale-body, 1))', fontWeight: 500,
+                border: startPage === opt.value ? '2px solid var(--text-primary)' : '2px solid var(--border-primary)',
+                background: startPage === opt.value ? 'var(--bg-hover)' : 'var(--bg-card)',
+                color: 'var(--text-primary)',
+                transition: 'all 0.15s',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs mt-1 text-content-faint">{t('settings.startPageHint')}</p>
+      </div>
+
+      {/* Which planner tab the trip opens on — only meaningful for 'active_trip' */}
+      {startPage === 'active_trip' && (
+        <div>
+          <label className="block text-sm font-medium mb-2 text-content-secondary">{t('settings.startTripTab')}</label>
+          <CustomSelect
+            value={startTripTab}
+            onChange={async v => {
+              try { await updateSetting('start_trip_tab', String(v)) }
+              catch (e: unknown) { toast.error(e instanceof Error ? e.message : t('common.error')) }
+            }}
+            options={TRIP_TAB_IDS.map(id => ({ value: id, label: t(TRIP_TAB_LABEL_KEYS[id]) }))}
+          />
+          <p className="text-xs text-content-faint mt-2">{t('settings.startTripTabHint')}</p>
+        </div>
+      )}
+      </Section>
+
       <Section title={t('settings.general.languageRegion')} icon={Languages}>
       {/* Display currency */}
       <div>

--- a/client/src/constants/tripTabs.ts
+++ b/client/src/constants/tripTabs.ts
@@ -1,0 +1,50 @@
+/**
+ * The trip planner's core tab ids, in the order the tab bar shows them.
+ *
+ * These are the German legacy names the planner has always used internally
+ * ('buchungen', 'finanzplan', 'dateien', 'listen') — not the English labels.
+ * They are what sessionStorage, the ?tab= deep link and the startup-destination
+ * setting persist, so renaming one would silently strand saved preferences.
+ *
+ * Addon-owned tabs are listed here even while their addon is off: useTripPlanner
+ * builds TRIP_TABS from what is actually enabled, and anything pointing at a tab
+ * that isn't there falls back to the plan view.
+ */
+export const TRIP_TAB_IDS = [
+  'plan',
+  'transports',
+  'buchungen',
+  'listen',
+  'finanzplan',
+  'dateien',
+  'collab',
+] as const
+
+export type TripTabId = (typeof TRIP_TAB_IDS)[number]
+
+/**
+ * Translation key per tab, so the startup-destination picker in Settings names
+ * the tabs exactly as the planner's own tab bar does. useTripPlanner builds its
+ * TRIP_TABS from these too — one source, or the two would drift apart the first
+ * time a tab is renamed.
+ */
+export const TRIP_TAB_LABEL_KEYS: Record<TripTabId, string> = {
+  plan: 'trip.tabs.plan',
+  transports: 'trip.tabs.transports',
+  buchungen: 'trip.tabs.reservations',
+  listen: 'trip.tabs.lists',
+  finanzplan: 'trip.tabs.budget',
+  dateien: 'trip.tabs.files',
+  collab: 'admin.addons.catalog.collab.name',
+}
+
+export const isTripTabId = (value: unknown): value is TripTabId =>
+  typeof value === 'string' && (TRIP_TAB_IDS as readonly string[]).includes(value)
+
+/**
+ * What `/trips/:id?tab=…` accepts. Trip-page plugins mount as tabs too and are
+ * addressable by their `plugin:<id>` form, so a shortcut can point at one — the
+ * planner's own guard still drops it if that plugin isn't installed.
+ */
+export const isDeepLinkableTripTab = (value: string): boolean =>
+  isTripTabId(value) || value.startsWith('plugin:')

--- a/client/src/mobile/screens/settings/MSettingsGeneral.tsx
+++ b/client/src/mobile/screens/settings/MSettingsGeneral.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
-import { ChevronDown, Languages, Map } from 'lucide-react'
+import { ChevronDown, Languages, Map, Rocket } from 'lucide-react'
 import { useTranslation, SUPPORTED_LANGUAGES } from '../../../i18n'
 import { useSettingsStore } from '../../../store/settingsStore'
 import { useToast } from '../../../components/shared/Toast'
 import { SYMBOLS, currenciesWith } from '../../../components/Budget/BudgetPanel.constants'
+import { TRIP_TAB_IDS, TRIP_TAB_LABEL_KEYS, isTripTabId } from '../../../constants/tripTabs'
+import { DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB, type StartPage } from '../../../utils/startDestination'
 import type { Settings, DistanceUnit } from '../../../types'
 import { MSetCard, MSetEyebrow, MSetSelectRow, MSetSegments, MSetRow } from './MSettingsUi'
 import MToggle from '../../components/MToggle'
@@ -19,6 +21,7 @@ export default function MSettingsGeneral() {
   const { settings, updateSetting } = useSettingsStore()
   const [currencyOpen, setCurrencyOpen] = useState(false)
   const [langOpen, setLangOpen] = useState(false)
+  const [startTabOpen, setStartTabOpen] = useState(false)
 
   const save = async (key: keyof Settings, value: Settings[keyof Settings]) => {
     try {
@@ -28,6 +31,8 @@ export default function MSettingsGeneral() {
     }
   }
 
+  const startPage: StartPage = settings.start_page === 'active_trip' ? 'active_trip' : DEFAULT_START_PAGE
+  const startTripTab = isTripTabId(settings.start_trip_tab) ? settings.start_trip_tab : DEFAULT_START_TRIP_TAB
   const currency = settings.default_currency || ''
   const currencyLabel = currency ? `${currency} — ${SYMBOLS[currency] || currency}` : t('settings.currencyTrip')
   const language = SUPPORTED_LANGUAGES.find((l) => l.value === settings.language) || SUPPORTED_LANGUAGES[0]
@@ -73,7 +78,29 @@ export default function MSettingsGeneral() {
 
   return (
     <>
-      <MSetCard title={t('settings.general.languageRegion')} icon={Languages}>
+      <MSetCard title={t('settings.general.startup')} icon={Rocket}>
+        <MSetEyebrow className="mb-[6px]">{t('settings.startPage')}</MSetEyebrow>
+        <MSetSegments<StartPage>
+          value={startPage}
+          onChange={(v) => save('start_page', v)}
+          options={[
+            { value: 'dashboard', label: t('settings.startPageDashboard') },
+            { value: 'active_trip', label: t('settings.startPageActiveTrip') },
+          ]}
+        />
+        {startPage === 'active_trip' && (
+          <>
+            <MSetEyebrow className="mb-[5px] mt-[14px]">{t('settings.startTripTab')}</MSetEyebrow>
+            <MSetSelectRow
+              label={t(TRIP_TAB_LABEL_KEYS[startTripTab])}
+              trailing={chevron}
+              onClick={() => setStartTabOpen(true)}
+            />
+          </>
+        )}
+      </MSetCard>
+
+      <MSetCard title={t('settings.general.languageRegion')} icon={Languages} className="mt-3">
         <MSetEyebrow className="mb-[5px]">{t('settings.currency')}</MSetEyebrow>
         <MSetSelectRow label={currencyLabel} trailing={chevron} onClick={() => setCurrencyOpen(true)} />
 
@@ -149,6 +176,15 @@ export default function MSettingsGeneral() {
         value={settings.language}
         onSelect={(v) => save('language', v)}
         options={SUPPORTED_LANGUAGES.map((l) => ({ value: l.value, label: l.label }))}
+      />
+
+      <MSetPickerSheet
+        open={startTabOpen}
+        onClose={() => setStartTabOpen(false)}
+        title={t('settings.startTripTab')}
+        value={startTripTab}
+        onSelect={(v) => save('start_trip_tab', v)}
+        options={TRIP_TAB_IDS.map((id) => ({ value: id, label: t(TRIP_TAB_LABEL_KEYS[id]) }))}
       />
     </>
   )

--- a/client/src/pages/LoginPage.oidc-redirect.test.tsx
+++ b/client/src/pages/LoginPage.oidc-redirect.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '../../tests/helpers/render';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../tests/helpers/msw/server';
 import { resetAllStores } from '../../tests/helpers/store';
+import { START_DESTINATION_ROUTE } from '../utils/startDestination';
 import LoginPage from './LoginPage';
 
 const mockNavigate = vi.fn();
@@ -81,12 +82,12 @@ describe('LoginPage — OIDC redirect preservation', () => {
       expect(sessionStorage.getItem('oidc_redirect')).toBeNull();
     });
 
-    it('falls back to /dashboard when no sessionStorage redirect is set', async () => {
+    it('falls back to the startup destination when no sessionStorage redirect is set', async () => {
       setSearch('?oidc_code=testcode123');
       render(<LoginPage />);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+        expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE, { replace: true });
       });
     });
   });

--- a/client/src/pages/login/useLogin.test.tsx
+++ b/client/src/pages/login/useLogin.test.tsx
@@ -11,6 +11,7 @@ import { TranslationProvider } from '../../i18n/TranslationContext';
 import { useAuthStore, type LoginResult } from '../../store/authStore';
 import { useSettingsStore } from '../../store/settingsStore';
 import { startAuthentication } from '@simplewebauthn/browser';
+import { START_DESTINATION_ROUTE } from '../../utils/startDestination';
 import { useLogin } from './useLogin';
 
 const mockNavigate = vi.fn();
@@ -242,6 +243,30 @@ describe('useLogin — redirect target', () => {
 
     expect(sessionStorage.getItem('oidc_redirect')).toBeNull();
   });
+
+  it('FE-LOGIN-HOOK-056: without a redirect param it defers to the startup destination, not the dashboard', async () => {
+    setSearch('');
+    const { result } = renderLogin();
+    await ready(result);
+
+    // Nothing stashed: '/' is the resolver route, not a place worth returning to.
+    expect(sessionStorage.getItem('oidc_redirect')).toBeNull();
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await act(async () => {
+      await result.current.handleDemoLogin();
+    });
+    act(() => { vi.advanceTimersByTime(2600); });
+    expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE);
+  });
+
+  it('FE-LOGIN-HOOK-057: an explicit redirect still beats the startup destination', async () => {
+    setSearch('?redirect=/trips/9%3Ftab%3Dfinanzplan');
+    const { result } = renderLogin();
+    await ready(result);
+
+    expect(sessionStorage.getItem('oidc_redirect')).toBe('/trips/9?tab=finanzplan');
+  });
 });
 
 describe('useLogin — invite links', () => {
@@ -293,7 +318,7 @@ describe('useLogin — OIDC callback', () => {
     );
 
     renderLogin();
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE, { replace: true }));
 
     // Switching language rebuilds `t`, which the callback effect depends on.
     await act(async () => {
@@ -507,7 +532,7 @@ describe('useLogin — passkey login', () => {
     act(() => {
       vi.advanceTimersByTime(2600);
     });
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE);
   });
 
   it.each(['NotAllowedError', 'AbortError'])(
@@ -654,7 +679,7 @@ describe('useLogin — password submit', () => {
     act(() => {
       vi.advanceTimersByTime(2600);
     });
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE);
   });
 
   it('FE-LOGIN-HOOK-040: stops on a dropped Secure cookie instead of dead-ending later', async () => {
@@ -790,7 +815,7 @@ describe('useLogin — MFA step', () => {
     act(() => {
       vi.advanceTimersByTime(2600);
     });
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE);
   });
 
   it('FE-LOGIN-HOOK-047: hands over to the password-change step after MFA when the account is flagged', async () => {
@@ -888,7 +913,7 @@ describe('useLogin — forced password change', () => {
     act(() => {
       vi.advanceTimersByTime(2600);
     });
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    expect(mockNavigate).toHaveBeenCalledWith(START_DESTINATION_ROUTE);
   });
 
   it('FE-LOGIN-HOOK-052: surfaces a rejected password change', async () => {

--- a/client/src/pages/login/useLogin.ts
+++ b/client/src/pages/login/useLogin.ts
@@ -62,7 +62,7 @@ export function useLogin() {
   const [confirmPassword, setConfirmPassword] = useState('')
 
   const { login, register, demoLogin, completeMfaLogin, loadUser } = useAuthStore()
-  const { setLanguageLocal, setLanguageTransient } = useSettingsStore()
+  const { setLanguageLocal, setLanguageTransient, loadSettings } = useSettingsStore()
   const navigate = useNavigate()
   const location = useLocation()
   const noRedirect = !!(location.state as { noRedirect?: boolean } | null)?.noRedirect
@@ -84,6 +84,18 @@ export function useLogin() {
       sessionStorage.setItem('oidc_redirect', redirectTarget)
     }
   }, [redirectTarget])
+
+  /**
+   * Start the takeoff animation, and spend those 2.6 seconds fetching the
+   * settings instead of letting them sit idle. Whoever we hand over to then
+   * already has them — which matters for the startup destination, decided the
+   * moment we navigate, and otherwise racing this exact request.
+   */
+  const takeOff = (): void => {
+    setShowTakeoff(true)
+    loadSettings()
+    setTimeout(() => navigate(redirectTarget), 2600)
+  }
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -197,8 +209,7 @@ export function useLogin() {
     setIsLoading(true)
     try {
       await demoLogin()
-      setShowTakeoff(true)
-      setTimeout(() => navigate(redirectTarget), 2600)
+      takeOff()
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : t('login.demoFailed'))
     } finally {
@@ -214,8 +225,7 @@ export function useLogin() {
       const assertion = await startAuthentication({ optionsJSON: options })
       await authApi.passkey.loginVerify(assertion)
       await loadUser({ silent: true })
-      setShowTakeoff(true)
-      setTimeout(() => navigate(redirectTarget), 2600)
+      takeOff()
     } catch (err: unknown) {
       // The user dismissing the native prompt isn't an error worth surfacing.
       const name = (err as { name?: string })?.name
@@ -240,8 +250,7 @@ export function useLogin() {
         if (newPassword !== confirmPassword) { setError(t('settings.passwordMismatch')); setIsLoading(false); return }
         await authApi.changePassword({ current_password: savedLoginPassword, new_password: newPassword })
         await loadUser({ silent: true })
-        setShowTakeoff(true)
-        setTimeout(() => navigate(redirectTarget), 2600)
+        takeOff()
         return
       }
       if (mode === 'login' && mfaStep) {
@@ -257,8 +266,7 @@ export function useLogin() {
           setIsLoading(false)
           return
         }
-        setShowTakeoff(true)
-        setTimeout(() => navigate(redirectTarget), 2600)
+        takeOff()
         return
       }
       if (mode === 'register') {
@@ -288,8 +296,7 @@ export function useLogin() {
           return
         }
       }
-      setShowTakeoff(true)
-      setTimeout(() => navigate(redirectTarget), 2600)
+      takeOff()
     } catch (err: unknown) {
       setError(getApiErrorMessage(err, t('login.error')))
       setIsLoading(false)

--- a/client/src/pages/login/useLogin.ts
+++ b/client/src/pages/login/useLogin.ts
@@ -6,6 +6,7 @@ import { useTranslation, detectBrowserLanguage } from '../../i18n'
 import { startAuthentication } from '@simplewebauthn/browser'
 import { authApi, configApi } from '../../api/client'
 import { getApiErrorMessage } from '../../types'
+import { START_DESTINATION_ROUTE } from '../../utils/startDestination'
 
 interface AppConfig {
   has_users: boolean
@@ -73,11 +74,13 @@ export function useLogin() {
     if (redirect && redirect.startsWith('/') && !redirect.startsWith('//') && !redirect.startsWith('/\\')) {
       return redirect
     }
-    return '/dashboard'
+    // No page to return to: hand the choice to RootRedirect, which is the one
+    // place that knows whether this user starts on the dashboard or in a trip.
+    return START_DESTINATION_ROUTE
   }, [])
 
   useEffect(() => {
-    if (redirectTarget !== '/dashboard') {
+    if (redirectTarget !== START_DESTINATION_ROUTE) {
       sessionStorage.setItem('oidc_redirect', redirectTarget)
     }
   }, [redirectTarget])
@@ -110,7 +113,7 @@ export function useLogin() {
           window.history.replaceState({}, '', '/login')
           if (data.token) {
             await loadUser()
-            const savedRedirect = sessionStorage.getItem('oidc_redirect') || '/dashboard'
+            const savedRedirect = sessionStorage.getItem('oidc_redirect') || START_DESTINATION_ROUTE
             sessionStorage.removeItem('oidc_redirect')
             navigate(savedRedirect, { replace: true })
           } else {

--- a/client/src/pages/tripPlanner/useTripPlanner.test.tsx
+++ b/client/src/pages/tripPlanner/useTripPlanner.test.tsx
@@ -1,4 +1,4 @@
-// FE-TP-HOOK-001 to FE-TP-HOOK-103
+// FE-TP-HOOK-001 to FE-TP-HOOK-110
 import React from 'react'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { TranslationProvider } from '../../i18n/TranslationContext'
@@ -500,6 +500,85 @@ describe('useTripPlanner — tabs', () => {
     const { result } = await renderPlanner()
 
     expect(result.current.activeTab).toBe('plugin:late')
+  })
+
+  // ── ?tab= deep link (startup destination, shortcuts, wrapper apps) ──────────
+
+  it('FE-TP-HOOK-104: ?tab= opens that tab on the very first render and clears the param', async () => {
+    vi.mocked(addonsApi.enabled).mockResolvedValue({ addons: [{ id: 'budget' }] })
+    searchParams = new URLSearchParams('tab=finanzplan')
+    seedTrip()
+
+    const { result } = await renderPlanner()
+
+    // No frame on 'plan' first — the tab is right from the initial state.
+    expect(result.current.activeTab).toBe('finanzplan')
+    await waitFor(() => expect(searchParams.get('tab')).toBeNull())
+  })
+
+  it('FE-TP-HOOK-105: ?tab= beats the tab the last session ended on', async () => {
+    sessionStorage.setItem('trip-tab-42', 'buchungen')
+    searchParams = new URLSearchParams('tab=transports')
+    seedTrip()
+
+    const { result } = await renderPlanner()
+
+    expect(result.current.activeTab).toBe('transports')
+    await waitFor(() => expect(sessionStorage.getItem('trip-tab-42')).toBe('transports'))
+  })
+
+  it('FE-TP-HOOK-106: a junk ?tab= is ignored rather than rendering a dead panel', async () => {
+    searchParams = new URLSearchParams('tab=../../etc/passwd')
+    seedTrip()
+
+    const { result } = await renderPlanner()
+
+    expect(result.current.activeTab).toBe('plan')
+  })
+
+  // The lazy loads live in handleTabChange, which a deep link never goes through.
+  it('FE-TP-HOOK-107: starting on Costs still loads the budget items', async () => {
+    vi.mocked(addonsApi.enabled).mockResolvedValue({ addons: [{ id: 'budget' }] })
+    searchParams = new URLSearchParams('tab=finanzplan')
+    seedTrip()
+
+    await renderPlanner()
+
+    await waitFor(() => expect(actions.loadBudgetItems).toHaveBeenCalledWith(42))
+  })
+
+  it('FE-TP-HOOK-108: starting on Files still loads the files', async () => {
+    vi.mocked(addonsApi.enabled).mockResolvedValue({ addons: [{ id: 'documents' }] })
+    searchParams = new URLSearchParams('tab=dateien')
+    seedTrip()
+
+    await renderPlanner()
+
+    await waitFor(() => expect(actions.loadFiles).toHaveBeenCalledWith(42))
+  })
+
+  // enabledAddons is an optimistic guess until the feed answers, and 'collab'
+  // is guessed off — evicting on that guess would drop a requested tab.
+  it('FE-TP-HOOK-109: a requested collab tab survives until the addon feed answers', async () => {
+    vi.mocked(addonsApi.enabled).mockResolvedValue({ addons: [{ id: 'collab' }] })
+    searchParams = new URLSearchParams('tab=collab')
+    seedTrip()
+
+    const { result } = await renderPlanner()
+
+    expect(result.current.activeTab).toBe('collab')
+    await waitFor(() => expect(result.current.TRIP_TABS.map(t => t.id)).toContain('collab'))
+    expect(result.current.activeTab).toBe('collab')
+  })
+
+  it('FE-TP-HOOK-110: but a tab whose addon really is off still falls back to plan', async () => {
+    vi.mocked(addonsApi.enabled).mockResolvedValue({ addons: [] })
+    searchParams = new URLSearchParams('tab=finanzplan')
+    seedTrip()
+
+    const { result } = await renderPlanner()
+
+    await waitFor(() => expect(result.current.activeTab).toBe('plan'))
   })
 })
 

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -27,6 +27,7 @@ import { usePluginStore } from '../../store/pluginStore'
 import type { Accommodation, TripMember, Day, Place, Reservation } from '../../types'
 import { DEFAULT_MAP_LAT, DEFAULT_MAP_LNG, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 import { resolvePoolAssignmentId } from './tripPlannerModel'
+import { isDeepLinkableTripTab, TRIP_TAB_LABEL_KEYS } from '../../constants/tripTabs'
 import { isRoutableReservation } from '../../utils/reservationRoutes'
 import {
   parseStoredConnections, resolveEffectiveConnections, resolveVisibleConnectionIds,
@@ -81,6 +82,10 @@ export function useTripPlanner() {
   }, [undo, lastActionLabel, toast])
 
   const [enabledAddons, setEnabledAddons] = useState<Record<string, boolean>>({ packing: true, budget: true, documents: true, collab: false })
+  // The values above are an optimistic guess until the addon feed answers. The
+  // tab guard below waits for this before evicting anything, so a tab we were
+  // asked to open ('collab' in particular, guessed off) survives the gap.
+  const [addonsLoaded, setAddonsLoaded] = useState<boolean>(false)
   const [collabFeatures, setCollabFeatures] = useState<{ chat: boolean; notes: boolean; polls: boolean; whatsnext: boolean }>({ chat: true, notes: true, polls: true, whatsnext: true })
   const [tripAccommodations, setTripAccommodations] = useState<Accommodation[]>([])
   const [allowedFileTypes, setAllowedFileTypes] = useState<string | null>(null)
@@ -109,7 +114,7 @@ export function useTripPlanner() {
       data.addons.forEach(a => { map[a.id] = true })
       setEnabledAddons({ packing: !!map.packing, budget: !!map.budget, documents: !!map.documents, collab: !!map.collab })
       if (data.collabFeatures) setCollabFeatures(data.collabFeatures)
-    }).catch(() => {})
+    }).catch(() => {}).finally(() => setAddonsLoaded(true))
     authApi.getAppConfig().then(config => {
       if (config.allowed_file_types) setAllowedFileTypes(config.allowed_file_types)
     }).catch(() => {})
@@ -124,13 +129,13 @@ export function useTripPlanner() {
   // them; 'plan' is never replaceable) and may pick where its own tab sits.
   const replacedTabs = new Set(tripPagePlugins.flatMap(p => p.tripPage?.replaces ?? []))
   const TRIP_TABS = [
-    { id: 'plan', label: t('trip.tabs.plan'), icon: Map },
-    { id: 'transports', label: t('trip.tabs.transports'), icon: Train },
-    { id: 'buchungen', label: t('trip.tabs.reservations'), shortLabel: t('trip.tabs.reservationsShort'), icon: Ticket },
-    ...(enabledAddons.packing ? [{ id: 'listen', label: t('trip.tabs.lists'), shortLabel: t('trip.tabs.listsShort'), icon: PackageCheck }] : []),
-    ...(enabledAddons.budget ? [{ id: 'finanzplan', label: t('trip.tabs.budget'), icon: Wallet }] : []),
-    ...(enabledAddons.documents ? [{ id: 'dateien', label: t('trip.tabs.files'), icon: FolderOpen }] : []),
-    ...(enabledAddons.collab ? [{ id: 'collab', label: t('admin.addons.catalog.collab.name'), icon: Users }] : []),
+    { id: 'plan', label: t(TRIP_TAB_LABEL_KEYS.plan), icon: Map },
+    { id: 'transports', label: t(TRIP_TAB_LABEL_KEYS.transports), icon: Train },
+    { id: 'buchungen', label: t(TRIP_TAB_LABEL_KEYS.buchungen), shortLabel: t('trip.tabs.reservationsShort'), icon: Ticket },
+    ...(enabledAddons.packing ? [{ id: 'listen', label: t(TRIP_TAB_LABEL_KEYS.listen), shortLabel: t('trip.tabs.listsShort'), icon: PackageCheck }] : []),
+    ...(enabledAddons.budget ? [{ id: 'finanzplan', label: t(TRIP_TAB_LABEL_KEYS.finanzplan), icon: Wallet }] : []),
+    ...(enabledAddons.documents ? [{ id: 'dateien', label: t(TRIP_TAB_LABEL_KEYS.dateien), icon: FolderOpen }] : []),
+    ...(enabledAddons.collab ? [{ id: 'collab', label: t(TRIP_TAB_LABEL_KEYS.collab), icon: Users }] : []),
   ].filter(tab => tab.id === 'plan' || !replacedTabs.has(tab.id))
   // Positioned plugin tabs splice in ascending order so two positions stay stable;
   // the rest append, exactly as before this capability existed.
@@ -138,20 +143,31 @@ export function useTripPlanner() {
   for (const p of positioned) TRIP_TABS.splice(Math.min(p.tripPage!.position!, TRIP_TABS.length), 0, { id: `plugin:${p.id}`, label: p.name, icon: resolvePluginIcon(p.icon) })
   for (const p of tripPagePlugins.filter(p => p.tripPage?.position == null)) TRIP_TABS.push({ id: `plugin:${p.id}`, label: p.name, icon: resolvePluginIcon(p.icon) })
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // ?tab=<id> opens the trip straight on that tab (the startup destination
+  // setting, a browser shortcut, a wrapper app). It beats the session's last
+  // tab because it is an explicit request for this one, and it is read in the
+  // initializer rather than an effect so the planner never paints the plan view
+  // first and swaps a frame later.
   const [activeTab, setActiveTab] = useState<string>(() => {
-    const saved = sessionStorage.getItem(`trip-tab-${tripId}`)
-    return saved || 'plan'
+    const requested = searchParams.get('tab')
+    if (requested && isDeepLinkableTripTab(requested)) return requested
+    return sessionStorage.getItem(`trip-tab-${tripId}`) || 'plan'
   })
 
   useEffect(() => {
     // Don't evict a saved plugin tab before the plugin feed has loaded.
     if (activeTab.startsWith('plugin:') && !pluginsLoaded) return
+    // Same for the addon-owned tabs: until the feed answers, enabledAddons is a
+    // guess, and evicting on a guess would drop a legitimately requested tab.
+    if (!addonsLoaded) return
     const validTabIds = TRIP_TABS.map(t => t.id)
     if (!validTabIds.includes(activeTab)) {
       setActiveTab('plan')
       sessionStorage.setItem(`trip-tab-${tripId}`, 'plan')
     }
-  }, [activeTab, enabledAddons, tripPluginIds, pluginsLoaded])
+  }, [activeTab, enabledAddons, addonsLoaded, tripPluginIds, pluginsLoaded])
 
   const handleTabChange = (rawTabId: string): void => {
     // A core tab a plugin replaced is gone from the bar, but a programmatic jump
@@ -163,6 +179,19 @@ export function useTripPlanner() {
     if (tabId === 'finanzplan') tripActions.loadBudgetItems?.(tripId)
     if (tabId === 'dateien' && (!files || files.length === 0)) tripActions.loadFiles?.(tripId)
   }
+
+  // handleTabChange is where a tab's lazy load and its session memory happen, and
+  // the tab we *start* on never goes through it — neither a ?tab= deep link nor a
+  // tab restored from a previous visit. Catch both up once per trip, or opening
+  // straight into Files shows an empty list.
+  const startTabSettled = useRef<number | null>(null)
+  useEffect(() => {
+    if (!tripId || startTabSettled.current === tripId) return
+    startTabSettled.current = tripId
+    sessionStorage.setItem(`trip-tab-${tripId}`, activeTab)
+    if (activeTab === 'finanzplan') tripActions.loadBudgetItems?.(tripId)
+    if (activeTab === 'dateien' && (!files || files.length === 0)) tripActions.loadFiles?.(tripId)
+  }, [tripId])
   const { leftWidth, rightWidth, leftCollapsed, rightCollapsed, setLeftCollapsed, setRightCollapsed, startResizeLeft, startResizeRight } = useResizablePanels()
   const { selectedPlaceId, selectedAssignmentId, setSelectedPlaceId, selectAssignment } = usePlaceSelection()
   const [showDayDetail, setShowDayDetail] = useState<Day | null>(null)
@@ -171,7 +200,6 @@ export function useTripPlanner() {
   const [editingPlace, setEditingPlace] = useState<Place | null>(null)
   const [prefillCoords, setPrefillCoords] = useState<{ lat: number; lng: number; name?: string; address?: string; website?: string; phone?: string; osm_id?: string } | null>(null)
   const [editingAssignmentId, setEditingAssignmentId] = useState<number | null>(null)
-  const [searchParams, setSearchParams] = useSearchParams()
 
   // The bottom-nav "+" opens the new-place form via ?create=place.
   useEffect(() => {
@@ -179,6 +207,14 @@ export function useTripPlanner() {
       setEditingPlace(null); setEditingAssignmentId(null); setShowPlaceForm(true)
       setSearchParams(p => { p.delete('create'); return p }, { replace: true })
     }
+  }, [searchParams])
+
+  // ?tab= has done its job in the state initializer above — drop it so the URL
+  // stops claiming a tab the user may have since switched away from. The session
+  // memory keeps the choice across a reload.
+  useEffect(() => {
+    if (searchParams.get('tab') === null) return
+    setSearchParams(p => { p.delete('tab'); return p }, { replace: true })
   }, [searchParams])
   const [showTripForm, setShowTripForm] = useState<boolean>(false)
   const [showMembersModal, setShowMembersModal] = useState<boolean>(false)

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -33,6 +33,10 @@ interface AuthState {
    *  outage doesn't render as a blank, error-free page that looks like lost data.
    *  Transient, never persisted. #1283 */
   authCheckFailed: boolean
+  /** The user pressed "log out" — as opposed to a session that simply ended.
+   *  Read by ProtectedRoute: a deliberate sign-out should not leave a
+   *  ?redirect= pointing back at the page they just left. Transient. */
+  loggingOut: boolean
   error: string | null
   demoMode: boolean
   devMode: boolean
@@ -95,6 +99,7 @@ export const useAuthStore = create<AuthState>()(
   isAuthenticated: false,
   isLoading: true,
   authCheckFailed: false,
+  loggingOut: false,
   error: null,
   demoMode: localStorage.getItem('demo_mode') === 'true',
   devMode: false,
@@ -120,6 +125,7 @@ export const useAuthStore = create<AuthState>()(
       set({
         user: data.user,
         isAuthenticated: true,
+        loggingOut: false,
         isLoading: false,
         error: null,
       })
@@ -145,6 +151,7 @@ export const useAuthStore = create<AuthState>()(
       set({
         user: data.user,
         isAuthenticated: true,
+        loggingOut: false,
         isLoading: false,
         error: null,
       })
@@ -170,6 +177,7 @@ export const useAuthStore = create<AuthState>()(
       set({
         user: data.user,
         isAuthenticated: true,
+        loggingOut: false,
         isLoading: false,
         error: null,
       })
@@ -188,7 +196,11 @@ export const useAuthStore = create<AuthState>()(
   logout: async () => {
     // 1. Gate first so any in-flight flush/syncAll bails before we wipe the DB.
     setAuthed(false)
-    set({ isAuthenticated: false })
+    // Flagged in the same update that drops the session: clearing isAuthenticated
+    // re-renders ProtectedRoute for whatever page is still on screen, and without
+    // this it would stamp a ?redirect= back to it — which then beats the user's
+    // startup destination on the next login.
+    set({ isAuthenticated: false, loggingOut: true })
     // 2. Stop background sync triggers (30s interval, WS pre-reconnect hook, listeners).
     unregisterSyncTriggers()
     // 3. Tear down the live connection.
@@ -233,6 +245,7 @@ export const useAuthStore = create<AuthState>()(
       set({
         user: data.user,
         isAuthenticated: true,
+        loggingOut: false,
         isLoading: false,
         authCheckFailed: false,
       })
@@ -336,6 +349,7 @@ export const useAuthStore = create<AuthState>()(
       set({
         user: data.user,
         isAuthenticated: true,
+        loggingOut: false,
         isLoading: false,
         demoMode: true,
         error: null,

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -11,6 +11,7 @@ import { unregisterSyncTriggers } from '../sync/syncTriggers'
 import { useSystemNoticeStore } from './systemNoticeStore.js'
 import { clearAppearanceSnapshot } from '../theme/applyAppearance'
 import { clearAllPluginSessions } from './pluginStore'
+import { forgetStartDestination } from '../utils/startDestination'
 
 interface AuthResponse {
   user: User
@@ -199,6 +200,9 @@ export const useAuthStore = create<AuthState>()(
     // Same reason for the brokered plugin session state: it is keyed by user id,
     // but sessionStorage outlives a logout within the tab.
     clearAllPluginSessions()
+    // And the startup-destination mirror, or the next account on this browser
+    // gets bounced into a trip it may not even be able to see.
+    forgetStartDestination()
     // 4. Tell server to clear the httpOnly cookie (best-effort).
     await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
     // 5. Clear service worker caches containing sensitive data.

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -5,6 +5,7 @@ import { DEFAULT_APPEARANCE } from '@trek/shared'
 import { getApiErrorMessage } from '../types'
 import { SUPPORTED_LANGUAGE_CODES } from '../i18n/supportedLanguages'
 import { normalizeTileUrl } from '../utils/tileUrl'
+import { rememberStartDestination, DEFAULT_START_PAGE, DEFAULT_START_TRIP_TAB } from '../utils/startDestination'
 
 interface SettingsState {
   settings: Settings
@@ -49,6 +50,8 @@ export const DEFAULT_SETTINGS: Settings = {
   mapbox_quality_mode: false,
   dashboard_fx_from: 'EUR',
   dashboard_fx_to: 'USD',
+  start_page: DEFAULT_START_PAGE,
+  start_trip_tab: DEFAULT_START_TRIP_TAB,
   appearance: DEFAULT_APPEARANCE,
   // dashboard_timezones is intentionally left unset so the widget can tell "never
   // chosen" (fall back to home + defaults) from an explicitly emptied list.
@@ -84,6 +87,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
           settings: { ...state.settings, ...incoming },
           isLoaded: true,
         }))
+        // The startup redirect runs before this ever resolves, so keep a mirror
+        // it can read synchronously on the next launch.
+        rememberStartDestination(incoming)
       } catch (err: unknown) {
         // Leave isLoaded false so a transient failure — offline at launch, or a
         // (docker) server cold-start racing the first request — is retried on
@@ -104,6 +110,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       settings: { ...state.settings, [key]: next },
     }))
     if (key === 'language') localStorage.setItem('app_language', next as string)
+    rememberStartDestination({ [key]: next } as Partial<Settings>)
     try {
       await settingsApi.set(key, next)
     } catch (err: unknown) {
@@ -130,6 +137,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     set((state) => ({
       settings: { ...state.settings, ...patch },
     }))
+    rememberStartDestination(patch)
     try {
       await settingsApi.setBulk(patch)
     } catch (err: unknown) {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -133,6 +133,10 @@ export interface Settings {
   dashboard_fx_from?: string
   dashboard_fx_to?: string
   dashboard_timezones?: string[]
+  /** Where opening TREK lands: the dashboard, or straight in the active trip. */
+  start_page?: 'dashboard' | 'active_trip'
+  /** Which planner tab 'active_trip' opens on — a TripTabId (constants/tripTabs). */
+  start_trip_tab?: string
   // AI booking-import fallback (per-user config; used when the admin has not set
   // instance-wide config on the llm_parsing addon). llm_api_key is masked on read.
   llm_provider?: 'local' | 'openai' | 'anthropic'

--- a/client/src/utils/startDestination.ts
+++ b/client/src/utils/startDestination.ts
@@ -19,6 +19,13 @@ export const DEFAULT_START_TRIP_TAB = 'plan'
  */
 export const START_DESTINATION_ROUTE = '/'
 
+/**
+ * How long a device that has never seen the preference waits for the settings
+ * before giving up and opening the dashboard. Long enough for a normal request,
+ * short enough that a launch with no backend isn't stuck staring at a spinner.
+ */
+export const SETTINGS_WAIT_MS = 2500
+
 export interface StartDestination {
   page: StartPage
   tab: string
@@ -36,17 +43,24 @@ const TAB_KEY = 'trek_start_trip_tab'
 const isStartPage = (value: unknown): value is StartPage =>
   value === 'dashboard' || value === 'active_trip'
 
-export function readStartDestination(): StartDestination {
+/**
+ * What this device last knew, or null if it has never been told — a fresh
+ * browser, another machine, or one that has logged out since.
+ *
+ * The null case matters: the preference lives on the server, so "this device
+ * doesn't know" is not the same as "this user wants the dashboard". Callers
+ * have to wait for the real settings rather than assume the default, or the
+ * setting is silently ignored on every device that didn't set it.
+ */
+export function readStartDestination(): StartDestination | null {
   try {
     const page = localStorage.getItem(PAGE_KEY)
+    if (!isStartPage(page)) return null
     const tab = localStorage.getItem(TAB_KEY)
-    return {
-      page: isStartPage(page) ? page : DEFAULT_START_PAGE,
-      tab: isTripTabId(tab) ? tab : DEFAULT_START_TRIP_TAB,
-    }
+    return { page, tab: isTripTabId(tab) ? tab : DEFAULT_START_TRIP_TAB }
   } catch {
     // Private-mode Safari and friends throw on access, not just on write.
-    return { page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB }
+    return null
   }
 }
 

--- a/client/src/utils/startDestination.ts
+++ b/client/src/utils/startDestination.ts
@@ -1,0 +1,89 @@
+import { isTripTabId } from '../constants/tripTabs'
+import type { Settings } from '../types'
+
+/**
+ * Where opening TREK lands. 'dashboard' is what TREK has always done; with
+ * 'active_trip' the app skips straight into the trip the dashboard would
+ * feature, on the tab picked below — three clicks and three loads less for
+ * someone entering expenses while they're actually travelling.
+ */
+export type StartPage = 'dashboard' | 'active_trip'
+
+export const DEFAULT_START_PAGE: StartPage = 'dashboard'
+export const DEFAULT_START_TRIP_TAB = 'plan'
+
+/**
+ * The route that resolves the destination (RootRedirect in App.tsx). Anywhere
+ * that used to navigate to '/dashboard' for lack of a better idea sends people
+ * here instead, so the preference is applied in exactly one place.
+ */
+export const START_DESTINATION_ROUTE = '/'
+
+export interface StartDestination {
+  page: StartPage
+  tab: string
+}
+
+// Mirrored in localStorage, not read from the settings store, because the
+// redirect has to be decided on the first paint — waiting for GET /api/settings
+// would put a spinner in front of every launch, including the default one that
+// isn't redirecting anywhere. Same trick as 'app_language' and the theme boot
+// snapshot: the server's answer wins on the next load, this is only what we
+// knew last time.
+const PAGE_KEY = 'trek_start_page'
+const TAB_KEY = 'trek_start_trip_tab'
+
+const isStartPage = (value: unknown): value is StartPage =>
+  value === 'dashboard' || value === 'active_trip'
+
+export function readStartDestination(): StartDestination {
+  try {
+    const page = localStorage.getItem(PAGE_KEY)
+    const tab = localStorage.getItem(TAB_KEY)
+    return {
+      page: isStartPage(page) ? page : DEFAULT_START_PAGE,
+      tab: isTripTabId(tab) ? tab : DEFAULT_START_TRIP_TAB,
+    }
+  } catch {
+    // Private-mode Safari and friends throw on access, not just on write.
+    return { page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB }
+  }
+}
+
+/** Called whenever the settings store learns a value — load, single or bulk save. */
+export function rememberStartDestination(settings: Partial<Settings>): void {
+  try {
+    if ('start_page' in settings) {
+      const page = settings.start_page
+      if (isStartPage(page)) localStorage.setItem(PAGE_KEY, page)
+      else localStorage.removeItem(PAGE_KEY)
+    }
+    if ('start_trip_tab' in settings) {
+      const tab = settings.start_trip_tab
+      if (isTripTabId(tab)) localStorage.setItem(TAB_KEY, tab)
+      else localStorage.removeItem(TAB_KEY)
+    }
+  } catch {
+    // A browser that won't persist this just falls back to the dashboard.
+  }
+}
+
+/** On logout, so the next account on this browser starts on its own preference. */
+export function forgetStartDestination(): void {
+  try {
+    localStorage.removeItem(PAGE_KEY)
+    localStorage.removeItem(TAB_KEY)
+  } catch {
+    // Nothing to clean up if storage is unavailable.
+  }
+}
+
+/**
+ * The planner URL for a startup redirect. The tab always goes on the query
+ * string, including 'plan' — leaving it off would hand the decision back to
+ * whichever tab the last session happened to end on.
+ */
+export function tripStartPath(tripId: number, tab: string): string {
+  const safeTab = isTripTabId(tab) ? tab : DEFAULT_START_TRIP_TAB
+  return `/trips/${tripId}?tab=${safeTab}`
+}

--- a/client/tests/unit/mobile/settings/MSettingsGeneral.test.tsx
+++ b/client/tests/unit/mobile/settings/MSettingsGeneral.test.tsx
@@ -156,4 +156,38 @@ describe('MSettingsGeneral', () => {
     await user.click(screen.getByRole('button', { name: '°F Fahrenheit' }));
     await screen.findByText('Error');
   });
+
+  it('FE-MOB-SET-012: the startup card defaults to the dashboard and hides the tab row', () => {
+    render(<MSettingsGeneral />);
+
+    expect(screen.getByText('Startup')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dashboard' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByText('Start tab')).not.toBeInTheDocument();
+  });
+
+  it('FE-MOB-SET-013: picking the active trip persists it and reveals the tab row', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, { settings: buildSettings({ language: 'en' }), updateSetting });
+    render(<MSettingsGeneral />);
+
+    await user.click(screen.getByRole('button', { name: 'Active trip' }));
+    expect(updateSetting).toHaveBeenCalledWith('start_page', 'active_trip');
+  });
+
+  it('FE-MOB-SET-014: the start-tab sheet saves the planner tab id behind the label', async () => {
+    const user = userEvent.setup();
+    const updateSetting = vi.fn().mockResolvedValue(undefined);
+    seedStore(useSettingsStore, {
+      settings: buildSettings({ language: 'en', start_page: 'active_trip', start_trip_tab: 'plan' }),
+      updateSetting,
+    });
+    render(<MSettingsGeneral />);
+
+    expect(screen.getByText('Start tab')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Plan' }));
+    await user.click(await screen.findByText('Costs'));
+
+    expect(updateSetting).toHaveBeenCalledWith('start_trip_tab', 'finanzplan');
+  });
 });

--- a/client/tests/unit/utils/startDestination.test.ts
+++ b/client/tests/unit/utils/startDestination.test.ts
@@ -18,8 +18,12 @@ afterEach(() => {
 })
 
 describe('readStartDestination', () => {
-  it('FE-UTIL-START-001: falls back to the dashboard when nothing was ever mirrored', () => {
-    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  // Not the dashboard: the preference lives on the server, so a device that has
+  // never seen it has to say "I don't know" and let the caller wait for the
+  // settings. Answering 'dashboard' here ignored the setting on every device
+  // that hadn't set it — including any browser that had logged out since.
+  it('FE-UTIL-START-001: reports "unknown" when nothing was ever mirrored', () => {
+    expect(readStartDestination()).toBeNull()
   })
 
   it('FE-UTIL-START-002: returns what was mirrored', () => {
@@ -27,19 +31,27 @@ describe('readStartDestination', () => {
     expect(readStartDestination()).toEqual({ page: 'active_trip', tab: 'finanzplan' })
   })
 
+  it('FE-UTIL-START-002b: an explicitly mirrored dashboard is an answer, not "unknown"', () => {
+    rememberStartDestination({ start_page: 'dashboard' })
+    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  })
+
   // A value a user (or an older/newer build) could have written by hand must not
   // become a route we then navigate to.
   it('FE-UTIL-START-003: ignores values that are not a known page or tab', () => {
     localStorage.setItem('trek_start_page', 'somewhere_else')
+    expect(readStartDestination()).toBeNull()
+
+    localStorage.setItem('trek_start_page', 'active_trip')
     localStorage.setItem('trek_start_trip_tab', '../../etc/passwd')
-    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+    expect(readStartDestination()).toEqual({ page: 'active_trip', tab: DEFAULT_START_TRIP_TAB })
   })
 
   it('FE-UTIL-START-004: survives a browser that refuses storage access', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('SecurityError')
     })
-    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+    expect(readStartDestination()).toBeNull()
   })
 })
 
@@ -65,10 +77,12 @@ describe('rememberStartDestination', () => {
 })
 
 describe('forgetStartDestination', () => {
-  it('FE-UTIL-START-008: leaves the next account on this browser with the default', () => {
+  it('FE-UTIL-START-008: leaves the next account on this browser knowing nothing', () => {
     rememberStartDestination({ start_page: 'active_trip', start_trip_tab: 'finanzplan' })
     forgetStartDestination()
-    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+    // "unknown", so the next login waits for its own settings instead of
+    // inheriting the previous account's preference.
+    expect(readStartDestination()).toBeNull()
   })
 })
 

--- a/client/tests/unit/utils/startDestination.test.ts
+++ b/client/tests/unit/utils/startDestination.test.ts
@@ -1,0 +1,82 @@
+// FE-UTIL-START-001 to FE-UTIL-START-009
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  readStartDestination,
+  rememberStartDestination,
+  forgetStartDestination,
+  tripStartPath,
+  DEFAULT_START_PAGE,
+  DEFAULT_START_TRIP_TAB,
+} from '../../../src/utils/startDestination'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('readStartDestination', () => {
+  it('FE-UTIL-START-001: falls back to the dashboard when nothing was ever mirrored', () => {
+    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  })
+
+  it('FE-UTIL-START-002: returns what was mirrored', () => {
+    rememberStartDestination({ start_page: 'active_trip', start_trip_tab: 'finanzplan' })
+    expect(readStartDestination()).toEqual({ page: 'active_trip', tab: 'finanzplan' })
+  })
+
+  // A value a user (or an older/newer build) could have written by hand must not
+  // become a route we then navigate to.
+  it('FE-UTIL-START-003: ignores values that are not a known page or tab', () => {
+    localStorage.setItem('trek_start_page', 'somewhere_else')
+    localStorage.setItem('trek_start_trip_tab', '../../etc/passwd')
+    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  })
+
+  it('FE-UTIL-START-004: survives a browser that refuses storage access', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError')
+    })
+    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  })
+})
+
+describe('rememberStartDestination', () => {
+  it('FE-UTIL-START-005: only touches the keys present in the patch', () => {
+    rememberStartDestination({ start_page: 'active_trip', start_trip_tab: 'dateien' })
+    rememberStartDestination({ start_trip_tab: 'buchungen' })
+    expect(readStartDestination()).toEqual({ page: 'active_trip', tab: 'buchungen' })
+  })
+
+  it('FE-UTIL-START-006: clears a key that comes back invalid instead of keeping a stale one', () => {
+    rememberStartDestination({ start_page: 'active_trip' })
+    rememberStartDestination({ start_page: undefined })
+    expect(localStorage.getItem('trek_start_page')).toBeNull()
+  })
+
+  it('FE-UTIL-START-007: swallows a quota error rather than failing the settings save', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => rememberStartDestination({ start_page: 'active_trip' })).not.toThrow()
+  })
+})
+
+describe('forgetStartDestination', () => {
+  it('FE-UTIL-START-008: leaves the next account on this browser with the default', () => {
+    rememberStartDestination({ start_page: 'active_trip', start_trip_tab: 'finanzplan' })
+    forgetStartDestination()
+    expect(readStartDestination()).toEqual({ page: DEFAULT_START_PAGE, tab: DEFAULT_START_TRIP_TAB })
+  })
+})
+
+describe('tripStartPath', () => {
+  it('FE-UTIL-START-009: always spells the tab out, and never a tab that does not exist', () => {
+    // Explicit even for 'plan', or the last session's tab would decide instead.
+    expect(tripStartPath(7, 'plan')).toBe('/trips/7?tab=plan')
+    expect(tripStartPath(7, 'finanzplan')).toBe('/trips/7?tab=finanzplan')
+    expect(tripStartPath(7, 'nonsense')).toBe('/trips/7?tab=plan')
+  })
+})

--- a/server/src/nest/trips/trips.controller.ts
+++ b/server/src/nest/trips/trips.controller.ts
@@ -24,6 +24,7 @@ import { diskStorage } from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
+import type { ActiveTripResponse } from '@trek/shared';
 import type { User } from '../../types';
 import { TripsService } from './trips.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -74,6 +75,18 @@ export class TripsController {
   @Get()
   list(@CurrentUser() user: User, @Query('archived') archived?: string) {
     return { trips: this.trips.list(user.id, archived === '1' ? 1 : 0) };
+  }
+
+  /**
+   * Where "open TREK straight in my trip" lands. Declared above @Get(':id') —
+   * a literal segment below it would never be reached.
+   */
+  @Get('active')
+  active(@CurrentUser() user: User): ActiveTripResponse {
+    const row = this.trips.activeTrip(user.id);
+    if (!row) return { trip: null };
+    const { id, title, start_date, end_date } = row;
+    return { trip: { id, title, start_date, end_date } };
   }
 
   @Get('cover-images/search')

--- a/server/src/nest/trips/trips.service.ts
+++ b/server/src/nest/trips/trips.service.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
 import { DatabaseService } from '../database/database.service';
-import type { TrekWsPayload, TrekWsTripEventName } from '@trek/shared';
+import type { ActiveTrip, TrekWsPayload, TrekWsTripEventName } from '@trek/shared';
 import { RealtimeService } from '../realtime/realtime.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import type { Trip, User } from '../../types';
@@ -414,6 +414,35 @@ export class TripsService {
       LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = :userId
       WHERE t.id = :tripId AND (t.user_id = :userId OR m.user_id IS NOT NULL)
     `).get({ userId, tripId }) as Trip | undefined;
+  }
+
+  /**
+   * The trip a user most likely means by "my trip" right now: the one running
+   * today, else the next one starting, else the one that started most recently.
+   * Archived trips never qualify. Same order the dashboard hero picks its
+   * spotlight with (client sortTrips) — the two must agree, or "open my trip on
+   * startup" would land somewhere other than the trip the dashboard features.
+   *
+   * Kept separate from list() on purpose: this runs on the very first paint of
+   * a startup redirect, so it reads four columns of one row instead of every
+   * trip with its per-trip day/place counts.
+   */
+  activeTrip(userId: number, today = new Date().toISOString().slice(0, 10)) {
+    return this.db.prepare(`
+      SELECT t.id, t.title, t.start_date, t.end_date,
+        CASE
+          WHEN t.start_date IS NOT NULL AND t.end_date IS NOT NULL AND t.start_date <= :today AND t.end_date >= :today THEN 0
+          WHEN t.start_date IS NOT NULL AND t.start_date >= :today THEN 1
+          ELSE 2
+        END AS relevance
+      FROM trips t
+      LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = :userId
+      WHERE (t.user_id = :userId OR m.user_id IS NOT NULL) AND t.is_archived = 0
+      ORDER BY relevance ASC,
+        CASE WHEN relevance < 2 THEN t.start_date END ASC,
+        CASE WHEN relevance = 2 THEN t.start_date END DESC
+      LIMIT 1
+    `).get({ userId, today }) as ActiveTrip & { relevance: number } | undefined;
   }
 
   getRaw(tripId: string | number): Trip | undefined {

--- a/server/tests/e2e/trips.e2e.test.ts
+++ b/server/tests/e2e/trips.e2e.test.ts
@@ -200,6 +200,37 @@ describe('Trips e2e (real auth guard + temp SQLite)', () => {
     expect(res.body).toEqual({ error: 'Trip not found' });
   });
 
+  describe('GET /active (startup destination)', () => {
+    const seedDated = (title: string, start: string, end: string) =>
+      Number(db.prepare('INSERT INTO trips (user_id, title, start_date, end_date) VALUES (1, ?, ?, ?)')
+        .run(title, start, end).lastInsertRowid);
+
+    it('401 without a cookie', async () => {
+      expect((await request(server).get('/api/trips/active')).status).toBe(401);
+    });
+
+    // The literal route sits above @Get(':id'); if it ever slips below, this
+    // asks for a trip with the id "active" and comes back 404 instead.
+    it('resolves as its own route rather than as /api/trips/:id', async () => {
+      const running = seedDated('Running', '2000-01-01', '2999-12-31');
+      const res = await request(server).get('/api/trips/active').set('Cookie', sessionCookie(1));
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ trip: { id: running, title: 'Running', start_date: '2000-01-01', end_date: '2999-12-31' } });
+    });
+
+    it('answers { trip: null } when the user has no trip at all', async () => {
+      const res = await request(server).get('/api/trips/active').set('Cookie', sessionCookie(1));
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ trip: null });
+    });
+
+    it('carries no wide trip columns — it is read on first paint', async () => {
+      seedDated('Running', '2000-01-01', '2999-12-31');
+      const res = await request(server).get('/api/trips/active').set('Cookie', sessionCookie(1));
+      expect(Object.keys(res.body.trip).sort()).toEqual(['end_date', 'id', 'start_date', 'title']);
+    });
+  });
+
   it('200 bundle for an accessible trip (real member list)', async () => {
     const tripId = seedTrip('B');
     const res = await request(server).get(`/api/trips/${tripId}/bundle`).set('Cookie', sessionCookie(1));

--- a/server/tests/unit/nest/trips.controller.test.ts
+++ b/server/tests/unit/nest/trips.controller.test.ts
@@ -20,7 +20,7 @@ import { TripsController } from '../../../src/nest/trips/trips.controller';
 import type { TripsService } from '../../../src/nest/trips/trips.service';
 import { NotFoundError, ValidationError } from '../../../src/nest/trips/trips.service';
 import type { User } from '../../../src/types';
-import { tripCreateRequestSchema, tripTransferOwnershipRequestSchema } from '@trek/shared';
+import { activeTripResponseSchema, tripCreateRequestSchema, tripTransferOwnershipRequestSchema } from '@trek/shared';
 
 const user = { id: 1, role: 'user', email: 'u@example.test' } as User;
 const req = { headers: {} } as Request;
@@ -75,6 +75,24 @@ describe('TripsController (parity with the legacy /api/trips route)', () => {
     expect(list).toHaveBeenLastCalledWith(1, 0);
     c.list(user, '0');
     expect(list).toHaveBeenLastCalledWith(1, 0);
+  });
+
+  describe('GET /active (startup destination)', () => {
+    it('narrows the row to the contract shape and drops the sort helper', () => {
+      const activeTrip = vi.fn().mockReturnValue({
+        id: 7, title: 'Japan', start_date: '2026-09-01', end_date: '2026-09-14', relevance: 1,
+      });
+      const res = tc(svc({ activeTrip } as Partial<TripsService>)).active(user);
+      expect(res).toEqual({ trip: { id: 7, title: 'Japan', start_date: '2026-09-01', end_date: '2026-09-14' } });
+      expect(activeTripResponseSchema.safeParse(res).success).toBe(true);
+      expect(activeTrip).toHaveBeenCalledWith(1);
+    });
+
+    it('answers null instead of 404 when the user has no trip, so the caller can fall back', () => {
+      const res = tc(svc({ activeTrip: vi.fn().mockReturnValue(undefined) } as Partial<TripsService>)).active(user);
+      expect(res).toEqual({ trip: null });
+      expect(activeTripResponseSchema.safeParse(res).success).toBe(true);
+    });
   });
 
   describe('POST / (create)', () => {

--- a/server/tests/unit/nest/trips.service.test.ts
+++ b/server/tests/unit/nest/trips.service.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the DI-native TripsService — TRIP-SVC-001 through TRIP-SVC-053
+ * Unit tests for the DI-native TripsService — TRIP-SVC-001 through TRIP-SVC-058
  * (001–038 moved 1:1 from the legacy tests/unit/services/tripService.test.ts;
  * the exportICS cases that duplicated the generateDays 010–012 numbering were
  * renumbered to 024–026 with the post-fold quirk-fix commit; 040–041 pin the
@@ -1253,5 +1253,53 @@ describe('quirk fixes', () => {
     const trip = createTrip(testDb, owner.id);
     const { owner: row } = svc.listMembers(trip.id, owner.id);
     expect(row.username).toBe('Olive Displayed');
+  });
+});
+
+/**
+ * activeTrip powers the startup redirect, so its order has to stay identical to
+ * the dashboard's sortTrips (client/src/pages/dashboard/dashboardModel.ts):
+ * running today → next one starting (earliest first) → most recently started →
+ * undated last. If these drift, "open my trip" and the hero show different trips.
+ */
+describe('activeTrip (startup destination)', () => {
+  const TODAY = '2026-08-08';
+
+  it('TRIP-SVC-054: prefers the trip running today over anything upcoming', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'soon', start_date: '2026-08-20', end_date: '2026-08-25' });
+    createTrip(testDb, user.id, { title: 'running', start_date: '2026-08-05', end_date: '2026-08-12' });
+    expect(svc.activeTrip(user.id, TODAY)?.title).toBe('running');
+  });
+
+  it('TRIP-SVC-055: without a running trip it takes the next one starting, earliest first', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'late', start_date: '2026-12-01', end_date: '2026-12-10' });
+    createTrip(testDb, user.id, { title: 'soon', start_date: '2026-09-01', end_date: '2026-09-10' });
+    expect(svc.activeTrip(user.id, TODAY)?.title).toBe('soon');
+  });
+
+  it('TRIP-SVC-056: falls back to the most recently started trip, undated ones last', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'undated' });
+    createTrip(testDb, user.id, { title: 'old', start_date: '2020-01-01', end_date: '2020-01-10' });
+    createTrip(testDb, user.id, { title: 'recent', start_date: '2026-07-01', end_date: '2026-07-10' });
+    expect(svc.activeTrip(user.id, TODAY)?.title).toBe('recent');
+  });
+
+  it('TRIP-SVC-057: skips archived trips and returns undefined when nothing is left', () => {
+    const { user } = createUser(testDb);
+    const archived = createTrip(testDb, user.id, { title: 'archived', start_date: '2026-08-05', end_date: '2026-08-12' });
+    testDb.prepare('UPDATE trips SET is_archived = 1 WHERE id = ?').run(archived.id);
+    expect(svc.activeTrip(user.id, TODAY)).toBeUndefined();
+  });
+
+  it('TRIP-SVC-058: sees shared trips but never another user\'s private ones', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: guest } = createUser(testDb);
+    createTrip(testDb, owner.id, { title: 'private', start_date: '2026-08-05', end_date: '2026-08-12' });
+    const shared = createTrip(testDb, owner.id, { title: 'shared', start_date: '2026-09-01', end_date: '2026-09-10' });
+    addTripMember(testDb, shared.id, guest.id);
+    expect(svc.activeTrip(guest.id, TODAY)?.title).toBe('shared');
   });
 });

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -431,6 +431,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'مخفي',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'البدء',
+  'settings.startPage': 'صفحة البدء',
+  'settings.startPageDashboard': 'لوحة التحكم',
+  'settings.startPageActiveTrip': 'الرحلة النشطة',
+  'settings.startPageHint':
+    'يفتح TREK مباشرةً على الرحلة الجارية، وإن لم توجد فعلى الرحلة القادمة التالية. وهي نفس الرحلة التي تبرزها لوحة التحكم.',
+  'settings.startTripTab': 'علامة تبويب البدء',
+  'settings.startTripTabHint':
+    'علامة التبويب التي تفتح بها الرحلة. إذا كانت تابعة لإضافة أوقفت تشغيلها، تُفتح الخطة بدلاً منها.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'ذاكرة التخزين المؤقت دون اتصال',

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -446,6 +446,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Oculto',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Inicialização',
+  'settings.startPage': 'Página inicial',
+  'settings.startPageDashboard': 'Painel',
+  'settings.startPageActiveTrip': 'Viagem ativa',
+  'settings.startPageHint':
+    'O TREK abre direto na viagem que está acontecendo, ou na próxima que começa. É a mesma viagem que o painel destaca.',
+  'settings.startTripTab': 'Aba inicial',
+  'settings.startTripTabHint':
+    'A aba com que a viagem abre. Se ela pertencer a um complemento desativado, abre a visão de plano.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Cache offline',

--- a/shared/src/i18n/ca/settings.ts
+++ b/shared/src/i18n/ca/settings.ts
@@ -429,6 +429,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Ocult',
   'settings.general.languageRegion': 'Idioma i regió',
   'settings.general.travelMap': 'Viatge i mapa',
+  'settings.general.startup': 'Inici',
+  'settings.startPage': "Pàgina d'inici",
+  'settings.startPageDashboard': 'Tauler',
+  'settings.startPageActiveTrip': 'Viatge actiu',
+  'settings.startPageHint':
+    'TREK obre directament el viatge que està en curs, o el següent que comença. És el mateix viatge que destaca el tauler.',
+  'settings.startTripTab': "Pestanya d'inici",
+  'settings.startTripTabHint':
+    "La pestanya amb què s'obre el viatge. Si pertany a un complement desactivat, s'obre la vista de planificació.",
   'settings.offline.cache.title': 'Memòria cau fora de línia',
   'settings.offline.mode.title': 'Mode fora de línia',
   'settings.offline.mode.force': 'Forçar mode fora de línia',

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -439,6 +439,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Skryto',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Spuštění',
+  'settings.startPage': 'Úvodní stránka',
+  'settings.startPageDashboard': 'Přehled',
+  'settings.startPageActiveTrip': 'Aktivní cesta',
+  'settings.startPageHint':
+    'TREK se otevře rovnou na cestě, která právě probíhá, jinak na nejbližší nadcházející. Je to táž cesta, kterou zvýrazňuje přehled.',
+  'settings.startTripTab': 'Úvodní karta',
+  'settings.startTripTabHint':
+    'Karta, kterou se cesta otevře. Pokud patří k vypnutému doplňku, otevře se místo ní plán.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Offline mezipaměť',

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -448,6 +448,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Ausgeblendet',
   'settings.general.languageRegion': 'Sprache & Region',
   'settings.general.travelMap': 'Reise & Karte',
+  'settings.general.startup': 'Start',
+  'settings.startPage': 'Startseite',
+  'settings.startPageDashboard': 'Dashboard',
+  'settings.startPageActiveTrip': 'Aktive Reise',
+  'settings.startPageHint':
+    'TREK öffnet direkt die Reise, die gerade läuft, sonst die nächste anstehende. Also genau die Reise, die auch das Dashboard hervorhebt.',
+  'settings.startTripTab': 'Start-Tab',
+  'settings.startTripTabHint':
+    'Der Tab, mit dem die Reise öffnet. Gehört er zu einem ausgeschalteten Addon, öffnet stattdessen die Planung.',
 
   // ── Offline (#1135) ────────────────────────────────────────────────────────
   'settings.offline.cache.title': 'Offline-Cache',

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -447,6 +447,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Hidden',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Startup',
+  'settings.startPage': 'Start page',
+  'settings.startPageDashboard': 'Dashboard',
+  'settings.startPageActiveTrip': 'Active trip',
+  'settings.startPageHint':
+    'TREK opens straight in the trip running today, or the next one coming up. That is the same trip the dashboard features.',
+  'settings.startTripTab': 'Start tab',
+  'settings.startTripTabHint':
+    'The tab the trip opens on. If it belongs to an addon you switched off, the plan view opens instead.',
 
   // ── Offline (#1135) ────────────────────────────────────────────────────────
   'settings.offline.cache.title': 'Offline cache',

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -447,6 +447,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Oculto',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Inicio',
+  'settings.startPage': 'Página de inicio',
+  'settings.startPageDashboard': 'Panel',
+  'settings.startPageActiveTrip': 'Viaje activo',
+  'settings.startPageHint':
+    'TREK abre directamente el viaje que está en curso o el siguiente que empieza. Es el mismo viaje que destaca el panel.',
+  'settings.startTripTab': 'Pestaña de inicio',
+  'settings.startTripTabHint':
+    'La pestaña con la que se abre el viaje. Si pertenece a un complemento desactivado, se abre la vista de plan.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Caché offline',

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -453,6 +453,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Masqué',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Démarrage',
+  'settings.startPage': 'Page de démarrage',
+  'settings.startPageDashboard': 'Tableau de bord',
+  'settings.startPageActiveTrip': 'Voyage en cours',
+  'settings.startPageHint':
+    "TREK s'ouvre directement sur le voyage en cours, ou sur le prochain à venir. C'est le même voyage que celui mis en avant sur le tableau de bord.",
+  'settings.startTripTab': 'Onglet de démarrage',
+  'settings.startTripTabHint':
+    "L'onglet sur lequel le voyage s'ouvre. S'il appartient à un module désactivé, la vue Plan s'ouvre à la place.",
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Cache hors ligne',

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -456,6 +456,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Κρυφό',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Εκκίνηση',
+  'settings.startPage': 'Αρχική σελίδα',
+  'settings.startPageDashboard': 'Πίνακας ελέγχου',
+  'settings.startPageActiveTrip': 'Ενεργό ταξίδι',
+  'settings.startPageHint':
+    'Το TREK ανοίγει απευθείας στο ταξίδι που είναι σε εξέλιξη ή στο επόμενο που ξεκινά. Είναι το ίδιο ταξίδι που προβάλλει ο πίνακας ελέγχου.',
+  'settings.startTripTab': 'Αρχική καρτέλα',
+  'settings.startTripTabHint':
+    'Η καρτέλα με την οποία ανοίγει το ταξίδι. Αν ανήκει σε απενεργοποιημένο πρόσθετο, ανοίγει το πλάνο.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Προσωρινή μνήμη εκτός σύνδεσης',

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -446,6 +446,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Rejtett',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Indítás',
+  'settings.startPage': 'Kezdőoldal',
+  'settings.startPageDashboard': 'Irányítópult',
+  'settings.startPageActiveTrip': 'Aktív utazás',
+  'settings.startPageHint':
+    'A TREK egyből a most zajló utazást nyitja meg, vagy a következőt, amelyik indul. Ugyanaz az utazás, amelyet az irányítópult is kiemel.',
+  'settings.startTripTab': 'Kezdő fül',
+  'settings.startTripTabHint':
+    'Az a fül, amellyel az utazás megnyílik. Ha kikapcsolt bővítményhez tartozik, helyette a terv nézet nyílik meg.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Offline gyorsítótár',

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -444,6 +444,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Tersembunyi',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Mulai',
+  'settings.startPage': 'Halaman awal',
+  'settings.startPageDashboard': 'Dasbor',
+  'settings.startPageActiveTrip': 'Perjalanan aktif',
+  'settings.startPageHint':
+    'TREK langsung membuka perjalanan yang sedang berlangsung, atau yang paling dekat akan dimulai. Perjalanan yang sama yang disorot dasbor.',
+  'settings.startTripTab': 'Tab awal',
+  'settings.startTripTabHint':
+    'Tab yang dibuka bersama perjalanan. Jika tab itu milik addon yang dimatikan, tampilan rencana yang dibuka.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Cache offline',

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -446,6 +446,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Nascosto',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Avvio',
+  'settings.startPage': 'Pagina iniziale',
+  'settings.startPageDashboard': 'Dashboard',
+  'settings.startPageActiveTrip': 'Viaggio attivo',
+  'settings.startPageHint':
+    'TREK si apre direttamente sul viaggio in corso, o sul prossimo in arrivo. È lo stesso viaggio che la dashboard mette in evidenza.',
+  'settings.startTripTab': 'Scheda iniziale',
+  'settings.startTripTabHint':
+    'La scheda con cui si apre il viaggio. Se appartiene a un componente aggiuntivo disattivato, si apre la vista Programma.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Cache offline',

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -419,6 +419,14 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': '非表示',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': '起動',
+  'settings.startPage': '起動時の画面',
+  'settings.startPageDashboard': 'ダッシュボード',
+  'settings.startPageActiveTrip': '進行中の旅行',
+  'settings.startPageHint':
+    'TREK を開くと、進行中の旅行、なければ次に始まる旅行が直接開きます。ダッシュボードで大きく表示される旅行と同じです。',
+  'settings.startTripTab': '起動時のタブ',
+  'settings.startTripTabHint': '旅行を開くタブです。無効にしたアドオンのタブの場合は、代わりに計画が開きます。',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'オフラインキャッシュ',

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -433,6 +433,14 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': '숨김',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': '시작',
+  'settings.startPage': '시작 화면',
+  'settings.startPageDashboard': '대시보드',
+  'settings.startPageActiveTrip': '진행 중인 여행',
+  'settings.startPageHint':
+    'TREK을 열면 지금 진행 중인 여행, 없으면 다음에 시작하는 여행으로 바로 이동합니다. 대시보드가 강조하는 여행과 같습니다.',
+  'settings.startTripTab': '시작 탭',
+  'settings.startTripTabHint': '여행이 열릴 탭입니다. 꺼 둔 애드온의 탭이면 대신 계획이 열립니다.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': '오프라인 캐시',

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -447,6 +447,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Verborgen',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Opstarten',
+  'settings.startPage': 'Startpagina',
+  'settings.startPageDashboard': 'Dashboard',
+  'settings.startPageActiveTrip': 'Actieve reis',
+  'settings.startPageHint':
+    'TREK opent direct de reis die nu loopt, of anders de eerstvolgende. Dat is dezelfde reis die het dashboard uitlicht.',
+  'settings.startTripTab': 'Starttabblad',
+  'settings.startTripTabHint':
+    'Het tabblad waarmee de reis opent. Hoort het bij een uitgeschakelde add-on, dan opent het plan in plaats daarvan.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Offline cache',

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -446,6 +446,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Ukryte',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Uruchamianie',
+  'settings.startPage': 'Strona startowa',
+  'settings.startPageDashboard': 'Panel',
+  'settings.startPageActiveTrip': 'Aktywna podróż',
+  'settings.startPageHint':
+    'TREK otwiera się od razu na podróży, która właśnie trwa, albo na najbliższej nadchodzącej. To ta sama podróż, którą wyróżnia panel.',
+  'settings.startTripTab': 'Karta startowa',
+  'settings.startTripTabHint':
+    'Karta, na której otwiera się podróż. Jeśli należy do wyłączonego dodatku, otworzy się widok planu.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Pamięć podręczna offline',

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -447,6 +447,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Скрыто',
   'settings.general.languageRegion': 'Язык и регион',
   'settings.general.travelMap': 'Карта и путешествия',
+  'settings.general.startup': 'Запуск',
+  'settings.startPage': 'Стартовая страница',
+  'settings.startPageDashboard': 'Панель управления',
+  'settings.startPageActiveTrip': 'Активная поездка',
+  'settings.startPageHint':
+    'TREK сразу открывает поездку, которая идёт сейчас, иначе ближайшую предстоящую. Это та же поездка, которую выделяет панель управления.',
+  'settings.startTripTab': 'Стартовая вкладка',
+  'settings.startTripTabHint':
+    'Вкладка, с которой открывается поездка. Если она относится к отключённому дополнению, откроется план.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Офлайн-кэш',

--- a/shared/src/i18n/sv/settings.ts
+++ b/shared/src/i18n/sv/settings.ts
@@ -445,6 +445,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Dold',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Start',
+  'settings.startPage': 'Startsida',
+  'settings.startPageDashboard': 'Översikt',
+  'settings.startPageActiveTrip': 'Aktiv resa',
+  'settings.startPageHint':
+    'TREK öppnar direkt i resan som pågår, annars i nästa som börjar. Det är samma resa som översikten lyfter fram.',
+  'settings.startTripTab': 'Startflik',
+  'settings.startTripTabHint':
+    'Fliken som resan öppnas med. Hör den till ett avstängt tillägg öppnas planvyn i stället.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Offline-cache',

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -443,6 +443,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Gizli',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Başlangıç',
+  'settings.startPage': 'Başlangıç sayfası',
+  'settings.startPageDashboard': 'Pano',
+  'settings.startPageActiveTrip': 'Aktif seyahat',
+  'settings.startPageHint':
+    'TREK doğrudan devam eden seyahati, yoksa sıradaki seyahati açar. Panonun öne çıkardığı seyahatin aynısı.',
+  'settings.startTripTab': 'Başlangıç sekmesi',
+  'settings.startTripTabHint':
+    'Seyahatin açılacağı sekme. Kapalı bir eklentiye aitse onun yerine plan görünümü açılır.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Çevrimdışı önbellek',

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -446,6 +446,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Приховано',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': 'Запуск',
+  'settings.startPage': 'Стартова сторінка',
+  'settings.startPageDashboard': 'Панель',
+  'settings.startPageActiveTrip': 'Активна поїздка',
+  'settings.startPageHint':
+    'TREK одразу відкриває поїздку, яка триває зараз, інакше найближчу майбутню. Це та сама поїздка, яку виділяє панель.',
+  'settings.startTripTab': 'Стартова вкладка',
+  'settings.startTripTabHint':
+    'Вкладка, з якою відкривається поїздка. Якщо вона належить до вимкненого доповнення, натомість відкриється план.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Офлайн-кеш',

--- a/shared/src/i18n/vi/settings.ts
+++ b/shared/src/i18n/vi/settings.ts
@@ -448,6 +448,15 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': 'Đã ẩn',
   'settings.general.languageRegion': 'Ngôn ngữ & khu vực',
   'settings.general.travelMap': 'Du lịch & bản đồ',
+  'settings.general.startup': 'Khởi động',
+  'settings.startPage': 'Trang khởi động',
+  'settings.startPageDashboard': 'Bảng điều khiển',
+  'settings.startPageActiveTrip': 'Chuyến đi đang diễn ra',
+  'settings.startPageHint':
+    'TREK mở thẳng chuyến đi đang diễn ra, nếu không thì chuyến gần nhất sắp tới. Đó cũng là chuyến mà bảng điều khiển làm nổi bật.',
+  'settings.startTripTab': 'Tab khởi động',
+  'settings.startTripTabHint':
+    'Tab mà chuyến đi mở ra. Nếu tab đó thuộc tiện ích đã tắt, chế độ xem kế hoạch sẽ mở thay thế.',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': 'Bộ nhớ đệm ngoại tuyến',

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -420,6 +420,13 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': '已隱藏',
   'settings.general.languageRegion': 'Language & region',
   'settings.general.travelMap': 'Travel & map',
+  'settings.general.startup': '啟動',
+  'settings.startPage': '啟動頁面',
+  'settings.startPageDashboard': '儀表板',
+  'settings.startPageActiveTrip': '進行中的旅行',
+  'settings.startPageHint': 'TREK 會直接開啟正在進行的旅行，沒有則開啟最近要開始的那次。與儀表板突顯的是同一次旅行。',
+  'settings.startTripTab': '啟動分頁',
+  'settings.startTripTabHint': '旅行開啟時所在的分頁。如果該分頁屬於已關閉的附加元件，則改為開啟計劃檢視。',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': '離線快取',

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -416,6 +416,14 @@ const settings: TranslationStrings = {
   'settings.appearance.dashOrder.hidden': '已隐藏',
   'settings.general.languageRegion': '语言与地区',
   'settings.general.travelMap': '旅行与地图',
+  'settings.general.startup': '启动',
+  'settings.startPage': '启动页面',
+  'settings.startPageDashboard': '仪表盘',
+  'settings.startPageActiveTrip': '进行中的旅行',
+  'settings.startPageHint':
+    'TREK 会直接打开正在进行的旅行，没有则打开最近要开始的那次。与仪表盘突出显示的是同一次旅行。',
+  'settings.startTripTab': '启动标签页',
+  'settings.startTripTabHint': '旅行打开时所在的标签页。如果该标签页属于已关闭的插件，则改为打开计划视图。',
 
   // ── Offline (#1135)
   'settings.offline.cache.title': '离线缓存',

--- a/shared/src/trip/trip.schema.spec.ts
+++ b/shared/src/trip/trip.schema.spec.ts
@@ -1,4 +1,9 @@
-import { tripCreateRequestSchema, tripUpdateRequestSchema, tripAddMemberRequestSchema } from './trip.schema';
+import {
+  tripCreateRequestSchema,
+  tripUpdateRequestSchema,
+  tripAddMemberRequestSchema,
+  activeTripResponseSchema,
+} from './trip.schema';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +32,20 @@ describe('tripAddMemberRequestSchema', () => {
   it('requires an identifier', () => {
     expect(tripAddMemberRequestSchema.safeParse({ identifier: 'bob@x.y' }).success).toBe(true);
     expect(tripAddMemberRequestSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('activeTripResponseSchema', () => {
+  it('accepts a trip with or without dates, and an explicit null', () => {
+    expect(activeTripResponseSchema.safeParse({ trip: { id: 1, title: 'Japan' } }).success).toBe(true);
+    expect(
+      activeTripResponseSchema.safeParse({ trip: { id: 1, title: 'Japan', start_date: null, end_date: null } }).success,
+    ).toBe(true);
+    expect(activeTripResponseSchema.safeParse({ trip: null }).success).toBe(true);
+  });
+
+  it('rejects a missing trip key — "no trip" is null, not absent', () => {
+    expect(activeTripResponseSchema.safeParse({}).success).toBe(false);
+    expect(activeTripResponseSchema.safeParse({ trip: { title: 'Japan' } }).success).toBe(false);
   });
 });

--- a/shared/src/trip/trip.schema.ts
+++ b/shared/src/trip/trip.schema.ts
@@ -118,3 +118,28 @@ export const tripTransferOwnershipRequestSchema = z.object({
   newOwnerId: z.number().int().positive(),
 });
 export type TripTransferOwnershipRequest = z.infer<typeof tripTransferOwnershipRequestSchema>;
+
+/**
+ * The one trip TREK opens on for a user who wants to land in their trip instead
+ * of on the dashboard (GET /api/trips/active). Deliberately narrow: it is read
+ * on the very first paint to decide where to navigate, so it carries the id plus
+ * enough to label the destination — nothing that would make it as wide (or as
+ * slow) as the trip list it replaces there.
+ *
+ * Relevance order matches the dashboard hero (client sortTrips): the trip
+ * running today, else the next one starting, else the most recently started.
+ */
+export const activeTripSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  start_date: z.string().nullable().optional(),
+  end_date: z.string().nullable().optional(),
+});
+export type ActiveTrip = z.infer<typeof activeTripSchema>;
+
+// null when the user has no unarchived trip at all — the caller falls back to
+// the dashboard rather than navigating into nothing.
+export const activeTripResponseSchema = z.object({
+  trip: activeTripSchema.nullable(),
+});
+export type ActiveTripResponse = z.infer<typeof activeTripResponseSchema>;

--- a/wiki/Display-Settings.md
+++ b/wiki/Display-Settings.md
@@ -8,9 +8,51 @@ The General tab (Settings → General) controls your locale preferences and a fe
 
 Open the user menu in the top navigation bar, select **Settings**, and stay on the **General** tab — it is the tab the page opens on.
 
-The tab is split into two sections: **Language & region** (currency, language, temperature, distance, time format) and **Travel & map** (booking route labels, POI pills, blur booking codes).
+The tab is split into three sections: **Startup** (where opening TREK lands), **Language & region** (currency, language, temperature, distance, time format) and **Travel & map** (booking route labels, POI pills, blur booking codes).
 
 > Color mode (Light / Dark / Auto) is **not** here — it lives on the **Appearance** tab. See [Appearance-Settings](Appearance-Settings).
+
+## Start page
+
+Where TREK goes when you open it — the app root (`/`), which is also what the installed PWA and any home-screen shortcut launch.
+
+| Option | Behaviour |
+|--------|-----------|
+| **Dashboard** (default) | The trip overview, exactly as before. |
+| **Active trip** | Straight into your active trip, skipping the dashboard. |
+
+Your **active trip** is the one running today; if none is, the next one starting; if you have only past trips, the most recent one. That is the same trip the dashboard features in its hero, so the two never disagree. Archived trips are never picked, and if you have no trip at all, TREK opens the dashboard as usual.
+
+The dashboard stays reachable at `/dashboard` — only the root redirects.
+
+## Start tab
+
+Shown once **Active trip** is selected: which tab of the trip planner to open on. Handy when you mostly reach for one thing on the road, for example entering expenses on the Costs tab.
+
+If the tab you picked belongs to an addon that is switched off, the trip opens on **Plan** instead.
+
+### Linking to a tab directly
+
+Any trip URL accepts a `tab` parameter, which is what the start-tab setting uses internally. It works for bookmarks, home-screen shortcuts and wrapper apps too:
+
+```
+/trips/42?tab=finanzplan
+```
+
+The parameter takes the planner's internal tab ids, which are historic German names:
+
+| Tab | Id |
+|-----|-----|
+| Plan | `plan` |
+| Transport | `transports` |
+| Bookings | `buchungen` |
+| Lists | `listen` |
+| Costs | `finanzplan` |
+| Files | `dateien` |
+| Collab | `collab` |
+| A trip-page plugin | `plugin:<plugin-id>` |
+
+The parameter is consumed on arrival and disappears from the address bar; switching tabs afterwards works normally, and a reload keeps whatever tab you were last on.
 
 ## Currency
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -40,3 +40,9 @@ Yes. An admin can disable open registration so that new accounts can only be cre
 ## Does TREK support single sign-on?
 
 Yes, via OpenID Connect (OIDC). Compatible providers include Google, Authentik, Keycloak, and any standard OIDC-compliant IdP. Set `OIDC_ONLY=true` to disable password login entirely. See [OIDC SSO](OIDC-SSO).
+
+## Can TREK open straight on my trip instead of the dashboard?
+
+Yes. In Settings → General → **Startup**, set the start page to **Active trip** and pick the tab it should open on — Costs, for instance, if you mostly add expenses while travelling. Opening TREK (including the installed PWA or a home-screen shortcut) then goes there in one step instead of three.
+
+If you would rather build the shortcut yourself, or point a wrapper app at it, any trip URL takes a tab directly: `/trips/42?tab=finanzplan`. See [Display-Settings](Display-Settings) for the full list of tab ids.

--- a/wiki/Offline-Mode-and-PWA.md
+++ b/wiki/Offline-Mode-and-PWA.md
@@ -18,6 +18,8 @@ TREK must be served over **HTTPS** — the install prompt does not appear on pla
 
 Once installed, TREK launches in **standalone** mode (fullscreen, no browser UI) using the TREK icon.
 
+The installed app starts at the app root, so the **Start page** setting decides what you see when you tap the icon — the dashboard, or straight into your active trip on a tab of your choice. See [Display-Settings](Display-Settings).
+
 ## What works offline
 
 TREK uses Workbox service-worker caching plus an IndexedDB database (Dexie) for structured trip data. The following content is available offline after the first sync:

--- a/wiki/User-Settings.md
+++ b/wiki/User-Settings.md
@@ -12,7 +12,7 @@ If your account requires MFA setup, TREK redirects you directly to the **Account
 
 | Tab | Purpose | Shown when |
 |-----|---------|------------|
-| General | Currency, language, temperature unit, distance unit, time format, booking route labels, map POI pills, and blur booking codes | Always |
+| General | Start page and start tab, currency, language, temperature unit, distance unit, time format, booking route labels, map POI pills, and blur booking codes | Always |
 | Appearance | Color mode, color scheme / accent, readability (transparency, reduce motion, density, text size), and which widgets appear on your dashboard | Always |
 | Map | Map provider (Leaflet, Mapbox GL, or MapLibre GL), tile presets, map style and Mapbox token, 3D buildings, high-quality mode | Always |
 | Notifications | Email, webhook, ntfy, and in-app notification preferences | Always |
@@ -25,6 +25,11 @@ If your account requires MFA setup, TREK redirects you directly to the **Account
 ## General tab
 
 The General tab controls the following preferences, all saved immediately on change. See [Display-Settings](Display-Settings) for the detail.
+
+**Startup**
+
+- **Start page** — open TREK on the dashboard (the default) or straight in your active trip.
+- **Start tab** — which planner tab that trip opens on, e.g. Costs for entering expenses on the road.
 
 **Language & region**
 


### PR DESCRIPTION
Opening TREK on the road takes three clicks and three loads before you can type an expense: the app, the trip, the tab. This lets you skip to the end.

**Settings -> General -> Startup**

- **Start page** - Dashboard (unchanged default) or **Active trip**
- **Start tab** - which planner tab that trip opens on, e.g. Costs

Your active trip is the one running today, else the next one starting, else the most recently started - the same trip the dashboard features in its hero, so the two can't disagree. No trip, or the lookup fails? Dashboard, as before.

## How it works

The redirect sits on `/`, because that is what a shortcut, a bookmark and the installed PWA all launch. `/dashboard` keeps working as itself - redirecting there too would leave no way back to it.

Once a device has seen the preference it comes from a `localStorage` mirror, the way the language and the theme snapshot already work, so the common launch waits for nothing. A device that has *never* seen it waits for the settings rather than assuming the default - the preference lives on the server, and guessing would ignore it on every browser that didn't set it. Only `active_trip` costs the one lookup, `GET /api/trips/active`, which reads four columns of one row instead of the whole trip list.

Login stops hardcoding `/dashboard` as its fallback and defers to the same resolver, so there is a single answer to "where does TREK open".

## Deep link

`/trips/:id?tab=<id>` works on its own, which is what the setting uses internally - useful for a hand-built shortcut or a wrapper app:

```
/trips/42?tab=finanzplan
```

Tab ids are the planner's historic German names (`plan`, `transports`, `buchungen`, `listen`, `finanzplan`, `dateien`, `collab`, plus `plugin:<id>`). Documented in the wiki, since nobody would guess them.

## Behaviour change worth a look

**A deliberate logout no longer leaves a `?redirect=`.** `logout()` clears `isAuthenticated` while the page you were on is still mounted, so `ProtectedRoute` re-renders for it and stamps `/login?redirect=<that page>`. Log out from the dashboard and the next login goes to the dashboard, whatever the user picked. A session that ended on its own still gets the return ticket - coming back to where you were is the point of that parameter - but a deliberate sign-out is a fresh start and now gets none.

This affects everyone, not just users of the new setting: signing out and back in now lands on your start page instead of on the last page you happened to be looking at. `Navbar.handleLogout` already passed an unused `noRedirect` state, so the intent predates this PR; the flag now lives in the store because all seven callers of `logout()` need it.

## Bugs this surfaced

Nothing had ever started on a tab other than Plan, so the tab machinery got away with two things:

- The invalid-tab guard evicted anything missing from `TRIP_TABS`, but `enabledAddons` is an optimistic guess until the addon feed answers - and `collab` is guessed *off*. A requested collab tab was dropped a render before we knew the addon was on. It now waits for the feed, exactly as it already did for plugin tabs.
- The lazy loads hang off `handleTabChange`, which the tab you *start* on never goes through. Opening on Files showed an empty list - already true for a tab restored from a previous visit, so that is fixed too.

## Notes

- No migration: user settings are free key/value.
- i18n in all 23 languages, parity check green.
- Wiki updated (Display-Settings, User-Settings, Offline-Mode-and-PWA, FAQ).
- Verified end to end in a browser, not just in tests: login, log out, log back in, three rounds, plus the deep link and the expired-session case.

Comes out of the Discord thread where Martin asked for a shortcut into a trip's expenses and Simeon offered to build a wrapper app for it. The `?tab=` link means that wrapper is still possible for anyone who wants one.
