### PR TITLE
Move the planner and trip surfaces onto the plugin RPC decorators

### DIFF
--- a/server/src/nest/assignments/assignments.module.ts
+++ b/server/src/nest/assignments/assignments.module.ts
@@ -5,6 +5,9 @@ import { PermissionsModule } from '../permissions/permissions.module';
 import { QueryHelpersModule } from '../query-helpers/query-helpers.module';
 import { DayAssignmentsController, AssignmentOpsController } from './assignments.controller';
 import { AssignmentsService } from './assignments.service';
+import { ItineraryRpc } from './itinerary.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { AssignmentsMcp } from './assignments.mcp';
 import { AuthModule } from '../auth/auth.module';
 
@@ -16,9 +19,9 @@ import { AuthModule } from '../auth/auth.module';
  */
 @Module({
   // DaysModule: AssignmentsMcp injects DaysService for the target-day checks.
-  imports: [DaysModule, PermissionsModule, QueryHelpersModule, AuthModule, JourneyDomainModule],
+  imports: [DaysModule, PermissionsModule, QueryHelpersModule, AuthModule, JourneyDomainModule, RealtimeModule, PluginGuardsModule],
   controllers: [DayAssignmentsController, AssignmentOpsController],
-  providers: [AssignmentsService, AssignmentsMcp],
+  providers: [AssignmentsService, AssignmentsMcp, ItineraryRpc],
   exports: [AssignmentsService],
 })
 export class AssignmentsModule {}

--- a/server/src/nest/assignments/itinerary.rpc.ts
+++ b/server/src/nest/assignments/itinerary.rpc.ts
@@ -1,0 +1,61 @@
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { ForbiddenResource } from '../plugins/host/rpc-errors';
+import { num, str } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { AssignmentsService } from './assignments.service';
+
+/** Assigning a place to a day counts as a DAY edit in the app, not an edit of its own. */
+const DAY_EDIT_ACTION = 'day_edit';
+
+/**
+ * The itinerary surface a plugin may reach (#plugins).
+ *
+ * Both the day AND the place have to belong to the trip. AssignmentsService does not
+ * check that itself, the controllers do, so it is reproduced here: without it a
+ * plugin could cross-link another trip's rows.
+ */
+@PluginController()
+export class ItineraryRpc {
+  constructor(
+    private readonly assignments: AssignmentsService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('itinerary.assign', { permission: 'db:write:itinerary' })
+  assign(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const placeId = num(params.placeId, 'placeId');
+    const actor = this.guards.requireActor(ctx, 'itinerary');
+    const notes = params.notes === undefined || params.notes === null ? null : str(params.notes, 'notes');
+    this.guards.requireTripEdit(tripId, actor, DAY_EDIT_ACTION);
+    if (!this.assignments.dayExists(dayId, tripId)) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
+    if (!this.assignments.placeExists(placeId, tripId)) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
+    const assignment = this.assignments.createAssignment(dayId, placeId, notes);
+    this.realtime.broadcast(tripId, 'assignment:created', { assignment });
+    this.assignments.reconcile(tripId);
+    return assignment;
+  }
+
+  @PluginMethod('itinerary.unassign', { permission: 'db:write:itinerary' })
+  unassign(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const assignmentId = num(params.assignmentId, 'assignmentId');
+    const actor = this.guards.requireActor(ctx, 'itinerary');
+    this.guards.requireTripEdit(tripId, actor, DAY_EDIT_ACTION);
+    const existing = this.assignments.getAssignmentForTrip(assignmentId, tripId);
+    if (!existing) throw new ForbiddenResource(`no assignment ${assignmentId} on trip ${tripId}`);
+    this.assignments.deleteAssignment(assignmentId);
+    // The dayId is what the client reducer keys the eviction on. Without it nothing
+    // leaves the day, so keep the payload shape identical to the REST/MCP delete.
+    this.realtime.broadcast(tripId, 'assignment:deleted', { assignmentId, dayId: existing.day_id });
+    // Create, delete, move and time re-mirror the linked journey skeletons afterwards,
+    // in the controller and the MCP tool alike; reorder, transport and participants do
+    // not. Without it an open journey keeps the removed place until the next reload.
+    this.assignments.reconcile(tripId);
+    return { deleted: true };
+  }
+}

--- a/server/src/nest/days/days.module.ts
+++ b/server/src/nest/days/days.module.ts
@@ -5,6 +5,7 @@ import { DaysMcp } from './days.mcp';
 import { DayNotesController } from './day-notes.controller';
 import { DayNotesService } from './day-notes.service';
 import { DayNotesRpc } from './day-notes.rpc';
+import { DaysRpc } from './days.rpc';
 import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
 import { RealtimeModule } from '../realtime/realtime.module';
 import { DayNotesMcp } from './day-notes.mcp';
@@ -25,7 +26,7 @@ import { AuthModule } from '../auth/auth.module';
 @Module({
   imports: [PermissionsModule, QueryHelpersModule, PlacesModule, AuthModule, RealtimeModule, PluginGuardsModule],
   controllers: [DaysController, DayNotesController],
-  providers: [DaysService, DaysMcp, DayNotesService, DayNotesMcp, DayNotesRpc],
+  providers: [DaysService, DaysMcp, DayNotesService, DayNotesMcp, DayNotesRpc, DaysRpc],
   exports: [DaysService, DayNotesService],
 })
 export class DaysModule {}

--- a/server/src/nest/days/days.rpc.ts
+++ b/server/src/nest/days/days.rpc.ts
@@ -1,0 +1,66 @@
+import { dayCreateRequestSchema, dayUpdateRequestSchema } from '@trek/shared';
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { DaysService } from './days.service';
+
+const DAY_EDIT_ACTION = 'day_edit';
+
+/**
+ * The day surface a plugin may reach (#plugins). Every write scopes the day to the
+ * trip before touching it, so a plugin cannot edit another trip's day by naming its
+ * id. The itinerary half lives in assignments/itinerary.rpc.ts, because
+ * AssignmentsModule already imports DaysModule and the reverse would be a cycle.
+ */
+@PluginController()
+export class DaysRpc {
+  constructor(
+    private readonly days: DaysService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('days.create', { permission: 'db:write:days' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'day');
+    const parsed = dayCreateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid day: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.requireTripEdit(tripId, actor, DAY_EDIT_ACTION);
+    const input = parsed.data as { date?: string; notes?: string };
+    const day = this.days.create(tripId, input.date, input.notes);
+    this.realtime.broadcast(tripId, 'day:created', { day });
+    return day;
+  }
+
+  @PluginMethod('days.update', { permission: 'db:write:days' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const actor = this.guards.requireActor(ctx, 'day');
+    const parsed = dayUpdateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid day: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.requireTripEdit(tripId, actor, DAY_EDIT_ACTION);
+    // getDay scopes the row to the trip before the write touches it.
+    const current = this.days.getDay(dayId, tripId);
+    if (!current) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
+    const day = this.days.update(dayId, current, parsed.data as { notes?: string; title?: string | null });
+    this.realtime.broadcast(tripId, 'day:updated', { day });
+    return day;
+  }
+
+  @PluginMethod('days.delete', { permission: 'db:write:days' })
+  delete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const dayId = num(params.dayId, 'dayId');
+    const actor = this.guards.requireActor(ctx, 'day');
+    this.guards.requireTripEdit(tripId, actor, DAY_EDIT_ACTION);
+    if (!this.days.getDay(dayId, tripId)) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
+    this.days.remove(dayId);
+    this.realtime.broadcast(tripId, 'day:deleted', { dayId });
+    return { deleted: true };
+  }
+}

--- a/server/src/nest/places/places.module.ts
+++ b/server/src/nest/places/places.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { JourneyDomainModule } from '../journey/journey-domain.module';
 import { PlacesController } from './places.controller';
 import { PlacesService } from './places.service';
+import { PlacesRpc } from './places.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { PlacesMcp } from './places.mcp';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AppConfigModule } from '../app-config/app-config.module';
@@ -20,9 +23,9 @@ import { AuthModule } from '../auth/auth.module';
  * is no places.bridge.ts: nothing outside the container consumes this domain.
  */
 @Module({
-  imports: [PermissionsModule, QueryHelpersModule, MapsModule, AuthModule, AppConfigModule, UnsplashModule, PlacePhotosModule, JourneyDomainModule],
+  imports: [PermissionsModule, QueryHelpersModule, MapsModule, AuthModule, AppConfigModule, UnsplashModule, PlacePhotosModule, JourneyDomainModule, RealtimeModule, PluginGuardsModule],
   controllers: [PlacesController],
-  providers: [PlacesService, PlacesMcp],
+  providers: [PlacesService, PlacesMcp, PlacesRpc],
   exports: [PlacesService],
 })
 export class PlacesModule {}

--- a/server/src/nest/places/places.rpc.ts
+++ b/server/src/nest/places/places.rpc.ts
@@ -1,0 +1,98 @@
+import { placeCreateRequestSchema, placeUpdateRequestSchema } from '@trek/shared';
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { JourneyDomainService } from '../journey/journey-domain.service';
+import { PlacesService } from './places.service';
+import type { PlaceCreateInput, PlaceUpdateInput } from './places.service';
+
+const PLACE_EDIT_ACTION = 'place_edit';
+
+/**
+ * The @trek/shared write schemas carry no string-length caps, so the plugin path
+ * mirrors the ones the REST controller adds. Without them a plugin could store a
+ * field the web app refuses with a 400, e.g. a 100k-character place name.
+ */
+const PLACE_STR_LIMITS: Record<string, number> = { name: 200, description: 2000, address: 500, notes: 2000 };
+
+/**
+ * The place surface a plugin may reach (#plugins).
+ *
+ * Journey mirroring is best-effort on every path that triggers it, in the REST
+ * controller and the MCP tool alike, so a broken journey link can never turn a
+ * successful write into an RPC error.
+ */
+@PluginController()
+export class PlacesRpc {
+  constructor(
+    private readonly places: PlacesService,
+    private readonly journey: JourneyDomainService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('places.create', { permission: 'db:write:places' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'place');
+    const parsed = placeCreateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid place: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
+    this.guards.requireTripEdit(tripId, actor, PLACE_EDIT_ACTION);
+    const place = this.places.create(String(tripId), parsed.data as unknown as PlaceCreateInput);
+    this.realtime.broadcast(tripId, 'place:created', { place });
+    this.mirrorJourneys(() => this.journey.onPlaceCreated(tripId, place.id));
+    return place;
+  }
+
+  @PluginMethod('places.update', { permission: 'db:write:places' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const placeId = num(params.placeId, 'placeId');
+    const actor = this.guards.requireActor(ctx, 'place');
+    const parsed = placeUpdateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid place: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
+    this.guards.requireTripEdit(tripId, actor, PLACE_EDIT_ACTION);
+    const place = this.places.update(String(tripId), String(placeId), parsed.data as PlaceUpdateInput);
+    if (place === null) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
+    this.realtime.broadcast(tripId, 'place:updated', { place });
+    this.mirrorJourneys(() => this.journey.onPlaceUpdated(placeId));
+    return place;
+  }
+
+  @PluginMethod('places.delete', { permission: 'db:write:places' })
+  delete(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const placeId = num(params.placeId, 'placeId');
+    const actor = this.guards.requireActor(ctx, 'place');
+    this.guards.requireTripEdit(tripId, actor, PLACE_EDIT_ACTION);
+    // Scope the id to the trip before anything else: onPlaceDeleted keys on the place
+    // alone, so an id belonging to a foreign trip would detach THAT trip's journey
+    // entries even though the delete below refuses it.
+    if (!this.places.get(String(tripId), String(placeId))) {
+      throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
+    }
+    // Ahead of the DELETE, like the REST route and the MCP tool:
+    // journey_entries.source_place_id is ON DELETE SET NULL, so afterwards the hook
+    // finds nothing left to detach and the entries linger as orphans.
+    this.mirrorJourneys(() => this.journey.onPlaceDeleted(placeId));
+    if (!this.places.remove(String(tripId), String(placeId))) {
+      throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
+    }
+    this.realtime.broadcast(tripId, 'place:deleted', { placeId });
+    return { deleted: true };
+  }
+
+  /** Journey mirroring never fails a write that already succeeded. */
+  private mirrorJourneys(run: () => void): void {
+    try {
+      run();
+    } catch {
+      /* non-fatal */
+    }
+  }
+}

--- a/server/src/nest/plugins/host/plugin-guards.service.ts
+++ b/server/src/nest/plugins/host/plugin-guards.service.ts
@@ -75,6 +75,16 @@ export class PluginGuards {
   }
 
   /**
+   * A permission that is NOT bound to a trip, so it cannot go through
+   * requireTripEdit. `trip_create` is the only one today: it has no trip to check
+   * against yet, which is why the owner id is passed as null.
+   */
+  canCreateAs(action: string, userId: number): boolean {
+    const user = this.db.prepare('SELECT role FROM users WHERE id = ?').get(userId) as { role?: string } | undefined;
+    return this.permissions.checkPermission(action, user?.role ?? 'user', null, userId, false);
+  }
+
+  /**
    * A subsystem read is refused when its addon is off, matching the app, where a
    * disabled addon means there is simply nothing to read.
    */

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -237,20 +237,6 @@ export class PluginHostDepsFactory {
       },
       // --- Member add (member_manage). Grants trip access — the target must exist;
       // the acting user is recorded as the inviter. Owner/duplicate adds are no-ops. ---
-      canManageMembers: (tripId, userId) => this.canEditTripAs('member_manage', tripId, userId),
-      addTripMember: (tripId, targetUserId, invitedBy) => {
-        const target = this.db.prepare('SELECT id FROM users WHERE id = ?').get(targetUserId) as { id: number } | undefined;
-        if (!target) throw new ForbiddenResource(`no user ${targetUserId}`);
-        return this.membership.joinTripAsMember(tripId, targetUserId, invitedBy);
-      },
-      removeTripMember: (tripId, targetUserId) => {
-        // Never remove the OWNER via this path — that would orphan the trip. Ownership
-        // transfer is a separate, deliberate action, not a member-management side effect.
-        const trip = this.db.prepare('SELECT user_id FROM trips WHERE id = ?').get(tripId) as { user_id: number } | undefined;
-        if (trip && trip.user_id === targetUserId) throw new ForbiddenResource('cannot remove the trip owner');
-        this.trips.removeMember(tripId, targetUserId);
-        return { removed: true };
-      },
       // --- Host-mediated notifications. Recipient resolution + channel fan-out +
       // per-user preferences are all owned by NotificationsService.send; the plugin
       // supplies only the target (host-scoped by the router) + plain text. actorId is
@@ -366,6 +352,8 @@ export class PluginHostDepsFactory {
       // linked to the trip carries a skeleton entry per day-assigned place, and
       // without the hooks it keeps the old title/location — or a dead entry — until
       // somebody reloads it. ---
+      // Consumed by the db:meta gate; the trip writes themselves have moved.
+      canEditTrip: (tripId, userId) => this.canEditTripAs('trip_edit', tripId, userId),
       canEditPlaces: (tripId, userId) => this.canEditTripAs('place_edit', tripId, userId),
       // --- Days (day_edit). getDay scopes the row to the trip before any write. ---
       canEditDays: (tripId, userId) => this.canEditTripAs('day_edit', tripId, userId),
@@ -374,59 +362,14 @@ export class PluginHostDepsFactory {
       // self-check this — the controllers do, so we reproduce it here). ---
       // --- Trip creation (trip_create; owner = acting user). No broadcast — a new trip
       // is only visible to its owner, who refetches (same as the REST POST). ---
-      canCreateTrip: (userId) => {
-        const u = this.db.prepare('SELECT role FROM users WHERE id = ?').get(userId) as { role?: string } | undefined;
-        return this.permissions.checkPermission('trip_create', u?.role ?? 'user', null, userId, false);
-      },
-      createTripForUser: (userId, input) => {
-        try {
-          const result = this.trips.create(userId, input as unknown as Parameters<TripsService['create']>[1]);
-          return result.trip;
-        } catch (e) {
-          if (e instanceof ValidationError) throw new BadParams(e.message);
-          throw e;
-        }
-      },
       // --- Exchange rates: the same cached upstream feed the budget uses (tenant-free). ---
       // --- Trip (trip_edit). Only the schema-writable fields reach updateTrip; its
       // NotFound/Validation errors are mapped to clean RPC codes. ---
-      canEditTrip: (tripId, userId) => this.canEditTripAs('trip_edit', tripId, userId),
-      updateTrip: (tripId, userId, input) => {
-        // The REST controller gates two fields behind their OWN admin-configurable
-        // permissions, separate from trip_edit — reproduce that here so a plugin (or
-        // its member user) can't archive or re-cover a trip it may only edit.
-        if ('is_archived' in input && !this.canEditTripAs('trip_archive', tripId, userId)) {
-          throw new ForbiddenResource(`no permission to archive trip ${tripId}`);
-        }
-        if ('cover_image' in input && !this.canEditTripAs('trip_cover_upload', tripId, userId)) {
-          throw new ForbiddenResource(`no permission to change the cover of trip ${tripId}`);
-        }
-        const u = this.db.prepare('SELECT role FROM users WHERE id = ?').get(userId) as { role?: string } | undefined;
-        try {
-          // The no-rebase updateTrip core — parity with the legacy host path,
-          // which never re-anchored the budget currency.
-          const result = this.trips.updateTrip(tripId, userId, input as Parameters<TripsService['updateTrip']>[2], u?.role ?? 'user');
-          this.realtime.broadcast(tripId, 'trip:updated', { trip: result.updatedTrip });
-          return result.updatedTrip;
-        } catch (e) {
-          if (e instanceof ValidationError) throw new BadParams(e.message);
-          if (e instanceof NotFoundError) throw new ForbiddenResource(e.message);
-          throw e;
-        }
-      },
       // --- Cross-trip reads. The membership predicate is baked into listTrips, so a
       // plugin only ever sees the acting user's own trips/reservations (no raw
       // cross-tenant SELECT). Reuses the same hydrated services as the REST paths. ---
-      listTripsForUser: (userId) => this.trips.list(userId, null),
-      listReservationsForUser: (userId) => {
-        const trips = this.trips.list(userId, null) as Array<{ id: number }>;
-        return trips.flatMap((t) => this.reservations.list(String(t.id)));
-      },
       // --- Trip-scoped hydrated reads (membership already checked by tripRead). Same
       // services as the REST GETs, so plugins see the exact planner shapes. ---
-      listTripDays: (tripId) => (this.days.list(tripId) as { days: unknown[] }).days,
-      listTripReservations: (tripId) => this.reservations.list(String(tripId)),
-      listTripAccommodations: (tripId) => this.days.listAccommodations(tripId) as unknown[],
       // --- Accommodations (lodging blocks, day_edit). Delegates to DaysService so the
       // partner hotel reservation, the metadata sync and the delete cascade behave
       // exactly like the accommodations REST controller, cascade broadcasts included. ---
@@ -596,14 +539,6 @@ export class PluginHostDepsFactory {
         this.notifyBooking(actingUserId, tripId, deleted.title, deleted.type || '');
         return { deleted: true };
       },
-      // --- Packing (packing_edit). Reuses PackingService + replicates the #858
-      // privacy-scoped broadcasts (create/delete via emitPackingToViewers, update via
-      // the four-case broadcastPackingUpdate) so a private item never leaks room-wide. ---
-      // --- Packing bags (no privacy — plain room broadcasts). ---
-      // --- Read-convenience: weather (host cache, tenant-free), categories (global), roster ---
-      tripMembers: (tripId) =>
-        this.db.prepare('SELECT u.id, u.username, u.display_name, u.avatar FROM trip_members tm JOIN users u ON u.id = tm.user_id WHERE tm.trip_id = ?').all(tripId) as unknown[],
-      // --- Todos (core, trip-scoped; the app's 'packing_edit' permission). ---
       // --- Plugin metadata (db:meta). A per-plugin namespaced key/value store keyed
       // to a core entity; the plugin only ever sees rows tagged with its own id. ---
       metaEntityTrip: (entityType, entityId) => {

--- a/server/src/nest/plugins/host/plugin-host-deps.factory.ts
+++ b/server/src/nest/plugins/host/plugin-host-deps.factory.ts
@@ -367,82 +367,11 @@ export class PluginHostDepsFactory {
       // without the hooks it keeps the old title/location — or a dead entry — until
       // somebody reloads it. ---
       canEditPlaces: (tripId, userId) => this.canEditTripAs('place_edit', tripId, userId),
-      createPlace: (tripId, input) => {
-        const place = this.places.create(String(tripId), input as unknown as PlaceCreateInput);
-        this.realtime.broadcast(tripId, 'place:created', { place });
-        mirrorJourneys(() => this.journey.onPlaceCreated(Number(tripId), place.id));
-        return place;
-      },
-      updatePlace: (tripId, placeId, input) => {
-        const place = this.places.update(String(tripId), String(placeId), input as PlaceUpdateInput);
-        if (place === null) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'place:updated', { place });
-        mirrorJourneys(() => this.journey.onPlaceUpdated(Number(placeId)));
-        return place;
-      },
-      deletePlace: (tripId, placeId) => {
-        // Scope the id to the trip before anything else: onPlaceDeleted keys on the
-        // place alone, so an id belonging to a foreign trip would detach that trip's
-        // journey entries even though the delete below refuses it.
-        if (!this.places.get(String(tripId), String(placeId))) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
-        // Ahead of the DELETE, like the REST route and the MCP tool: journey_entries
-        // .source_place_id is ON DELETE SET NULL, so afterwards the hook finds nothing
-        // left to detach and the entries linger as orphans.
-        mirrorJourneys(() => this.journey.onPlaceDeleted(Number(placeId)));
-        const deleted = this.places.remove(String(tripId), String(placeId));
-        if (!deleted) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
-        this.realtime.broadcast(tripId, 'place:deleted', { placeId });
-        return { deleted: true };
-      },
       // --- Days (day_edit). getDay scopes the row to the trip before any write. ---
       canEditDays: (tripId, userId) => this.canEditTripAs('day_edit', tripId, userId),
-      createDay: (tripId, input) => {
-        const i = input as { date?: string; notes?: string };
-        const day = this.days.create(tripId, i.date, i.notes);
-        this.realtime.broadcast(tripId, 'day:created', { day });
-        return day;
-      },
-      updateDay: (tripId, dayId, input) => {
-        const current = this.days.getDay(dayId, tripId);
-        if (!current) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
-        const day = this.days.update(dayId, current, input as { notes?: string; title?: string | null });
-        this.realtime.broadcast(tripId, 'day:updated', { day });
-        return day;
-      },
-      deleteDay: (tripId, dayId) => {
-        const current = this.days.getDay(dayId, tripId);
-        if (!current) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
-        this.days.remove(dayId);
-        this.realtime.broadcast(tripId, 'day:deleted', { dayId });
-        return { deleted: true };
-      },
       // --- Itinerary (day_edit). Both the day AND the place must belong to the trip,
       // so a plugin can't cross-link another trip's rows (AssignmentsService doesn't
       // self-check this — the controllers do, so we reproduce it here). ---
-      assignPlaceToDay: (tripId, dayId, placeId, notes) => {
-        if (!this.assignments.dayExists(dayId, tripId)) throw new ForbiddenResource(`no day ${dayId} on trip ${tripId}`);
-        if (!this.assignments.placeExists(placeId, tripId)) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);
-        const assignment = this.assignments.createAssignment(dayId, placeId, notes);
-        this.realtime.broadcast(tripId, 'assignment:created', { assignment });
-        this.assignments.reconcile(tripId);
-        return assignment;
-      },
-      unassignPlace: (tripId, assignmentId) => {
-        const existing = this.assignments.getAssignmentForTrip(assignmentId, tripId);
-        if (!existing) throw new ForbiddenResource(`no assignment ${assignmentId} on trip ${tripId}`);
-        this.assignments.deleteAssignment(assignmentId);
-        // Same payload shape as the REST/MCP delete, so client stores can
-        // evict the assignment from the right day. The dayId is what the client
-        // reducer keys the eviction on — without it nothing leaves the day.
-        this.realtime.broadcast(tripId, 'assignment:deleted', { assignmentId, dayId: existing.day_id });
-        // Create, delete, move and time re-mirror the linked journey skeletons
-        // afterwards, in the controller and in the MCP tool alike (reorder,
-        // transport and participants don't). Without it an open journey keeps
-        // the removed place until the next reload. No sid — a plugin has no
-        // originating socket.
-        this.assignments.reconcile(tripId);
-        return { deleted: true };
-      },
       // --- Trip creation (trip_create; owner = acting user). No broadcast — a new trip
       // is only visible to its owner, who refetches (same as the REST POST). ---
       canCreateTrip: (userId) => {

--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -166,18 +166,10 @@ export interface HostDeps {
   deleteCost(tripId: number, itemId: number): unknown;
   // --- Places (the 'place_edit' permission) ---
   canEditPlaces(tripId: number, userId: number): boolean;
-  createPlace(tripId: number, input: Record<string, unknown>): unknown;
-  updatePlace(tripId: number, placeId: number, input: Record<string, unknown>): unknown;
-  deletePlace(tripId: number, placeId: number): unknown;
   // --- Days + itinerary (the 'day_edit' permission) ---
   canEditDays(tripId: number, userId: number): boolean;
-  createDay(tripId: number, input: Record<string, unknown>): unknown;
-  updateDay(tripId: number, dayId: number, input: Record<string, unknown>): unknown;
-  deleteDay(tripId: number, dayId: number): unknown;
   /** Assign a place to a day (both trip-scoped by the wiring); returns the assignment. */
-  assignPlaceToDay(tripId: number, dayId: number, placeId: number, notes: string | null): unknown;
   /** Remove a day-assignment (trip-scoped by the wiring). */
-  unassignPlace(tripId: number, assignmentId: number): unknown;
   // --- Trip (the 'trip_edit' permission) ---
   canEditTrip(tripId: number, userId: number): boolean;
   updateTrip(tripId: number, userId: number, input: Record<string, unknown>): unknown;
@@ -573,83 +565,11 @@ export class PluginRpcHost {
     // trip access + the entity's edit permission for the HOST-bound acting user
     // (a job/onLoad has no user, so its writes are refused). The delegating deps
     // reuse the real services + broadcast the same events, so the app stays live. ---
-    if (has('db:write:places')) {
-      this.methods.set('places.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'place');
-        const parsed = placeCreateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid place: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
-        this.requireTripEdit(tripId, actor, deps.canEditPlaces);
-        return deps.createPlace(tripId, parsed.data as Record<string, unknown>);
-      });
-      this.methods.set('places.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const placeId = num(p.placeId, 'placeId');
-        const actor = this.requireActor(uid, 'place');
-        const parsed = placeUpdateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid place: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
-        this.requireTripEdit(tripId, actor, deps.canEditPlaces);
-        return deps.updatePlace(tripId, placeId, parsed.data as Record<string, unknown>);
-      });
-      this.methods.set('places.delete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const placeId = num(p.placeId, 'placeId');
-        const actor = this.requireActor(uid, 'place');
-        this.requireTripEdit(tripId, actor, deps.canEditPlaces);
-        return deps.deletePlace(tripId, placeId);
-      });
-    }
+    // places.* now lives in src/nest/places/places.rpc.ts.
 
-    if (has('db:write:days')) {
-      this.methods.set('days.create', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'day');
-        const parsed = dayCreateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid day: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.createDay(tripId, parsed.data as Record<string, unknown>);
-      });
-      this.methods.set('days.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const actor = this.requireActor(uid, 'day');
-        const parsed = dayUpdateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid day: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.updateDay(tripId, dayId, parsed.data as Record<string, unknown>);
-      });
-      this.methods.set('days.delete', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const actor = this.requireActor(uid, 'day');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.deleteDay(tripId, dayId);
-      });
-    }
+    // days.* now lives in src/nest/days/days.rpc.ts.
 
-    if (has('db:write:itinerary')) {
-      // Assigning/removing a place on a day is a DAY edit in the app (day_edit), so
-      // gate it with canEditDays; the wiring also checks the day AND place belong to
-      // the trip so a plugin can't cross-link another trip's rows.
-      this.methods.set('itinerary.assign', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const dayId = num(p.dayId, 'dayId');
-        const placeId = num(p.placeId, 'placeId');
-        const actor = this.requireActor(uid, 'itinerary');
-        const notes = p.notes === undefined || p.notes === null ? null : str(p.notes, 'notes');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.assignPlaceToDay(tripId, dayId, placeId, notes);
-      });
-      this.methods.set('itinerary.unassign', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const assignmentId = num(p.assignmentId, 'assignmentId');
-        const actor = this.requireActor(uid, 'itinerary');
-        this.requireTripEdit(tripId, actor, deps.canEditDays);
-        return deps.unassignPlace(tripId, assignmentId);
-      });
-    }
+    // itinerary.* now lives in src/nest/assignments/itinerary.rpc.ts.
 
     if (has('db:write:trips')) {
       this.methods.set('trips.update', (p, uid) => {

--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -109,9 +109,6 @@ export interface HostDeps {
   voteCollabPoll(tripId: number, pollId: number, optionIndex: number, actingUserId: number): unknown;
   createCollabMessage(tripId: number, text: string, replyTo: number | undefined, actingUserId: number): unknown;
   // --- Member add (the DISTINCT member_manage permission — never bundled) ---
-  canManageMembers(tripId: number, userId: number): boolean;
-  addTripMember(tripId: number, targetUserId: number, invitedBy: number): unknown;
-  removeTripMember(tripId: number, targetUserId: number, actingUserId: number): unknown;
   /** The acting user's own journals (journey addon must be enabled). */
   listJournalsForUser(userId: number): unknown;
   /** The entries of one of the acting user's journeys (journey addon; access-checked). */
@@ -165,29 +162,22 @@ export interface HostDeps {
   /** Delete a budget item from a trip (and broadcast); returns { deleted: true }. */
   deleteCost(tripId: number, itemId: number): unknown;
   // --- Places (the 'place_edit' permission) ---
+  /** Still needed by the db:meta gate, which has not moved yet. */
+  canEditTrip(tripId: number, userId: number): boolean;
   canEditPlaces(tripId: number, userId: number): boolean;
   // --- Days + itinerary (the 'day_edit' permission) ---
   canEditDays(tripId: number, userId: number): boolean;
   /** Assign a place to a day (both trip-scoped by the wiring); returns the assignment. */
   /** Remove a day-assignment (trip-scoped by the wiring). */
   // --- Trip (the 'trip_edit' permission) ---
-  canEditTrip(tripId: number, userId: number): boolean;
-  updateTrip(tripId: number, userId: number, input: Record<string, unknown>): unknown;
   // --- Trip creation (the 'trip_create' permission; owner = acting user) ---
-  canCreateTrip(userId: number): boolean;
-  createTripForUser(userId: number, input: Record<string, unknown>): unknown;
   // --- Exchange rates (tenant-free, like weather) ---
   // --- Cross-trip reads (membership baked in — every trip the acting user can access) ---
   /** Every trip the acting user owns or is a member of (the listTrips baseline). */
-  listTripsForUser(userId: number): unknown[];
   /** Every reservation across the acting user's accessible trips. */
-  listReservationsForUser(userId: number): unknown[];
   /** A trip's days with their assignments + day notes — the planner GET's shape. */
-  listTripDays(tripId: number): unknown[];
   /** A trip's reservations, hydrated like the REST list (endpoints, day_positions, joins). */
-  listTripReservations(tripId: number): unknown[];
   /** A trip's lodging blocks (day_accommodations) with the joined place fields. */
-  listTripAccommodations(tripId: number): unknown[];
   // --- Accommodations write (the 'day_edit' permission, like the accommodations REST path) ---
   /** Create a lodging block (auto-creates its partner hotel reservation + broadcasts); returns it. */
   createAccommodation(tripId: number, input: Record<string, unknown>): unknown;
@@ -209,7 +199,6 @@ export interface HostDeps {
   /** Delete a packing item; owner+recipients-scoped packing:deleted broadcast; returns { deleted: true }. */
   // --- Packing bags (packing_edit; no privacy — broadcast to the whole room) ---
   // --- Read-convenience: weather (tenant-free), categories (global), the trip roster ---
-  tripMembers(tripId: number): unknown[];
   // --- Tags (the acting user's own; no trip) ---
   // --- Todos (core, trip-scoped; the 'packing_edit' permission, like the REST path) ---
   // --- Plugin metadata on core entities (db:meta) ---
@@ -255,49 +244,8 @@ export class PluginRpcHost {
       this.methods.set('db.tx', (p) => deps.data.tx(asTxOps(p.ops)));
     }
 
-    if (has('db:read:trips')) {
-      this.methods.set('trips.getById', (p, uid) =>
-        this.tripRead(p, uid, () => deps.db.prepare('SELECT * FROM trips WHERE id = ?').get(num(p.tripId, 'tripId'))),
-      );
-      // The trip's place POOL — places carry no itinerary position of their own
-      // (day_id/order_index live on day_assignments), so order by created_at like
-      // the REST list does. Use trips.getDays for the day-ordered itinerary.
-      this.methods.set('trips.getPlaces', (p, uid) =>
-        this.tripRead(p, uid, () => deps.db.prepare('SELECT * FROM places WHERE trip_id = ? ORDER BY created_at DESC').all(num(p.tripId, 'tripId'))),
-      );
-      // Hydrated like the REST list (endpoints, day_positions, joins, normalized
-      // accommodation_id) — a strict superset of the raw row, so older callers
-      // only ever gain fields.
-      this.methods.set('trips.getReservations', (p, uid) =>
-        this.tripRead(p, uid, () => deps.listTripReservations(num(p.tripId, 'tripId'))),
-      );
-      // Days with their assignments + day notes: the read half of db:write:days —
-      // without it a writer can't even discover the day ids it may edit.
-      this.methods.set('trips.getDays', (p, uid) =>
-        this.tripRead(p, uid, () => deps.listTripDays(num(p.tripId, 'tripId'))),
-      );
-      // Lodging blocks (day_accommodations) with their joined place fields. Reads
-      // ride on db:read:trips like every other trip entity: the REST GET, too,
-      // asks only for trip access.
-      this.methods.set('trips.getAccommodations', (p, uid) =>
-        this.tripRead(p, uid, () => deps.listTripAccommodations(num(p.tripId, 'tripId'))),
-      );
-      // Cross-trip enumeration: every trip the acting user can access. Membership is
-      // baked into listTripsForUser, so there is no tripId to check — but a job/onLoad
-      // (no bound user) is refused, exactly like costs.listMine.
-      this.methods.set('trips.listMine', (_p, uid) => {
-        if (uid === undefined) throw new ForbiddenResource('trip reads require an authenticated user context');
-        return deps.listTripsForUser(uid);
-      });
-      // Cross-trip reservations feed (dashboards): reservations across every accessible
-      // trip. Same membership predicate + no-user refusal.
-      this.methods.set('reservations.listMine', (_p, uid) => {
-        if (uid === undefined) throw new ForbiddenResource('reservation reads require an authenticated user context');
-        return deps.listReservationsForUser(uid);
-      });
-      // The trip's member roster (ids + display fields only), membership-checked.
-      this.methods.set('trips.members', (p, uid) => this.tripRead(p, uid, () => deps.tripMembers(num(p.tripId, 'tripId'))));
-    }
+    // trips.*, reservations.listMine and the member roster now live in
+    // src/nest/trips/trips.rpc.ts.
     // files.* now lives in src/nest/files/files.rpc.ts.
     if (has('db:write:collab')) {
       // Collab content (notes/polls/messages) under the app's collab_edit right.
@@ -330,27 +278,6 @@ export class PluginRpcHost {
         if (typeof p.text !== 'string' || p.text.trim() === '' || p.text.length > 4000) throw new BadParams('message text is required (max 4000 chars)');
         this.requireTripEdit(tripId, actor, deps.canEditCollab);
         return deps.createCollabMessage(tripId, p.text, typeof p.replyTo === 'number' ? p.replyTo : undefined, actor);
-      });
-    }
-    if (has('db:write:members')) {
-      // Adding a member GRANTS TRIP ACCESS — deliberately its own permission behind
-      // the app's member_manage right (default: trip owner only), never bundled with
-      // a lower-risk write. The acting user is recorded as the inviter.
-      this.methods.set('trips.addMember', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const targetUserId = num(p.userId, 'userId');
-        const actor = this.requireActor(uid, 'trip member');
-        this.requireTripEdit(tripId, actor, deps.canManageMembers);
-        return deps.addTripMember(tripId, targetUserId, actor);
-      });
-      // Symmetry with addMember: a directory-sync integration must be able to reconcile
-      // DEPARTURES, not only additions. Same grant + the same manage-members gate.
-      this.methods.set('trips.removeMember', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const targetUserId = num(p.userId, 'userId');
-        const actor = this.requireActor(uid, 'trip member');
-        this.requireTripEdit(tripId, actor, deps.canManageMembers);
-        return deps.removeTripMember(tripId, targetUserId, actor);
       });
     }
 
@@ -571,31 +498,7 @@ export class PluginRpcHost {
 
     // itinerary.* now lives in src/nest/assignments/itinerary.rpc.ts.
 
-    if (has('db:write:trips')) {
-      this.methods.set('trips.update', (p, uid) => {
-        const tripId = num(p.tripId, 'tripId');
-        const actor = this.requireActor(uid, 'trip');
-        const parsed = tripUpdateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid trip: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.capStrings(parsed.data as Record<string, unknown>, TRIP_STR_LIMITS);
-        this.requireTripEdit(tripId, actor, deps.canEditTrip);
-        return deps.updateTrip(tripId, actor, parsed.data as Record<string, unknown>);
-      });
-    }
 
-    if (has('db:create:trips')) {
-      // Create a brand-new trip owned by the acting user — the capability that
-      // unlocks importers (Google MyMaps, booking dumps, calendar sync). Gated by
-      // the app's own 'trip_create' right + a bound user (a job can't create one).
-      this.methods.set('trips.create', (p, uid) => {
-        const actor = this.requireActor(uid, 'trip');
-        const parsed = tripCreateRequestSchema.safeParse(p.input);
-        if (!parsed.success) throw new BadParams(`invalid trip: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
-        this.capStrings(parsed.data as Record<string, unknown>, TRIP_STR_LIMITS);
-        if (!deps.canCreateTrip(actor)) throw new ForbiddenResource('no permission to create trips');
-        return deps.createTripForUser(actor, parsed.data as Record<string, unknown>);
-      });
-    }
 
     // rates.get now lives in src/nest/budget/exchange-rates.rpc.ts.
 

--- a/server/src/nest/trips/trips.module.ts
+++ b/server/src/nest/trips/trips.module.ts
@@ -12,6 +12,10 @@ import { AuditModule } from '../audit/audit.module';
 import { PlacesModule } from '../places/places.module';
 import { TripsController } from './trips.controller';
 import { TripsService } from './trips.service';
+import { TripsRpc } from './trips.rpc';
+import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
+import { RealtimeModule } from '../realtime/realtime.module';
+import { TripMembershipModule } from '../trip-membership/trip-membership.module';
 import { AppConfigModule } from '../app-config/app-config.module';
 import { UnsplashModule } from '../unsplash/unsplash.module';
 import { TripsMcp } from './trips.mcp';
@@ -20,9 +24,9 @@ import { AuthModule } from '../auth/auth.module';
 /** Trips aggregate root (C1 — Phase 3). Uses exact strangler prefixes so it does
  *  not capture the nested sub-domain mounts (collab, files, ...). */
 @Module({
-  imports: [TodoModule, PackingModule, FilesModule, ReservationsModule, DaysModule, PermissionsModule, AuditModule, BudgetModule, CollabModule, VacayModule, PlacesModule, AuthModule, AppConfigModule, UnsplashModule],
+  imports: [TodoModule, PackingModule, FilesModule, ReservationsModule, DaysModule, PermissionsModule, AuditModule, BudgetModule, CollabModule, VacayModule, PlacesModule, AuthModule, AppConfigModule, UnsplashModule, RealtimeModule, PluginGuardsModule, TripMembershipModule],
   controllers: [TripsController],
-  providers: [TripsService, TripsMcp],
+  providers: [TripsService, TripsMcp, TripsRpc],
   // Exported for FeedsModule (ICS feeds) and PluginsModule (RPC host injection).
   exports: [TripsService],
 })

--- a/server/src/nest/trips/trips.rpc.ts
+++ b/server/src/nest/trips/trips.rpc.ts
@@ -1,0 +1,186 @@
+import { tripCreateRequestSchema, tripUpdateRequestSchema } from '@trek/shared';
+import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
+import { PluginGuards } from '../plugins/host/plugin-guards.service';
+import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
+import { num } from '../plugins/host/rpc-params';
+import type { PluginRpcContext } from '../plugins/host/rpc-kit/types';
+import { RealtimeService } from '../realtime/realtime.service';
+import { DatabaseService } from '../database/database.service';
+import { ReservationsService } from '../reservations/reservations.service';
+import { DaysService } from '../days/days.service';
+import { TripMembershipService } from '../trip-membership/trip-membership.service';
+import { TripsService, NotFoundError, ValidationError } from './trips.service';
+
+const TRIP_EDIT_ACTION = 'trip_edit';
+const MEMBER_MANAGE_ACTION = 'member_manage';
+
+/** The REST controller caps these two, while the shared schema leaves them open. */
+const TRIP_STR_LIMITS: Record<string, number> = { title: 200, description: 2000 };
+
+/**
+ * The trip surface a plugin may reach (#plugins), including the cross-trip feeds and
+ * the member roster.
+ *
+ * Two things are specific to trips. updateTrip gates two individual FIELDS behind
+ * their own admin-configurable permissions, on top of trip_edit, so a plugin cannot
+ * archive or re-cover a trip it may otherwise edit. And adding a member GRANTS TRIP
+ * ACCESS, which is why it sits behind its own permission and the app's member_manage
+ * right rather than being bundled with a lower-risk write.
+ */
+@PluginController()
+export class TripsRpc {
+  constructor(
+    private readonly trips: TripsService,
+    private readonly reservations: ReservationsService,
+    private readonly days: DaysService,
+    private readonly membership: TripMembershipService,
+    private readonly db: DatabaseService,
+    private readonly realtime: RealtimeService,
+    private readonly guards: PluginGuards,
+  ) {}
+
+  @PluginMethod('trips.getById', { permission: 'db:read:trips' })
+  getById(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () =>
+      this.db.prepare('SELECT * FROM trips WHERE id = ?').get(num(params.tripId, 'tripId')),
+    );
+  }
+
+  @PluginMethod('trips.getPlaces', { permission: 'db:read:trips' })
+  getPlaces(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // The trip's place POOL. Places carry no itinerary position of their own
+    // (day_id/order_index live on day_assignments), so order by created_at like the
+    // REST list does. trips.getDays is the day-ordered itinerary.
+    return this.guards.tripRead(params, ctx, () =>
+      this.db
+        .prepare('SELECT * FROM places WHERE trip_id = ? ORDER BY created_at DESC')
+        .all(num(params.tripId, 'tripId')),
+    );
+  }
+
+  @PluginMethod('trips.getReservations', { permission: 'db:read:trips' })
+  getReservations(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () => this.reservations.list(String(num(params.tripId, 'tripId'))));
+  }
+
+  @PluginMethod('trips.getDays', { permission: 'db:read:trips' })
+  getDays(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // Days with their assignments and notes: the read half of db:write:days, without
+    // which a writer cannot even discover the day ids it may edit.
+    return this.guards.tripRead(
+      params,
+      ctx,
+      () => (this.days.list(num(params.tripId, 'tripId')) as { days: unknown[] }).days,
+    );
+  }
+
+  @PluginMethod('trips.getAccommodations', { permission: 'db:read:trips' })
+  getAccommodations(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () => this.days.listAccommodations(num(params.tripId, 'tripId')) as unknown[]);
+  }
+
+  @PluginMethod('trips.listMine', { permission: 'db:read:trips' })
+  listMine(_params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // Membership is baked into the service, so there is no tripId to check, but a
+    // job or onLoad with no bound user is refused exactly like costs.listMine.
+    if (ctx.actingUserId === undefined) throw new ForbiddenResource('trip reads require an authenticated user context');
+    return this.trips.list(ctx.actingUserId, null);
+  }
+
+  @PluginMethod('reservations.listMine', { permission: 'db:read:trips' })
+  listMyReservations(_params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    if (ctx.actingUserId === undefined) {
+      throw new ForbiddenResource('reservation reads require an authenticated user context');
+    }
+    const trips = this.trips.list(ctx.actingUserId, null) as Array<{ id: number }>;
+    return trips.flatMap((t) => this.reservations.list(String(t.id)));
+  }
+
+  @PluginMethod('trips.members', { permission: 'db:read:trips' })
+  members(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    return this.guards.tripRead(params, ctx, () =>
+      this.db
+        .prepare('SELECT u.id, u.username, u.display_name, u.avatar FROM trip_members tm JOIN users u ON u.id = tm.user_id WHERE tm.trip_id = ?')
+        .all(num(params.tripId, 'tripId')) as unknown[],
+    );
+  }
+
+  @PluginMethod('trips.update', { permission: 'db:write:trips' })
+  update(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const actor = this.guards.requireActor(ctx, 'trip');
+    const parsed = tripUpdateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid trip: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.capStrings(parsed.data as Record<string, unknown>, TRIP_STR_LIMITS);
+    this.guards.requireTripEdit(tripId, actor, TRIP_EDIT_ACTION);
+    const input = parsed.data as Record<string, unknown>;
+    // Two fields carry their own permissions on top of trip_edit, exactly as the REST
+    // controller gates them.
+    if ('is_archived' in input && !this.guards.canEditAs('trip_archive', tripId, actor)) {
+      throw new ForbiddenResource(`no permission to archive trip ${tripId}`);
+    }
+    if ('cover_image' in input && !this.guards.canEditAs('trip_cover_upload', tripId, actor)) {
+      throw new ForbiddenResource(`no permission to change the cover of trip ${tripId}`);
+    }
+    const user = this.db.prepare('SELECT role FROM users WHERE id = ?').get(actor) as { role?: string } | undefined;
+    try {
+      // The no-rebase core, parity with the legacy host path, which never
+      // re-anchored the budget currency.
+      const result = this.trips.updateTrip(tripId, actor, input as Parameters<TripsService['updateTrip']>[2], user?.role ?? 'user');
+      this.realtime.broadcast(tripId, 'trip:updated', { trip: result.updatedTrip });
+      return result.updatedTrip;
+    } catch (e) {
+      if (e instanceof ValidationError) throw new BadParams(e.message);
+      if (e instanceof NotFoundError) throw new ForbiddenResource(e.message);
+      throw e;
+    }
+  }
+
+  @PluginMethod('trips.create', { permission: 'db:create:trips' })
+  create(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    // The capability that unlocks importers (MyMaps, booking dumps, calendar sync).
+    // No broadcast: a new trip is only visible to its owner, who refetches.
+    const actor = this.guards.requireActor(ctx, 'trip');
+    const parsed = tripCreateRequestSchema.safeParse(params.input);
+    if (!parsed.success) throw new BadParams(`invalid trip: ${parsed.error.issues[0]?.message ?? 'bad input'}`);
+    this.guards.capStrings(parsed.data as Record<string, unknown>, TRIP_STR_LIMITS);
+    if (!this.canCreateTrip(actor)) throw new ForbiddenResource('no permission to create trips');
+    try {
+      return this.trips.create(actor, parsed.data as unknown as Parameters<TripsService['create']>[1]).trip;
+    } catch (e) {
+      if (e instanceof ValidationError) throw new BadParams(e.message);
+      throw e;
+    }
+  }
+
+  /** trip_create is not trip-scoped, so it cannot go through requireTripEdit. */
+  private canCreateTrip(userId: number): boolean {
+    return this.guards.canCreateAs('trip_create', userId);
+  }
+
+  @PluginMethod('trips.addMember', { permission: 'db:write:members' })
+  addMember(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const targetUserId = num(params.userId, 'userId');
+    const actor = this.guards.requireActor(ctx, 'trip member');
+    this.guards.requireTripEdit(tripId, actor, MEMBER_MANAGE_ACTION);
+    const target = this.db.prepare('SELECT id FROM users WHERE id = ?').get(targetUserId) as { id: number } | undefined;
+    if (!target) throw new ForbiddenResource(`no user ${targetUserId}`);
+    // The acting user is recorded as the inviter.
+    return this.membership.joinTripAsMember(tripId, targetUserId, actor);
+  }
+
+  @PluginMethod('trips.removeMember', { permission: 'db:write:members' })
+  removeMember(params: Record<string, unknown>, ctx: PluginRpcContext): unknown {
+    const tripId = num(params.tripId, 'tripId');
+    const targetUserId = num(params.userId, 'userId');
+    const actor = this.guards.requireActor(ctx, 'trip member');
+    this.guards.requireTripEdit(tripId, actor, MEMBER_MANAGE_ACTION);
+    // Never remove the OWNER through this path: that would orphan the trip.
+    // Ownership transfer is a separate, deliberate action.
+    const trip = this.db.prepare('SELECT user_id FROM trips WHERE id = ?').get(tripId) as { user_id: number } | undefined;
+    if (trip && trip.user_id === targetUserId) throw new ForbiddenResource('cannot remove the trip owner');
+    this.trips.removeMember(tripId, targetUserId);
+    return { removed: true };
+  }
+}

--- a/server/tests/helpers/rpc-host-deps.ts
+++ b/server/tests/helpers/rpc-host-deps.ts
@@ -11,6 +11,7 @@ import { FilesRpc } from '../../src/nest/files/files.rpc';
 import { PlacesRpc } from '../../src/nest/places/places.rpc';
 import { DaysRpc } from '../../src/nest/days/days.rpc';
 import { ItineraryRpc } from '../../src/nest/assignments/itinerary.rpc';
+import { TripsRpc } from '../../src/nest/trips/trips.rpc';
 
 /**
  * The stubbed HostDeps every plugin router test builds on. It used to live inside
@@ -196,5 +197,6 @@ export function allRpcControllers(): object[] {
     new PlacesRpc(anyService(), anyService(), anyService(), anyService()),
     new DaysRpc(anyService(), anyService(), anyService()),
     new ItineraryRpc(anyService(), anyService(), anyService()),
+    new TripsRpc(anyService(), anyService(), anyService(), anyService(), anyService(), anyService(), anyService()),
   ];
 }

--- a/server/tests/helpers/rpc-host-deps.ts
+++ b/server/tests/helpers/rpc-host-deps.ts
@@ -8,6 +8,9 @@ import { TodoRpc } from '../../src/nest/todo/todo.rpc';
 import { DayNotesRpc } from '../../src/nest/days/day-notes.rpc';
 import { PackingRpc } from '../../src/nest/packing/packing.rpc';
 import { FilesRpc } from '../../src/nest/files/files.rpc';
+import { PlacesRpc } from '../../src/nest/places/places.rpc';
+import { DaysRpc } from '../../src/nest/days/days.rpc';
+import { ItineraryRpc } from '../../src/nest/assignments/itinerary.rpc';
 
 /**
  * The stubbed HostDeps every plugin router test builds on. It used to live inside
@@ -190,5 +193,8 @@ export function allRpcControllers(): object[] {
     new DayNotesRpc(anyService(), anyService(), anyService()),
     new PackingRpc(anyService(), anyService(), anyService()),
     new FilesRpc(anyService(), anyService(), anyService(), anyService()),
+    new PlacesRpc(anyService(), anyService(), anyService(), anyService()),
+    new DaysRpc(anyService(), anyService(), anyService()),
+    new ItineraryRpc(anyService(), anyService(), anyService()),
   ];
 }

--- a/server/tests/unit/days/days-itinerary.rpc.test.ts
+++ b/server/tests/unit/days/days-itinerary.rpc.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The day and itinerary plugin surfaces after they moved onto @PluginMethod.
+ *
+ * They are tested together because they share the gate: assigning a place to a day
+ * counts as a DAY edit in the app, so itinerary.* runs under day_edit rather than a
+ * permission of its own, and both halves scope their rows to the trip before writing.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { DaysRpc } from '../../../src/nest/days/days.rpc';
+import { DaysModule } from '../../../src/nest/days/days.module';
+import { ItineraryRpc } from '../../../src/nest/assignments/itinerary.rpc';
+import { AssignmentsModule } from '../../../src/nest/assignments/assignments.module';
+import type { DaysService } from '../../../src/nest/days/days.service';
+import type { AssignmentsService } from '../../../src/nest/assignments/assignments.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+/** Trip 1 belongs to user 42; day 3, place 7 and assignment 30 sit on it. */
+function build(opts: { canEdit?: boolean } = {}) {
+  const days = {
+    create: vi.fn((tripId: number, date?: string) => ({ id: 20, trip_id: tripId, date })),
+    getDay: vi.fn((dayId: number, tripId: number) => (dayId === 3 && tripId === 1 ? { id: 3 } : undefined)),
+    update: vi.fn((id: number) => ({ id })),
+    remove: vi.fn(),
+  } as unknown as DaysService & Record<string, ReturnType<typeof vi.fn>>;
+  const assignments = {
+    dayExists: vi.fn((dayId: number, tripId: number) => dayId === 3 && tripId === 1),
+    placeExists: vi.fn((placeId: number, tripId: number) => placeId === 7 && tripId === 1),
+    createAssignment: vi.fn(() => ({ id: 30, day_id: 3, place_id: 7 })),
+    getAssignmentForTrip: vi.fn((id: number, tripId: number) => (id === 30 && tripId === 1 ? { id: 30, day_id: 3 } : undefined)),
+    deleteAssignment: vi.fn(),
+    reconcile: vi.fn(),
+  } as unknown as AssignmentsService & Record<string, ReturnType<typeof vi.fn>>;
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const guards = new PluginGuards(
+    {
+      canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+      prepare: vi.fn(() => ({ get: () => ({ role: 'user' }) })),
+    } as unknown as DatabaseService,
+    { checkPermission: vi.fn(() => opts.canEdit ?? true) } as unknown as PermissionsService,
+    { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+  );
+  const registry = createTestPluginRegistry([new DaysRpc(days, realtime, guards), new ItineraryRpc(assignments, realtime, guards)]);
+  const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), registry);
+  return { days, assignments, realtime, host };
+}
+
+describe('DaysRpc', () => {
+  it('DAYS-RPC-001 writes need the grant, the edit right and a bound user', async () => {
+    const f = build();
+    const host = f.host('db:write:days');
+    expect((await host.dispatch(req('days.create', { tripId: 1, input: { date: '2027-01-01' } }), 42)).ok).toBe(true);
+    expect(((await host.dispatch(req('days.create', { tripId: 2, input: {} }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+    const noUser = (await host.dispatch(req('days.create', { tripId: 1, input: {} }), undefined)) as RpcError;
+    expect(noUser.error.message).toBe('day writes require an authenticated user context');
+  });
+
+  it('DAYS-RPC-002 a day on another trip is refused for update and delete alike', async () => {
+    const f = build();
+    const host = f.host('db:write:days');
+    expect(((await host.dispatch(req('days.update', { tripId: 1, dayId: 404, input: {} }), 42)) as RpcError).error.message)
+      .toBe('no day 404 on trip 1');
+    expect(((await host.dispatch(req('days.delete', { tripId: 1, dayId: 404 }), 42)) as RpcError).error.message)
+      .toBe('no day 404 on trip 1');
+    expect(f.days.remove).not.toHaveBeenCalled();
+  });
+
+  it('DAYS-RPC-003 every write broadcasts its event', async () => {
+    const f = build();
+    const host = f.host('db:write:days');
+    await host.dispatch(req('days.create', { tripId: 1, input: {} }), 42);
+    await host.dispatch(req('days.update', { tripId: 1, dayId: 3, input: { notes: 'x' } }), 42);
+    await host.dispatch(req('days.delete', { tripId: 1, dayId: 3 }), 42);
+    expect(f.realtime.broadcast.mock.calls.map((c) => c[1])).toEqual(['day:created', 'day:updated', 'day:deleted']);
+  });
+
+  it('DAYS-RPC-004 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', DaysModule) as unknown[]).toContain(DaysRpc);
+  });
+});
+
+describe('ItineraryRpc', () => {
+  it('ITIN-RPC-001 assign links a day and a place that both belong to the trip', async () => {
+    const f = build();
+    const res = await f.host('db:write:itinerary').dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 }), 42);
+    expect(res.ok).toBe(true);
+    expect(f.assignments.createAssignment).toHaveBeenCalledWith(3, 7, null);
+  });
+
+  it('ITIN-RPC-002 a day or place from another trip is refused, so nothing cross-links', async () => {
+    const f = build();
+    const host = f.host('db:write:itinerary');
+    expect(((await host.dispatch(req('itinerary.assign', { tripId: 1, dayId: 404, placeId: 7 }), 42)) as RpcError).error.message)
+      .toBe('no day 404 on trip 1');
+    expect(((await host.dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 404 }), 42)) as RpcError).error.message)
+      .toBe('no place 404 on trip 1');
+    expect(f.assignments.createAssignment).not.toHaveBeenCalled();
+  });
+
+  it('ITIN-RPC-003 it runs under day_edit, not an itinerary permission of its own', async () => {
+    const f = build({ canEdit: false });
+    const res = (await f.host('db:write:itinerary').dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to edit trip 1');
+  });
+
+  it('ITIN-RPC-004 notes are optional and pass through as null when absent', async () => {
+    const f = build();
+    await f.host('db:write:itinerary').dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 7, notes: 'lunch' }), 42);
+    expect(f.assignments.createAssignment).toHaveBeenCalledWith(3, 7, 'lunch');
+  });
+
+  it('ITIN-RPC-005 unassign carries the dayId, which the client keys its eviction on', async () => {
+    const f = build();
+    await f.host('db:write:itinerary').dispatch(req('itinerary.unassign', { tripId: 1, assignmentId: 30 }), 42);
+    expect(f.realtime.broadcast).toHaveBeenCalledWith(1, 'assignment:deleted', { assignmentId: 30, dayId: 3 });
+  });
+
+  it('ITIN-RPC-006 both writes re-mirror the journey skeletons afterwards', async () => {
+    const f = build();
+    const host = f.host('db:write:itinerary');
+    await host.dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 }), 42);
+    await host.dispatch(req('itinerary.unassign', { tripId: 1, assignmentId: 30 }), 42);
+    expect(f.assignments.reconcile).toHaveBeenCalledTimes(2);
+  });
+
+  it('ITIN-RPC-007 an assignment on another trip is refused and nothing is deleted', async () => {
+    const f = build();
+    const res = (await f.host('db:write:itinerary').dispatch(req('itinerary.unassign', { tripId: 1, assignmentId: 404 }), 42)) as RpcError;
+    expect(res.error.message).toBe('no assignment 404 on trip 1');
+    expect(f.assignments.deleteAssignment).not.toHaveBeenCalled();
+  });
+
+  it('ITIN-RPC-008 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', AssignmentsModule) as unknown[]).toContain(ItineraryRpc);
+  });
+});

--- a/server/tests/unit/places/places.rpc.test.ts
+++ b/server/tests/unit/places/places.rpc.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The place plugin surface after it moved onto @PluginMethod.
+ *
+ * The delete path carries an ordering constraint that is easy to lose in a move and
+ * silent when broken, so it gets its own cases: the journey hook has to run BEFORE
+ * the row is deleted, and the id has to be scoped to the trip before the hook runs
+ * at all.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { PlacesRpc } from '../../../src/nest/places/places.rpc';
+import { PlacesModule } from '../../../src/nest/places/places.module';
+import type { PlacesService } from '../../../src/nest/places/places.service';
+import type { JourneyDomainService } from '../../../src/nest/journey/journey-domain.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+/** Trip 1 belongs to user 42; place 7 sits on it. */
+function build(opts: { canEdit?: boolean; journeyThrows?: boolean } = {}) {
+  const places = {
+    create: vi.fn((_t: string, i: Record<string, unknown>) => ({ id: 10, ...i })),
+    update: vi.fn((_t: string, id: string) => (id === '7' ? { id: 7, name: 'updated' } : null)),
+    get: vi.fn((_t: string, id: string) => (id === '7' ? { id: 7 } : undefined)),
+    remove: vi.fn((_t: string, id: string) => id === '7'),
+  } as unknown as PlacesService & Record<string, ReturnType<typeof vi.fn>>;
+  const journey = {
+    onPlaceCreated: vi.fn(() => { if (opts.journeyThrows) throw new Error('journey down'); }),
+    onPlaceUpdated: vi.fn(() => { if (opts.journeyThrows) throw new Error('journey down'); }),
+    onPlaceDeleted: vi.fn(() => { if (opts.journeyThrows) throw new Error('journey down'); }),
+  } as unknown as JourneyDomainService & Record<string, ReturnType<typeof vi.fn>>;
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const guards = new PluginGuards(
+    {
+      canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+      prepare: vi.fn(() => ({ get: () => ({ role: 'user' }) })),
+    } as unknown as DatabaseService,
+    { checkPermission: vi.fn(() => opts.canEdit ?? true) } as unknown as PermissionsService,
+    { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService,
+  );
+  const rpc = new PlacesRpc(places, journey, realtime, guards);
+  const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
+  return { places, journey, realtime, host };
+}
+
+describe('PlacesRpc', () => {
+  it('PLACES-RPC-001 writes need the grant, the edit right and a bound user', async () => {
+    const f = build();
+    const host = f.host('db:write:places');
+    expect((await host.dispatch(req('places.create', { tripId: 1, input: { name: 'Shrine' } }), 42)).ok).toBe(true);
+    expect(((await host.dispatch(req('places.create', { tripId: 2, input: { name: 'x' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+    const noUser = (await host.dispatch(req('places.create', { tripId: 1, input: { name: 'x' } }), undefined)) as RpcError;
+    expect(noUser.error.message).toBe('place writes require an authenticated user context');
+    const denied = (await f.host().dispatch(req('places.create', { tripId: 1, input: { name: 'x' } }), 42)) as RpcError;
+    expect(denied.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('PLACES-RPC-002 an invalid place is BAD_PARAMS with the schema message', async () => {
+    const f = build();
+    const res = (await f.host('db:write:places').dispatch(req('places.create', { tripId: 1, input: {} }), 42)) as RpcError;
+    expect(res.error.code).toBe('BAD_PARAMS');
+    expect(res.error.message).toMatch(/^invalid place: /);
+  });
+
+  it('PLACES-RPC-003 an oversized field is capped like the REST controller caps it', async () => {
+    const f = build();
+    const res = (await f.host('db:write:places').dispatch(
+      req('places.create', { tripId: 1, input: { name: 'x'.repeat(201) } }), 42,
+    )) as RpcError;
+    expect(res.error.message).toBe('name must be 200 characters or fewer');
+    expect(f.places.create).not.toHaveBeenCalled();
+  });
+
+  it('PLACES-RPC-004 a place on another trip is refused, naming it', async () => {
+    const f = build();
+    const host = f.host('db:write:places');
+    expect(((await host.dispatch(req('places.update', { tripId: 1, placeId: 404, input: { name: 'x' } }), 42)) as RpcError).error.message)
+      .toBe('no place 404 on trip 1');
+    expect(((await host.dispatch(req('places.delete', { tripId: 1, placeId: 404 }), 42)) as RpcError).error.message)
+      .toBe('no place 404 on trip 1');
+  });
+
+  it('PLACES-RPC-005 delete runs the journey hook BEFORE the row goes', async () => {
+    const f = build();
+    await f.host('db:write:places').dispatch(req('places.delete', { tripId: 1, placeId: 7 }), 42);
+    // journey_entries.source_place_id is ON DELETE SET NULL. Run the hook afterwards
+    // and it finds nothing left to detach, leaving the entries as orphans.
+    expect(f.journey.onPlaceDeleted.mock.invocationCallOrder[0]).toBeLessThan(f.places.remove.mock.invocationCallOrder[0]);
+  });
+
+  it('PLACES-RPC-006 a foreign place id never reaches the journey hook', async () => {
+    const f = build();
+    await f.host('db:write:places').dispatch(req('places.delete', { tripId: 1, placeId: 404 }), 42);
+    // The hook keys on the place alone, so an unscoped id would detach ANOTHER
+    // trip's journey entries even though the delete itself is refused.
+    expect(f.journey.onPlaceDeleted).not.toHaveBeenCalled();
+  });
+
+  it('PLACES-RPC-007 a broken journey link never fails a write that already succeeded', async () => {
+    const f = build({ journeyThrows: true });
+    const host = f.host('db:write:places');
+    expect((await host.dispatch(req('places.create', { tripId: 1, input: { name: 'Shrine' } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('places.update', { tripId: 1, placeId: 7, input: { name: 'x' } }), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('places.delete', { tripId: 1, placeId: 7 }), 42)).ok).toBe(true);
+  });
+
+  it('PLACES-RPC-008 every write broadcasts its event, a refused one broadcasts nothing', async () => {
+    const f = build();
+    const host = f.host('db:write:places');
+    await host.dispatch(req('places.create', { tripId: 1, input: { name: 'Shrine' } }), 42);
+    await host.dispatch(req('places.update', { tripId: 1, placeId: 7, input: { name: 'x' } }), 42);
+    await host.dispatch(req('places.delete', { tripId: 1, placeId: 7 }), 42);
+    expect(f.realtime.broadcast.mock.calls.map((c) => c[1])).toEqual(['place:created', 'place:updated', 'place:deleted']);
+    f.realtime.broadcast.mockClear();
+    await host.dispatch(req('places.delete', { tripId: 1, placeId: 404 }), 42);
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('PLACES-RPC-009 without the edit right nothing is written', async () => {
+    const f = build({ canEdit: false });
+    const res = (await f.host('db:write:places').dispatch(req('places.create', { tripId: 1, input: { name: 'x' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to edit trip 1');
+    expect(f.places.create).not.toHaveBeenCalled();
+  });
+
+  it('PLACES-RPC-010 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', PlacesModule) as unknown[]).toContain(PlacesRpc);
+  });
+});

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -441,93 +441,16 @@ describe('host-deps factory — planner write + metadata deps', () => {
   beforeEach(() => { checkPermission.mockReset(); checkPermission.mockReturnValue(true); });
   afterAll(() => closePluginDataDb('writer'));
 
-  it('places.create/update/delete delegate + broadcast; a missing place is RESOURCE_FORBIDDEN', async () => {
-    const h = host('db:write:places');
-    expect((await call(h, 'places.create', { tripId: 1, input: { name: 'P' } })).ok).toBe(true);
-    // Write deps re-emit the SAME core event the controllers do (not the plugin: namespace).
-    expect(broadcast).toHaveBeenCalledWith(1, 'place:created', expect.anything());
-    expect((await call(h, 'places.update', { tripId: 1, placeId: 5, input: { name: 'Q' } })).ok).toBe(true);
-    expect((await call(h, 'places.update', { tripId: 1, placeId: 99, input: {} })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'places.delete', { tripId: 1, placeId: 5 })).ok).toBe(true);
-    expect((await call(h, 'places.delete', { tripId: 1, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
+  // places, days and itinerary left this factory with the decorator migration; the
+  // cases now run in tests/unit/places/ and tests/unit/days/.
   // #1705: a place write from a plugin has to update a linked journey the same way
   // the REST route does, otherwise the journey shows the old title (or an entry for
   // a place that no longer exists) until it is reloaded.
-  it('places writes fire the journey hooks, delete ahead of the row, and skip a foreign id', async () => {
-    const h = host('db:write:places');
-    const created = vi.mocked(onPlaceCreated);
-    const updated = vi.mocked(onPlaceUpdated);
-    const deleted = vi.mocked(onPlaceDeleted);
-    const removePlace = removePlaceStub;
-    [created, updated, deleted, removePlace].forEach((m) => m.mockClear());
-
-    expect((await call(h, 'places.create', { tripId: 1, input: { name: 'P' } })).ok).toBe(true);
-    expect(created).toHaveBeenCalledWith(1, 10);
-
-    expect((await call(h, 'places.update', { tripId: 1, placeId: 5, input: { name: 'Q' } })).ok).toBe(true);
-    expect(updated).toHaveBeenCalledWith(5);
-
-    expect((await call(h, 'places.delete', { tripId: 1, placeId: 5 })).ok).toBe(true);
-    expect(deleted).toHaveBeenCalledWith(5);
-    // source_place_id is ON DELETE SET NULL — after the row is gone the hook has
-    // nothing left to detach, so the order is part of the fix.
-    expect(deleted.mock.invocationCallOrder[0]).toBeLessThan(removePlace.mock.invocationCallOrder[0]);
-
-    // A place on another trip: refused before the hook can touch that trip's journeys.
-    deleted.mockClear();
-    updated.mockClear();
-    expect((await call(h, 'places.delete', { tripId: 1, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'places.update', { tripId: 1, placeId: 99, input: {} })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(deleted).not.toHaveBeenCalled();
-    expect(updated).not.toHaveBeenCalled();
-  });
-
   // A journey link that blows up must not turn a successful place write into an
   // RPC error — every other caller of these hooks swallows them too.
-  it('places writes survive a throwing journey hook', async () => {
-    const h = host('db:write:places');
-    const updated = vi.mocked(onPlaceUpdated);
-    updated.mockImplementationOnce(() => { throw new Error('journey db locked'); });
-    expect((await call(h, 'places.update', { tripId: 1, placeId: 5, input: { name: 'Q' } })).ok).toBe(true);
-  });
-
-  it('days + itinerary delegate; a day/place/assignment outside the trip is refused', async () => {
-    const h = host('db:write:days', 'db:write:itinerary');
-    expect((await call(h, 'days.create', { tripId: 1, input: { notes: 'n' } })).ok).toBe(true);
-    expect((await call(h, 'days.update', { tripId: 1, dayId: 3, input: { notes: 'x' } })).ok).toBe(true);
-    expect((await call(h, 'days.delete', { tripId: 1, dayId: 3 })).ok).toBe(true);
-    expect((await call(h, 'days.update', { tripId: 1, dayId: 99, input: {} })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 })).ok).toBe(true);
-    expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 99, placeId: 7 })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 3, placeId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 30 })).ok).toBe(true);
-    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
   // #1705: a plugin itinerary write has to reach open sessions exactly like the REST
   // route. The delete payload needs the dayId the client reducer evicts by, and both
   // directions run the same journey-skeleton reconcile the controller/MCP tool run.
-  it('itinerary writes carry the dayId the client evicts by and re-mirror linked journeys', async () => {
-    const h = host('db:write:itinerary');
-    const reconcile = vi.mocked(assignmentsStub.reconcile);
-
-    reconcile.mockClear();
-    expect((await call(h, 'itinerary.assign', { tripId: 1, dayId: 3, placeId: 7 })).ok).toBe(true);
-    expect(reconcile).toHaveBeenCalledWith(1);
-
-    reconcile.mockClear();
-    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 30 })).ok).toBe(true);
-    expect(broadcast).toHaveBeenCalledWith(1, 'assignment:deleted', { assignmentId: 30, dayId: 3 });
-    expect(reconcile).toHaveBeenCalledWith(1);
-
-    // A refused unassign deletes nothing, so it must not touch the journeys either.
-    reconcile.mockClear();
-    expect((await call(h, 'itinerary.unassign', { tripId: 1, assignmentId: 99 })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(reconcile).not.toHaveBeenCalled();
-  });
-
   it('trips.update: archive/cover need their own permission; service errors map to RPC codes', async () => {
     const h = host('db:write:trips');
     expect((await call(h, 'trips.update', { tripId: 1, input: { title: 'T' } })).ok).toBe(true);

--- a/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
+++ b/server/tests/unit/plugins/plugin-host-deps.factory.test.ts
@@ -451,19 +451,8 @@ describe('host-deps factory — planner write + metadata deps', () => {
   // #1705: a plugin itinerary write has to reach open sessions exactly like the REST
   // route. The delete payload needs the dayId the client reducer evicts by, and both
   // directions run the same journey-skeleton reconcile the controller/MCP tool run.
-  it('trips.update: archive/cover need their own permission; service errors map to RPC codes', async () => {
-    const h = host('db:write:trips');
-    expect((await call(h, 'trips.update', { tripId: 1, input: { title: 'T' } })).ok).toBe(true);
-    checkPermission.mockImplementation((action: string) => action !== 'trip_archive');
-    expect((await call(h, 'trips.update', { tripId: 1, input: { is_archived: 1 } })).error.code).toBe('RESOURCE_FORBIDDEN');
-    checkPermission.mockImplementation((action: string) => action !== 'trip_cover_upload');
-    expect((await call(h, 'trips.update', { tripId: 1, input: { cover_image: '/x.jpg' } })).error.code).toBe('RESOURCE_FORBIDDEN');
-    checkPermission.mockReturnValue(true);
-    expect((await call(h, 'trips.update', { tripId: 1, input: { title: 'boom' } })).error.code).toBe('BAD_PARAMS');
-    expect((await call(h, 'trips.update', { tripId: 1, input: { title: 'gone' } })).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await call(h, 'trips.update', { tripId: 1, input: { title: 'crash' } })).error.code).toBe('HOST_ERROR'); // rethrow of an unknown error
-  });
-
+  // trips.*, the cross-trip feeds and member management left this factory with the
+  // decorator migration; the cases now run in tests/unit/trips/trips.rpc.test.ts.
   it('metadata: round-trips and enforces the key/value/access limits', async () => {
     const h = host('db:meta');
     expect((await call(h, 'meta.set', { entityType: 'trip', entityId: 1, key: 'k', value: { a: 1 } })).ok).toBe(true);
@@ -541,48 +530,6 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
   // daynotes.* left this factory with the decorator migration; the cases now run in
   // tests/unit/days/day-notes.rpc.test.ts against DayNotesRpc.
 
-  it('cross-trip reads enumerate accessible trips and reservations', async () => {
-    const h = host('db:read:trips');
-    expect((await call(h, 'trips.listMine', {})).ok).toBe(true);
-    const r = await call(h, 'reservations.listMine', {});
-    expect(r.ok).toBe(true);
-    expect(r.result).toHaveLength(1);
-  });
-
-  it('wave-13 wiring: collab reads, journal entries, atlas bucket and trip create delegate correctly', async () => {
-    // collab reads delegate to collabService and require the collab addon
-    const collab = host('db:read:collab');
-    expect((await call(collab, 'collab.listNotes', { tripId: 1 })).result).toEqual([{ id: 1, trip_id: 1, title: 'Note' }]);
-    expect((await call(collab, 'collab.listMessages', { tripId: 1, before: 9 })).result).toEqual([{ id: 3, trip_id: 1, text: 'hi', _before: 9 }]);
-    isAddonEnabled.mockReturnValueOnce(false);
-    expect((await call(collab, 'collab.listPolls', { tripId: 1 })).error.code).toBeDefined(); // addon off -> refused
-    // journal.getEntries: delegates + self-gate (journey 88 = no access)
-    const journal = host('db:read:journal');
-    expect((await call(journal, 'journal.getEntries', { journeyId: 7 })).result).toEqual([{ id: 10, journey_id: 7, author_id: 5 }]);
-    expect((await call(journal, 'journal.getEntries', { journeyId: 88 })).error.code).toBe('RESOURCE_FORBIDDEN');
-    // atlas.bucketList
-    const atlas = host('db:read:atlas');
-    expect((await call(atlas, 'atlas.bucketList', {})).result).toEqual([{ id: 5, user_id: 5, name: 'Kyoto' }]);
-    // trips.create: owner = acting user, delegates to createTrip; validation error mapped
-    const create = host('db:create:trips');
-    expect((await call(create, 'trips.create', { input: { title: 'Japan' } })).result).toMatchObject({ id: 99, user_id: 5, title: 'Japan' });
-    expect((await call(create, 'trips.create', { input: { title: 'boom' } })).error.code).toBe('BAD_PARAMS');
-  });
-
-  it('trip-scoped reads are wired to the hydrated services (days incl. assignments, reservations incl. endpoints)', async () => {
-    const h = host('db:read:trips');
-    const days = await call(h, 'trips.getDays', { tripId: 1 });
-    expect(days.ok).toBe(true);
-    // listDays returns { days: [...] }; the wiring unwraps to the bare array like getPlaces
-    expect(days.result).toEqual([{ id: 3, trip_id: 1, day_number: 1, assignments: [], notes_items: [] }]);
-    const res = await call(h, 'trips.getReservations', { tripId: 1 });
-    expect(res.ok).toBe(true);
-    expect(res.result).toEqual([{ id: 1, trip_id: 1, title: 'Flight' }]);
-    const acc = await call(h, 'trips.getAccommodations', { tripId: 1 });
-    expect(acc.ok).toBe(true);
-    expect(acc.result).toEqual([{ id: 11, trip_id: 1, place_name: 'Ryokan' }]);
-  });
-
   it('accommodations create validates refs, creates via DaysService and emits the cascade broadcasts', async () => {
     const h = host('db:write:accommodations');
     const good = await call(h, 'accommodations.create', { tripId: 1, input: { place_id: 7, start_day_id: 3, end_day_id: 4, check_in: '15:00' } });
@@ -626,30 +573,9 @@ describe('host-deps factory — reservations, day notes, cross-trip + addon read
 // transitions are asserted in tests/unit/packing/packing.rpc.test.ts, against the
 // PackingService methods the REST controller uses too, so there is one copy now.
 
-describe('host-deps factory — Wave 1 wiring (weather/categories/tags/todos/roster/bags)', () => {
-  const host = (...perms: string[]) => createRealRpcHost('w1', new Set(perms))
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const call = async (h: ReturnType<typeof host>, method: string, params: Record<string, unknown>, uid: number | undefined = 5): Promise<any> =>
-    h.dispatch({ k: 'req', id: 'x', method, params }, uid)
-  beforeEach(() => { checkPermission.mockReset(); checkPermission.mockReturnValue(true) })
-  afterAll(() => closePluginDataDb('w1'))
-
-  // weather.get, categories.list and rates.get left this factory with the decorator
-  // migration; the cases now run in tests/unit/plugins/tenant-free.rpc.test.ts.
-
-  // tags.* left this factory with the decorator migration. The same cases now run in
-  // tests/unit/tags/tags.rpc.test.ts against TagsRpc.
-
-  it('trips.members returns the roster', async () => {
-    const r = await call(host('db:read:trips'), 'trips.members', { tripId: 1 }, 5)
-    expect(r.ok).toBe(true)
-    expect(Array.isArray(r.result)).toBe(true)
-  })
-
-  // todos.* left this factory with the decorator migration; the cases now run in
-  // tests/unit/todo/todo.rpc.test.ts against TodoRpc.
-
-})
+// The Wave 1 wiring suite is gone: weather, categories, rates, tags, todos, the
+// roster and the packing bags all moved onto the decorators, so there was nothing
+// left in it. Their cases live in the domain suites now.
 
 describe('host-deps factory — Wave 2 wiring (atlas/vacay/journal/collections writes)', () => {
   const host = (...perms: string[]) => createRealRpcHost('w2', new Set(perms))
@@ -725,15 +651,6 @@ describe('host-deps factory — Wave 3 wiring (files write / collab / member-add
     expect(((await call(h, 'collab.createNote', { tripId: 1, input: { title: 'x' } })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
   })
 
-  it('trips.addMember verifies the target user exists and reports owner-add as joined:false', async () => {
-    const h = host('db:write:members')
-    const r = await call(h, 'trips.addMember', { tripId: 1, userId: 6 })
-    expect(r.ok).toBe(true)
-    expect(r.result).toMatchObject({ joined: true })
-    const ownerAdd = await call(h, 'trips.addMember', { tripId: 1, userId: 5 }) // owner -> no-op
-    expect(ownerAdd.result).toMatchObject({ joined: false })
-    expect(((await call(h, 'trips.addMember', { tripId: 1, userId: 12345 })) as { error: { code: string } }).error.code).toBe('RESOURCE_FORBIDDEN')
-  })
 })
 
 describe('host-deps factory — Wave 4 wiring (notify / ai)', () => {

--- a/server/tests/unit/plugins/rpc-coverage.test.ts
+++ b/server/tests/unit/plugins/rpc-coverage.test.ts
@@ -54,8 +54,8 @@ describe('plugin RPC coverage ledger', () => {
     // Update these two numbers in every rollout PR. They make the diff state the size
     // of the move out loud, which is the number a reviewer wants to see.
     const total = KNOWN_METHODS.length + UNCONDITIONAL_METHODS.length;
-    expect(fromRegistry.size).toBe(30);
-    expect(legacy.size).toBe(total - 30);
+    expect(fromRegistry.size).toBe(38);
+    expect(legacy.size).toBe(total - 38);
   });
 
   it('RPCLEDGER-006 the migrated methods are exactly the ones this PR claims', () => {
@@ -65,12 +65,17 @@ describe('plugin RPC coverage ledger', () => {
       'daynotes.delete',
       'daynotes.list',
       'daynotes.update',
+      'days.create',
+      'days.delete',
+      'days.update',
       'files.create',
       'files.createLink',
       'files.getContent',
       'files.list',
       'files.softDelete',
       'files.update',
+      'itinerary.assign',
+      'itinerary.unassign',
       'packing.create',
       'packing.createBag',
       'packing.delete',
@@ -80,6 +85,9 @@ describe('plugin RPC coverage ledger', () => {
       'packing.setBagMembers',
       'packing.update',
       'packing.updateBag',
+      'places.create',
+      'places.delete',
+      'places.update',
       'rates.get',
       'tags.create',
       'tags.delete',

--- a/server/tests/unit/plugins/rpc-coverage.test.ts
+++ b/server/tests/unit/plugins/rpc-coverage.test.ts
@@ -54,8 +54,8 @@ describe('plugin RPC coverage ledger', () => {
     // Update these two numbers in every rollout PR. They make the diff state the size
     // of the move out loud, which is the number a reviewer wants to see.
     const total = KNOWN_METHODS.length + UNCONDITIONAL_METHODS.length;
-    expect(fromRegistry.size).toBe(38);
-    expect(legacy.size).toBe(total - 38);
+    expect(fromRegistry.size).toBe(50);
+    expect(legacy.size).toBe(total - 50);
   });
 
   it('RPCLEDGER-006 the migrated methods are exactly the ones this PR claims', () => {
@@ -89,6 +89,7 @@ describe('plugin RPC coverage ledger', () => {
       'places.delete',
       'places.update',
       'rates.get',
+      'reservations.listMine',
       'tags.create',
       'tags.delete',
       'tags.list',
@@ -97,6 +98,17 @@ describe('plugin RPC coverage ledger', () => {
       'todos.delete',
       'todos.list',
       'todos.update',
+      'trips.addMember',
+      'trips.create',
+      'trips.getAccommodations',
+      'trips.getById',
+      'trips.getDays',
+      'trips.getPlaces',
+      'trips.getReservations',
+      'trips.listMine',
+      'trips.members',
+      'trips.removeMember',
+      'trips.update',
       'weather.get',
     ]);
   });

--- a/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
+++ b/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
@@ -13,10 +13,24 @@ import { makeDeps } from '../../helpers/rpc-host-deps';
 import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
 import { PackingRpc } from '../../../src/nest/packing/packing.rpc';
 import type { PackingService } from '../../../src/nest/packing/packing.service';
-import type { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
 import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import { TripsRpc } from '../../../src/nest/trips/trips.rpc';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
 
 const req = (method: string, params: Record<string, unknown>): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+/** trips.getById lives on the decorators now, so the audit cases bind it through them. */
+const tripsRegistry = () => {
+  const db = {
+    canAccessTrip: (tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined),
+    prepare: () => ({ get: () => ({ id: 1, title: 'Japan' }), all: () => [] }),
+  } as unknown as DatabaseService;
+  const guards = new PluginGuards(db, {} as never, {} as never);
+  return createTestPluginRegistry([
+    new TripsRpc({} as never, {} as never, {} as never, {} as never, db, {} as never, guards),
+  ]);
+};
 
 describe('dispatch strips the supervisor _inv marker', () => {
   it('RPCINV-001 the handler never sees _inv', async () => {
@@ -37,7 +51,7 @@ describe('dispatch strips the supervisor _inv marker', () => {
   it('RPCINV-003 the audit row is unchanged, because auditResource reads named fields only', async () => {
     const deps = makeDeps();
     const audit = vi.fn();
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), { ...deps, audit });
+    const host = new PluginRpcHost('p', new Set(['db:read:trips']), { ...deps, audit }, tripsRegistry());
     await host.dispatch(req('trips.getById', { tripId: 1, _inv: 'req-7' }), 42);
     expect(audit).toHaveBeenCalledWith({
       pluginId: 'p',
@@ -50,7 +64,7 @@ describe('dispatch strips the supervisor _inv marker', () => {
 
   it('RPCINV-004 the acting user still comes from the host, not from the params', async () => {
     const deps = makeDeps();
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
+    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps, tripsRegistry());
     // No acting user bound: the trip read is refused even though _inv is present.
     const res = await host.dispatch(req('trips.getById', { tripId: 1, _inv: 'req-7' }));
     expect(res.ok).toBe(false);

--- a/server/tests/unit/plugins/rpc-host.test.ts
+++ b/server/tests/unit/plugins/rpc-host.test.ts
@@ -42,41 +42,7 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((res as RpcError).error.code).toBe('UNKNOWN_METHOD');
   });
 
-  it('db:read:trips reads a trip the acting user can access', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    // The acting user is bound by the HOST (2nd dispatch arg), never from params.
-    const res = await host.dispatch(req('trips.getById', { tripId: 1 }), 42);
-    expect(ok(res)).toBe(true);
-    // returns the ACTUAL trip row (title/start_date), not the access-check object
-    expect((res as RpcResponse).result).toMatchObject({ id: 1, title: 'Japan', start_date: '2027-01-01' });
-    expect(deps.db.prepare).toHaveBeenCalledWith(expect.stringContaining('FROM trips'));
-  });
-
-  it('db:read:trips is still RESOURCE_FORBIDDEN when the user is not a member', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const res = await host.dispatch(req('trips.getById', { tripId: 1 }), 99);
-    expect((res as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('a trip read with NO bound acting user is RESOURCE_FORBIDDEN (jobs / forged calls)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    // A plugin-supplied asUserId is ignored; without a host-bound user, deny.
-    const res = await host.dispatch(req('trips.getById', { tripId: 1, asUserId: 42 }), undefined);
-    expect((res as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(deps.canAccessTrip).not.toHaveBeenCalled();
-  });
-
-  it('trips.getPlaces is membership-checked before the core read', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const forbidden = await host.dispatch(req('trips.getPlaces', { tripId: 2 }), 42);
-    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(deps.db.prepare).not.toHaveBeenCalled();
-
-    const allowed = await host.dispatch(req('trips.getPlaces', { tripId: 1 }), 42);
-    expect(ok(allowed)).toBe(true);
-    expect((allowed as RpcResponse).result).toEqual([{ id: 7, name: 'Place' }]);
-  });
-
+  // The trips, roster and member cases moved to tests/unit/trips/trips.rpc.test.ts.
   it('db:read:users returns only the public projection for a visible user', async () => {
     const host = new PluginRpcHost('p', new Set(['db:read:users']), deps);
     const res = await host.dispatch(req('users.getById', { id: 3 }), 42);
@@ -149,50 +115,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     const host = new PluginRpcHost('p', new Set(['db:own']), deps);
     host.dispose();
     expect(deps.data.close).toHaveBeenCalled();
-  });
-
-  it('trips.getReservations is membership-checked and returns the hydrated list', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const res = await host.dispatch(req('trips.getReservations', { tripId: 1 }), 42);
-    expect(ok(res)).toBe(true);
-    // the REST-parity list (endpoints/day_positions), not a raw row scan
-    expect(deps.listTripReservations).toHaveBeenCalledWith(1);
-    expect(((res as RpcResponse).result as Array<{ endpoints: unknown[] }>)[0].endpoints).toEqual([]);
-    const forbidden = await host.dispatch(req('trips.getReservations', { tripId: 2 }), 42);
-    expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('trips.getDays / trips.getAccommodations ride on db:read:trips, membership-checked', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const days = await host.dispatch(req('trips.getDays', { tripId: 1 }), 42);
-    expect(ok(days)).toBe(true);
-    expect(deps.listTripDays).toHaveBeenCalledWith(1);
-    const acc = await host.dispatch(req('trips.getAccommodations', { tripId: 1 }), 42);
-    expect(ok(acc)).toBe(true);
-    expect(deps.listTripAccommodations).toHaveBeenCalledWith(1);
-    for (const m of ['trips.getDays', 'trips.getAccommodations']) {
-      const forbidden = await host.dispatch(req(m, { tripId: 2 }), 42);
-      expect((forbidden as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-      const noUser = await host.dispatch(req(m, { tripId: 1 }), undefined);
-      expect((noUser as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    }
-  });
-
-  it('trips.listMine returns the acting user\'s trips; a job (no user) is refused', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const res = await host.dispatch(req('trips.listMine'), 42);
-    expect(ok(res)).toBe(true);
-    expect((res as RpcResponse).result).toHaveLength(2);
-    const noUser = await host.dispatch(req('trips.listMine'), undefined);
-    expect((noUser as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('reservations.listMine aggregates across accessible trips; refused without a user', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const res = await host.dispatch(req('reservations.listMine'), 42);
-    expect(ok(res)).toBe(true);
-    expect((res as RpcResponse).result).toHaveLength(2);
-    expect((await host.dispatch(req('reservations.listMine'), undefined)).ok).toBe(false);
   });
 
   it('reservations.create needs db:write:reservations + reservation_edit, membership-checked', async () => {
@@ -277,28 +199,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     }
   });
 
-  it('wave-13 reads: collab / journal.getEntries / atlas.bucketList / trips.create gated correctly', async () => {
-    // collab reads: membership-checked, need db:read:collab
-    const collab = new PluginRpcHost('p', new Set(['db:read:collab']), deps);
-    expect(ok(await collab.dispatch(req('collab.listNotes', { tripId: 1 }), 42))).toBe(true);
-    expect(ok(await collab.dispatch(req('collab.listMessages', { tripId: 1, before: 5 }), 42))).toBe(true);
-    expect((await collab.dispatch(req('collab.listPolls', { tripId: 2 }), 42)).ok).toBe(false); // no access to trip 2
-    // journal.getEntries: user-bound, needs db:read:journal; a job is refused
-    const journal = new PluginRpcHost('p', new Set(['db:read:journal']), deps);
-    expect(ok(await journal.dispatch(req('journal.getEntries', { journeyId: 7 }), 42))).toBe(true);
-    expect((await journal.dispatch(req('journal.getEntries', { journeyId: 7 }), undefined)).ok).toBe(false);
-    // atlas.bucketList: user-bound, needs db:read:atlas
-    const atlas = new PluginRpcHost('p', new Set(['db:read:atlas']), deps);
-    expect(ok(await atlas.dispatch(req('atlas.bucketList'), 42))).toBe(true);
-    expect((await atlas.dispatch(req('atlas.bucketList'), undefined)).ok).toBe(false);
-    // trips.create: needs db:create:trips + the acting user's trip_create + a bound user
-    const create = new PluginRpcHost('p', new Set(['db:create:trips']), deps);
-    expect(ok(await create.dispatch(req('trips.create', { input: { title: 'Japan' } }), 42))).toBe(true);
-    expect((await create.dispatch(req('trips.create', { input: { title: 'x' } }), 7) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN'); // canCreateTrip false for 7
-    expect((await create.dispatch(req('trips.create', { input: { title: 'x' } }), undefined) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN'); // no user
-    expect((await create.dispatch(req('trips.create', { input: {} }), 42) as RpcError).error.code).toBe('BAD_PARAMS'); // title required
-  });
-
   // The daynotes cases moved to tests/unit/days/day-notes.rpc.test.ts.
 
   it('collections reads are user-scoped and need db:read:collections + a bound user', async () => {
@@ -313,12 +213,6 @@ describe('PluginRpcHost — capability enforcement', () => {
   // weather.get, categories.list and rates.get moved to tests/unit/plugins/tenant-free.rpc.test.ts.
 
   // The tags cases moved to tests/unit/tags/tags.rpc.test.ts with the handlers.
-
-  it('trips.members is trip-membership-gated', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    expect(ok(await host.dispatch(req('trips.members', { tripId: 1 }), 42))).toBe(true);
-    expect(((await host.dispatch(req('trips.members', { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
 
   it('atlas writes are uid-bound (code-validated, userless refused)', async () => {
     const host = new PluginRpcHost('p', new Set(['db:write:atlas']), deps);
@@ -370,18 +264,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect(ok(await host.dispatch(req('collab.createMessage', { tripId: 1, text: 'hi' }), 42))).toBe(true);
     expect((await host.dispatch(req('collab.createMessage', { tripId: 1, text: '' }), 42)).ok).toBe(false);
     expect(((await host.dispatch(req('collab.createNote', { tripId: 2, input: { title: 'x' } }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('trips.addMember is its own permission (member_manage), host-bound inviter', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:members']), deps);
-    const good = await host.dispatch(req('trips.addMember', { tripId: 1, userId: 6 }), 42);
-    expect(ok(good)).toBe(true);
-    expect(deps.addTripMember).toHaveBeenCalledWith(1, 6, 42); // inviter = HOST-bound acting user
-    expect(((await host.dispatch(req('trips.addMember', { tripId: 2, userId: 6 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect((await host.dispatch(req('trips.addMember', { tripId: 1, userId: 6 }), undefined)).ok).toBe(false);
-    // and NOT reachable via any other write grant
-    const otherGrant = new PluginRpcHost('p', new Set(['db:write:trips', 'db:write:collab']), deps);
-    expect((await otherGrant.dispatch(req('trips.addMember', { tripId: 1, userId: 6 }), 42)).ok).toBe(false);
   });
 
   it('notify.send forces the recipient to the acting user or a member trip; admin scope refused', async () => {
@@ -476,16 +358,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     const res = await host.dispatch(req('db.query', { sql: 'SELECT 1' }));
     expect((res as RpcError).error.code).toBe('HOST_ERROR');
     expect((res as RpcError).error.message).toBe('internal error');
-  });
-
-  it('coerces numeric string params and tolerates a missing params object', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:read:trips', 'db:own']), deps);
-    // tripId as a string -> coerced to a number; acting user is the bound host arg
-    const res = await host.dispatch(req('trips.getById', { tripId: '1' }), 42);
-    expect(ok(res)).toBe(true);
-    // a request with no params object at all -> BAD_PARAMS (sql missing), not a crash
-    const noParams = await host.dispatch({ k: 'req', id: 'y', method: 'db.query', params: undefined });
-    expect((noParams as RpcError).error.code).toBe('BAD_PARAMS');
   });
 
   // ── Costs (budget items): db:read:costs / db:write:costs ────────────────────
@@ -669,13 +541,6 @@ describe('PluginRpcHost — capability enforcement', () => {
     expect((res as RpcError).error.code).toBe('PERMISSION_DENIED');
   });
 
-  it('db:write:trips updates a trip the acting user may edit', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:trips']), deps);
-    const res = await host.dispatch(req('trips.update', { tripId: 1, input: { title: 'Renamed' } }), 42);
-    expect(ok(res)).toBe(true);
-    expect(deps.updateTrip).toHaveBeenCalledWith(1, 42, expect.objectContaining({ title: 'Renamed' }));
-  });
-
   // --- Plugin metadata (db:meta) ---
   it('db:meta stores and reads namespaced metadata on an accessible entity', async () => {
     const host = new PluginRpcHost('p', new Set(['db:meta']), deps);
@@ -726,29 +591,6 @@ describe('PluginRpcHost — capability enforcement', () => {
   // invalid column sails through. Drive the trip reads against a REAL schema-loaded
   // SQLite instead — `places` has no day_id/position (those live on day_assignments),
   // so the old `ORDER BY day_id, position` threw `no such column` on every call.
-  it('trips.getPlaces runs against the real places schema and returns the trip pool', async () => {
-    const realDb = new Database(':memory:');
-    createTables(realDb);
-    realDb.exec(`
-      INSERT INTO users (id, username, email, password_hash) VALUES (42, 'ada', 'ada@example.com', 'x');
-      INSERT INTO trips (id, user_id, title) VALUES (1, 42, 'Japan'), (2, 42, 'Peru');
-      INSERT INTO places (id, trip_id, name, created_at) VALUES
-        (1, 1, 'Older', '2027-01-01 10:00:00'),
-        (2, 1, 'Newer', '2027-01-02 10:00:00'),
-        (3, 2, 'Other trip', '2027-01-03 10:00:00');
-    `);
-    deps.db = realDb as unknown as HostDeps['db'];
-
-    const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
-    const res = await host.dispatch(req('trips.getPlaces', { tripId: 1 }), 42);
-
-    expect(ok(res)).toBe(true);
-    const rows = (res as RpcResponse).result as Array<{ id: number; name: string }>;
-    // only trip 1's places, newest first (mirrors the REST list's created_at DESC)
-    expect(rows.map(r => r.name)).toEqual(['Newer', 'Older']);
-    realDb.close();
-  });
-
   it('meta WRITES need the entity edit permission — a read-only member is RESOURCE_FORBIDDEN', async () => {
     // Member can access the trip but not edit it (viewer role).
     (deps.canEditTrip as ReturnType<typeof vi.fn>).mockReturnValue(false);

--- a/server/tests/unit/plugins/rpc-host.test.ts
+++ b/server/tests/unit/plugins/rpc-host.test.ts
@@ -662,51 +662,11 @@ describe('PluginRpcHost — capability enforcement', () => {
   });
 
   // --- Planner writes (#1429) ---
-  it('db:write:places creates a place on a trip the acting user may edit', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:places']), deps);
-    const res = await host.dispatch(req('places.create', { tripId: 1, input: { name: 'Fushimi Inari' } }), 42);
-    expect(ok(res)).toBe(true);
-    expect(deps.createPlace).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Fushimi Inari' }));
-  });
-
-  it('places.create rejects an over-long string field (mirrors the REST STRING_LIMITS)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:places']), deps);
-    const res = await host.dispatch(req('places.create', { tripId: 1, input: { name: 'A'.repeat(201) } }), 42);
-    expect((res as RpcError).error.code).toBe('BAD_PARAMS');
-    expect(deps.createPlace).not.toHaveBeenCalled();
-  });
-
+  // The places, days and itinerary cases moved to their own domain suites.
   it('places.create is PERMISSION_DENIED without db:write:places', async () => {
     const host = new PluginRpcHost('p', new Set(['db:read:trips']), deps);
     const res = await host.dispatch(req('places.create', { tripId: 1, input: { name: 'X' } }), 42);
     expect((res as RpcError).error.code).toBe('PERMISSION_DENIED');
-  });
-
-  it('places.create is RESOURCE_FORBIDDEN on a trip the acting user cannot edit', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:places']), deps);
-    const res = await host.dispatch(req('places.create', { tripId: 2, input: { name: 'X' } }), 42);
-    expect((res as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-    expect(deps.createPlace).not.toHaveBeenCalled();
-  });
-
-  it('places.create with no bound acting user is RESOURCE_FORBIDDEN (jobs / forged calls)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:places']), deps);
-    const res = await host.dispatch(req('places.create', { tripId: 1, input: { name: 'X' } }), undefined);
-    expect((res as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
-  });
-
-  it('places.create with an invalid payload (no name) is BAD_PARAMS', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:places']), deps);
-    const res = await host.dispatch(req('places.create', { tripId: 1, input: {} }), 42);
-    expect((res as RpcError).error.code).toBe('BAD_PARAMS');
-    expect(deps.createPlace).not.toHaveBeenCalled();
-  });
-
-  it('db:write:itinerary assigns a place to a day (day_edit gated)', async () => {
-    const host = new PluginRpcHost('p', new Set(['db:write:itinerary']), deps);
-    const res = await host.dispatch(req('itinerary.assign', { tripId: 1, dayId: 3, placeId: 10 }), 42);
-    expect(ok(res)).toBe(true);
-    expect(deps.assignPlaceToDay).toHaveBeenCalledWith(1, 3, 10, null);
   });
 
   it('db:write:trips updates a trip the acting user may edit', async () => {

--- a/server/tests/unit/trips/trips.rpc.test.ts
+++ b/server/tests/unit/trips/trips.rpc.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The trip plugin surface after it moved onto @PluginMethod: the trip-scoped reads,
+ * the two cross-trip feeds, the roster, the update, the create and the two member
+ * operations.
+ *
+ * Two things get their own cases. trips.update gates two individual FIELDS behind
+ * permissions of their own on top of trip_edit, and adding a member GRANTS TRIP
+ * ACCESS, which is why it sits behind its own permission rather than any other write.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PluginRpcHost } from '../../../src/nest/plugins/host/rpc-host';
+import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit/testing';
+import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
+import { TripsRpc } from '../../../src/nest/trips/trips.rpc';
+import { TripsModule } from '../../../src/nest/trips/trips.module';
+import { NotFoundError, ValidationError } from '../../../src/nest/trips/trips.service';
+import type { TripsService } from '../../../src/nest/trips/trips.service';
+import type { ReservationsService } from '../../../src/nest/reservations/reservations.service';
+import type { DaysService } from '../../../src/nest/days/days.service';
+import type { TripMembershipService } from '../../../src/nest/trip-membership/trip-membership.service';
+import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import type { DatabaseService } from '../../../src/nest/database/database.service';
+import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
+import type { RpcRequest, RpcError } from '../../../src/nest/plugins/protocol/envelope';
+import { makeDeps } from '../../helpers/rpc-host-deps';
+
+const req = (method: string, params: Record<string, unknown> = {}): RpcRequest => ({ k: 'req', id: 'x', method, params });
+
+const ALL_TRIP_GRANTS = ['db:read:trips', 'db:write:trips', 'db:create:trips', 'db:write:members'];
+
+/** Trip 1 belongs to user 42. `allow` decides each individual permission check. */
+export function build(opts: { allow?: (action: string) => boolean; updateThrows?: Error } = {}) {
+  const trips = {
+    list: vi.fn(() => [{ id: 1, title: 'Japan' }]),
+    updateTrip: vi.fn(() => {
+      if (opts.updateThrows) throw opts.updateThrows;
+      return { updatedTrip: { id: 1, title: 'Japan' } };
+    }),
+    create: vi.fn((userId: number) => ({ trip: { id: 99, user_id: userId } })),
+    removeMember: vi.fn(),
+  } as unknown as TripsService & Record<string, ReturnType<typeof vi.fn>>;
+  const reservations = { list: vi.fn(() => [{ id: 5 }]) } as unknown as ReservationsService & Record<string, ReturnType<typeof vi.fn>>;
+  const days = {
+    list: vi.fn(() => ({ days: [{ id: 3 }] })),
+    listAccommodations: vi.fn(() => [{ id: 11 }]),
+  } as unknown as DaysService & Record<string, ReturnType<typeof vi.fn>>;
+  const membership = { joinTripAsMember: vi.fn(() => ({ joined: true })) } as unknown as TripMembershipService & Record<string, ReturnType<typeof vi.fn>>;
+  const db = {
+    canAccessTrip: vi.fn((tripId: number, userId: number) => (tripId === 1 && userId === 42 ? { id: 1, user_id: 42 } : undefined)),
+    prepare: vi.fn((sql: string) => ({
+      get: (arg: number) => {
+        if (sql.includes('FROM users WHERE')) return arg === 404 ? undefined : { id: arg, role: 'user' };
+        if (sql.includes('SELECT user_id FROM trips')) return { user_id: 42 };
+        return { id: 1, title: 'Japan' };
+      },
+      all: () => [{ id: 7, name: 'Place' }],
+    })),
+  } as unknown as DatabaseService;
+  const permissions = { checkPermission: vi.fn((a: string) => (opts.allow ? opts.allow(a) : true)) } as unknown as PermissionsService;
+  const realtime = { broadcast: vi.fn() } as unknown as RealtimeService & { broadcast: ReturnType<typeof vi.fn> };
+  const guards = new PluginGuards(db, permissions, { isAddonEnabled: vi.fn(() => true) } as unknown as AddonsService);
+  const rpc = new TripsRpc(trips, reservations, days, membership, db, realtime, guards);
+  const host = (...grants: string[]) =>
+    new PluginRpcHost('p', new Set(grants.length ? grants : ALL_TRIP_GRANTS), makeDeps(), createTestPluginRegistry([rpc]));
+  return { trips, reservations, days, membership, realtime, permissions, host };
+}
+
+describe('TripsRpc reads', () => {
+  it('TRIPS-RPC-001 every trip-scoped read is membership-checked', async () => {
+    const f = build();
+    const host = f.host();
+    for (const method of ['trips.getById', 'trips.getPlaces', 'trips.getReservations', 'trips.getDays', 'trips.getAccommodations', 'trips.members']) {
+      expect((await host.dispatch(req(method, { tripId: 1 }), 42)).ok).toBe(true);
+      expect(((await host.dispatch(req(method, { tripId: 2 }), 42)) as RpcError).error.code).toBe('RESOURCE_FORBIDDEN');
+    }
+  });
+
+  it('TRIPS-RPC-002 the cross-trip feeds refuse a userless context instead of listing everything', async () => {
+    const f = build();
+    const host = f.host();
+    expect((await host.dispatch(req('trips.listMine'), 42)).ok).toBe(true);
+    expect((await host.dispatch(req('reservations.listMine'), 42)).ok).toBe(true);
+    expect(((await host.dispatch(req('trips.listMine'), undefined)) as RpcError).error.message)
+      .toBe('trip reads require an authenticated user context');
+    expect(((await host.dispatch(req('reservations.listMine'), undefined)) as RpcError).error.message)
+      .toBe('reservation reads require an authenticated user context');
+    expect(f.trips.list).toHaveBeenCalledWith(42, null);
+  });
+
+  it('TRIPS-RPC-003 the reservation feed spans the accessible trips', async () => {
+    const f = build();
+    await f.host().dispatch(req('reservations.listMine'), 42);
+    expect(f.reservations.list).toHaveBeenCalledWith('1');
+  });
+
+  it('TRIPS-RPC-004 getDays returns the days array, not the wrapper the service returns', async () => {
+    const f = build();
+    const res = await f.host().dispatch(req('trips.getDays', { tripId: 1 }), 42);
+    expect((res as { result: unknown }).result).toEqual([{ id: 3 }]);
+  });
+});
+
+describe('TripsRpc writes', () => {
+  it('TRIPS-RPC-005 update needs the grant, trip_edit and a bound user', async () => {
+    const f = build();
+    const host = f.host();
+    expect((await host.dispatch(req('trips.update', { tripId: 1, input: { title: 'New' } }), 42)).ok).toBe(true);
+    const noUser = (await host.dispatch(req('trips.update', { tripId: 1, input: { title: 'x' } }), undefined)) as RpcError;
+    expect(noUser.error.message).toBe('trip writes require an authenticated user context');
+    const readOnly = (await f.host('db:read:trips').dispatch(req('trips.update', { tripId: 1, input: {} }), 42)) as RpcError;
+    expect(readOnly.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('TRIPS-RPC-006 archiving needs trip_archive on top of trip_edit', async () => {
+    const f = build({ allow: (a) => a !== 'trip_archive' });
+    const res = (await f.host().dispatch(req('trips.update', { tripId: 1, input: { is_archived: true } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to archive trip 1');
+    expect(f.trips.updateTrip).not.toHaveBeenCalled();
+  });
+
+  it('TRIPS-RPC-007 changing the cover needs trip_cover_upload on top of trip_edit', async () => {
+    const f = build({ allow: (a) => a !== 'trip_cover_upload' });
+    const res = (await f.host().dispatch(req('trips.update', { tripId: 1, input: { cover_image: '/uploads/covers/a.jpg' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to change the cover of trip 1');
+  });
+
+  it('TRIPS-RPC-008 a plain edit is unaffected by those two field permissions', async () => {
+    const f = build({ allow: (a) => a !== 'trip_archive' && a !== 'trip_cover_upload' });
+    expect((await f.host().dispatch(req('trips.update', { tripId: 1, input: { title: 'New' } }), 42)).ok).toBe(true);
+  });
+
+  it('TRIPS-RPC-009 service errors map onto the right RPC codes', async () => {
+    const invalid = build({ updateThrows: new ValidationError('bad dates') });
+    expect(((await invalid.host().dispatch(req('trips.update', { tripId: 1, input: { title: 'x' } }), 42)) as RpcError).error)
+      .toMatchObject({ code: 'BAD_PARAMS', message: 'bad dates' });
+    const missing = build({ updateThrows: new NotFoundError('trip not found') });
+    expect(((await missing.host().dispatch(req('trips.update', { tripId: 1, input: { title: 'x' } }), 42)) as RpcError).error)
+      .toMatchObject({ code: 'RESOURCE_FORBIDDEN', message: 'trip not found' });
+  });
+
+  it('TRIPS-RPC-010 an over-long title is capped like the REST controller caps it', async () => {
+    const f = build();
+    const res = (await f.host().dispatch(req('trips.update', { tripId: 1, input: { title: 'x'.repeat(201) } }), 42)) as RpcError;
+    expect(res.error.message).toBe('title must be 200 characters or fewer');
+  });
+
+  it('TRIPS-RPC-011 create runs under trip_create and never broadcasts', async () => {
+    const f = build();
+    expect((await f.host().dispatch(req('trips.create', { input: { title: 'Japan' } }), 42)).ok).toBe(true);
+    expect(f.permissions.checkPermission).toHaveBeenCalledWith('trip_create', 'user', null, 42, false);
+    // A new trip is only visible to its owner, who refetches.
+    expect(f.realtime.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('TRIPS-RPC-012 without trip_create the trip is refused', async () => {
+    const f = build({ allow: (a) => a !== 'trip_create' });
+    const res = (await f.host().dispatch(req('trips.create', { input: { title: 'Japan' } }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to create trips');
+    expect(f.trips.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('TripsRpc membership', () => {
+  it('TRIPS-RPC-013 adding a member needs member_manage and records the inviter', async () => {
+    const f = build();
+    expect((await f.host().dispatch(req('trips.addMember', { tripId: 1, userId: 7 }), 42)).ok).toBe(true);
+    expect(f.membership.joinTripAsMember).toHaveBeenCalledWith(1, 7, 42);
+  });
+
+  it('TRIPS-RPC-014 member management is its own grant, separate from every other write', async () => {
+    const f = build();
+    const res = (await f.host('db:write:trips').dispatch(req('trips.addMember', { tripId: 1, userId: 7 }), 42)) as RpcError;
+    // Adding a member GRANTS TRIP ACCESS, so db:write:trips must not be enough.
+    expect(res.error.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('TRIPS-RPC-015 an unknown target user is refused', async () => {
+    const f = build();
+    const res = (await f.host().dispatch(req('trips.addMember', { tripId: 1, userId: 404 }), 42)) as RpcError;
+    expect(res.error.message).toBe('no user 404');
+    expect(f.membership.joinTripAsMember).not.toHaveBeenCalled();
+  });
+
+  it('TRIPS-RPC-016 the owner can never be removed through this path', async () => {
+    const f = build();
+    // The stub reports user 42 as the owner of trip 1.
+    const res = (await f.host().dispatch(req('trips.removeMember', { tripId: 1, userId: 42 }), 42)) as RpcError;
+    expect(res.error.message).toBe('cannot remove the trip owner');
+    expect(f.trips.removeMember).not.toHaveBeenCalled();
+  });
+
+  it('TRIPS-RPC-017 a non-owner member is removed', async () => {
+    const f = build();
+    expect((await f.host().dispatch(req('trips.removeMember', { tripId: 1, userId: 7 }), 42)).ok).toBe(true);
+    expect(f.trips.removeMember).toHaveBeenCalledWith(1, 7);
+  });
+
+  it('TRIPS-RPC-018 without member_manage nothing changes', async () => {
+    const f = build({ allow: (a) => a !== 'member_manage' });
+    const res = (await f.host().dispatch(req('trips.addMember', { tripId: 1, userId: 7 }), 42)) as RpcError;
+    expect(res.error.message).toBe('no permission to edit trip 1');
+  });
+
+  it('TRIPS-RPC-019 the class is listed in its module providers', () => {
+    expect(Reflect.getMetadata('providers', TripsModule) as unknown[]).toContain(TripsRpc);
+  });
+});


### PR DESCRIPTION
places, days, itinerary, trips, the cross-trip feeds and member management: 20 more
methods, so the registry owns 50 of 113. rpc-host.ts is down from 1332 lines to 830 and
the deps factory from 944 to 500.

itinerary.* landed in assignments/ rather than days/, because AssignmentsModule already
imports DaysModule and the other direction would have been a cycle. It still rides on
day_edit, which is what the app gates it on.

Three behaviours worth checking in the diff, since each is silent when broken. Deleting a
place runs the journey hook BEFORE the row goes, because journey_entries.source_place_id
is ON DELETE SET NULL and afterwards there is nothing left to detach; the place id is
scoped to the trip before that hook runs, or it would detach another trip's entries even
while refusing the delete itself. trips.update keeps its two field-level gates, so
archiving or re-covering a trip needs its own permission on top of trip_edit. And member
management keeps its own grant, because adding a member grants trip access.

canEditTrip stays in HostDeps for now: the db:meta gate still resolves an entity's edit
permission through it and has not moved yet.
