### PR TITLE
Move five more domains onto the plugin RPC decorators

### DIFF
--- a/server/src/nest/budget/budget.module.ts
+++ b/server/src/nest/budget/budget.module.ts
@@ -3,6 +3,7 @@ import { BudgetController } from './budget.controller';
 import { BudgetService } from './budget.service';
 import { BudgetMcp } from './budget.mcp';
 import { ExchangeRatesService } from './exchange-rates.service';
+import { ExchangeRatesRpc } from './exchange-rates.rpc';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AuthModule } from '../auth/auth.module';
 
@@ -11,7 +12,7 @@ import { AuthModule } from '../auth/auth.module';
 @Module({
   imports: [PermissionsModule, AuthModule],
   controllers: [BudgetController],
-  providers: [BudgetService, ExchangeRatesService, BudgetMcp],
+  providers: [BudgetService, ExchangeRatesService, BudgetMcp, ExchangeRatesRpc],
   // For in-container consumers (PluginHostDepsFactory, TripsService,
   // ReservationsService, BookingImportService).
   exports: [BudgetService, ExchangeRatesService],

--- a/server/src/nest/budget/exchange-rates.rpc.ts
+++ b/server/src/nest/budget/exchange-rates.rpc.ts
@@ -1,0 +1,21 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { str } from '../plugins/host/rpc-params';
+import { ExchangeRatesService } from './exchange-rates.service';
+
+/**
+ * The exchange-rate surface a plugin may reach (#plugins). Tenant-free like
+ * weather: a cached upstream feed with no user and no trip behind it, useful to any
+ * plugin that shows or converts money.
+ *
+ * Note this is NOT gated on the Costs addon. It carries no budget data, and the
+ * router never gated it either.
+ */
+@PluginController()
+export class ExchangeRatesRpc {
+  constructor(private readonly exchangeRates: ExchangeRatesService) {}
+
+  @PluginMethod('rates.get', { permission: 'rates:read' })
+  get(params: Record<string, unknown>): unknown {
+    return this.exchangeRates.getRates(str(params.base, 'base'));
+  }
+}

--- a/server/src/nest/categories/categories.module.ts
+++ b/server/src/nest/categories/categories.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { CategoriesController } from './categories.controller';
 import { CategoriesMcp } from './categories.mcp';
 import { CategoriesService } from './categories.service';
+import { CategoriesRpc } from './categories.rpc';
 
 /** Categories domain (L4 leaf module). Registered in AppModule. */
 @Module({
   controllers: [CategoriesController],
-  providers: [CategoriesService, CategoriesMcp],
+  providers: [CategoriesService, CategoriesMcp, CategoriesRpc],
   // For in-container consumers (PluginHostDepsFactory).
   exports: [CategoriesService],
 })

--- a/server/src/nest/categories/categories.rpc.ts
+++ b/server/src/nest/categories/categories.rpc.ts
@@ -1,0 +1,17 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { CategoriesService } from './categories.service';
+
+/**
+ * The category surface a plugin may reach (#plugins). A global, read-only
+ * reference list that carries no tenant data, so it needs neither an acting user
+ * nor a trip gate.
+ */
+@PluginController()
+export class CategoriesRpc {
+  constructor(private readonly categories: CategoriesService) {}
+
+  @PluginMethod('categories.list', { permission: 'db:read:categories' })
+  list(): unknown[] {
+    return this.categories.list() as unknown[];
+  }
+}

--- a/server/src/nest/days/day-notes.rpc.ts
+++ b/server/src/nest/days/day-notes.rpc.ts
@@ -1,0 +1,79 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { asPayload, num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { DayNotesService } from './day-notes.service';
+
+/** Day notes ride on the day permission, like the rest of the day surface. */
+const DAY_NOTE_EDIT_ACTION = 'day_edit';
+
+type DayNoteInput = { text?: string; time?: string; icon?: string; sort_order?: number };
+
+/**
+ * The day-note surface a plugin may reach (#plugins). Core data with no addon
+ * behind it, trip-scoped, so the standard membership gate applies.
+ *
+ * Every write re-checks that the day (or the note) really belongs to the trip it
+ * was addressed with, so a plugin cannot write a note onto another trip's day by
+ * naming its id. The dayNote:* broadcasts match what the REST controller emits.
+ */
+@PluginController()
+export class DayNotesRpc {
+  constructor(
+    private readonly dayNotes: DayNotesService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('daynotes.list', { permission: 'db:read:daynotes' })
+  list(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () =>
+      this.dayNotes.list(num(params.dayId, 'dayId'), num(params.tripId, 'tripId')),
+    );
+  }
+
+  @PluginMethod('daynotes.create', { permission: 'db:write:daynotes' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const actor = this.guards.requireActor(ctx, 'day note');
+    const input = asPayload(params.input);
+    if (typeof input.text !== 'string' || input.text.trim() === '') throw new BadParams('note text is required');
+    this.guards.requireTripEdit(tripId, actor, DAY_NOTE_EDIT_ACTION);
+    if (!this.dayNotes.dayExists(dayId, tripId)) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
+    const i = input as DayNoteInput;
+    const note = this.dayNotes.create(dayId, tripId, i.text ?? '', i.time, i.icon, i.sort_order);
+    this.realtime.broadcast(tripId, 'dayNote:created', { dayId, note }, undefined);
+    return note;
+  }
+
+  @PluginMethod('daynotes.update', { permission: 'db:write:daynotes' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const noteId = num(params.noteId, 'noteId');
+    const actor = this.guards.requireActor(ctx, 'day note');
+    this.guards.requireTripEdit(tripId, actor, DAY_NOTE_EDIT_ACTION);
+    const current = this.dayNotes.getNote(noteId, dayId, tripId);
+    if (!current) throw new ForbiddenResource(`no note ${noteId} on day ${dayId}`);
+    const note = this.dayNotes.update(noteId, current as never, asPayload(params.input) as DayNoteInput);
+    this.realtime.broadcast(tripId, 'dayNote:updated', { dayId, note }, undefined);
+    return note;
+  }
+
+  @PluginMethod('daynotes.delete', { permission: 'db:write:daynotes' })
+  delete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const noteId = num(params.noteId, 'noteId');
+    const actor = this.guards.requireActor(ctx, 'day note');
+    this.guards.requireTripEdit(tripId, actor, DAY_NOTE_EDIT_ACTION);
+    const current = this.dayNotes.getNote(noteId, dayId, tripId);
+    if (!current) throw new ForbiddenResource(`no note ${noteId} on day ${dayId}`);
+    this.dayNotes.remove(noteId);
+    this.realtime.broadcast(tripId, 'dayNote:deleted', { noteId, dayId }, undefined);
+    return { deleted: true };
+  }
+}

--- a/server/src/nest/days/days.module.ts
+++ b/server/src/nest/days/days.module.ts
@@ -4,6 +4,9 @@ import { DaysService } from './days.service';
 import { DaysMcp } from './days.mcp';
 import { DayNotesController } from './day-notes.controller';
 import { DayNotesService } from './day-notes.service';
+import { DayNotesRpc } from './day-notes.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { DayNotesMcp } from './day-notes.mcp';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { QueryHelpersModule } from '../query-helpers/query-helpers.module';
@@ -20,9 +23,9 @@ import { AuthModule } from '../auth/auth.module';
  * controllers).
  */
 @Module({
-  imports: [PermissionsModule, QueryHelpersModule, PlacesModule, AuthModule],
+  imports: [PermissionsModule, QueryHelpersModule, PlacesModule, AuthModule, RealtimeModule, PluginGuardsModule],
   controllers: [DaysController, DayNotesController],
-  providers: [DaysService, DaysMcp, DayNotesService, DayNotesMcp],
+  providers: [DaysService, DaysMcp, DayNotesService, DayNotesMcp, DayNotesRpc],
   exports: [DaysService, DayNotesService],
 })
 export class DaysModule {}

--- a/server/src/nest/files/files.module.ts
+++ b/server/src/nest/files/files.module.ts
@@ -2,13 +2,16 @@ import { Module } from '@nestjs/common';
 import { FilesController } from './files.controller';
 import { FilesDownloadController } from './files-download.controller';
 import { FilesService } from './files.service';
+import { FilesRpc } from './files.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AppConfigModule } from '../app-config/app-config.module';
 
 @Module({
-  imports: [PermissionsModule, AppConfigModule],
+  imports: [PermissionsModule, AppConfigModule, RealtimeModule, PluginGuardsModule],
   controllers: [FilesController, FilesDownloadController],
-  providers: [FilesService],
+  providers: [FilesService, FilesRpc],
   exports: [FilesService],
 })
 export class FilesModule {}

--- a/server/src/nest/files/files.rpc.ts
+++ b/server/src/nest/files/files.rpc.ts
@@ -1,0 +1,210 @@
+import fsMod from 'node:fs';
+import pathMod from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { asPayload, num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { DatabaseService } from '../database/database.service';
+import { readEnv } from '../../app-config';
+import { isDemoEmail } from '../common/demo';
+import { BLOCKED_EXTENSIONS, filesDir } from './files.constants';
+import { FilesService } from './files.service';
+
+/** Files use three separate rights, one per operation, unlike every other domain. */
+const UPLOAD_ACTION = 'file_upload';
+const EDIT_ACTION = 'file_edit';
+const DELETE_ACTION = 'file_delete';
+
+/** Decoded bytes a plugin may read or write in one call. */
+const CONTENT_MAX = 10 * 1024 * 1024;
+
+type FileRow = {
+  filename: string;
+  original_name: string;
+  mime_type: string | null;
+  file_size: number | null;
+  deleted_at: string | null;
+};
+
+type CreateInput = {
+  name: string;
+  content_base64: string;
+  mimetype?: string;
+  description?: string;
+  place_id?: number;
+  reservation_id?: number;
+};
+
+/**
+ * The file surface a plugin may reach (#plugins).
+ *
+ * Two things here are unlike the rest of the plugin surface. Reading a file's BYTES
+ * is a separate grant from reading its metadata, because a passport scan is more
+ * sensitive than its filename. And the three write operations use three distinct
+ * rights (file_upload / file_edit / file_delete) rather than one domain action.
+ *
+ * The upload path is the only one in the plugin surface that touches disk, so the
+ * extension is checked against the central blocklist and the size is capped before
+ * anything is written, and a demo user is refused outright.
+ */
+@PluginController()
+export class FilesRpc {
+  constructor(
+    private readonly files: FilesService,
+    private readonly realtime: RealtimeService,
+    private readonly db: DatabaseService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('files.list', { permission: 'db:read:files' })
+  list(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // Trash excluded, the same view the files tab shows.
+    return this.guards.tripRead(params, ctx, () => this.files.listFiles(num(params.tripId, 'tripId'), false));
+  }
+
+  @PluginMethod('files.getContent', { permission: 'db:read:files:content' })
+  getContent(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () =>
+      this.readContent(num(params.tripId, 'tripId'), num(params.fileId, 'fileId')),
+    );
+  }
+
+  /**
+   * Size-capped BEFORE the read, so a 500MB video cannot be pulled through the IPC
+   * pipe as ~667MB of base64. The read itself runs off the event loop: 10MB of
+   * readFile plus base64 on the host thread would stall every other plugin RPC and
+   * every HTTP request for its duration.
+   */
+  private async readContent(tripId: number, fileId: number): Promise<unknown> {
+    const file = this.files.getFileById(fileId, tripId) as FileRow | undefined;
+    if (!file || file.deleted_at) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
+    if ((file.file_size ?? 0) > CONTENT_MAX) {
+      throw new BadParams(`file too large to read (>${CONTENT_MAX} bytes); use the download UI`);
+    }
+    const { resolved, safe } = this.files.resolveFilePath(file.filename);
+    if (!safe) throw new ForbiddenResource('file path is not accessible');
+    const buf = await fsMod.promises.readFile(resolved);
+    if (buf.length > CONTENT_MAX) throw new BadParams('file too large to read');
+    return {
+      name: file.original_name,
+      mimetype: file.mime_type ?? 'application/octet-stream',
+      size: buf.length,
+      content_base64: buf.toString('base64'),
+    };
+  }
+
+  @PluginMethod('files.create', { permission: 'db:write:files' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'file');
+    const input = asPayload(params.input);
+    if (typeof input.name !== 'string' || input.name.trim() === '' || input.name.length > 255) {
+      throw new BadParams('file name is required (max 255 chars)');
+    }
+    if (typeof input.content_base64 !== 'string' || input.content_base64 === '') {
+      throw new BadParams('content_base64 is required');
+    }
+    // Bound the ENCODED length first: 14MB of base64 is roughly the 10MB cap, and
+    // rejecting here avoids decoding an oversized payload just to measure it.
+    if (input.content_base64.length > 14 * 1024 * 1024) {
+      throw new BadParams('file exceeds the 10MB plugin upload cap');
+    }
+    this.guards.requireTripEdit(tripId, actor, UPLOAD_ACTION);
+    return this.writeFile(tripId, input as unknown as CreateInput, actor);
+  }
+
+  private writeFile(tripId: number, input: CreateInput, actingUserId: number): unknown {
+    // Mirrors the REST upload guard: a demo user must not write bytes to the shared
+    // demo instance, not even through a plugin's db:write:files. The email is only
+    // resolved when demo mode is actually on, so self-hosted installs pay nothing.
+    if (readEnv().demo.enabled) {
+      const uploader = this.db.prepare('SELECT email FROM users WHERE id = ?').get(actingUserId) as { email?: string } | undefined;
+      if (isDemoEmail(uploader?.email)) throw new ForbiddenResource('Uploads are disabled in demo mode.');
+    }
+    const original = pathMod.basename(input.name);
+    const ext = pathMod.extname(original).toLowerCase();
+    if (!ext || BLOCKED_EXTENSIONS.includes(ext)) {
+      throw new BadParams(`file extension '${ext || '(none)'}' is not allowed`);
+    }
+    const buf = Buffer.from(input.content_base64, 'base64');
+    if (buf.length === 0) throw new BadParams('file content is empty');
+    if (buf.length > CONTENT_MAX) throw new BadParams('file exceeds the 10MB plugin upload cap');
+    const foreign = this.files.findForeignLinkTarget(tripId, {
+      reservation_id: input.reservation_id ?? null,
+      place_id: input.place_id ?? null,
+    });
+    if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
+    const filename = `${randomUUID()}${ext}`;
+    fsMod.mkdirSync(filesDir, { recursive: true });
+    fsMod.writeFileSync(pathMod.join(filesDir, filename), buf);
+    const file = this.files.createFile(
+      tripId,
+      { filename, originalname: original, size: buf.length, mimetype: input.mimetype || 'application/octet-stream' },
+      actingUserId,
+      {
+        place_id: input.place_id != null ? String(input.place_id) : null,
+        reservation_id: input.reservation_id != null ? String(input.reservation_id) : null,
+        description: input.description ?? null,
+      },
+    );
+    this.realtime.broadcast(tripId, 'file:created', { file }, undefined);
+    return file;
+  }
+
+  @PluginMethod('files.createLink', { permission: 'db:write:files' })
+  createLink(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const fileId = num(params.fileId, 'fileId');
+    const actor = this.guards.requireActor(ctx, 'file link');
+    this.guards.requireTripEdit(tripId, actor, EDIT_ACTION);
+    if (!this.files.getFileById(fileId, tripId)) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
+    const opts = asPayload(params.opts) as { reservation_id?: number; assignment_id?: number; place_id?: number };
+    // A link target on another trip would otherwise attach this trip's file to it.
+    const foreign = this.files.findForeignLinkTarget(tripId, opts);
+    if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
+    return this.files.createFileLink(fileId, {
+      reservation_id: opts.reservation_id != null ? String(opts.reservation_id) : null,
+      assignment_id: opts.assignment_id != null ? String(opts.assignment_id) : null,
+      place_id: opts.place_id != null ? String(opts.place_id) : null,
+    });
+  }
+
+  @PluginMethod('files.update', { permission: 'db:write:files' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const fileId = num(params.fileId, 'fileId');
+    const actor = this.guards.requireActor(ctx, 'file');
+    this.guards.requireTripEdit(tripId, actor, EDIT_ACTION);
+    const current = this.files.getFileById(fileId, tripId);
+    if (!current) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
+    const input = asPayload(params.input) as { description?: string; place_id?: number | null; reservation_id?: number | null };
+    const foreign = this.files.findForeignLinkTarget(tripId, {
+      reservation_id: input.reservation_id ?? null,
+      place_id: input.place_id ?? null,
+    });
+    if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
+    const file = this.files.updateFile(fileId, current, {
+      description: input.description,
+      // null clears the link, undefined leaves it alone: the two are distinct here.
+      place_id: input.place_id != null ? String(input.place_id) : input.place_id === null ? null : undefined,
+      reservation_id: input.reservation_id != null ? String(input.reservation_id) : input.reservation_id === null ? null : undefined,
+    });
+    this.realtime.broadcast(tripId, 'file:updated', { file }, undefined);
+    return file;
+  }
+
+  @PluginMethod('files.softDelete', { permission: 'db:write:files' })
+  softDelete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const fileId = num(params.fileId, 'fileId');
+    const actor = this.guards.requireActor(ctx, 'file');
+    this.guards.requireTripEdit(tripId, actor, DELETE_ACTION);
+    if (!this.files.getFileById(fileId, tripId)) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
+    this.files.softDeleteFile(fileId);
+    this.realtime.broadcast(tripId, 'file:deleted', { fileId }, undefined);
+    return { deleted: true };
+  }
+}

--- a/server/src/nest/packing/packing.controller.ts
+++ b/server/src/nest/packing/packing.controller.ts
@@ -109,19 +109,8 @@ export class PackingController {
     this.requireEdit(trip, user);
     // checked arrives as boolean or legacy 0/1 — the service coerces by truthiness.
     const item = this.packing.createItem(tripId, { name: body.name, category: body.category, checked: body.checked === undefined ? undefined : !!body.checked, is_private: body.is_private, visibility: body.visibility, recipient_ids: body.recipient_ids }, user.id);
-    this.emitToViewers(tripId, 'packing:created', { item }, item, socketId);
+    this.packing.emitToViewers(tripId, 'packing:created', { item }, item, socketId);
     return { item };
-  }
-
-  /** Deliver an item event to exactly the people who can see it (#858): the whole
-   *  room for a Common item, or owner + recipients for a restricted one. */
-  private emitToViewers<E extends TrekWsTripEventName>(tripId: string, event: E, payload: TrekWsPayload<E>, item: PackingItemRow, socketId: string | undefined): void {
-    const viewers = this.packing.viewersOf(item);
-    if (viewers === null) {
-      this.packing.broadcast(tripId, event, payload, socketId);
-    } else {
-      this.packing.broadcastToViewers(tripId, event, payload, viewers, socketId);
-    }
   }
 
   @Put('reorder')
@@ -163,39 +152,8 @@ export class PackingController {
     if (isUpdateConflict(updated)) {
       throw new HttpException({ error: 'conflict', server: updated.server }, 409);
     }
-    this.broadcastUpdate(tripId, id, updated as PackingItemRow, !!before?.is_private, socketId);
+    this.packing.broadcastUpdate(tripId, id, updated as PackingItemRow, !!before?.is_private, socketId);
     return { item: updated };
-  }
-
-  /**
-   * Routes a packing-item update over WebSocket so private items (#858) stay
-   * scoped to their owner across the four public↔private transitions:
-   *  - stays private  → owner-only update
-   *  - public→private → drop it from the whole room, re-add for the owner
-   *  - private→public → create for members who lacked it, then update for all
-   *  - stays public   → plain update to all
-   */
-  private broadcastUpdate(
-    tripId: string,
-    id: string,
-    item: PackingItemRow,
-    wasPrivate: boolean,
-    socketId: string | undefined,
-  ): void {
-    const nowPrivate = !!item.is_private;
-    if (nowPrivate) {
-      if (wasPrivate) {
-        this.packing.broadcastItem(tripId, 'packing:updated', { item }, item, socketId);
-      } else {
-        this.packing.broadcast(tripId, 'packing:deleted', { itemId: Number(id) }, socketId);
-        this.packing.broadcastItem(tripId, 'packing:created', { item }, item, socketId);
-      }
-    } else {
-      if (wasPrivate) {
-        this.packing.broadcast(tripId, 'packing:created', { item }, socketId);
-      }
-      this.packing.broadcast(tripId, 'packing:updated', { item }, socketId);
-    }
   }
 
   @Delete(':id')
@@ -212,7 +170,7 @@ export class PackingController {
       throw new HttpException({ error: 'Item not found' }, 404);
     }
     // Scope the delete to the people who could see it (owner + recipients, #858).
-    this.emitToViewers(tripId, 'packing:deleted', { itemId: Number(id) }, deleted as PackingItemRow, socketId);
+    this.packing.emitToViewers(tripId, 'packing:deleted', { itemId: Number(id) }, deleted as PackingItemRow, socketId);
     return { success: true };
   }
 
@@ -236,7 +194,7 @@ export class PackingController {
     // The viewer set just changed: drop the item from the whole room, then re-add
     // it for whoever can now see it (owner + recipients, or everyone if Common).
     this.packing.broadcast(tripId, 'packing:deleted', { itemId: Number(id) }, socketId);
-    this.emitToViewers(tripId, 'packing:created', { item: updated }, updated as PackingItemRow, socketId);
+    this.packing.emitToViewers(tripId, 'packing:created', { item: updated }, updated as PackingItemRow, socketId);
     return { item: updated };
   }
 
@@ -255,7 +213,7 @@ export class PackingController {
       throw new HttpException({ error: 'Item not found' }, 404);
     }
     // The clone is personal to the caller — only their sockets need it.
-    this.emitToViewers(tripId, 'packing:created', { item }, item, socketId);
+    this.packing.emitToViewers(tripId, 'packing:created', { item }, item, socketId);
     return { item };
   }
 

--- a/server/src/nest/packing/packing.module.ts
+++ b/server/src/nest/packing/packing.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { PackingController } from './packing.controller';
 import { PackingMcp } from './packing.mcp';
 import { PackingService } from './packing.service';
+import { PackingRpc } from './packing.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AuthModule } from '../auth/auth.module';
 
@@ -9,9 +12,9 @@ import { AuthModule } from '../auth/auth.module';
  *  Exports PackingService for in-container consumers (TripsService bundle,
  *  PluginHostDepsFactory). */
 @Module({
-  imports: [PermissionsModule, AuthModule],
+  imports: [PermissionsModule, AuthModule, RealtimeModule, PluginGuardsModule],
   controllers: [PackingController],
-  providers: [PackingService, PackingMcp],
+  providers: [PackingService, PackingMcp, PackingRpc],
   exports: [PackingService],
 })
 export class PackingModule {}

--- a/server/src/nest/packing/packing.rpc.ts
+++ b/server/src/nest/packing/packing.rpc.ts
@@ -1,0 +1,144 @@
+import { packingCreateItemRequestSchema, packingUpdateItemRequestSchema } from '@trek/shared';
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { asPayload, num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { PackingService } from './packing.service';
+import { isUpdateConflict } from '../common/conflictResult';
+
+/** Packing rides on the app's own 'packing_edit' permission, exactly like the REST path. */
+const PACKING_EDIT_ACTION = 'packing_edit';
+
+type PrivacyItem = { is_private?: number; owner_id?: number | null; recipients?: { user_id: number }[] };
+
+/**
+ * The packing surface a plugin may reach (#plugins).
+ *
+ * The privacy-scoped broadcasts (#858) go through PackingService, the same methods
+ * the REST controller calls. They used to be duplicated inside the plugin deps
+ * factory, with a comment asking for both copies to be kept in lockstep by hand;
+ * that copy is gone. Getting this wrong leaks a private item to the whole trip room,
+ * which is why `wasPrivate` is read BEFORE the write and why the four transitions
+ * live in exactly one place.
+ *
+ * Bags carry no privacy, so they broadcast to the room unfiltered.
+ */
+@PluginController()
+export class PackingRpc {
+  constructor(
+    private readonly packing: PackingService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('packing.list', { permission: 'db:read:packing' })
+  list(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // Scoped to the acting user so the #858 visibility filter applies: a plugin must
+    // not see another member's private items.
+    return this.guards.tripRead(params, ctx, (userId) => this.packing.listItems(num(params.tripId, 'tripId'), userId));
+  }
+
+  @PluginMethod('packing.create', { permission: 'db:write:packing' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'packing item');
+    const parsed = packingCreateItemRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid packing item: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    const item = this.packing.createItem(String(tripId), parsed.data as never, actor) as PrivacyItem;
+    this.packing.emitToViewers(String(tripId), 'packing:created', { item }, item, undefined);
+    return item;
+  }
+
+  @PluginMethod('packing.update', { permission: 'db:write:packing' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const itemId = num(params.itemId, 'itemId');
+    const actor = this.guards.requireActor(ctx, 'packing item');
+    const parsed = packingUpdateItemRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid packing item: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    // Read the privacy BEFORE the write, so a public/private toggle routes correctly.
+    const before = this.packing.getItemPrivacy(tripId, itemId);
+    const input = parsed.data as Record<string, unknown>;
+    const updated = this.packing.updateItem(String(tripId), String(itemId), input as never, Object.keys(input), undefined, actor);
+    if (!updated) throw new ForbiddenResource(`no packing item ${itemId} on trip ${tripId}`);
+    if (isUpdateConflict(updated)) throw new BadParams('packing item was modified concurrently');
+    this.packing.broadcastUpdate(String(tripId), itemId, updated as PrivacyItem, !!before?.is_private, undefined);
+    return updated;
+  }
+
+  @PluginMethod('packing.delete', { permission: 'db:write:packing' })
+  delete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const itemId = num(params.itemId, 'itemId');
+    const actor = this.guards.requireActor(ctx, 'packing item');
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    const deleted = this.packing.deleteItem(String(tripId), String(itemId)) as PrivacyItem | null;
+    if (!deleted) throw new ForbiddenResource(`no packing item ${itemId} on trip ${tripId}`);
+    this.packing.emitToViewers(String(tripId), 'packing:deleted', { itemId }, deleted, undefined);
+    return { deleted: true };
+  }
+
+  @PluginMethod('packing.listBags', { permission: 'db:write:packing' })
+  listBags(params: Record<string, unknown>, ctx: PluginRpcContext): unknown[] {
+    // Note the permission: the envelope really does gate this READ on the write
+    // grant. The decorator makes the oddity visible instead of burying it.
+    return this.guards.tripRead(params, ctx, () => this.packing.listBags(String(num(params.tripId, 'tripId'))) as unknown[]);
+  }
+
+  @PluginMethod('packing.createBag', { permission: 'db:write:packing' })
+  createBag(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'packing bag');
+    const input = asPayload(params.input);
+    if (typeof input.name !== 'string' || input.name.trim() === '') throw new BadParams('bag name is required');
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    const bag = this.packing.createBag(String(tripId), { name: input.name, color: typeof input.color === 'string' ? input.color : undefined });
+    this.realtime.broadcast(tripId, 'packing:bag-created', { bag }, undefined);
+    return bag;
+  }
+
+  @PluginMethod('packing.updateBag', { permission: 'db:write:packing' })
+  updateBag(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const bagId = num(params.bagId, 'bagId');
+    const actor = this.guards.requireActor(ctx, 'packing bag');
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    const input = asPayload(params.input);
+    const bag = this.packing.updateBag(String(tripId), String(bagId), input as never, Object.keys(input));
+    if (!bag) throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
+    this.realtime.broadcast(tripId, 'packing:bag-updated', { bag }, undefined);
+    return bag;
+  }
+
+  @PluginMethod('packing.deleteBag', { permission: 'db:write:packing' })
+  deleteBag(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const bagId = num(params.bagId, 'bagId');
+    const actor = this.guards.requireActor(ctx, 'packing bag');
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    if (!this.packing.deleteBag(String(tripId), String(bagId))) {
+      throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
+    }
+    this.realtime.broadcast(tripId, 'packing:bag-deleted', { bagId }, undefined);
+    return { deleted: true };
+  }
+
+  @PluginMethod('packing.setBagMembers', { permission: 'db:write:packing' })
+  setBagMembers(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const bagId = num(params.bagId, 'bagId');
+    const actor = this.guards.requireActor(ctx, 'packing bag');
+    this.guards.requireTripEdit(tripId, actor, PACKING_EDIT_ACTION);
+    // userIds sits on the params object itself, not under `input`.
+    const raw = asPayload(params).userIds;
+    const userIds = Array.isArray(raw) ? raw.filter((x): x is number => typeof x === 'number') : [];
+    const members = this.packing.setBagMembers(String(tripId), String(bagId), userIds);
+    if (!members) throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
+    this.realtime.broadcast(tripId, 'packing:bag-members-updated', { bagId, members }, undefined);
+    return members;
+  }
+}

--- a/server/src/nest/packing/packing.service.ts
+++ b/server/src/nest/packing/packing.service.ts
@@ -84,6 +84,49 @@ export class PackingService {
     return ids;
   }
 
+  /** Deliver an item event to exactly the people who can see it (#858): the whole
+   *  room for a Common item, or owner + recipients for a restricted one. */
+  emitToViewers<E extends TrekWsTripEventName>(tripId: string, event: E, payload: TrekWsPayload<E>, item: PrivacyFields | null | undefined, socketId: string | undefined): void {
+    const viewers = this.viewersOf(item);
+    if (viewers === null) {
+      this.broadcast(tripId, event, payload, socketId);
+    } else {
+      this.broadcastToViewers(tripId, event, payload, viewers, socketId);
+    }
+  }
+
+  /**
+   * The four public/private transitions after an update (#858). `wasPrivate` must be
+   * read BEFORE the write: getting it wrong leaks a freshly-privatized item to the
+   * whole room.
+   *
+   *  - private -> private: owner-only update
+   *  - public  -> private: drop it from the room, then re-add it for the owner
+   *  - private -> public:  add it for the members who did not have it, then update
+   *  - public  -> public:  a plain update to everyone
+   *
+   * Both the REST controller and the plugin RPC handler call this. It used to exist
+   * three times over (here, in the controller, and as a standalone copy inside the
+   * plugin deps factory), with a comment asking for all of them to be kept in
+   * lockstep by hand.
+   */
+  broadcastUpdate(tripId: string, id: string | number, item: PrivacyFields, wasPrivate: boolean, socketId: string | undefined): void {
+    const nowPrivate = !!item.is_private;
+    if (nowPrivate) {
+      if (wasPrivate) {
+        this.broadcastItem(tripId, 'packing:updated', { item } as TrekWsPayload<'packing:updated'>, item, socketId);
+      } else {
+        this.broadcast(tripId, 'packing:deleted', { itemId: Number(id) }, socketId);
+        this.broadcastItem(tripId, 'packing:created', { item } as TrekWsPayload<'packing:created'>, item, socketId);
+      }
+    } else {
+      if (wasPrivate) {
+        this.broadcast(tripId, 'packing:created', { item } as TrekWsPayload<'packing:created'>, socketId);
+      }
+      this.broadcast(tripId, 'packing:updated', { item } as TrekWsPayload<'packing:updated'>, socketId);
+    }
+  }
+
   // ── Items ──────────────────────────────────────────────────────────────────
 
   /**

--- a/server/src/nest/plugins/host/plugin-guards.module.ts
+++ b/server/src/nest/plugins/host/plugin-guards.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { PermissionsModule } from '../../permissions/permissions.module';
+import { AddonsModule } from '../../addons/addons.module';
+import { PluginGuards } from './plugin-guards.service';
+
+/**
+ * A leaf module whose only job is to hand PluginGuards to the domain modules.
+ *
+ * It cannot live in PluginsModule: that module imports 22 domain modules, so a
+ * domain importing it back to reach the guards would close a hard cycle
+ * (PluginsModule -> TodoModule -> PluginsModule) and the only way out would be
+ * forwardRef. PermissionsModule and AddonsModule are themselves leaves and
+ * DatabaseModule is @Global, so this module imports nothing that leads back here.
+ *
+ * Same shape and same reason as MailerModule, which broke
+ * AuthModule <-> NotificationsModule.
+ */
+@Module({
+  imports: [PermissionsModule, AddonsModule],
+  providers: [PluginGuards],
+  exports: [PluginGuards],
+})
+export class PluginGuardsModule {}

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -196,82 +196,12 @@ export class PluginHostDepsFactory {
       },
       // --- Read scopes (packing/files). Membership is checked by the host (tripRead);
       // these just delegate to the same services the REST paths use. ---
-      listTripFiles: (tripId) => this.files.listFiles(tripId, false),
       // A file's bytes as base64, size-capped BEFORE the read so a 500MB video can't
       // be pulled (~667MB base64) through the IPC pipe. 10MB matches the plugin upload
       // cap; trashed files (deleted_at set) are refused like the download path.
-      getTripFileContent: async (tripId, fileId) => {
-        const CONTENT_MAX = 10 * 1024 * 1024;
-        const file = this.files.getFileById(fileId, tripId) as { filename: string; original_name: string; mime_type: string | null; file_size: number | null; deleted_at: string | null } | undefined;
-        if (!file || file.deleted_at) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
-        if ((file.file_size ?? 0) > CONTENT_MAX) throw new BadParams(`file too large to read (>${CONTENT_MAX} bytes); use the download UI`);
-        const { resolved, safe } = this.files.resolveFilePath(file.filename);
-        if (!safe) throw new ForbiddenResource('file path is not accessible');
-        // Read off the event loop — a 10MB read + base64 on the host thread would
-        // otherwise stall every other plugin RPC and request for its duration.
-        const buf = await fsMod.promises.readFile(resolved);
-        if (buf.length > CONTENT_MAX) throw new BadParams('file too large to read');
-        return { name: file.original_name, mimetype: file.mime_type ?? 'application/octet-stream', size: buf.length, content_base64: buf.toString('base64') };
-      },
       // --- Files write. Bytes arrive as bounded base64; the extension is validated
       // against the central blocklist BEFORE anything touches disk, and link targets
       // must live on the same trip (findForeignLinkTarget). Same events as the app. ---
-      canUploadFiles: (tripId, userId) => this.canEditTripAs('file_upload', tripId, userId),
-      canEditFiles: (tripId, userId) => this.canEditTripAs('file_edit', tripId, userId),
-      canDeleteFiles: (tripId, userId) => this.canEditTripAs('file_delete', tripId, userId),
-      createTripFile: (tripId, input, actingUserId) => {
-        // Mirror the REST upload guard (files.controller): a demo user must not write
-        // bytes to the shared demo instance, even through a plugin's db:write:files.
-        // Only resolve the email when demo mode is actually on — keeps the hot path
-        // (and the schema surface) untouched for self-hosted installs.
-        if (readEnv().demo.enabled) {
-          const uploader = this.db.prepare('SELECT email FROM users WHERE id = ?').get(actingUserId) as { email?: string } | undefined;
-          if (isDemoEmail(uploader?.email)) throw new ForbiddenResource('Uploads are disabled in demo mode.');
-        }
-        const i = input as { name: string; content_base64: string; mimetype?: string; description?: string; place_id?: number; reservation_id?: number };
-        const original = pathMod.basename(i.name);
-        const ext = pathMod.extname(original).toLowerCase();
-        if (!ext || BLOCKED_EXTENSIONS.includes(ext)) throw new BadParams(`file extension '${ext || '(none)'}' is not allowed`);
-        const buf = Buffer.from(i.content_base64, 'base64');
-        if (buf.length === 0) throw new BadParams('file content is empty');
-        if (buf.length > 10 * 1024 * 1024) throw new BadParams('file exceeds the 10MB plugin upload cap');
-        const foreign = this.files.findForeignLinkTarget(tripId, { reservation_id: i.reservation_id ?? null, place_id: i.place_id ?? null });
-        if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
-        const filename = `${randomUUID()}${ext}`;
-        fsMod.mkdirSync(filesDir, { recursive: true });
-        fsMod.writeFileSync(pathMod.join(filesDir, filename), buf);
-        const file = this.files.createFile(
-          tripId,
-          { filename, originalname: original, size: buf.length, mimetype: i.mimetype || 'application/octet-stream' },
-          actingUserId,
-          { place_id: i.place_id != null ? String(i.place_id) : null, reservation_id: i.reservation_id != null ? String(i.reservation_id) : null, description: i.description ?? null },
-        );
-        this.realtime.broadcast(tripId, 'file:created', { file }, undefined);
-        return file;
-      },
-      createTripFileLink: (tripId, fileId, opts) => {
-        if (!this.files.getFileById(fileId, tripId)) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
-        const o = opts as { reservation_id?: number; assignment_id?: number; place_id?: number };
-        const foreign = this.files.findForeignLinkTarget(tripId, o);
-        if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
-        return this.files.createFileLink(fileId, { reservation_id: o.reservation_id != null ? String(o.reservation_id) : null, assignment_id: o.assignment_id != null ? String(o.assignment_id) : null, place_id: o.place_id != null ? String(o.place_id) : null });
-      },
-      updateTripFile: (tripId, fileId, input) => {
-        const current = this.files.getFileById(fileId, tripId);
-        if (!current) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
-        const i = input as { description?: string; place_id?: number | null; reservation_id?: number | null };
-        const foreign = this.files.findForeignLinkTarget(tripId, { reservation_id: i.reservation_id ?? null, place_id: i.place_id ?? null });
-        if (foreign) throw new ForbiddenResource(`${foreign} does not belong to trip ${tripId}`);
-        const file = this.files.updateFile(fileId, current, { description: i.description, place_id: i.place_id != null ? String(i.place_id) : i.place_id === null ? null : undefined, reservation_id: i.reservation_id != null ? String(i.reservation_id) : i.reservation_id === null ? null : undefined });
-        this.realtime.broadcast(tripId, 'file:updated', { file }, undefined);
-        return file;
-      },
-      softDeleteTripFile: (tripId, fileId) => {
-        if (!this.files.getFileById(fileId, tripId)) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
-        this.files.softDeleteFile(fileId);
-        this.realtime.broadcast(tripId, 'file:deleted', { fileId }, undefined);
-        return { deleted: true };
-      },
       // --- Collab reads (collab addon; membership checked by the host). Same hydrated
       // shapes as the REST GETs, so a collab plugin can finally read what it writes. ---
       listCollabNotes: (tripId) => { requireAddon(ADDON_IDS.COLLAB, 'collab'); return this.collab.listNotes(tripId) as unknown[]; },

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import type { TrekWsPayload, TrekWsTripEventName } from '@trek/shared';
 import { readEnv } from '../../../app-config';
 import { RealtimeService } from '../../realtime/realtime.service';
-import { isUpdateConflict } from '../../common/conflictResult';
-import { getWeather } from '../../weather/weather.impl';
 import { BLOCKED_EXTENSIONS, filesDir } from '../../files/files.constants';
 import { TripMembershipService } from '../../trip-membership/trip-membership.service';
 import { NotificationsService } from '../../notifications/notifications.service';
@@ -64,54 +61,10 @@ function mirrorJourneys(run: () => void): void {
   try { run(); } catch { /* non-fatal */ }
 }
 
-// --- #858 packing privacy: viewer-scoped fan-out mirrored from
-// packing.controller.broadcastUpdate/emitToViewers and PackingService's
-// broadcastItem/viewersOf/broadcastToViewers. A private item's events reach ONLY
-// its owner (+ recipients for a shared item), never the whole trip room; passing the
-// wrong onlyUserId — or forgetting to drop a freshly-privatized item from the room —
-// leaks it. Kept as a local copy (rather than delegating to the injected
-// PackingService) so the factory's unit test can assert the fan-out through the
-// websocket mock while PackingService stays a plain data stub. Keep in lockstep
-// with packing.controller.ts + packing.service.ts. ---
-type PackingPrivacy = { is_private?: number; owner_id?: number | null; recipients?: { user_id: number }[] };
-
-function packingViewersOf(item: PackingPrivacy | null | undefined): number[] | null {
-  if (!item || !item.is_private) return null; // Common — visible to the whole room
-  return [item.owner_id, ...(item.recipients || []).map((r) => r.user_id)].filter((x): x is number => x != null);
-}
-
-/** CREATE/DELETE fan-out: whole room for a Common item, else owner + recipients only. */
-function emitPackingToViewers<E extends TrekWsTripEventName>(realtime: RealtimeService, tripId: number, event: E, payload: TrekWsPayload<E>, item: PackingPrivacy): void {
-  const viewers = packingViewersOf(item);
-  if (viewers === null) {
-    realtime.broadcast(tripId, event, payload, undefined);
-    return;
-  }
-  for (const uid of new Set(viewers)) if (uid != null) realtime.broadcast(tripId, event, payload, undefined, uid);
-}
-
-/** An item event delivered owner-only when the item is private (else to the room). */
-function broadcastPackingItem<E extends TrekWsTripEventName>(realtime: RealtimeService, tripId: number, event: E, payload: TrekWsPayload<E>, item: PackingPrivacy): void {
-  const onlyUserId = item?.is_private && item.owner_id != null ? item.owner_id : undefined;
-  realtime.broadcast(tripId, event, payload, undefined, onlyUserId);
-}
-
-/** The four public<->private transitions (packing.controller.broadcastUpdate). `wasPrivate`
- * is read BEFORE the write — getting this wrong LEAKS a freshly-privatized item. */
-function broadcastPackingUpdate(realtime: RealtimeService, tripId: number, itemId: number, item: PackingPrivacy, wasPrivate: boolean): void {
-  const nowPrivate = !!item.is_private;
-  if (nowPrivate) {
-    if (wasPrivate) {
-      broadcastPackingItem(realtime, tripId, 'packing:updated', { item }, item); // stays private -> owner-only
-    } else {
-      realtime.broadcast(tripId, 'packing:deleted', { itemId }, undefined); // public->private: drop from the room...
-      broadcastPackingItem(realtime, tripId, 'packing:created', { item }, item); // ...then re-add for the owner
-    }
-  } else {
-    if (wasPrivate) realtime.broadcast(tripId, 'packing:created', { item }, undefined); // private->public: add for members who lacked it
-    realtime.broadcast(tripId, 'packing:updated', { item }, undefined);
-  }
-}
+// The #858 privacy-scoped packing broadcasts used to be copied here, with a comment
+// asking for the copy to be kept in lockstep with packing.controller.ts and
+// packing.service.ts by hand. They now live once, in PackingService, and both the
+// REST controller and PackingRpc call them there.
 
 // Quotas for plugin entity metadata (db:meta) — a cheap disk-DoS guard on the
 // shared trek.db volume. Generous for real use, small enough to bound abuse.
@@ -243,7 +196,6 @@ export class PluginHostDepsFactory {
       },
       // --- Read scopes (packing/files). Membership is checked by the host (tripRead);
       // these just delegate to the same services the REST paths use. ---
-      listPackingItems: (tripId, userId) => this.packing.listItems(tripId, userId),
       listTripFiles: (tripId) => this.files.listFiles(tripId, false),
       // A file's bytes as base64, size-capped BEFORE the read so a 500MB video can't
       // be pulled (~667MB base64) through the IPC pipe. 10MB matches the plugin upload
@@ -788,53 +740,7 @@ export class PluginHostDepsFactory {
       // --- Packing (packing_edit). Reuses PackingService + replicates the #858
       // privacy-scoped broadcasts (create/delete via emitPackingToViewers, update via
       // the four-case broadcastPackingUpdate) so a private item never leaks room-wide. ---
-      canEditPacking: (tripId, userId) => this.canEditTripAs('packing_edit', tripId, userId),
-      createPackingItem: (tripId, input, actingUserId) => {
-        const i = input as { name: string; category?: string; checked?: boolean; is_private?: boolean; visibility?: 'common' | 'personal' | 'shared'; recipient_ids?: number[] };
-        const item = this.packing.createItem(String(tripId), i, actingUserId) as PackingPrivacy;
-        emitPackingToViewers(this.realtime, tripId, 'packing:created', { item }, item);
-        return item;
-      },
-      updatePackingItem: (tripId, itemId, input, actingUserId) => {
-        // Privacy BEFORE the write, so a public<->private toggle routes correctly.
-        const before = this.packing.getItemPrivacy(tripId, itemId);
-        const updated = this.packing.updateItem(String(tripId), String(itemId), input as never, Object.keys(input), undefined, actingUserId);
-        if (!updated) throw new ForbiddenResource(`no packing item ${itemId} on trip ${tripId}`);
-        if (isUpdateConflict(updated)) throw new BadParams('packing item was modified concurrently');
-        broadcastPackingUpdate(this.realtime, tripId, itemId, updated as PackingPrivacy, !!before?.is_private);
-        return updated;
-      },
-      deletePackingItem: (tripId, itemId) => {
-        const deleted = this.packing.deleteItem(String(tripId), String(itemId)) as PackingPrivacy | null;
-        if (!deleted) throw new ForbiddenResource(`no packing item ${itemId} on trip ${tripId}`);
-        emitPackingToViewers(this.realtime, tripId, 'packing:deleted', { itemId }, deleted);
-        return { deleted: true };
-      },
       // --- Packing bags (no privacy — plain room broadcasts). ---
-      listPackingBags: (tripId) => this.packing.listBags(String(tripId)) as unknown[],
-      createPackingBag: (tripId, input) => {
-        const i = input as { name: string; color?: string };
-        const bag = this.packing.createBag(String(tripId), { name: i.name, color: i.color });
-        this.realtime.broadcast(tripId, 'packing:bag-created', { bag }, undefined);
-        return bag;
-      },
-      updatePackingBag: (tripId, bagId, input) => {
-        const bag = this.packing.updateBag(String(tripId), String(bagId), input as never, Object.keys(input));
-        if (!bag) throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'packing:bag-updated', { bag }, undefined);
-        return bag;
-      },
-      deletePackingBag: (tripId, bagId) => {
-        if (!this.packing.deleteBag(String(tripId), String(bagId))) throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'packing:bag-deleted', { bagId }, undefined);
-        return { deleted: true };
-      },
-      setPackingBagMembers: (tripId, bagId, userIds) => {
-        const members = this.packing.setBagMembers(String(tripId), String(bagId), userIds);
-        if (!members) throw new ForbiddenResource(`no packing bag ${bagId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'packing:bag-members-updated', { bagId, members }, undefined);
-        return members;
-      },
       // --- Read-convenience: weather (host cache, tenant-free), categories (global), roster ---
       tripMembers: (tripId) =>
         this.db.prepare('SELECT u.id, u.username, u.display_name, u.avatar FROM trip_members tm JOIN users u ON u.id = tm.user_id WHERE tm.trip_id = ?').all(tripId) as unknown[],

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -577,7 +577,6 @@ export class PluginHostDepsFactory {
         }
       },
       // --- Exchange rates: the same cached upstream feed the budget uses (tenant-free). ---
-      getRates: (base) => this.exchangeRates.getRates(base),
       // --- Trip (trip_edit). Only the schema-writable fields reach updateTrip; its
       // NotFound/Validation errors are mapped to clean RPC codes. ---
       canEditTrip: (tripId, userId) => this.canEditTripAs('trip_edit', tripId, userId),
@@ -750,30 +749,8 @@ export class PluginHostDepsFactory {
         return { deleted: true };
       },
       // Day notes are core (no addon) and trip-scoped; membership is enforced by the host.
-      listDayNotes: (tripId, dayId) => this.dayNotes.list(dayId, tripId),
       // --- Day notes write (day_edit). The day must belong to the trip; broadcasts the
       // same dayNote:* events the REST controller emits so open sessions update live. ---
-      createDayNote: (tripId, dayId, input) => {
-        if (!this.dayNotes.dayExists(dayId, tripId)) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
-        const i = input as { text?: string; time?: string; icon?: string; sort_order?: number };
-        const note = this.dayNotes.create(dayId, tripId, i.text ?? '', i.time, i.icon, i.sort_order);
-        this.realtime.broadcast(tripId, 'dayNote:created', { dayId, note }, undefined);
-        return note;
-      },
-      updateDayNote: (tripId, dayId, noteId, input) => {
-        const current = this.dayNotes.getNote(noteId, dayId, tripId);
-        if (!current) throw new ForbiddenResource(`no note ${noteId} on day ${dayId}`);
-        const note = this.dayNotes.update(noteId, current as never, input as { text?: string; time?: string; icon?: string; sort_order?: number });
-        this.realtime.broadcast(tripId, 'dayNote:updated', { dayId, note }, undefined);
-        return note;
-      },
-      deleteDayNote: (tripId, dayId, noteId) => {
-        const current = this.dayNotes.getNote(noteId, dayId, tripId);
-        if (!current) throw new ForbiddenResource(`no note ${noteId} on day ${dayId}`);
-        this.dayNotes.remove(noteId);
-        this.realtime.broadcast(tripId, 'dayNote:deleted', { noteId, dayId }, undefined);
-        return { deleted: true };
-      },
       // --- Reservations (bookings, reservation_edit). Delegates to ReservationsService
       // so the accommodation/budget-sync/notification/broadcast side effects match the
       // web app EXACTLY. socketId is undefined — a plugin has no originating socket. ---
@@ -859,29 +836,9 @@ export class PluginHostDepsFactory {
         return members;
       },
       // --- Read-convenience: weather (host cache, tenant-free), categories (global), roster ---
-      getWeather: (lat, lng, date) => getWeather(String(lat), String(lng), date, 'en'),
-      listCategories: () => this.categories.list() as unknown[],
       tripMembers: (tripId) =>
         this.db.prepare('SELECT u.id, u.username, u.display_name, u.avatar FROM trip_members tm JOIN users u ON u.id = tm.user_id WHERE tm.trip_id = ?').all(tripId) as unknown[],
       // --- Todos (core, trip-scoped; the app's 'packing_edit' permission). ---
-      canEditTodos: (tripId, userId) => this.canEditTripAs('packing_edit', tripId, userId),
-      listTodos: (tripId) => this.todos.listItems(String(tripId)) as unknown[],
-      createTodo: (tripId, input) => {
-        const item = this.todos.createItem(String(tripId), input as never);
-        this.realtime.broadcast(tripId, 'todo:created', { item }, undefined);
-        return item;
-      },
-      updateTodo: (tripId, todoId, input) => {
-        const updated = this.todos.updateItem(String(tripId), String(todoId), input as never, Object.keys(input));
-        if (!updated) throw new ForbiddenResource(`no todo ${todoId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'todo:updated', { item: updated }, undefined);
-        return updated;
-      },
-      deleteTodo: (tripId, todoId) => {
-        if (!this.todos.deleteItem(String(tripId), String(todoId))) throw new ForbiddenResource(`no todo ${todoId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'todo:deleted', { itemId: todoId }, undefined);
-        return { deleted: true };
-      },
       // --- Plugin metadata (db:meta). A per-plugin namespaced key/value store keyed
       // to a core entity; the plugin only ever sees rows tagged with its own id. ---
       metaEntityTrip: (entityType, entityId) => {

--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -91,7 +91,6 @@ export interface HostDeps {
   /** True if the acting user may create costs on the trip (the 'budget_edit' permission). */
   canEditCosts(tripId: number, userId: number): boolean;
   /** A trip's packing items visible to `userId` (#858 private-item filter), for `packing.list`. */
-  listPackingItems(tripId: number, userId: number): unknown[];
   /** A trip's files (trash excluded), for `files.list`. */
   listTripFiles(tripId: number): unknown[];
   /** One trip file's bytes as base64 (size-capped), for `files.getContent`. Throws if it's not on the trip or exceeds the cap. */
@@ -222,19 +221,10 @@ export interface HostDeps {
   /** Delete a reservation from a trip (same side effects); returns { deleted: true }. */
   deleteReservation(tripId: number, reservationId: number, actingUserId: number): unknown;
   // --- Packing (the 'packing_edit' permission; #858 privacy-scoped broadcasts) ---
-  canEditPacking(tripId: number, userId: number): boolean;
   /** Create a packing item (owner = acting user); privacy-scoped packing:created broadcast; returns it. */
-  createPackingItem(tripId: number, input: Record<string, unknown>, actingUserId: number): unknown;
   /** Update a packing item; four-case public<->private broadcast; throws if not on the trip. */
-  updatePackingItem(tripId: number, itemId: number, input: Record<string, unknown>, actingUserId: number): unknown;
   /** Delete a packing item; owner+recipients-scoped packing:deleted broadcast; returns { deleted: true }. */
-  deletePackingItem(tripId: number, itemId: number): unknown;
   // --- Packing bags (packing_edit; no privacy — broadcast to the whole room) ---
-  listPackingBags(tripId: number): unknown[];
-  createPackingBag(tripId: number, input: Record<string, unknown>): unknown;
-  updatePackingBag(tripId: number, bagId: number, input: Record<string, unknown>): unknown;
-  deletePackingBag(tripId: number, bagId: number): unknown;
-  setPackingBagMembers(tripId: number, bagId: number, userIds: number[]): unknown;
   // --- Read-convenience: weather (tenant-free), categories (global), the trip roster ---
   tripMembers(tripId: number): unknown[];
   // --- Tags (the acting user's own; no trip) ---
@@ -324,13 +314,6 @@ export class PluginRpcHost {
       });
       // The trip's member roster (ids + display fields only), membership-checked.
       this.methods.set('trips.members', (p, uid) => this.tripRead(p, uid, () => deps.tripMembers(num(p.tripId, 'tripId'))));
-    }
-    if (has('db:read:packing')) {
-      // Delegate to the packing service, scoped to the acting user so its #858 private-
-      // item visibility filter applies (a plugin must not see other members' private items).
-      this.methods.set('packing.list', (p, uid) =>
-        this.tripRead(p, uid, (userId) => deps.listPackingItems(num(p.tripId, 'tripId'), userId)),
-      );
     }
     if (has('db:read:files')) {
       // Trip files, trash excluded — same view the files tab shows.
@@ -823,69 +806,7 @@ export class PluginRpcHost {
       });
     }
 
-    if (has('db:write:packing')) {
-      // Packing list write. Gated exactly like the packing REST path — trip access +
-      // the 'packing_edit' permission for the HOST-bound acting user. The deps reuse
-      // packingService and replicate the #858 privacy-scoped broadcasts 1:1, so a
-      // private item is never leaked to the whole trip room.
-      this.methods.set('packing.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'packing item');
-        const parsed = packingCreateItemRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid packing item: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.createPackingItem(tripId, parsed.data as Record<string, unknown>, actor);
-      });
-      this.methods.set('packing.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const itemId = num(p.itemId, 'itemId');
-        const actor = this.requireActor(uid, 'packing item');
-        const parsed = packingUpdateItemRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid packing item: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.updatePackingItem(tripId, itemId, parsed.data as Record<string, unknown>, actor);
-      });
-      this.methods.set('packing.delete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const itemId = num(p.itemId, 'itemId');
-        const actor = this.requireActor(uid, 'packing item');
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.deletePackingItem(tripId, itemId);
-      });
-      // Bags carry no privacy — a plain packing:bag-* broadcast to the whole room.
-      this.methods.set('packing.listBags', (p, uid) => this.tripRead(p, uid, () => deps.listPackingBags(num(p.tripId, 'tripId'))));
-      this.methods.set('packing.createBag', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'packing bag');
-        const input = asPayload(p.input);
-        if (typeof input.name !== 'string' || input.name.trim() === '') throw new BadParams('bag name is required');
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.createPackingBag(tripId, input);
-      });
-      this.methods.set('packing.updateBag', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const bagId = num(p.bagId, 'bagId');
-        const actor = this.requireActor(uid, 'packing bag');
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.updatePackingBag(tripId, bagId, asPayload(p.input));
-      });
-      this.methods.set('packing.deleteBag', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const bagId = num(p.bagId, 'bagId');
-        const actor = this.requireActor(uid, 'packing bag');
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        return deps.deletePackingBag(tripId, bagId);
-      });
-      this.methods.set('packing.setBagMembers', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const bagId = num(p.bagId, 'bagId');
-        const actor = this.requireActor(uid, 'packing bag');
-        this.requireTripEdit(tripId, actor, deps.canEditPacking);
-        const raw = asPayload(p).userIds;
-        const userIds = Array.isArray(raw) ? raw.filter((x): x is number => typeof x === 'number') : [];
-        return deps.setPackingBagMembers(tripId, bagId, userIds);
-      });
-    }
+    // packing.* now lives in src/nest/packing/packing.rpc.ts.
 
     // weather.get and categories.list now live in their own domains' *.rpc.ts.
     // tags.* now lives in src/nest/tags/tags.rpc.ts, bound through the registry below.

--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -161,13 +161,9 @@ export interface HostDeps {
   createJournal(userId: number, input: Record<string, unknown>): unknown;
   deleteJournal(userId: number, journeyId: number): unknown;
   /** A trip day's notes (trip-scoped), for `daynotes.list`. */
-  listDayNotes(tripId: number, dayId: number): unknown[];
   /** Create a day note (the day must be on the trip); broadcasts dayNote:created. */
-  createDayNote(tripId: number, dayId: number, input: Record<string, unknown>): unknown;
   /** Update a day note (scoped to the day+trip); broadcasts dayNote:updated. */
-  updateDayNote(tripId: number, dayId: number, noteId: number, input: Record<string, unknown>): unknown;
   /** Delete a day note (scoped to the day+trip); broadcasts dayNote:deleted. */
-  deleteDayNote(tripId: number, dayId: number, noteId: number): unknown;
   /** All budget items of one trip, hydrated with members/payers. */
   listCostsForTrip(tripId: number): unknown[];
   /** All budget items across every trip the acting user can access. */
@@ -199,7 +195,6 @@ export interface HostDeps {
   canCreateTrip(userId: number): boolean;
   createTripForUser(userId: number, input: Record<string, unknown>): unknown;
   // --- Exchange rates (tenant-free, like weather) ---
-  getRates(base: string): Promise<unknown>;
   // --- Cross-trip reads (membership baked in — every trip the acting user can access) ---
   /** Every trip the acting user owns or is a member of (the listTrips baseline). */
   listTripsForUser(userId: number): unknown[];
@@ -241,16 +236,9 @@ export interface HostDeps {
   deletePackingBag(tripId: number, bagId: number): unknown;
   setPackingBagMembers(tripId: number, bagId: number, userIds: number[]): unknown;
   // --- Read-convenience: weather (tenant-free), categories (global), the trip roster ---
-  getWeather(lat: number, lng: number, date: string | undefined): unknown;
-  listCategories(): unknown[];
   tripMembers(tripId: number): unknown[];
   // --- Tags (the acting user's own; no trip) ---
   // --- Todos (core, trip-scoped; the 'packing_edit' permission, like the REST path) ---
-  canEditTodos(tripId: number, userId: number): boolean;
-  listTodos(tripId: number): unknown[];
-  createTodo(tripId: number, input: Record<string, unknown>): unknown;
-  updateTodo(tripId: number, todoId: number, input: Record<string, unknown>): unknown;
-  deleteTodo(tripId: number, todoId: number): unknown;
   // --- Plugin metadata on core entities (db:meta) ---
   /** The trip a trip/place/day belongs to (for the membership gate), or undefined. */
   metaEntityTrip(entityType: string, entityId: number): number | undefined;
@@ -596,12 +584,6 @@ export class PluginRpcHost {
       this.methods.set('journal.createJourney', (p, uid) => deps.createJournal(requireUid(uid), asPayload(p.input)));
       this.methods.set('journal.deleteJourney', (p, uid) => deps.deleteJournal(requireUid(uid), num(p.journeyId, 'journeyId')));
     }
-    if (has('db:read:daynotes')) {
-      // Day notes are trip-scoped (core, no addon), so the standard membership gate applies.
-      this.methods.set('daynotes.list', (p, uid) =>
-        this.tripRead(p, uid, () => deps.listDayNotes(num(p.tripId, 'tripId'), num(p.dayId, 'dayId'))),
-      );
-    }
 
     if (has('db:read:costs')) {
       // "Costs" = budget items (trip-scoped). Same membership gate as trip reads;
@@ -772,42 +754,9 @@ export class PluginRpcHost {
       });
     }
 
-    if (has('rates:read')) {
-      // Exchange rates are tenant-free (like weather) — a cached upstream feed, no
-      // user or trip. Useful for any plugin that shows or converts money.
-      this.methods.set('rates.get', (p) => deps.getRates(str(p.base, 'base')));
-    }
+    // rates.get now lives in src/nest/budget/exchange-rates.rpc.ts.
 
-    if (has('db:write:daynotes')) {
-      // Day notes are edited under the app's 'day_edit' permission (like days). The
-      // wiring verifies the day belongs to the trip, so a plugin can't note a day on
-      // another trip. Text is required; time/icon/sort_order are optional.
-      this.methods.set('daynotes.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const actor = this.requireActor(uid, 'day note');
-        const input = asPayload(p.input);
-        if (typeof input.text !== 'string' || input.text.trim() === '') throw new BadParams('note text is required');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.createDayNote(tripId, dayId, input);
-      });
-      this.methods.set('daynotes.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const noteId = num(p.noteId, 'noteId');
-        const actor = this.requireActor(uid, 'day note');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.updateDayNote(tripId, dayId, noteId, asPayload(p.input));
-      });
-      this.methods.set('daynotes.delete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const noteId = num(p.noteId, 'noteId');
-        const actor = this.requireActor(uid, 'day note');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.deleteDayNote(tripId, dayId, noteId);
-      });
-    }
+    // daynotes.* now live in src/nest/days/day-notes.rpc.ts.
 
     if (has('db:write:reservations')) {
       // Bookings write. Gated exactly like the reservations REST/MCP path: trip
@@ -938,43 +887,9 @@ export class PluginRpcHost {
       });
     }
 
-    if (has('weather:read')) {
-      // Tenant-free host cache: forecast by coordinates + optional date. No user needed.
-      this.methods.set('weather.get', (p) => deps.getWeather(num(p.lat, 'lat'), num(p.lng, 'lng'), typeof p.date === 'string' ? p.date : undefined));
-    }
-    if (has('db:read:categories')) {
-      // Global, read-only reference list — carries no tenant data.
-      this.methods.set('categories.list', () => deps.listCategories());
-    }
+    // weather.get and categories.list now live in their own domains' *.rpc.ts.
     // tags.* now lives in src/nest/tags/tags.rpc.ts, bound through the registry below.
-    if (has('db:read:todos')) {
-      this.methods.set('todos.list', (p, uid) => this.tripRead(p, uid, () => deps.listTodos(num(p.tripId, 'tripId'))));
-    }
-    if (has('db:write:todos')) {
-      // Todos are edited under the app's 'packing_edit' permission (like the REST path).
-      this.methods.set('todos.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'todo');
-        const input = asPayload(p.input);
-        if (typeof input.name !== 'string' || input.name.trim() === '') throw new BadParams('todo name is required');
-        this.requireTripEdit(tripId, actor, deps.canEditTodos);
-        return deps.createTodo(tripId, input);
-      });
-      this.methods.set('todos.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const todoId = num(p.todoId, 'todoId');
-        const actor = this.requireActor(uid, 'todo');
-        this.requireTripEdit(tripId, actor, deps.canEditTodos);
-        return deps.updateTodo(tripId, todoId, asPayload(p.input));
-      });
-      this.methods.set('todos.delete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const todoId = num(p.todoId, 'todoId');
-        const actor = this.requireActor(uid, 'todo');
-        this.requireTripEdit(tripId, actor, deps.canEditTodos);
-        return deps.deleteTodo(tripId, todoId);
-      });
-    }
+    // todos.* now live in src/nest/todo/todo.rpc.ts.
 
     if (has('db:meta')) {
       // A plugin's OWN namespaced key/value store attached to a core entity. Not

--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -92,21 +92,12 @@ export interface HostDeps {
   canEditCosts(tripId: number, userId: number): boolean;
   /** A trip's packing items visible to `userId` (#858 private-item filter), for `packing.list`. */
   /** A trip's files (trash excluded), for `files.list`. */
-  listTripFiles(tripId: number): unknown[];
   /** One trip file's bytes as base64 (size-capped), for `files.getContent`. Throws if it's not on the trip or exceeds the cap. */
-  getTripFileContent(tripId: number, fileId: number): unknown;
   // --- Files write (the app's file_upload / file_edit / file_delete permissions) ---
-  canUploadFiles(tripId: number, userId: number): boolean;
-  canEditFiles(tripId: number, userId: number): boolean;
-  canDeleteFiles(tripId: number, userId: number): boolean;
   /** Store a bounded base64 payload as a trip file (extension + size validated); broadcasts file:created. */
-  createTripFile(tripId: number, input: Record<string, unknown>, actingUserId: number): unknown;
   /** Link an existing trip file to a reservation/place/assignment on the SAME trip. */
-  createTripFileLink(tripId: number, fileId: number, opts: Record<string, unknown>): unknown;
   /** Update a file's description/links (same-trip targets enforced); broadcasts file:updated. */
-  updateTripFile(tripId: number, fileId: number, input: Record<string, unknown>): unknown;
   /** Move a trip file to the trash; broadcasts file:deleted. */
-  softDeleteTripFile(tripId: number, fileId: number): unknown;
   // --- Collab reads (membership + collab addon; no separate right, like the REST GETs) ---
   listCollabNotes(tripId: number): unknown[];
   listCollabPolls(tripId: number): unknown[];
@@ -315,58 +306,7 @@ export class PluginRpcHost {
       // The trip's member roster (ids + display fields only), membership-checked.
       this.methods.set('trips.members', (p, uid) => this.tripRead(p, uid, () => deps.tripMembers(num(p.tripId, 'tripId'))));
     }
-    if (has('db:read:files')) {
-      // Trip files, trash excluded — same view the files tab shows.
-      this.methods.set('files.list', (p, uid) =>
-        this.tripRead(p, uid, () => deps.listTripFiles(num(p.tripId, 'tripId'))),
-      );
-    }
-    if (has('db:read:files:content')) {
-      // Reading a file's BYTES is a step up from its metadata (a passport scan is
-      // more sensitive than its filename), so it's a separate grant. Membership-
-      // checked like files.list; the wiring caps the size before base64-ing it
-      // through the IPC pipe.
-      this.methods.set('files.getContent', (p, uid) =>
-        this.tripRead(p, uid, () => deps.getTripFileContent(num(p.tripId, 'tripId'), num(p.fileId, 'fileId'))),
-      );
-    }
-    if (has('db:write:files')) {
-      // Files write, under the app's separate file_upload / file_edit / file_delete
-      // rights. A created file arrives as bounded base64 (10MB decoded cap — well
-      // under the app's 50MB upload limit); the wiring validates the extension
-      // against the central blocklist before anything touches disk.
-      this.methods.set('files.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'file');
-        const input = asPayload(p.input);
-        if (typeof input.name !== 'string' || input.name.trim() === '' || input.name.length > 255) throw new BadParams('file name is required (max 255 chars)');
-        if (typeof input.content_base64 !== 'string' || input.content_base64 === '') throw new BadParams('content_base64 is required');
-        if (input.content_base64.length > 14 * 1024 * 1024) throw new BadParams('file exceeds the 10MB plugin upload cap');
-        this.requireTripEdit(tripId, actor, deps.canUploadFiles);
-        return deps.createTripFile(tripId, input, actor);
-      });
-      this.methods.set('files.createLink', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const fileId = num(p.fileId, 'fileId');
-        const actor = this.requireActor(uid, 'file link');
-        this.requireTripEdit(tripId, actor, deps.canEditFiles);
-        return deps.createTripFileLink(tripId, fileId, asPayload(p.opts));
-      });
-      this.methods.set('files.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const fileId = num(p.fileId, 'fileId');
-        const actor = this.requireActor(uid, 'file');
-        this.requireTripEdit(tripId, actor, deps.canEditFiles);
-        return deps.updateTripFile(tripId, fileId, asPayload(p.input));
-      });
-      this.methods.set('files.softDelete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const fileId = num(p.fileId, 'fileId');
-        const actor = this.requireActor(uid, 'file');
-        this.requireTripEdit(tripId, actor, deps.canDeleteFiles);
-        return deps.softDeleteTripFile(tripId, fileId);
-      });
-    }
+    // files.* now lives in src/nest/files/files.rpc.ts.
     if (has('db:write:collab')) {
       // Collab content (notes/polls/messages) under the app's collab_edit right.
       this.methods.set('collab.createNote', (p, uid) => {

--- a/server/src/nest/plugins/plugins.module.ts
+++ b/server/src/nest/plugins/plugins.module.ts
@@ -28,7 +28,7 @@ import { PluginRuntimeService } from './plugin-runtime.service';
 import { PluginRegistryService } from './registry/registry.service';
 import { PluginHostDepsFactory } from './host/plugin-host-deps.factory';
 import { PluginRpcRegistryService } from './host/rpc-kit/registry.service';
-import { PluginGuards } from './host/plugin-guards.service';
+import { PluginGuardsModule } from './host/plugin-guards.module';
 import { TagsModule } from '../tags/tags.module';
 import { CategoriesModule } from '../categories/categories.module';
 import { BudgetModule } from '../budget/budget.module';
@@ -62,14 +62,14 @@ import { TripMembershipModule } from '../trip-membership/trip-membership.module'
   // The DI-native domain services the plugin host wiring injects
   // (PluginHostDepsFactory); DatabaseModule is @Global, so not listed.
   // DiscoveryModule is what lets PluginRpcRegistryService find the @PluginController
-  // providers at boot.
-  imports: [DiscoveryModule, TagsModule, CategoriesModule, BudgetModule, ReservationsModule, TodoModule, PackingModule, DaysModule, AssignmentsModule, LlmParseModule, FilesModule, CollabModule, VacayModule, TripsModule, PermissionsModule, AuditModule, AddonsModule, PlacesModule, CollectionsModule, AtlasModule, NotificationsModule, TripMembershipModule, JourneyDomainModule],
+  // providers at boot. PluginGuardsModule is a leaf that hands the resource gates to
+  // the domain modules; it must not be this module, because the domains would then
+  // have to import PluginsModule back and close a cycle.
+  imports: [DiscoveryModule, PluginGuardsModule, TagsModule, CategoriesModule, BudgetModule, ReservationsModule, TodoModule, PackingModule, DaysModule, AssignmentsModule, LlmParseModule, FilesModule, CollabModule, VacayModule, TripsModule, PermissionsModule, AuditModule, AddonsModule, PlacesModule, CollectionsModule, AtlasModule, NotificationsModule, TripMembershipModule, JourneyDomainModule],
   controllers: [PluginsController, PluginsFeedController, PluginsProxyController, PluginFrameController, PlaceDetailsController, TripWarningsController, ViewContributionsController, TripCardContributionsController, PluginPhotosController, PluginCalendarController, MapMarkersController, MapLayersController, PluginRoutesController, DayScheduleController, DayTintsController, PdfSectionsController, AtlasLayersController, JournalEntryRowsController, PluginUserSettingsController, PluginOAuthController, PluginActivityController],
-  providers: [PluginsService, PluginRuntimeService, PluginRegistryService, PluginOAuthService, PluginHostDepsFactory, PluginRpcRegistryService, PluginGuards],
-  // PluginRuntimeService is exported so the admin addon-toggle handler can
-  // cascade-disable plugins whose required addon was just turned off (#plugins
-  // dependencies). PluginGuards is exported so a domain module can inject it into
-  // its own <domain>.rpc.ts without importing the plugin host.
-  exports: [PluginRuntimeService, PluginGuards],
+  providers: [PluginsService, PluginRuntimeService, PluginRegistryService, PluginOAuthService, PluginHostDepsFactory, PluginRpcRegistryService],
+  // Exported so the admin addon-toggle handler can cascade-disable plugins whose
+  // required addon was just turned off (#plugins dependencies).
+  exports: [PluginRuntimeService],
 })
 export class PluginsModule {}

--- a/server/src/nest/todo/todo.module.ts
+++ b/server/src/nest/todo/todo.module.ts
@@ -2,15 +2,18 @@ import { Module } from '@nestjs/common';
 import { TodoController } from './todo.controller';
 import { TodoMcp } from './todo.mcp';
 import { TodoService } from './todo.service';
+import { TodoRpc } from './todo.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AuthModule } from '../auth/auth.module';
 
 /** To-do domain (S3 — Phase 2 trip sub-domain). Registered in AppModule.
  *  Exports TodoService for in-container consumers (TripsService bundle). */
 @Module({
-  imports: [PermissionsModule, AuthModule],
+  imports: [PermissionsModule, AuthModule, RealtimeModule, PluginGuardsModule],
   controllers: [TodoController],
-  providers: [TodoService, TodoMcp],
+  providers: [TodoService, TodoMcp, TodoRpc],
   exports: [TodoService],
 })
 export class TodoModule {}

--- a/server/src/nest/todo/todo.rpc.ts
+++ b/server/src/nest/todo/todo.rpc.ts
@@ -1,0 +1,71 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { asPayload, num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { TodoService } from './todo.service';
+
+/** The app edits todos under 'packing_edit', not under a todo-specific action. */
+const TODO_EDIT_ACTION = 'packing_edit';
+
+/**
+ * The todo surface a plugin may reach (#plugins). Trip-scoped core data, so reads
+ * go through the membership gate and writes additionally need the edit permission.
+ *
+ * The broadcasts are part of the contract, not decoration: they are the same
+ * todo:* events the REST controller emits, and without them an open session shows
+ * stale data after a plugin write. They came across from the deps factory with the
+ * handlers.
+ */
+@PluginController()
+export class TodoRpc {
+  constructor(
+    private readonly todos: TodoService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('todos.list', { permission: 'db:read:todos' })
+  list(params: Record<string, unknown>, ctx: PluginRpcContext): unknown[] {
+    return this.guards.tripRead(params, ctx, () => this.todos.listItems(String(num(params.tripId, 'tripId'))) as unknown[]);
+  }
+
+  @PluginMethod('todos.create', { permission: 'db:write:todos' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'todo');
+    const input = asPayload(params.input);
+    if (typeof input.name !== 'string' || input.name.trim() === '') throw new BadParams('todo name is required');
+    this.guards.requireTripEdit(tripId, actor, TODO_EDIT_ACTION);
+    const item = this.todos.createItem(String(tripId), input as never);
+    this.realtime.broadcast(tripId, 'todo:created', { item }, undefined);
+    return item;
+  }
+
+  @PluginMethod('todos.update', { permission: 'db:write:todos' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const todoId = num(params.todoId, 'todoId');
+    const actor = this.guards.requireActor(ctx, 'todo');
+    this.guards.requireTripEdit(tripId, actor, TODO_EDIT_ACTION);
+    const input = asPayload(params.input);
+    const updated = this.todos.updateItem(String(tripId), String(todoId), input as never, Object.keys(input));
+    if (!updated) throw new ForbiddenResource(`no todo ${todoId} on trip ${tripId}`);
+    this.realtime.broadcast(tripId, 'todo:updated', { item: updated }, undefined);
+    return updated;
+  }
+
+  @PluginMethod('todos.delete', { permission: 'db:write:todos' })
+  delete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const todoId = num(params.todoId, 'todoId');
+    const actor = this.guards.requireActor(ctx, 'todo');
+    this.guards.requireTripEdit(tripId, actor, TODO_EDIT_ACTION);
+    if (!this.todos.deleteItem(String(tripId), String(todoId))) {
+      throw new ForbiddenResource(`no todo ${todoId} on trip ${tripId}`);
+    }
+    this.realtime.broadcast(tripId, 'todo:deleted', { itemId: todoId }, undefined);
+    return { deleted: true };
+  }
+}

--- a/server/src/nest/weather/weather.module.ts
+++ b/server/src/nest/weather/weather.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { WeatherController } from './weather.controller';
 import { WeatherService } from './weather.service';
+import { WeatherRpc } from './weather.rpc';
 import { WeatherMcp } from './weather.mcp';
 
 /** Weather domain (pilot leaf module). Registered in AppModule. */
 @Module({
   controllers: [WeatherController],
-  providers: [WeatherService, WeatherMcp],
+  providers: [WeatherService, WeatherMcp, WeatherRpc],
 })
 export class WeatherModule {}

--- a/server/src/nest/weather/weather.rpc.ts
+++ b/server/src/nest/weather/weather.rpc.ts
@@ -1,0 +1,22 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { num } from '../plugins/host/rpc-params';
+import { WeatherService } from './weather.service';
+
+/**
+ * The weather surface a plugin may reach (#plugins). Tenant-free: a host-cached
+ * forecast by coordinates plus an optional date, so no user and no trip.
+ *
+ * The language is pinned to 'en' exactly as the deps factory pinned it. A plugin
+ * has no locale of its own, and the wire contract never carried one.
+ */
+@PluginController()
+export class WeatherRpc {
+  constructor(private readonly weather: WeatherService) {}
+
+  @PluginMethod('weather.get', { permission: 'weather:read' })
+  get(params: Record<string, unknown>): unknown {
+    const lat = num(params.lat, 'lat');
+    const lng = num(params.lng, 'lng');
+    return this.weather.get(String(lat), String(lng), typeof params.date === 'string' ? params.date : undefined, 'en');
+  }
+}

--- a/server/tests/helpers/rpc-host-deps.ts
+++ b/server/tests/helpers/rpc-host-deps.ts
@@ -7,6 +7,7 @@ import { ExchangeRatesRpc } from '../../src/nest/budget/exchange-rates.rpc';
 import { TodoRpc } from '../../src/nest/todo/todo.rpc';
 import { DayNotesRpc } from '../../src/nest/days/day-notes.rpc';
 import { PackingRpc } from '../../src/nest/packing/packing.rpc';
+import { FilesRpc } from '../../src/nest/files/files.rpc';
 
 /**
  * The stubbed HostDeps every plugin router test builds on. It used to live inside
@@ -188,5 +189,6 @@ export function allRpcControllers(): object[] {
     new TodoRpc(anyService(), anyService(), anyService()),
     new DayNotesRpc(anyService(), anyService(), anyService()),
     new PackingRpc(anyService(), anyService(), anyService()),
+    new FilesRpc(anyService(), anyService(), anyService(), anyService()),
   ];
 }

--- a/server/tests/helpers/rpc-host-deps.ts
+++ b/server/tests/helpers/rpc-host-deps.ts
@@ -6,6 +6,7 @@ import { WeatherRpc } from '../../src/nest/weather/weather.rpc';
 import { ExchangeRatesRpc } from '../../src/nest/budget/exchange-rates.rpc';
 import { TodoRpc } from '../../src/nest/todo/todo.rpc';
 import { DayNotesRpc } from '../../src/nest/days/day-notes.rpc';
+import { PackingRpc } from '../../src/nest/packing/packing.rpc';
 
 /**
  * The stubbed HostDeps every plugin router test builds on. It used to live inside
@@ -186,5 +187,6 @@ export function allRpcControllers(): object[] {
     new ExchangeRatesRpc(anyService()),
     new TodoRpc(anyService(), anyService(), anyService()),
     new DayNotesRpc(anyService(), anyService(), anyService()),
+    new PackingRpc(anyService(), anyService(), anyService()),
   ];
 }

--- a/server/tests/helpers/rpc-host-deps.ts
+++ b/server/tests/helpers/rpc-host-deps.ts
@@ -1,7 +1,11 @@
 import { vi } from 'vitest';
 import type { HostDeps } from '../../src/nest/plugins/host/rpc-host';
 import { TagsRpc } from '../../src/nest/tags/tags.rpc';
-import type { TagsService } from '../../src/nest/tags/tags.service';
+import { CategoriesRpc } from '../../src/nest/categories/categories.rpc';
+import { WeatherRpc } from '../../src/nest/weather/weather.rpc';
+import { ExchangeRatesRpc } from '../../src/nest/budget/exchange-rates.rpc';
+import { TodoRpc } from '../../src/nest/todo/todo.rpc';
+import { DayNotesRpc } from '../../src/nest/days/day-notes.rpc';
 
 /**
  * The stubbed HostDeps every plugin router test builds on. It used to live inside
@@ -173,12 +177,14 @@ export function makeDeps(): HostDeps {
  * them. Behaviour is asserted in each domain's own <domain>.rpc.test.ts.
  */
 export function allRpcControllers(): object[] {
-  const tags = {
-    list: vi.fn(() => []),
-    getByIdAndUser: vi.fn(() => undefined),
-    create: vi.fn(() => ({})),
-    update: vi.fn(() => ({})),
-    remove: vi.fn(),
-  } as unknown as TagsService;
-  return [new TagsRpc(tags)];
+  const anyService = () =>
+    new Proxy({}, { get: () => vi.fn(() => undefined) }) as unknown as never;
+  return [
+    new TagsRpc(anyService()),
+    new CategoriesRpc(anyService()),
+    new WeatherRpc(anyService()),
+    new ExchangeRatesRpc(anyService()),
+    new TodoRpc(anyService(), anyService(), anyService()),
+    new DayNotesRpc(anyService(), anyService(), anyService()),
+  ];
 }

--- a/server/tests/unit/days/day-notes.rpc.test.ts
+++ b/server/tests/unit/days/day-notes.rpc.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The day-note plugin surface after it moved onto @PluginMethod. The dispatch-level
+ * cases come from rpc-host.test.ts unchanged except for the construction line and
+ * the stub identity; the rest cover the per-handler paths the router-level test had
+ * no room for.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { DayNotesRpc } from '../../../src/nest/days/day-notes.rpc';
+import { DaysModule } from '../../../src/nest/days/days.module';
+import type { DayNotesService } from '../../../src/nest/days/day-notes.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+/** Trip 1 belongs to user 42; day 5 and note 50 sit on it. Nothing else does. */
+function build(canEdit = true) {
+  const notes = {
+    list: vi.fn((dayId: number, tripId: number) => [{ id: 50, day_id: dayId, trip_id: tripId, text: 'note' }]),
+    dayExists: vi.fn((dayId: number, tripId: number) => dayId === 5 && tripId === 1),
+    getNote: vi.fn((id: number, dayId: number, tripId: number) =>
+      id === 50 && dayId === 5 && tripId === 1 ? { id: 50, text: 'note' } : undefined,
+    ),
+    create: vi.fn((dayId: number, tripId: number, text: string) => ({ id: 51, day_id: dayId, trip_id: tripId, text })),
+    update: vi.fn((id: number) => ({ id, text: 'updated' })),
+    remove: vi.fn(),
+  } as unknown as DayNotesService & Record<string, ReturnType<typeof vi.fn>>;
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const db = {
+    canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+    prepare: vi.fn(() => ({ get: () => ({ role: 'user' }) })),
+  } as unknown as DatabaseService;
+  const guards = new PluginGuards(
+    db,
+    { checkPermission: vi.fn(() => canEdit) } as unknown as PermissionsService,
+    { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+  );
+  const rpc = new DayNotesRpc(notes, realtime, guards);
+  const host = (...grants: string[]) =>
+    new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
+  return { notes, realtime, rpc, host };
+}
+
+describe('DayNotesRpc through the router', () => {
+  let f: ReturnType<typeof build>;
+  beforeEach(() => {
+    f = build();
+  });
+
+  it('DAYNOTES-RPC-001 daynotes.list is membership-checked (trip-scoped)', async () => {
+    const host = f.host('db:read:daynotes');
+    expect((await host.dispatch(req('daynotes.list', { tripId: 1, dayId: 5 }), 42)).ok).toBe(true);
+    expect(f.notes.list).toHaveBeenCalledWith(5, 1);
+    const forbidden = await host.dispatch(req('daynotes.list', { tripId: 999, dayId: 5 }), 42);
+    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('DAYNOTES-RPC-002 create needs db:write:daynotes + day_edit, membership-checked, text required', async () => {
+    const host = f.host('db:write:daynotes');
+    expect((await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: 'Pack sunscreen' } }), 42)).ok).toBe(true);
+    expect(f.notes.create).toHaveBeenCalledWith(5, 1, 'Pack sunscreen', undefined, undefined, undefined);
+    const bad = await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: '  ' } }), 42);
+    expect((bad as RpcError).error.code).toBe('BAD_PARAMS');
+    const forbidden = await host.dispatch(req('daynotes.create', { tripId: 2, dayId: 5, input: { text: 'x' } }), 42);
+    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('DAYNOTES-RPC-003 delete is gated the same way (edit + membership + bound user)', async () => {
+    const host = f.host('db:write:daynotes');
+    expect((await host.dispatch(req('daynotes.delete', { tripId: 1, dayId: 5, noteId: 50 }), 42)).ok).toBe(true);
+    expect(f.notes.remove).toHaveBeenCalledWith(50);
+    const noUser = await host.dispatch(req('daynotes.delete', { tripId: 1, dayId: 5, noteId: 50 }), undefined);
+    expect((noUser as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('DAYNOTES-RPC-004 the read grant does not unlock a write', async () => {
+    const host = f.host('db:read:daynotes');
+    const res = (await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: 'x' } }), 42)) as RpcError;
+    expect(res.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('DAYNOTES-RPC-005 update broadcasts and returns the updated note', async () => {
+    const host = f.host('db:write:daynotes');
+    expect((await host.dispatch(req('daynotes.update', { tripId: 1, dayId: 5, noteId: 50, input: { text: 'new' } }), 42)).ok).toBe(true);
+    expect(f.realtime.broadcast).toHaveBeenCalledWith(1, 'dayNote:updated', expect.objectContaining({ dayId: 5 }), undefined);
+  });
+
+  it('DAYNOTES-RPC-006 a note on another day is refused, naming it', async () => {
+    const host = f.host('db:write:daynotes');
+    const res = (await host.dispatch(req('daynotes.update', { tripId: 1, dayId: 5, noteId: 404, input: {} }), 42)) as RpcError;
+    expect(res.error.code).toBe('RESOURCE_FORBIDDEN');
+    expect(res.error.message).toBe('no note 404 on day 5');
+  });
+
+  it('DAYNOTES-RPC-007 without the edit permission the write is refused before it touches the service', async () => {
+    const noEdit = build(false);
+    const host = noEdit.host('db:write:daynotes');
+    const res = (await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: 'x' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to edit trip 1');
+    expect(noEdit.notes.create).not.toHaveBeenCalled();
+  });
+
+  it('DAYNOTES-RPC-008 a day outside the trip is refused, naming it', async () => {
+    const host = f.host('db:write:daynotes');
+    const res = (await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 99, input: { text: 'x' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no day 99 on trip 1');
+  });
+
+  it('DAYNOTES-RPC-009 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', DaysModule) as unknown[]).toContain(DayNotesRpc);
+  });
+});

--- a/server/tests/unit/files/files.rpc.test.ts
+++ b/server/tests/unit/files/files.rpc.test.ts
@@ -207,7 +207,6 @@ describe('FilesRpc writes', () => {
     try {
       const f = build();
       // The demo guard resolves the uploader's email; user 9 is the demo account.
-      (f.files as unknown as { getFileById: unknown });
       const db = {
         canAccessTrip: vi.fn(() => ({ id: 1, user_id: 42 })),
         prepare: vi.fn(() => ({ get: (id: number) => (id === 9 ? { role: 'user', email: 'demo@trek.app' } : { role: 'user', email: 'real@example.test' }) })),

--- a/server/tests/unit/files/files.rpc.test.ts
+++ b/server/tests/unit/files/files.rpc.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The file plugin surface after it moved onto @PluginMethod.
+ *
+ * Files are the only plugin surface that touches disk and the only one that uses
+ * three separate rights, so the cases here lean on the upload path: the extension
+ * blocklist, the size cap, the demo-mode refusal, and that each operation asks for
+ * its own permission rather than one shared domain action.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { FilesRpc } from '../../../src/nest/files/files.rpc';
+import { FilesModule } from '../../../src/nest/files/files.module';
+import type { FilesService } from '../../../src/nest/files/files.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError, RpcResponse } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+const b64 = (s: string) => Buffer.from(s).toString('base64');
+
+let tmpDir: string;
+
+/** File 2 sits on trip 1, which belongs to user 42. */
+function build(opts: { file?: Record<string, unknown> | undefined; foreign?: string | null; allow?: (a: string) => boolean } = {}) {
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const files = {
+    listFiles: vi.fn(() => [{ id: 2, filename: 'visa.pdf' }]),
+    getFileById: vi.fn((id: number) =>
+      id === 2 ? (opts.file ?? { filename: 'visa.pdf', original_name: 'visa.pdf', mime_type: 'application/pdf', file_size: 2, deleted_at: null }) : undefined,
+    ),
+    resolveFilePath: vi.fn((name: string) => ({ resolved: path.join(tmpDir, name), safe: true })),
+    findForeignLinkTarget: vi.fn(() => opts.foreign ?? null),
+    createFile: vi.fn((_t: number, meta: Record<string, unknown>) => ({ id: 130, ...meta })),
+    createFileLink: vi.fn(() => [{ file_id: 2 }]),
+    updateFile: vi.fn((id: number) => ({ id })),
+    softDeleteFile: vi.fn(),
+  } as unknown as FilesService & Record<string, ReturnType<typeof vi.fn>>;
+  const db = {
+    canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+    prepare: vi.fn(() => ({ get: () => ({ role: 'user', email: 'real@example.test' }) })),
+  } as unknown as DatabaseService;
+  const permissions = {
+    checkPermission: vi.fn((action: string) => (opts.allow ? opts.allow(action) : true)),
+  } as unknown as PermissionsService;
+  const guards = new PluginGuards(db, permissions, { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService);
+  const rpc = new FilesRpc(files, realtime, db, guards);
+  const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
+  return { files, realtime, permissions, host };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trek-files-rpc-'));
+  fs.writeFileSync(path.join(tmpDir, 'visa.pdf'), 'hi');
+});
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('FilesRpc reads', () => {
+  it('FILES-RPC-001 files.list is membership-checked and excludes the trash', async () => {
+    const f = build();
+    const host = f.host('db:read:files');
+    expect((await host.dispatch(req('files.list', { tripId: 1 }), 42)).ok).toBe(true);
+    expect(f.files.listFiles).toHaveBeenCalledWith(1, false);
+    expect(((await host.dispatch(req('files.list', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('FILES-RPC-002 reading BYTES is a separate grant from reading metadata', async () => {
+    const f = build();
+    // db:read:files alone must not unlock the content.
+    const denied = (await f.host('db:read:files').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
+    expect(denied.error.code).toBe('PERMISSION_DENIED');
+    const ok = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcResponse;
+    expect(ok.ok).toBe(true);
+    expect(ok.result).toMatchObject({ name: 'visa.pdf', mimetype: 'application/pdf', content_base64: b64('hi') });
+  });
+
+  it('FILES-RPC-003 a trashed file is refused like the download path', async () => {
+    const f = build({ file: { filename: 'visa.pdf', original_name: 'visa.pdf', mime_type: null, file_size: 2, deleted_at: '2027-01-01' } });
+    const res = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
+    expect(res.error.message).toBe('no file 2 on trip 1');
+  });
+
+  it('FILES-RPC-004 the size is capped BEFORE the read, not after', async () => {
+    const f = build({ file: { filename: 'visa.pdf', original_name: 'visa.pdf', mime_type: null, file_size: 400 * 1024 * 1024, deleted_at: null } });
+    const res = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    // The path is never even resolved for an oversized file.
+    expect(f.files.resolveFilePath).not.toHaveBeenCalled();
+  });
+
+  it('FILES-RPC-005 a path outside the uploads root is refused', async () => {
+    const f = build();
+    (f.files.resolveFilePath as ReturnType<typeof vi.fn>).mockReturnValueOnce({ resolved: '/etc/passwd', safe: false });
+    const res = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
+    expect(res.error.message).toBe('file path is not accessible');
+  });
+});
+
+describe('FilesRpc writes', () => {
+  it('FILES-RPC-006 each operation asks for its own right', async () => {
+    const seen: string[] = [];
+    const f = build({ allow: (a) => { seen.push(a); return true; } });
+    const host = f.host('db:write:files');
+    await host.dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: b64('x') } }), 42);
+    await host.dispatch(req('files.update', { tripId: 1, fileId: 2, input: {} }), 42);
+    await host.dispatch(req('files.softDelete', { tripId: 1, fileId: 2 }), 42);
+    expect(seen).toEqual(['file_upload', 'file_edit', 'file_delete']);
+  });
+
+  it('FILES-RPC-007 a blocked extension never reaches disk', async () => {
+    const f = build();
+    const res = (await f.host('db:write:files').dispatch(req('files.create', { tripId: 1, input: { name: 'evil.exe', content_base64: b64('MZ') } }), 42)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    expect(res.error.message).toBe("file extension '.exe' is not allowed");
+    expect(f.files.createFile).not.toHaveBeenCalled();
+  });
+
+  it('FILES-RPC-008 a file with no extension at all is refused', async () => {
+    const f = build();
+    const res = (await f.host('db:write:files').dispatch(req('files.create', { tripId: 1, input: { name: 'README', content_base64: b64('x') } }), 42)) as RpcError;
+    expect(res.error.message).toBe("file extension '(none)' is not allowed");
+  });
+
+  it('FILES-RPC-009 name and content are required, and the name is length-capped', async () => {
+    const f = build();
+    const host = f.host('db:write:files');
+    const bad = async (input: Record<string, unknown>) => ((await host.dispatch(req('files.create', { tripId: 1, input }), 42)) as RpcError).error.message;
+    expect(await bad({ content_base64: b64('x') })).toBe('file name is required (max 255 chars)');
+    expect(await bad({ name: 'x'.repeat(256), content_base64: b64('x') })).toBe('file name is required (max 255 chars)');
+    expect(await bad({ name: 'a.pdf' })).toBe('content_base64 is required');
+    expect(await bad({ name: 'a.pdf', content_base64: '' })).toBe('content_base64 is required');
+  });
+
+  it('FILES-RPC-010 an oversized payload is rejected on its ENCODED length', async () => {
+    const f = build();
+    const res = (await f.host('db:write:files').dispatch(
+      req('files.create', { tripId: 1, input: { name: 'big.pdf', content_base64: 'A'.repeat(15 * 1024 * 1024) } }), 42,
+    )) as RpcError;
+    expect(res.error.message).toBe('file exceeds the 10MB plugin upload cap');
+  });
+
+  it('FILES-RPC-011 empty decoded content is refused', async () => {
+    const f = build();
+    const res = (await f.host('db:write:files').dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: '====' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('file content is empty');
+  });
+
+  it('FILES-RPC-012 a link target on another trip is refused, for create and update alike', async () => {
+    const f = build({ foreign: 'reservation 9' });
+    const host = f.host('db:write:files');
+    const created = (await host.dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: b64('x'), reservation_id: 9 } }), 42)) as RpcError;
+    expect(created.error.message).toBe('reservation 9 does not belong to trip 1');
+    const updated = (await host.dispatch(req('files.update', { tripId: 1, fileId: 2, input: { reservation_id: 9 } }), 42)) as RpcError;
+    expect(updated.error.message).toBe('reservation 9 does not belong to trip 1');
+  });
+
+  it('FILES-RPC-013 update tells null from undefined, so a link can be cleared', async () => {
+    const f = build();
+    const host = f.host('db:write:files');
+    await host.dispatch(req('files.update', { tripId: 1, fileId: 2, input: { place_id: null } }), 42);
+    expect(f.files.updateFile).toHaveBeenLastCalledWith(2, expect.anything(), expect.objectContaining({ place_id: null }));
+    await host.dispatch(req('files.update', { tripId: 1, fileId: 2, input: { description: 'x' } }), 42);
+    expect(f.files.updateFile).toHaveBeenLastCalledWith(2, expect.anything(), expect.objectContaining({ place_id: undefined }));
+  });
+
+  it('FILES-RPC-014 a missing file is RESOURCE_FORBIDDEN across every write', async () => {
+    const f = build();
+    const host = f.host('db:write:files');
+    for (const [method, params] of [
+      ['files.createLink', { tripId: 1, fileId: 404, opts: {} }],
+      ['files.update', { tripId: 1, fileId: 404, input: {} }],
+      ['files.softDelete', { tripId: 1, fileId: 404 }],
+    ] as const) {
+      const res = (await host.dispatch(req(method, params), 42)) as RpcError;
+      expect(res.error.message).toBe('no file 404 on trip 1');
+    }
+  });
+
+  it('FILES-RPC-015 a userless write is refused before anything else happens', async () => {
+    const f = build();
+    const res = (await f.host('db:write:files').dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: b64('x') } }), undefined)) as RpcError;
+    expect(res.error.message).toBe('file writes require an authenticated user context');
+    expect(f.files.createFile).not.toHaveBeenCalled();
+  });
+
+  it('FILES-RPC-016 a successful write broadcasts, a refused one does not', async () => {
+    const f = build();
+    const host = f.host('db:write:files');
+    await host.dispatch(req('files.softDelete', { tripId: 1, fileId: 2 }), 42);
+    expect(f.realtime.broadcast).toHaveBeenCalledWith(1, 'file:deleted', { fileId: 2 }, undefined);
+    f.realtime.broadcast.mockClear();
+    await host.dispatch(req('files.softDelete', { tripId: 1, fileId: 404 }), 42);
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('FILES-RPC-016b a demo account cannot upload while demo mode is on, other members can', async () => {
+    const prev = process.env.DEMO_MODE;
+    process.env.DEMO_MODE = 'true';
+    try {
+      const f = build();
+      // The demo guard resolves the uploader's email; user 9 is the demo account.
+      (f.files as unknown as { getFileById: unknown });
+      const db = {
+        canAccessTrip: vi.fn(() => ({ id: 1, user_id: 42 })),
+        prepare: vi.fn(() => ({ get: (id: number) => (id === 9 ? { role: 'user', email: 'demo@trek.app' } : { role: 'user', email: 'real@example.test' }) })),
+      } as unknown as DatabaseService;
+      const guards = new PluginGuards(
+        db,
+        { checkPermission: vi.fn(() => true) } as unknown as PermissionsService,
+        { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+      );
+      const files = {
+        findForeignLinkTarget: vi.fn(() => null),
+        createFile: vi.fn(() => ({ id: 130 })),
+      } as unknown as FilesService;
+      const rpc = new FilesRpc(files, { broadcast: vi.fn() } as unknown as RealtimeService, db, guards);
+      const host = new PluginRpcHost('p', new Set(['db:write:files']), makeDeps(), createTestPluginRegistry([rpc]));
+      const input = { name: 'a.pdf', content_base64: b64('x') };
+      const denied = (await host.dispatch(req('files.create', { tripId: 1, input }), 9)) as RpcError;
+      expect(denied.error.message).toBe('Uploads are disabled in demo mode.');
+      expect((await host.dispatch(req('files.create', { tripId: 1, input }), 42)).ok).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.DEMO_MODE;
+      else process.env.DEMO_MODE = prev;
+    }
+  });
+
+  it('FILES-RPC-017 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', FilesModule) as unknown[]).toContain(FilesRpc);
+  });
+});

--- a/server/tests/unit/nest/packing.controller.test.ts
+++ b/server/tests/unit/nest/packing.controller.test.ts
@@ -10,7 +10,7 @@ const trip = { id: 5, user_id: 1 };
 
 /** Service mock with trip access granted + edit allowed by default. */
 function makeService(overrides: Partial<PackingService> = {}): PackingService {
-  return {
+  const base = {
     verifyTripAccess: vi.fn().mockReturnValue(trip),
     canEdit: vi.fn().mockReturnValue(true),
     broadcast: vi.fn(),
@@ -23,6 +23,30 @@ function makeService(overrides: Partial<PackingService> = {}): PackingService {
     notifyTagged: vi.fn(),
     ...overrides,
   } as unknown as PackingService;
+  // emitToViewers and broadcastUpdate moved from the controller into the service, so
+  // the mock reproduces their routing on top of whatever broadcast stubs a test
+  // supplied. That keeps every #858 assertion below pointed at the same three
+  // primitives it always was.
+  const svc = base as unknown as PackingService & Record<string, (...a: never[]) => unknown>;
+  svc.emitToViewers = ((tripId, event, payload, item, socketId) => {
+    const viewers = svc.viewersOf(item);
+    if (viewers === null) svc.broadcast(tripId, event, payload, socketId);
+    else svc.broadcastToViewers(tripId, event, payload, viewers, socketId);
+  }) as PackingService['emitToViewers'];
+  svc.broadcastUpdate = ((tripId, id, item, wasPrivate, socketId) => {
+    if (item.is_private) {
+      if (wasPrivate) {
+        svc.broadcastItem(tripId, 'packing:updated', { item }, item, socketId);
+      } else {
+        svc.broadcast(tripId, 'packing:deleted', { itemId: Number(id) }, socketId);
+        svc.broadcastItem(tripId, 'packing:created', { item }, item, socketId);
+      }
+    } else {
+      if (wasPrivate) svc.broadcast(tripId, 'packing:created', { item }, socketId);
+      svc.broadcast(tripId, 'packing:updated', { item }, socketId);
+    }
+  }) as PackingService['broadcastUpdate'];
+  return svc;
 }
 
 function thrown(fn: () => unknown): { status: number; body: unknown } {

--- a/server/tests/unit/packing/packing.rpc.test.ts
+++ b/server/tests/unit/packing/packing.rpc.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The packing plugin surface after it moved onto @PluginMethod.
+ *
+ * The four public/private transitions (#858) are the reason this file is long. Each
+ * one is asserted separately, because getting any of them wrong leaks a private item
+ * to the whole trip room, and because the logic now lives once in PackingService
+ * instead of three times over.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { PackingRpc } from '../../../src/nest/packing/packing.rpc';
+import { PackingModule } from '../../../src/nest/packing/packing.module';
+import { PackingService } from '../../../src/nest/packing/packing.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+type Item = { id: number; name?: string; is_private?: number; owner_id?: number | null; recipients?: { user_id: number }[] };
+
+/**
+ * A REAL PackingService over a fake realtime, so the broadcast fan-out under test is
+ * the production one; only the data methods are stubbed.
+ */
+function build(opts: { canEdit?: boolean; before?: Item | undefined; updated?: Item | null } = {}) {
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const packing = new PackingService({} as never, {} as never, realtime);
+  const data = {
+    listItems: vi.fn(() => [{ id: 70, name: 'Socks' }]),
+    createItem: vi.fn((_t: string, i: Record<string, unknown>) => ({ id: 70, ...i })),
+    getItemPrivacy: vi.fn(() => opts.before),
+    updateItem: vi.fn(() => (opts.updated === undefined ? { id: 70, is_private: 0 } : opts.updated)),
+    deleteItem: vi.fn((_t: string, id: string) => (id === '70' ? { id: 70, is_private: 0 } : null)),
+    listBags: vi.fn(() => [{ id: 80, name: 'Backpack' }]),
+    createBag: vi.fn((_t: string, b: Record<string, unknown>) => ({ id: 80, ...b })),
+    updateBag: vi.fn((_t: string, id: string) => (id === '80' ? { id: 80 } : null)),
+    deleteBag: vi.fn((_t: string, id: string) => id === '80'),
+    setBagMembers: vi.fn((_t: string, id: string, ids: number[]) => (id === '80' ? { bagId: 80, members: ids } : null)),
+  };
+  Object.assign(packing, data);
+  const guards = new PluginGuards(
+    {
+      canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+      prepare: vi.fn(() => ({ get: () => ({ role: 'user' }) })),
+    } as unknown as DatabaseService,
+    { checkPermission: vi.fn(() => opts.canEdit ?? true) } as unknown as PermissionsService,
+    { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+  );
+  const rpc = new PackingRpc(packing, realtime, guards);
+  const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
+  return { packing, data, realtime, rpc, host };
+}
+
+/** Every (event, onlyUserId) pair the fan-out produced, in order. */
+const fanout = (realtime: { broadcast: ReturnType<typeof vi.fn> }) =>
+  realtime.broadcast.mock.calls.map((c) => [c[1], c[4]]);
+
+describe('PackingRpc through the router', () => {
+  it('PACKING-RPC-001 packing.list is membership-checked and scoped to the acting user', async () => {
+    const f = build();
+    const host = f.host('db:read:packing');
+    expect((await host.dispatch(req('packing.list', { tripId: 1 }), 42)).ok).toBe(true);
+    // The user id is handed through so the #858 visibility filter applies.
+    expect(f.data.listItems).toHaveBeenCalledWith(1, 42);
+    expect(((await host.dispatch(req('packing.list', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('PACKING-RPC-002 create needs the write grant, the edit right and a bound user', async () => {
+    const f = build();
+    const host = f.host('db:write:packing');
+    expect((await host.dispatch(req('packing.create', { tripId: 1, input: { name: 'Socks' } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('packing.create', { tripId: 1, input: { name: '' } }), 42)).ok).toBe(false);
+    expect(((await host.dispatch(req('packing.create', { tripId: 2, input: { name: 'x' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+    const noUser = (await host.dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), undefined)) as RpcError;
+    expect(noUser.error.message).toBe('packing item writes require an authenticated user context');
+  });
+
+  it('PACKING-RPC-003 db:read:packing does not unlock a write', async () => {
+    const f = build();
+    const res = (await f.host('db:read:packing').dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('PACKING-RPC-004 a missing item is RESOURCE_FORBIDDEN, naming it', async () => {
+    const f = build({ updated: null });
+    const res = (await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 404, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no packing item 404 on trip 1');
+  });
+
+  it('PACKING-RPC-005 bags are gated on the write grant too, listBags included', async () => {
+    const f = build();
+    const host = f.host('db:write:packing');
+    expect((await host.dispatch(req('packing.listBags', { tripId: 1 }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('packing.createBag', { tripId: 1, input: { name: 'Bag' } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [5, 6] }), 42)).ok).toBe(true);
+    expect(f.data.setBagMembers).toHaveBeenCalledWith('1', '80', [5, 6]);
+  });
+
+  it('PACKING-RPC-006 a bag name is required, and a missing bag is named', async () => {
+    const f = build();
+    const host = f.host('db:write:packing');
+    expect(((await host.dispatch(req('packing.createBag', { tripId: 1, input: { name: ' ' } }), 42)) as RpcError).error.message).toBe('bag name is required');
+    expect(((await host.dispatch(req('packing.updateBag', { tripId: 1, bagId: 404, input: {} }), 42)) as RpcError).error.message).toBe('no packing bag 404 on trip 1');
+  });
+
+  it('PACKING-RPC-007 non-numeric entries in userIds are dropped', async () => {
+    const f = build();
+    await f.host('db:write:packing').dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [5, 'six', null, 6] }), 42);
+    expect(f.data.setBagMembers).toHaveBeenCalledWith('1', '80', [5, 6]);
+  });
+
+  it('PACKING-RPC-008 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', PackingModule) as unknown[]).toContain(PackingRpc);
+  });
+});
+
+describe('PackingRpc keeps private items off the room (#858)', () => {
+  it('PACKING-RPC-009 a common item is created for the whole room', async () => {
+    const f = build();
+    await f.host('db:write:packing').dispatch(req('packing.create', { tripId: 1, input: { name: 'Socks' } }), 42);
+    expect(fanout(f.realtime)).toEqual([['packing:created', undefined]]);
+  });
+
+  it('PACKING-RPC-010 a private item is created only for its owner and recipients', async () => {
+    const f = build();
+    f.data.createItem.mockReturnValueOnce({ id: 70, is_private: 1, owner_id: 42, recipients: [{ user_id: 7 }] });
+    await f.host('db:write:packing').dispatch(req('packing.create', { tripId: 1, input: { name: 'Gift', is_private: true } }), 42);
+    expect(fanout(f.realtime)).toEqual([
+      ['packing:created', 42],
+      ['packing:created', 7],
+    ]);
+  });
+
+  it('PACKING-RPC-011 private stays private: an owner-only update, never a room event', async () => {
+    const f = build({ before: { id: 70, is_private: 1 }, updated: { id: 70, is_private: 1, owner_id: 42 } });
+    await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { name: 'x' } }), 42);
+    expect(fanout(f.realtime)).toEqual([['packing:updated', 42]]);
+  });
+
+  it('PACKING-RPC-012 public to private: dropped from the room FIRST, then re-added for the owner', async () => {
+    const f = build({ before: { id: 70, is_private: 0 }, updated: { id: 70, is_private: 1, owner_id: 42 } });
+    await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { is_private: true } }), 42);
+    // The order matters: a member who already had the item must lose it before the
+    // owner gets the private copy.
+    expect(fanout(f.realtime)).toEqual([
+      ['packing:deleted', undefined],
+      ['packing:created', 42],
+    ]);
+  });
+
+  it('PACKING-RPC-013 private to public: created for the members who lacked it, then updated for all', async () => {
+    const f = build({ before: { id: 70, is_private: 1 }, updated: { id: 70, is_private: 0 } });
+    await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { is_private: false } }), 42);
+    expect(fanout(f.realtime)).toEqual([
+      ['packing:created', undefined],
+      ['packing:updated', undefined],
+    ]);
+  });
+
+  it('PACKING-RPC-014 public stays public: one plain update to everyone', async () => {
+    const f = build({ before: { id: 70, is_private: 0 }, updated: { id: 70, is_private: 0 } });
+    await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { name: 'x' } }), 42);
+    expect(fanout(f.realtime)).toEqual([['packing:updated', undefined]]);
+  });
+
+  it('PACKING-RPC-015 the privacy is read BEFORE the write, not after', async () => {
+    const f = build({ before: { id: 70, is_private: 0 }, updated: { id: 70, is_private: 1, owner_id: 42 } });
+    await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { is_private: true } }), 42);
+    // Reading it afterwards would report "already private" and skip the room delete,
+    // leaving the item on every member's screen.
+    expect(f.data.getItemPrivacy.mock.invocationCallOrder[0]).toBeLessThan(f.data.updateItem.mock.invocationCallOrder[0]);
+  });
+
+  it('PACKING-RPC-016 deleting a private item tells only its viewers', async () => {
+    const f = build();
+    f.data.deleteItem.mockReturnValueOnce({ id: 70, is_private: 1, owner_id: 42, recipients: [{ user_id: 7 }] });
+    await f.host('db:write:packing').dispatch(req('packing.delete', { tripId: 1, itemId: 70 }), 42);
+    expect(fanout(f.realtime)).toEqual([
+      ['packing:deleted', 42],
+      ['packing:deleted', 7],
+    ]);
+  });
+
+  it('PACKING-RPC-016b a stale-write conflict is BAD_PARAMS and broadcasts nothing', async () => {
+    const f = build({ before: { id: 70, is_private: 0 }, updated: { conflict: true, server: { id: 70 } } as never });
+    const res = (await f.host('db:write:packing').dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    expect(res.error.message).toBe('packing item was modified concurrently');
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('PACKING-RPC-017 a refused write broadcasts nothing at all', async () => {
+    const f = build({ canEdit: false });
+    await f.host('db:write:packing').dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), 42);
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -626,7 +626,7 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
     expect(r.result).toHaveLength(1);
   });
 
-  it('wave-13 wiring: collab reads, journal entries, atlas bucket, file content and trip create delegate correctly', async () => {
+  it('wave-13 wiring: collab reads, journal entries, atlas bucket and trip create delegate correctly', async () => {
     // collab reads delegate to collabService and require the collab addon
     const collab = host('db:read:collab');
     expect((await call(collab, 'collab.listNotes', { tripId: 1 })).result).toEqual([{ id: 1, trip_id: 1, title: 'Note' }]);
@@ -640,14 +640,6 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
     // atlas.bucketList
     const atlas = host('db:read:atlas');
     expect((await call(atlas, 'atlas.bucketList', {})).result).toEqual([{ id: 5, user_id: 5, name: 'Kyoto' }]);
-    // files.getContent: size-capped (file 500 = 400MB -> BAD_PARAMS), 404 refused
-    fs.mkdirSync(testFilesDir, { recursive: true });
-    fs.writeFileSync(`${testFilesDir}/visa.pdf`, 'hi');
-    const files = host('db:read:files:content');
-    const content = await call(files, 'files.getContent', { tripId: 1, fileId: 2 });
-    expect(content.result).toMatchObject({ name: 'visa.pdf', mimetype: 'application/pdf', content_base64: Buffer.from('hi').toString('base64') });
-    expect((await call(files, 'files.getContent', { tripId: 1, fileId: 500 })).error.code).toBe('BAD_PARAMS');
-    expect((await call(files, 'files.getContent', { tripId: 1, fileId: 404 })).error.code).toBe('RESOURCE_FORBIDDEN');
     // trips.create: owner = acting user, delegates to createTrip; validation error mapped
     const create = host('db:create:trips');
     expect((await call(create, 'trips.create', { input: { title: 'Japan' } })).result).toMatchObject({ id: 99, user_id: 5, title: 'Japan' });
@@ -795,44 +787,8 @@ describe('host-deps factory — Wave 3 wiring (files write / collab / member-add
   beforeEach(() => { checkPermission.mockReset(); checkPermission.mockReturnValue(true); isAddonEnabled.mockReset(); isAddonEnabled.mockReturnValue(true); broadcast.mockClear() })
   afterAll(() => closePluginDataDb('w3'))
 
-  it('files.create writes bytes, blocks bad extensions + foreign targets, broadcasts file:created', async () => {
-    const h = host('db:write:files')
-    const good = await call(h, 'files.create', { tripId: 1, input: { name: 'plan.pdf', content_base64: Buffer.from('hello').toString('base64') } })
-    expect(good.ok).toBe(true)
-    expect(broadcast.mock.calls.some((c) => c[1] === 'file:created')).toBe(true)
-    expect(((await call(h, 'files.create', { tripId: 1, input: { name: 'evil.exe', content_base64: 'aGk=' } })) as { error: { code: string } }).error.code).toBe('BAD_PARAMS')
-    expect(((await call(h, 'files.create', { tripId: 1, input: { name: 'noext', content_base64: 'aGk=' } })) as { error: { code: string } }).error.code).toBe('BAD_PARAMS')
-    expect(((await call(h, 'files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: 'aGk=', reservation_id: 999 } })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
-
-  it('files.create blocks a demo user while DEMO_MODE is on, but not other members', async () => {
-    const prev = process.env.DEMO_MODE
-    process.env.DEMO_MODE = 'true'
-    try {
-      const h = host('db:write:files')
-      // user 77 is the demo account (demo@trek.app) → the plugin upload is refused
-      const denied = await call(h, 'files.create', { tripId: 1, input: { name: 'demo.pdf', content_base64: Buffer.from('x').toString('base64') } }, 77)
-      expect((denied as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-      // a normal member (user 5, no demo email) is unaffected
-      const ok = await call(h, 'files.create', { tripId: 1, input: { name: 'ok.pdf', content_base64: Buffer.from('x').toString('base64') } }, 5)
-      expect(ok.ok).toBe(true)
-    } finally {
-      if (prev === undefined) delete process.env.DEMO_MODE; else process.env.DEMO_MODE = prev
-    }
-  })
-
-  it('files link/update/softDelete verify the file is on the trip + same-trip targets', async () => {
-    const h = host('db:write:files')
-    expect((await call(h, 'files.createLink', { tripId: 1, fileId: 130, opts: { place_id: 7 } })).ok).toBe(true)
-    expect(((await call(h, 'files.createLink', { tripId: 1, fileId: 404, opts: {} })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-    expect(((await call(h, 'files.createLink', { tripId: 1, fileId: 130, opts: { place_id: 999 } })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-    expect((await call(h, 'files.update', { tripId: 1, fileId: 130, input: { description: 'new' } })).ok).toBe(true)
-    expect(broadcast.mock.calls.some((c) => c[1] === 'file:updated')).toBe(true)
-    expect((await call(h, 'files.softDelete', { tripId: 1, fileId: 130 })).ok).toBe(true)
-    expect(broadcast.mock.calls.some((c) => c[1] === 'file:deleted')).toBe(true)
-    expect(((await call(h, 'files.softDelete', { tripId: 1, fileId: 404 })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
-
+  // The files write deps left this factory with the decorator migration; the cases
+  // now run in tests/unit/files/files.rpc.test.ts against FilesRpc.
   it('collab writes delegate + broadcast; service errors map to BAD_PARAMS; addon gated', async () => {
     const h = host('db:write:collab')
     expect((await call(h, 'collab.createNote', { tripId: 1, input: { title: 'Ideas' } })).ok).toBe(true)

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -585,13 +585,6 @@ describe('host-deps factory — planner write + metadata deps', () => {
     expect((await call(h, 'costs.delete', { tripId: 1, itemId: 404 })).error.code).toBe('RESOURCE_FORBIDDEN');
   });
 
-  it('packing/files read deps delegate to their services (trash excluded for files)', async () => {
-    const h = host('db:read:packing', 'db:read:files');
-    // acting user 5 is threaded to the packing service (#858 private-item filter); _uid proves it
-    expect((await call(h, 'packing.list', { tripId: 1 })).result).toEqual([{ id: 1, trip_id: 1, name: 'Socks', _uid: 5 }]);
-    expect((await call(h, 'files.list', { tripId: 1 })).result).toEqual([{ id: 2, trip_id: 1, trash: false }]);
-  });
-
   it('users.getById is scoped to people the acting user shares a trip with', async () => {
     const h = host('db:read:users');
     expect((await call(h, 'users.getById', { id: 6 }, 5)).ok).toBe(true); // 5 (owner) + 6 (member) share trip 1
@@ -714,68 +707,9 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
   });
 });
 
-describe('host-deps factory — packing write with #858 privacy-scoped broadcasts', () => {
-  const host = () => createRealRpcHost('pk', new Set(['db:write:packing']))
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const call = async (method: string, params: Record<string, unknown>, uid = 5): Promise<any> =>
-    host().dispatch({ k: 'req', id: 'x', method, params }, uid)
-  // the onlyUserId (5th arg) of every broadcast for `event` since the last clear:
-  // undefined = whole trip room, a number = that user's sockets only.
-  const fanout = (event: string) => broadcast.mock.calls.filter((c) => c[1] === event).map((c) => c[4])
-  beforeEach(() => { checkPermission.mockReset(); checkPermission.mockReturnValue(true); isAddonEnabled.mockReset(); isAddonEnabled.mockReturnValue(true); broadcast.mockClear() })
-  afterAll(() => closePluginDataDb('pk'))
-
-  it('create: Common -> whole room; Personal -> owner-only; Shared -> owner + recipients', async () => {
-    expect((await call('packing.create', { tripId: 1, input: { name: 'Common', visibility: 'common' } })).ok).toBe(true)
-    expect(fanout('packing:created')).toEqual([undefined]) // whole room
-
-    broadcast.mockClear()
-    expect((await call('packing.create', { tripId: 1, input: { name: 'Mine', visibility: 'personal' } })).ok).toBe(true)
-    expect(fanout('packing:created')).toEqual([5]) // owner-only
-
-    broadcast.mockClear()
-    expect((await call('packing.create', { tripId: 1, input: { name: 'Ours', visibility: 'shared', recipient_ids: [6] } })).ok).toBe(true)
-    expect([...fanout('packing:created')].sort()).toEqual([5, 6]) // owner + recipient, never the room
-  })
-
-  it('update: the four public<->private transitions route correctly (never leaks a privatized item)', async () => {
-    await call('packing.update', { tripId: 1, itemId: 71, input: { is_private: true } }) // stays private (71 seeded private)
-    expect(fanout('packing:updated')).toEqual([5])
-    expect(fanout('packing:deleted')).toEqual([])
-    expect(fanout('packing:created')).toEqual([])
-
-    broadcast.mockClear()
-    await call('packing.update', { tripId: 1, itemId: 70, input: { is_private: true } }) // public -> private (70 seeded public)
-    expect(fanout('packing:deleted')).toEqual([undefined]) // drop from the room FIRST (the anti-leak)
-    expect(fanout('packing:created')).toEqual([5])         // then re-add owner-only
-
-    broadcast.mockClear()
-    await call('packing.update', { tripId: 1, itemId: 71, input: { is_private: false } }) // private -> public
-    expect(fanout('packing:created')).toEqual([undefined])
-    expect(fanout('packing:updated')).toEqual([undefined])
-
-    broadcast.mockClear()
-    await call('packing.update', { tripId: 1, itemId: 70, input: { is_private: false } }) // stays public
-    expect(fanout('packing:updated')).toEqual([undefined])
-    expect(fanout('packing:deleted')).toEqual([])
-  })
-
-  it('update: a stale-write conflict is BAD_PARAMS and never broadcasts', async () => {
-    const res = await call('packing.update', { tripId: 1, itemId: 99, input: { name: 'x' } })
-    expect((res as { error: { code: string } }).error.code).toBe('BAD_PARAMS')
-    expect(broadcast).not.toHaveBeenCalled()
-  })
-
-  it('delete: a private item is owner-scoped; a missing one is RESOURCE_FORBIDDEN', async () => {
-    await call('packing.delete', { tripId: 1, itemId: 71 })
-    expect(fanout('packing:deleted')).toEqual([5]) // owner-only (recipients get no packing:deleted)
-    broadcast.mockClear()
-    await call('packing.delete', { tripId: 1, itemId: 70 })
-    expect(fanout('packing:deleted')).toEqual([undefined]) // common -> room
-    const missing = await call('packing.delete', { tripId: 1, itemId: 404 })
-    expect((missing as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
-})
+// The packing write deps left this factory with the decorator migration. The #858
+// transitions are asserted in tests/unit/packing/packing.rpc.test.ts, against the
+// PackingService methods the REST controller uses too, so there is one copy now.
 
 describe('host-deps factory — Wave 1 wiring (weather/categories/tags/todos/roster/bags)', () => {
   const host = (...perms: string[]) => createRealRpcHost('w1', new Set(perms))
@@ -800,15 +734,6 @@ describe('host-deps factory — Wave 1 wiring (weather/categories/tags/todos/ros
   // todos.* left this factory with the decorator migration; the cases now run in
   // tests/unit/todo/todo.rpc.test.ts against TodoRpc.
 
-  it('packing bags list/create/update/delete/setMembers run the wiring', async () => {
-    const h = host('db:write:packing')
-    expect((await call(h, 'packing.listBags', { tripId: 1 }, 5)).ok).toBe(true)
-    expect((await call(h, 'packing.createBag', { tripId: 1, input: { name: 'Bag' } }, 5)).ok).toBe(true)
-    expect((await call(h, 'packing.updateBag', { tripId: 1, bagId: 80, input: { name: 'X' } }, 5)).ok).toBe(true)
-    expect((await call(h, 'packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [5] }, 5)).ok).toBe(true)
-    expect((await call(h, 'packing.deleteBag', { tripId: 1, bagId: 80 }, 5)).ok).toBe(true)
-    expect(((await call(h, 'packing.deleteBag', { tripId: 1, bagId: 404 }, 5)) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
 })
 
 describe('host-deps factory — Wave 2 wiring (atlas/vacay/journal/collections writes)', () => {

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -622,15 +622,8 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
     expect((await call(h, 'reservations.delete', { tripId: 1, reservationId: 404 })).error.code).toBe('RESOURCE_FORBIDDEN');
   });
 
-  it('day notes create/update/delete run the wiring; a day/note outside the trip is refused', async () => {
-    const h = host('db:write:daynotes');
-    expect((await call(h, 'daynotes.create', { tripId: 1, dayId: 3, input: { text: 'Pack' } })).ok).toBe(true);
-    expect((await call(h, 'daynotes.create', { tripId: 1, dayId: 88, input: { text: 'x' } })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'daynotes.update', { tripId: 1, dayId: 3, noteId: 5, input: { text: 'y' } })).ok).toBe(true);
-    expect((await call(h, 'daynotes.update', { tripId: 1, dayId: 3, noteId: 99, input: {} })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'daynotes.delete', { tripId: 1, dayId: 3, noteId: 5 })).ok).toBe(true);
-    expect((await call(h, 'daynotes.delete', { tripId: 1, dayId: 3, noteId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
+  // daynotes.* left this factory with the decorator migration; the cases now run in
+  // tests/unit/days/day-notes.rpc.test.ts against DayNotesRpc.
 
   it('cross-trip reads enumerate accessible trips and reservations', async () => {
     const h = host('db:read:trips');
@@ -640,7 +633,7 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
     expect(r.result).toHaveLength(1);
   });
 
-  it('wave-13 wiring: collab reads, journal entries, atlas bucket, file content, trip create, rates delegate correctly', async () => {
+  it('wave-13 wiring: collab reads, journal entries, atlas bucket, file content and trip create delegate correctly', async () => {
     // collab reads delegate to collabService and require the collab addon
     const collab = host('db:read:collab');
     expect((await call(collab, 'collab.listNotes', { tripId: 1 })).result).toEqual([{ id: 1, trip_id: 1, title: 'Note' }]);
@@ -666,9 +659,6 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
     const create = host('db:create:trips');
     expect((await call(create, 'trips.create', { input: { title: 'Japan' } })).result).toMatchObject({ id: 99, user_id: 5, title: 'Japan' });
     expect((await call(create, 'trips.create', { input: { title: 'boom' } })).error.code).toBe('BAD_PARAMS');
-    // rates.get: tenant-free, delegates to the cached service
-    const rates = host('rates:read');
-    expect((await call(rates, 'rates.get', { base: 'EUR' })).result).toMatchObject({ EUR: 1, USD: 1.08 });
   });
 
   it('trip-scoped reads are wired to the hydrated services (days incl. assignments, reservations incl. endpoints)', async () => {
@@ -795,10 +785,8 @@ describe('host-deps factory — Wave 1 wiring (weather/categories/tags/todos/ros
   beforeEach(() => { checkPermission.mockReset(); checkPermission.mockReturnValue(true) })
   afterAll(() => closePluginDataDb('w1'))
 
-  it('weather + categories are tenant-free reads (no user needed)', async () => {
-    expect((await call(host('weather:read'), 'weather.get', { lat: 48, lng: 11 }, undefined)).ok).toBe(true)
-    expect((await call(host('db:read:categories'), 'categories.list', {}, undefined)).ok).toBe(true)
-  })
+  // weather.get, categories.list and rates.get left this factory with the decorator
+  // migration; the cases now run in tests/unit/plugins/tenant-free.rpc.test.ts.
 
   // tags.* left this factory with the decorator migration. The same cases now run in
   // tests/unit/tags/tags.rpc.test.ts against TagsRpc.
@@ -809,15 +797,8 @@ describe('host-deps factory — Wave 1 wiring (weather/categories/tags/todos/ros
     expect(Array.isArray(r.result)).toBe(true)
   })
 
-  it('todos list/create/update/delete run the wiring; a missing one is RESOURCE_FORBIDDEN', async () => {
-    const h = host('db:write:todos', 'db:read:todos')
-    expect((await call(h, 'todos.list', { tripId: 1 }, 5)).ok).toBe(true)
-    expect((await call(h, 'todos.create', { tripId: 1, input: { name: 'Pack' } }, 5)).ok).toBe(true)
-    expect((await call(h, 'todos.update', { tripId: 1, todoId: 90, input: { checked: 1 } }, 5)).ok).toBe(true)
-    expect((await call(h, 'todos.delete', { tripId: 1, todoId: 90 }, 5)).ok).toBe(true)
-    expect(((await call(h, 'todos.update', { tripId: 1, todoId: 404, input: {} }, 5)) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-    expect(((await call(h, 'todos.delete', { tripId: 1, todoId: 404 }, 5)) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
+  // todos.* left this factory with the decorator migration; the cases now run in
+  // tests/unit/todo/todo.rpc.test.ts against TodoRpc.
 
   it('packing bags list/create/update/delete/setMembers run the wiring', async () => {
     const h = host('db:write:packing')

--- a/server/tests/unit/plugins/rpc-coverage.test.ts
+++ b/server/tests/unit/plugins/rpc-coverage.test.ts
@@ -54,11 +54,27 @@ describe('plugin RPC coverage ledger', () => {
     // Update these two numbers in every rollout PR. They make the diff state the size
     // of the move out loud, which is the number a reviewer wants to see.
     const total = KNOWN_METHODS.length + UNCONDITIONAL_METHODS.length;
-    expect(fromRegistry.size).toBe(4); // tags.list / create / update / delete
-    expect(legacy.size).toBe(total - 4);
+    expect(fromRegistry.size).toBe(15);
+    expect(legacy.size).toBe(total - 15);
   });
 
   it('RPCLEDGER-006 the migrated methods are exactly the ones this PR claims', () => {
-    expect([...fromRegistry].sort()).toEqual(['tags.create', 'tags.delete', 'tags.list', 'tags.update']);
+    expect([...fromRegistry].sort()).toEqual([
+      'categories.list',
+      'daynotes.create',
+      'daynotes.delete',
+      'daynotes.list',
+      'daynotes.update',
+      'rates.get',
+      'tags.create',
+      'tags.delete',
+      'tags.list',
+      'tags.update',
+      'todos.create',
+      'todos.delete',
+      'todos.list',
+      'todos.update',
+      'weather.get',
+    ]);
   });
 });

--- a/server/tests/unit/plugins/rpc-coverage.test.ts
+++ b/server/tests/unit/plugins/rpc-coverage.test.ts
@@ -54,8 +54,8 @@ describe('plugin RPC coverage ledger', () => {
     // Update these two numbers in every rollout PR. They make the diff state the size
     // of the move out loud, which is the number a reviewer wants to see.
     const total = KNOWN_METHODS.length + UNCONDITIONAL_METHODS.length;
-    expect(fromRegistry.size).toBe(15);
-    expect(legacy.size).toBe(total - 15);
+    expect(fromRegistry.size).toBe(24);
+    expect(legacy.size).toBe(total - 24);
   });
 
   it('RPCLEDGER-006 the migrated methods are exactly the ones this PR claims', () => {
@@ -65,6 +65,15 @@ describe('plugin RPC coverage ledger', () => {
       'daynotes.delete',
       'daynotes.list',
       'daynotes.update',
+      'packing.create',
+      'packing.createBag',
+      'packing.delete',
+      'packing.deleteBag',
+      'packing.list',
+      'packing.listBags',
+      'packing.setBagMembers',
+      'packing.update',
+      'packing.updateBag',
       'rates.get',
       'tags.create',
       'tags.delete',

--- a/server/tests/unit/plugins/rpc-coverage.test.ts
+++ b/server/tests/unit/plugins/rpc-coverage.test.ts
@@ -54,8 +54,8 @@ describe('plugin RPC coverage ledger', () => {
     // Update these two numbers in every rollout PR. They make the diff state the size
     // of the move out loud, which is the number a reviewer wants to see.
     const total = KNOWN_METHODS.length + UNCONDITIONAL_METHODS.length;
-    expect(fromRegistry.size).toBe(24);
-    expect(legacy.size).toBe(total - 24);
+    expect(fromRegistry.size).toBe(30);
+    expect(legacy.size).toBe(total - 30);
   });
 
   it('RPCLEDGER-006 the migrated methods are exactly the ones this PR claims', () => {
@@ -65,6 +65,12 @@ describe('plugin RPC coverage ledger', () => {
       'daynotes.delete',
       'daynotes.list',
       'daynotes.update',
+      'files.create',
+      'files.createLink',
+      'files.getContent',
+      'files.list',
+      'files.softDelete',
+      'files.update',
       'packing.create',
       'packing.createBag',
       'packing.delete',

--- a/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
+++ b/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
@@ -10,6 +10,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
 import type { RpcRequest, RpcResponse } from '../../../src/nest/plugins/protocol/envelope';
 import { makeDeps } from '../../helpers/rpc-host-deps';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PackingRpc } from '../../../src/nest/packing/packing.rpc';
+import type { PackingService } from '../../../src/nest/packing/packing.service';
+import type { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
 
 const req = (method: string, params: Record<string, unknown>): RpcRequest => ({ k: 'req', id: 'x', method, params });
 
@@ -60,11 +65,23 @@ describe('dispatch strips the supervisor _inv marker', () => {
   });
 
   it('RPCINV-006 a handler reading the whole payload object no longer finds _inv in it', async () => {
-    const deps = makeDeps();
-    const host = new PluginRpcHost('p', new Set(['db:write:packing']), deps);
     // packing.setBagMembers is the one handler that reads the params object as a
-    // whole (asPayload(p).userIds) rather than a named field off it.
+    // whole (asPayload(p).userIds) rather than a named field off it, which makes it
+    // the case where a stray _inv could actually change behaviour.
+    const setBagMembers = vi.fn(() => ({ bagId: 80, members: [3] }));
+    const packing = { setBagMembers } as unknown as PackingService;
+    const guards = {
+      requireActor: () => 42,
+      requireTripEdit: () => undefined,
+    } as unknown as PluginGuards;
+    const realtime = { broadcast: vi.fn() } as unknown as RealtimeService;
+    const host = new PluginRpcHost(
+      'p',
+      new Set(['db:write:packing']),
+      makeDeps(),
+      createTestPluginRegistry([new PackingRpc(packing, realtime, guards)]),
+    );
     await host.dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [3], _inv: 'req-7' }), 42);
-    expect(deps.setPackingBagMembers).toHaveBeenCalledWith(1, 80, [3]);
+    expect(setBagMembers).toHaveBeenCalledWith('1', '80', [3]);
   });
 });

--- a/server/tests/unit/plugins/rpc-host.test.ts
+++ b/server/tests/unit/plugins/rpc-host.test.ts
@@ -315,9 +315,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     // reading content is NOT unlocked by plain db:read:files
     const filesList = new PluginRpcHost('p', new Set(['db:read:files']), deps);
     expect((await filesList.dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42) as RpcError).error.code).toBe('PERMISSION_DENIED');
-    // rates.get: tenant-free (works without a user), needs rates:read
-    const rates = new PluginRpcHost('p', new Set(['rates:read']), deps);
-    expect(ok(await rates.dispatch(req('rates.get', { base: 'EUR' }), undefined))).toBe(true);
     // trips.create: needs db:create:trips + the acting user's trip_create + a bound user
     const create = new PluginRpcHost('p', new Set(['db:create:trips']), deps);
     expect(ok(await create.dispatch(req('trips.create', { input: { title: 'Japan' } }), 42))).toBe(true);
@@ -326,14 +323,7 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((await create.dispatch(req('trips.create', { input: {} }), 42) as RpcError).error.code).toBe('BAD_PARAMS'); // title required
   });
 
-  it('daynotes.list is membership-checked (trip-scoped)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:daynotes']), deps);
-    const good = await host.dispatch(req('daynotes.list', { tripId: 1, dayId: 5 }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.listDayNotes).toHaveBeenCalledWith(1, 5);
-    const forbidden = await host.dispatch(req('daynotes.list', { tripId: 999, dayId: 5 }), 42);
-    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
+  // The daynotes cases moved to tests/unit/days/day-notes.rpc.test.ts.
 
   it('collections reads are user-scoped and need db:read:collections + a bound user', async () => {
     const host = new PluginRpcHost('p', new Set(['db:read:collections']), deps);
@@ -342,26 +332,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect(ok(one)).toBe(true);
     expect(deps.getCollectionForUser).toHaveBeenCalledWith(42, 1);
     expect((await host.dispatch(req('collections.listMine'), undefined)).ok).toBe(false);
-  });
-
-  it('daynotes.create needs db:write:daynotes + day_edit, membership-checked, text required', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:daynotes']), deps);
-    const good = await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: 'Pack sunscreen' } }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.createDayNote).toHaveBeenCalledWith(1, 5, expect.objectContaining({ text: 'Pack sunscreen' }));
-    const bad = await host.dispatch(req('daynotes.create', { tripId: 1, dayId: 5, input: { text: '  ' } }), 42);
-    expect((bad as RpcError).error.code).toBe('BAD_PARAMS');
-    const forbidden = await host.dispatch(req('daynotes.create', { tripId: 2, dayId: 5, input: { text: 'x' } }), 42);
-    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('daynotes.delete is gated the same way (edit + membership + bound user)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:daynotes']), deps);
-    const good = await host.dispatch(req('daynotes.delete', { tripId: 1, dayId: 5, noteId: 50 }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.deleteDayNote).toHaveBeenCalledWith(1, 5, 50);
-    const noUser = await host.dispatch(req('daynotes.delete', { tripId: 1, dayId: 5, noteId: 50 }), undefined);
-    expect((noUser as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
   });
 
   it('packing.create needs db:write:packing + packing_edit, membership-checked, name required', async () => {
@@ -384,27 +354,18 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((await noGrant.dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), 42)).ok).toBe(false);
   });
 
-  it('weather.get + categories.list are tenant-free (work without a user)', async () => {
-    const w = new PluginRpcHost('p', new Set(['weather:read']), deps);
-    expect(ok(await w.dispatch(req('weather.get', { lat: 48, lng: 11 }), undefined))).toBe(true);
-    const c = new PluginRpcHost('p', new Set(['db:read:categories']), deps);
-    expect(ok(await c.dispatch(req('categories.list', {}), undefined))).toBe(true);
-  });
+  // weather.get, categories.list and rates.get moved to tests/unit/plugins/tenant-free.rpc.test.ts.
 
   // The tags cases moved to tests/unit/tags/tags.rpc.test.ts with the handlers.
 
-  it('trips.members + todos.list are trip-membership-gated', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips', 'db:read:todos']), deps);
+  it('trips.members is trip-membership-gated', async () => {
+    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
     expect(ok(await host.dispatch(req('trips.members', { tripId: 1 }), 42))).toBe(true);
-    expect(ok(await host.dispatch(req('todos.list', { tripId: 1 }), 42))).toBe(true);
     expect(((await host.dispatch(req('trips.members', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
   });
 
-  it('todos + packing-bags writes need the grant + edit right + a bound user', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:todos', 'db:write:packing']), deps);
-    expect(ok(await host.dispatch(req('todos.create', { tripId: 1, input: { name: 'Pack' } }), 42))).toBe(true);
-    expect((await host.dispatch(req('todos.create', { tripId: 1, input: { name: ' ' } }), 42)).ok).toBe(false);
-    expect(((await host.dispatch(req('todos.create', { tripId: 2, input: { name: 'x' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  it('packing-bags writes need the grant + edit right + a bound user', async () => {
+    const host = new PluginRpcHost('p', new Set(['db:write:packing']), deps);
     expect(ok(await host.dispatch(req('packing.createBag', { tripId: 1, input: { name: 'Bag' } }), 42))).toBe(true);
     expect(ok(await host.dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [5, 6] }), 42))).toBe(true);
     expect(deps.setPackingBagMembers).toHaveBeenCalledWith(1, 80, [5, 6]);

--- a/server/tests/unit/plugins/rpc-host.test.ts
+++ b/server/tests/unit/plugins/rpc-host.test.ts
@@ -277,7 +277,7 @@ describe('PluginRpcHost — capability enforcement', () => {
     }
   });
 
-  it('wave-13 reads: collab / journal.getEntries / atlas.bucketList / files.getContent / rates / trips.create gated correctly', async () => {
+  it('wave-13 reads: collab / journal.getEntries / atlas.bucketList / trips.create gated correctly', async () => {
     // collab reads: membership-checked, need db:read:collab
     const collab = new PluginRpcHost('p', new Set(['db:read:collab']), deps);
     expect(ok(await collab.dispatch(req('collab.listNotes', { tripId: 1 }), 42))).toBe(true);
@@ -291,13 +291,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     const atlas = new PluginRpcHost('p', new Set(['db:read:atlas']), deps);
     expect(ok(await atlas.dispatch(req('atlas.bucketList'), 42))).toBe(true);
     expect((await atlas.dispatch(req('atlas.bucketList'), undefined)).ok).toBe(false);
-    // files.getContent: separate grant from files.list, membership-checked
-    const files = new PluginRpcHost('p', new Set(['db:read:files:content']), deps);
-    expect(ok(await files.dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42))).toBe(true);
-    expect((await files.dispatch(req('files.getContent', { tripId: 2, fileId: 2 }), 42)).ok).toBe(false);
-    // reading content is NOT unlocked by plain db:read:files
-    const filesList = new PluginRpcHost('p', new Set(['db:read:files']), deps);
-    expect((await filesList.dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42) as RpcError).error.code).toBe('PERMISSION_DENIED');
     // trips.create: needs db:create:trips + the acting user's trip_create + a bound user
     const create = new PluginRpcHost('p', new Set(['db:create:trips']), deps);
     expect(ok(await create.dispatch(req('trips.create', { input: { title: 'Japan' } }), 42))).toBe(true);
@@ -366,25 +359,7 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((await noGrant.dispatch(req('collections.create', { input: { name: 'x' } }), 42)).ok).toBe(false);
   });
 
-  it('files.create validates name/content/size and is gated by file_upload', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:files']), deps);
-    const good = await host.dispatch(req('files.create', { tripId: 1, input: { name: 'itinerary.pdf', content_base64: 'aGk=' } }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.createTripFile).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'itinerary.pdf' }), 42);
-    expect((await host.dispatch(req('files.create', { tripId: 1, input: { name: '', content_base64: 'aGk=' } }), 42)).ok).toBe(false);
-    expect((await host.dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf' } }), 42)).ok).toBe(false); // no content
-    expect(((await host.dispatch(req('files.create', { tripId: 2, input: { name: 'a.pdf', content_base64: 'aGk=' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await host.dispatch(req('files.create', { tripId: 1, input: { name: 'a.pdf', content_base64: 'aGk=' } }), undefined)).ok).toBe(false);
-  });
-
-  it('files link/update/softDelete run under file_edit / file_delete', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:files']), deps);
-    expect(ok(await host.dispatch(req('files.createLink', { tripId: 1, fileId: 130, opts: { place_id: 7 } }), 42))).toBe(true);
-    expect(ok(await host.dispatch(req('files.update', { tripId: 1, fileId: 130, input: { description: 'x' } }), 42))).toBe(true);
-    expect(ok(await host.dispatch(req('files.softDelete', { tripId: 1, fileId: 130 }), 42))).toBe(true);
-    expect(deps.canDeleteFiles).toHaveBeenCalled();
-  });
-
+  // The files cases moved to tests/unit/files/files.rpc.test.ts with the handlers.
   it('collab writes are gated by collab_edit and validate their inputs', async () => {
     const host = new PluginRpcHost('p', new Set(['db:write:collab']), deps);
     expect(ok(await host.dispatch(req('collab.createNote', { tripId: 1, input: { title: 'Ideas' } }), 42))).toBe(true);

--- a/server/tests/unit/plugins/rpc-host.test.ts
+++ b/server/tests/unit/plugins/rpc-host.test.ts
@@ -77,23 +77,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((allowed as RpcResponse).result).toEqual([{ id: 7, name: 'Place' }]);
   });
 
-  it('db:read:packing / db:read:files delegate to the service, membership-checked, and stay separate scopes', async () => {
-    const packing = new PluginRpcHost('p', new Set(['db:read:packing']), deps);
-    // no access to trip 2 → refused before the service is called
-    expect(((await packing.dispatch(req('packing.list', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(deps.listPackingItems).not.toHaveBeenCalled();
-    const okP = await packing.dispatch(req('packing.list', { tripId: 1 }), 42);
-    expect(ok(okP)).toBe(true);
-    // the acting user is threaded through so packing's #858 private-item filter applies
-    expect(deps.listPackingItems).toHaveBeenCalledWith(1, 42);
-    // the packing scope does NOT unlock files
-    expect(((await packing.dispatch(req('files.list', { tripId: 1 }), 42)) as RpcError).error.code).toBe('PERMISSION_DENIED');
-
-    const files = new PluginRpcHost('p', new Set(['db:read:files']), deps);
-    const okF = await files.dispatch(req('files.list', { tripId: 1 }), 42);
-    expect((okF as RpcResponse).result).toEqual([{ id: 2, trip_id: 1, filename: 'visa.pdf' }]);
-  });
-
   it('db:read:users returns only the public projection for a visible user', async () => {
     const host = new PluginRpcHost('p', new Set(['db:read:users']), deps);
     const res = await host.dispatch(req('users.getById', { id: 3 }), 42);
@@ -334,26 +317,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((await host.dispatch(req('collections.listMine'), undefined)).ok).toBe(false);
   });
 
-  it('packing.create needs db:write:packing + packing_edit, membership-checked, name required', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:packing']), deps);
-    const good = await host.dispatch(req('packing.create', { tripId: 1, input: { name: 'Socks' } }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.createPackingItem).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Socks' }), 42);
-    expect((await host.dispatch(req('packing.create', { tripId: 1, input: { name: '' } }), 42)).ok).toBe(false); // schema: name min 1
-    expect(((await host.dispatch(req('packing.create', { tripId: 2, input: { name: 'x' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await host.dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), undefined)).ok).toBe(false); // no acting user
-  });
-
-  it('packing.update/delete are gated the same way; nothing without the grant', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:packing']), deps);
-    expect(ok(await host.dispatch(req('packing.update', { tripId: 1, itemId: 70, input: { checked: true } }), 42))).toBe(true);
-    expect(deps.updatePackingItem).toHaveBeenCalledWith(1, 70, expect.objectContaining({ checked: true }), 42);
-    expect(ok(await host.dispatch(req('packing.delete', { tripId: 1, itemId: 70 }), 42))).toBe(true);
-    expect(deps.deletePackingItem).toHaveBeenCalledWith(1, 70);
-    const noGrant = new PluginRpcHost('p', new Set(['db:read:packing']), deps);
-    expect((await noGrant.dispatch(req('packing.create', { tripId: 1, input: { name: 'x' } }), 42)).ok).toBe(false);
-  });
-
   // weather.get, categories.list and rates.get moved to tests/unit/plugins/tenant-free.rpc.test.ts.
 
   // The tags cases moved to tests/unit/tags/tags.rpc.test.ts with the handlers.
@@ -362,14 +325,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
     expect(ok(await host.dispatch(req('trips.members', { tripId: 1 }), 42))).toBe(true);
     expect(((await host.dispatch(req('trips.members', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('packing-bags writes need the grant + edit right + a bound user', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:packing']), deps);
-    expect(ok(await host.dispatch(req('packing.createBag', { tripId: 1, input: { name: 'Bag' } }), 42))).toBe(true);
-    expect(ok(await host.dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [5, 6] }), 42))).toBe(true);
-    expect(deps.setPackingBagMembers).toHaveBeenCalledWith(1, 80, [5, 6]);
-    expect((await host.dispatch(req('packing.createBag', { tripId: 1, input: { name: 'Bag' } }), undefined)).ok).toBe(false);
   });
 
   it('atlas writes are uid-bound (code-validated, userless refused)', async () => {

--- a/server/tests/unit/plugins/tenant-free.rpc.test.ts
+++ b/server/tests/unit/plugins/tenant-free.rpc.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The three tenant-free plugin methods: weather, categories and exchange rates.
+ *
+ * They are grouped because what matters about them is the same property, and it is
+ * the one a migration could quietly lose: they carry no tenant data, so they work
+ * with NO acting user. Everything else in the plugin surface refuses that.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { CategoriesRpc } from '../../../src/nest/categories/categories.rpc';
+import { CategoriesModule } from '../../../src/nest/categories/categories.module';
+import { WeatherRpc } from '../../../src/nest/weather/weather.rpc';
+import { WeatherModule } from '../../../src/nest/weather/weather.module';
+import { ExchangeRatesRpc } from '../../../src/nest/budget/exchange-rates.rpc';
+import { BudgetModule } from '../../../src/nest/budget/budget.module';
+import type { CategoriesService } from '../../../src/nest/categories/categories.service';
+import type { WeatherService } from '../../../src/nest/weather/weather.service';
+import type { ExchangeRatesService } from '../../../src/nest/budget/exchange-rates.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+function build() {
+  const categories = { list: vi.fn(() => [{ id: 1, name: 'Food' }]) } as unknown as CategoriesService & Record<string, ReturnType<typeof vi.fn>>;
+  const weather = { get: vi.fn(async () => ({ temp: 20 })) } as unknown as WeatherService & Record<string, ReturnType<typeof vi.fn>>;
+  const rates = { getRates: vi.fn(async (base: string) => ({ [base]: 1, USD: 1.08 })) } as unknown as ExchangeRatesService & Record<string, ReturnType<typeof vi.fn>>;
+  const registry = createTestPluginRegistry([
+    new CategoriesRpc(categories),
+    new WeatherRpc(weather),
+    new ExchangeRatesRpc(rates),
+  ]);
+  const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), registry);
+  return { categories, weather, rates, host };
+}
+
+describe('tenant-free plugin methods', () => {
+  it('TENANTFREE-001 weather.get and categories.list work without a user', async () => {
+    const f = build();
+    expect((await f.host('weather:read').dispatch(req('weather.get', { lat: 48, lng: 11 }), undefined)).ok).toBe(true);
+    expect((await f.host('db:read:categories').dispatch(req('categories.list', {}), undefined)).ok).toBe(true);
+  });
+
+  it('TENANTFREE-002 rates.get works without a user and needs rates:read', async () => {
+    const f = build();
+    expect((await f.host('rates:read').dispatch(req('rates.get', { base: 'EUR' }), undefined)).ok).toBe(true);
+    expect(f.rates.getRates).toHaveBeenCalledWith('EUR');
+    const denied = (await f.host().dispatch(req('rates.get', { base: 'EUR' }), undefined)) as RpcError;
+    expect(denied.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('TENANTFREE-003 weather coordinates are coerced, and the language stays pinned to en', async () => {
+    const f = build();
+    // Numeric strings are accepted, as the wire contract has always allowed.
+    await f.host('weather:read').dispatch(req('weather.get', { lat: '48.1', lng: '11.5', date: '2027-01-01' }), undefined);
+    expect(f.weather.get).toHaveBeenCalledWith('48.1', '11.5', '2027-01-01', 'en');
+  });
+
+  it('TENANTFREE-004 a non-numeric coordinate is BAD_PARAMS', async () => {
+    const res = (await build().host('weather:read').dispatch(req('weather.get', { lat: 'north', lng: 11 }), undefined)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    expect(res.error.message).toBe('lat must be a number');
+  });
+
+  it('TENANTFREE-005 a non-string base is BAD_PARAMS', async () => {
+    const res = (await build().host('rates:read').dispatch(req('rates.get', { base: 42 }), undefined)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+  });
+
+  it('TENANTFREE-006 an absent date is passed through as undefined, not as a string', async () => {
+    const f = build();
+    await f.host('weather:read').dispatch(req('weather.get', { lat: 1, lng: 2 }), undefined);
+    expect(f.weather.get).toHaveBeenCalledWith('1', '2', undefined, 'en');
+  });
+
+  it('TENANTFREE-007 each class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', CategoriesModule) as unknown[]).toContain(CategoriesRpc);
+    expect(Reflect.getMetadata('providers', WeatherModule) as unknown[]).toContain(WeatherRpc);
+    expect(Reflect.getMetadata('providers', BudgetModule) as unknown[]).toContain(ExchangeRatesRpc);
+  });
+});

--- a/server/tests/unit/todo/todo.rpc.test.ts
+++ b/server/tests/unit/todo/todo.rpc.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The todo plugin surface after it moved onto @PluginMethod. Note the edit gate: the
+ * app edits todos under 'packing_edit', not under a todo-specific action, which is
+ * easy to lose in a move and is asserted here explicitly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { TodoRpc } from '../../../src/nest/todo/todo.rpc';
+import { TodoModule } from '../../../src/nest/todo/todo.module';
+import type { TodoService } from '../../../src/nest/todo/todo.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+/** Trip 1 belongs to user 42; todo 90 sits on it. */
+function build(canEdit = true) {
+  const todos = {
+    listItems: vi.fn(() => [{ id: 90, name: 'Pack' }]),
+    createItem: vi.fn((tripId: string, input: Record<string, unknown>) => ({ id: 91, trip_id: tripId, ...input })),
+    updateItem: vi.fn((_t: string, id: string) => (id === '90' ? { id: 90, checked: 1 } : undefined)),
+    deleteItem: vi.fn((_t: string, id: string) => id === '90'),
+  } as unknown as TodoService & Record<string, ReturnType<typeof vi.fn>>;
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const permissions = { checkPermission: vi.fn(() => canEdit) } as unknown as PermissionsService;
+  const guards = new PluginGuards(
+    {
+      canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+      prepare: vi.fn(() => ({ get: () => ({ role: 'user' }) })),
+    } as unknown as DatabaseService,
+    permissions,
+    { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+  );
+  const rpc = new TodoRpc(todos, realtime, guards);
+  const host = (...grants: string[]) =>
+    new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
+  return { todos, realtime, permissions, host };
+}
+
+describe('TodoRpc through the router', () => {
+  let f: ReturnType<typeof build>;
+  beforeEach(() => {
+    f = build();
+  });
+
+  it('TODO-RPC-001 todos.list is trip-membership-gated', async () => {
+    const host = f.host('db:read:todos');
+    expect((await host.dispatch(req('todos.list', { tripId: 1 }), 42)).ok).toBe(true);
+    expect(((await host.dispatch(req('todos.list', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+  });
+
+  it('TODO-RPC-002 writes need the grant, the edit right and a bound user', async () => {
+    const host = f.host('db:write:todos');
+    expect((await host.dispatch(req('todos.create', { tripId: 1, input: { name: 'Pack' } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('todos.update', { tripId: 1, todoId: 90, input: { checked: 1 } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('todos.delete', { tripId: 1, todoId: 90 }), 42)).ok).toBe(true);
+    const noUser = (await host.dispatch(req('todos.create', { tripId: 1, input: { name: 'x' } }), undefined)) as RpcError;
+    expect(noUser.error.message).toBe('todo writes require an authenticated user context');
+  });
+
+  it('TODO-RPC-003 the edit gate is packing_edit, not a todo-specific action', async () => {
+    await f.host('db:write:todos').dispatch(req('todos.create', { tripId: 1, input: { name: 'Pack' } }), 42);
+    expect(f.permissions.checkPermission).toHaveBeenCalledWith('packing_edit', 'user', 42, 42, false);
+  });
+
+  it('TODO-RPC-004 a blank name is BAD_PARAMS', async () => {
+    const res = (await f.host('db:write:todos').dispatch(req('todos.create', { tripId: 1, input: { name: '  ' } }), 42)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    expect(res.error.message).toBe('todo name is required');
+  });
+
+  it('TODO-RPC-005 a missing todo is RESOURCE_FORBIDDEN, naming it', async () => {
+    const host = f.host('db:write:todos');
+    const upd = (await host.dispatch(req('todos.update', { tripId: 1, todoId: 404, input: {} }), 42)) as RpcError;
+    expect(upd.error.message).toBe('no todo 404 on trip 1');
+    const del = (await host.dispatch(req('todos.delete', { tripId: 1, todoId: 404 }), 42)) as RpcError;
+    expect(del.error.message).toBe('no todo 404 on trip 1');
+  });
+
+  it('TODO-RPC-006 every write broadcasts the event the REST path emits', async () => {
+    const host = f.host('db:write:todos');
+    await host.dispatch(req('todos.create', { tripId: 1, input: { name: 'Pack' } }), 42);
+    await host.dispatch(req('todos.update', { tripId: 1, todoId: 90, input: { checked: 1 } }), 42);
+    await host.dispatch(req('todos.delete', { tripId: 1, todoId: 90 }), 42);
+    expect(f.realtime.broadcast.mock.calls.map((c) => c[1])).toEqual(['todo:created', 'todo:updated', 'todo:deleted']);
+  });
+
+  it('TODO-RPC-007 a failed write never broadcasts', async () => {
+    await f.host('db:write:todos').dispatch(req('todos.update', { tripId: 1, todoId: 404, input: {} }), 42);
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('TODO-RPC-008 the read grant does not unlock a write', async () => {
+    const res = (await f.host('db:read:todos').dispatch(req('todos.create', { tripId: 1, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('TODO-RPC-009 without the edit right the write is refused before it touches the service', async () => {
+    const noEdit = build(false);
+    const res = (await noEdit.host('db:write:todos').dispatch(req('todos.create', { tripId: 1, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to edit trip 1');
+    expect(noEdit.todos.createItem).not.toHaveBeenCalled();
+  });
+
+  it('TODO-RPC-010 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', TodoModule) as unknown[]).toContain(TodoRpc);
+  });
+});


### PR DESCRIPTION
categories, weather, rates, todos and daynotes. 11 more methods, so the registry now owns
15 of 113. Handler bodies and messages are verbatim, and the ledger test tracks the split.

Two things the move surfaced. PluginGuards could not stay in PluginsModule, which imports
22 domain modules: a domain importing it back for the guards would close a hard cycle, and
the only way out would be forwardRef. It now sits in a PluginGuardsModule leaf, the same
shape MailerModule got. And the todo and daynote writes broadcast, which is what keeps an
open session from showing stale data after a plugin write, so those calls came across with
the handlers and there is a test that a failed write broadcasts nothing.

Worth carrying forward: todos are edited under `packing_edit`, not a todo-specific action.
Each new class also asserts it is really listed in its module providers, since one that
nobody registers is invisible to discovery and just answers PERMISSION_DENIED.
