### PR TITLE
Say in the README how we use AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,15 @@ The Atlas map's country and sub-national (province/county) boundaries come from
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See [NOTICE.md](NOTICE.md)
 for full third-party attributions.
 
+## AI usage
+
+We use LLM-assisted coding tools across parts of this codebase, from translations and
+tests to entire features. Every change goes through a pull request and is tested before
+it ships, and someone here is responsible for it either way.
+
+See [**How we use AI in TREK**](https://github.com/liketrek/TREK/discussions/1851) for
+the details.
+
 ## License
 
 TREK is [AGPL v3](LICENSE). Self-host freely for personal or internal company use. If you modify and offer TREK as a network service to third parties, your modifications must be open-sourced under the same licence.

--- a/README.md
+++ b/README.md
@@ -173,10 +173,13 @@ A self-hosted, real-time collaborative travel planner — with maps, budgets, pa
 
 ## AI usage
 
-We use LLM-assisted coding tools across parts of this codebase. Every change goes
-through a pull request and is tested before it ships. See
-[**How we use AI in TREK**](https://github.com/liketrek/TREK/discussions/1851) for the
-details.
+We use LLM-assisted coding tools across parts of this codebase. Nothing ships that a
+maintainer has not read and understood: every change goes through a pull request, is
+reviewed and tested, and has a human who can answer for it. "The AI wrote that" is not
+an answer any of us would accept from ourselves.
+
+See [**How we use AI in TREK**](https://github.com/liketrek/TREK/discussions/1851) for
+the details.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ A self-hosted, real-time collaborative travel planner — with maps, budgets, pa
 
 <br />
 
+## AI usage
+
+We use LLM-assisted coding tools across parts of this codebase. Every change goes
+through a pull request and is tested before it ships. See
+[**How we use AI in TREK**](https://github.com/liketrek/TREK/discussions/1851) for the
+details.
+
+<br />
+
 ## Get started in 30 seconds
 
 ```bash
@@ -475,15 +484,6 @@ The Atlas map's country and sub-national (province/county) boundaries come from
 [**geoBoundaries**](https://www.geoboundaries.org/) (Runfola et al., 2020), licensed
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See [NOTICE.md](NOTICE.md)
 for full third-party attributions.
-
-## AI usage
-
-We use LLM-assisted coding tools across parts of this codebase, from translations and
-tests to entire features. Every change goes through a pull request and is tested before
-it ships, and someone here is responsible for it either way.
-
-See [**How we use AI in TREK**](https://github.com/liketrek/TREK/discussions/1851) for
-the details.
 
 ## License
 


### PR DESCRIPTION
@
The repository said nothing about AI assistance until now, which was fair to criticise. This adds a short `AI usage` section to the README, next to the other project-meta sections, and points at the announcement for the full picture.

Closes nothing, follows up on discussion #1851.
@