### PR TITLE
Give the admin surfaces back to the domains that own them

### DIFF
--- a/server/src/nest/addons/addons.service.ts
+++ b/server/src/nest/addons/addons.service.ts
@@ -149,4 +149,29 @@ export class AddonsService {
       ],
     };
   }
+
+  // ── Places provider flags ──────────────────────────────────────────────────
+  // These three sat as raw app_settings SQL on AdminService, next to the
+  // bag-tracking and collab flags it already delegated here. They read
+  // `=== 'true'` — fail-closed, matching getBagTracking(). They read
+  // `!== 'false'` (fail-open) before the 2026-08 quirk fix; a migration
+  // backfills 'true' for installs that never touched the switches, so nobody
+  // loses a feature on upgrade.
+
+  private readFlag(key: string) {
+    const row = this.db.prepare('SELECT value FROM app_settings WHERE key = ?').get(key) as { value: string } | undefined;
+    return { enabled: row?.value === 'true' };
+  }
+
+  private writeFlag(key: string, enabled: boolean) {
+    this.db.prepare('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)').run(key, enabled ? 'true' : 'false');
+    return { enabled: !!enabled };
+  }
+
+  getPlacesPhotos() { return this.readFlag('places_photos_enabled'); }
+  updatePlacesPhotos(enabled: boolean) { return this.writeFlag('places_photos_enabled', enabled); }
+  getPlacesAutocomplete() { return this.readFlag('places_autocomplete_enabled'); }
+  updatePlacesAutocomplete(enabled: boolean) { return this.writeFlag('places_autocomplete_enabled', enabled); }
+  getPlacesDetails() { return this.readFlag('places_details_enabled'); }
+  updatePlacesDetails(enabled: boolean) { return this.writeFlag('places_details_enabled', enabled); }
 }

--- a/server/src/nest/admin/admin.bridge.ts
+++ b/server/src/nest/admin/admin.bridge.ts
@@ -47,7 +47,6 @@ const admin = new AdminService(
   new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
-  new PackingService(dbs, permissions, realtime),
   auth,
   permissions,
   new NotificationsService(dbs, realtime, mailer, new WebhookService(dbs), new NtfyService(dbs), notifPrefs),

--- a/server/src/nest/admin/admin.bridge.ts
+++ b/server/src/nest/admin/admin.bridge.ts
@@ -44,14 +44,12 @@ const notifPrefs = new NotificationPreferencesService(dbs, mailer);
 const auth = new AuthService(dbs, permissions, new AtlasService(dbs), new TripMembershipService(dbs), webauthn, userCleanup, mailer);
 const admin = new AdminService(
   dbs,
-  new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
   auth,
   permissions,
   new NotificationsService(dbs, realtime, mailer, new WebhookService(dbs), new NtfyService(dbs), notifPrefs),
   userCleanup,
-  notifPrefs,
 );
 
 export function checkAndNotifyVersion(): Promise<void> {

--- a/server/src/nest/admin/admin.controller.ts
+++ b/server/src/nest/admin/admin.controller.ts
@@ -17,6 +17,7 @@ import {
   AdminTestNotificationDto,
 } from './admin.dto';
 import { PluginRuntimeService } from '../plugins/plugin-runtime.service';
+import { AddonsService } from '../addons/addons.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -56,6 +57,7 @@ function ok<T>(result: T): Exclude<T, { error: string }> {
 export class AdminController {
   constructor(
     private readonly admin: AdminService,
+    private readonly addons: AddonsService,
     private readonly pluginRuntime: PluginRuntimeService,
     private readonly audit: AuditService,
     private readonly notifications: NotificationsService,
@@ -181,114 +183,66 @@ export class AdminController {
   }
 
   // ── Feature toggles ──
+  // ── Feature toggles ──
+  // Straight to AddonsService, which owns every one of these flags. They used to go
+  // through eleven-plus pass-through methods on AdminService, and the three places
+  // flags were raw app_settings SQL there even though the other flags lived in the
+  // addons domain. The routes stay HERE rather than moving next to the service: an
+  // admin-gated controller in AddonsModule would make that module import AuthModule,
+  // and PluginGuardsModule imports AddonsModule precisely because it is a leaf — the
+  // edge would close a cycle.
+
   @Get('bag-tracking')
-  getBagTracking() { return this.admin.getBagTracking(); }
+  getBagTracking() { return this.addons.getBagTracking(); }
 
   @Put('bag-tracking')
   updateBagTracking(@CurrentUser() user: User, @Body() body: AdminFeatureToggleDto, @Req() req: Request) {
-    const result = this.admin.updateBagTracking(body.enabled);
+    const result = this.addons.updateBagTracking(body.enabled);
     this.audit.writeAudit({ userId: user.id, action: 'admin.bag_tracking', ip: getClientIp(req), details: { enabled: result.enabled } });
     return result;
   }
 
   @Get('places-photos')
-  getPlacesPhotos() { return this.admin.getPlacesPhotos(); }
+  getPlacesPhotos() { return this.addons.getPlacesPhotos(); }
 
   @Put('places-photos')
   updatePlacesPhotos(@CurrentUser() user: User, @Body() body: AdminFeatureToggleDto, @Req() req: Request) {
-    const result = this.admin.updatePlacesPhotos(body.enabled);
+    const result = this.addons.updatePlacesPhotos(body.enabled);
     this.audit.writeAudit({ userId: user.id, action: 'admin.places_photos', ip: getClientIp(req), details: { enabled: result.enabled } });
     return result;
   }
 
   @Get('places-autocomplete')
-  getPlacesAutocomplete() { return this.admin.getPlacesAutocomplete(); }
+  getPlacesAutocomplete() { return this.addons.getPlacesAutocomplete(); }
 
   @Put('places-autocomplete')
   updatePlacesAutocomplete(@CurrentUser() user: User, @Body() body: AdminFeatureToggleDto, @Req() req: Request) {
-    const result = this.admin.updatePlacesAutocomplete(body.enabled);
+    const result = this.addons.updatePlacesAutocomplete(body.enabled);
     this.audit.writeAudit({ userId: user.id, action: 'admin.places_autocomplete', ip: getClientIp(req), details: { enabled: result.enabled } });
     return result;
   }
 
   @Get('places-details')
-  getPlacesDetails() { return this.admin.getPlacesDetails(); }
+  getPlacesDetails() { return this.addons.getPlacesDetails(); }
 
   @Put('places-details')
   updatePlacesDetails(@CurrentUser() user: User, @Body() body: AdminFeatureToggleDto, @Req() req: Request) {
-    const result = this.admin.updatePlacesDetails(body.enabled);
+    const result = this.addons.updatePlacesDetails(body.enabled);
     this.audit.writeAudit({ userId: user.id, action: 'admin.places_details', ip: getClientIp(req), details: { enabled: result.enabled } });
     return result;
   }
 
   @Get('collab-features')
-  getCollabFeatures() { return this.admin.getCollabFeatures(); }
+  getCollabFeatures() { return this.addons.getCollabFeatures(); }
 
   @Put('collab-features')
   updateCollabFeatures(@CurrentUser() user: User, @Body() body: AdminCollabFeaturesDto, @Req() req: Request) {
-    const { features, changed } = this.admin.updateCollabFeatures(body);
+    const { features, changed } = this.addons.updateCollabFeatures(body);
     // Collab flags gate MCP registration, but a no-op save must not tear down
     // every live MCP session (#1414).
     if (changed) this.admin.invalidateMcpSessions();
     this.audit.writeAudit({ userId: user.id, action: 'admin.collab_features', ip: getClientIp(req), details: features });
     return features;
-  }
-
-  // ── Packing templates ──
-  @Get('packing-templates')
-  listPackingTemplates() { return { templates: this.admin.listPackingTemplates() }; }
-
-  @Get('packing-templates/:id')
-  getPackingTemplate(@Param('id') id: string) { return ok(this.admin.getPackingTemplate(id)); }
-
-  @Post('packing-templates')
-  @HttpCode(201)
-  createPackingTemplate(@CurrentUser() user: User, @Body() body: AdminTemplateNameDto, @Req() req: Request) {
-    const result = ok(this.admin.createPackingTemplate(body.name, user.id));
-    this.audit.writeAudit({ userId: user.id, action: 'admin.packing_template_create', resource: String((result.template as { id?: number } | undefined)?.id ?? ''), ip: getClientIp(req), details: { name: body.name } });
-    return result;
-  }
-
-  @Put('packing-templates/:id')
-  updatePackingTemplate(@Param('id') id: string, @Body() body: AdminTemplateNameDto) { return ok(this.admin.updatePackingTemplate(id, body)); }
-
-  @Delete('packing-templates/:id')
-  deletePackingTemplate(@CurrentUser() user: User, @Param('id') id: string, @Req() req: Request) {
-    const result = ok(this.admin.deletePackingTemplate(id));
-    this.audit.writeAudit({ userId: user.id, action: 'admin.packing_template_delete', resource: String(id), ip: getClientIp(req), details: { name: result.name } });
-    return { success: true };
-  }
-
-  @Post('packing-templates/:id/categories')
-  @HttpCode(201)
-  createTemplateCategory(@Param('id') id: string, @Body() body: AdminTemplateNameDto) {
-    return ok(this.admin.createTemplateCategory(id, body.name));
-  }
-
-  @Put('packing-templates/:templateId/categories/:catId')
-  updateTemplateCategory(@Param('templateId') templateId: string, @Param('catId') catId: string, @Body() body: AdminTemplateNameDto) {
-    return ok(this.admin.updateTemplateCategory(templateId, catId, body));
-  }
-
-  @Delete('packing-templates/:templateId/categories/:catId')
-  deleteTemplateCategory(@Param('templateId') templateId: string, @Param('catId') catId: string) {
-    ok(this.admin.deleteTemplateCategory(templateId, catId));
-    return { success: true };
-  }
-
-  @Post('packing-templates/:templateId/categories/:catId/items')
-  @HttpCode(201)
-  createTemplateItem(@Param('templateId') templateId: string, @Param('catId') catId: string, @Body() body: AdminTemplateNameDto) {
-    return ok(this.admin.createTemplateItem(templateId, catId, body.name));
-  }
-
-  @Put('packing-templates/:templateId/items/:itemId')
-  updateTemplateItem(@Param('templateId') templateId: string, @Param('itemId') itemId: string, @Body() body: AdminTemplateNameDto) { return ok(this.admin.updateTemplateItem(templateId, itemId, body)); }
-
-  @Delete('packing-templates/:templateId/items/:itemId')
-  deleteTemplateItem(@Param('templateId') templateId: string, @Param('itemId') itemId: string) {
-    ok(this.admin.deleteTemplateItem(templateId, itemId));
-    return { success: true };
   }
 
   // ── Addons ──

--- a/server/src/nest/admin/admin.controller.ts
+++ b/server/src/nest/admin/admin.controller.ts
@@ -115,20 +115,6 @@ export class AdminController {
   @Get('audit-log')
   auditLog(@Query() query: { limit?: string; offset?: string }) { return this.admin.getAuditLog(query); }
 
-  // ── OIDC ──
-  @Get('oidc')
-  getOidc() { return this.admin.getOidcSettings(); }
-
-  @Put('oidc')
-  updateOidc(@CurrentUser() user: User, @Body() body: AdminOidcUpdateDto, @Req() req: Request) {
-    const result = this.admin.updateOidcSettings(body);
-    if (result.error) {
-      throw new HttpException({ error: result.error }, result.status || 400);
-    }
-    this.audit.writeAudit({ userId: user.id, action: 'admin.oidc_update', ip: getClientIp(req), details: { issuer_set: !!body.issuer } });
-    return { success: true };
-  }
-
   @Post('save-demo-baseline')
   @HttpCode(200)
   saveDemoBaseline(@CurrentUser() user: User, @Req() req: Request) {
@@ -148,16 +134,6 @@ export class AdminController {
 
   @Get('version-check')
   async versionCheck() { return this.admin.checkVersion(); }
-
-  // ── Admin notification preferences ──
-  @Get('notification-preferences')
-  getNotificationPrefs(@CurrentUser() user: User) { return this.admin.getPreferencesMatrix(user.id, user.role); }
-
-  @Put('notification-preferences')
-  setNotificationPrefs(@CurrentUser() user: User, @Body() body: AdminNotificationPreferencesDto) {
-    this.admin.setAdminPreferences(user.id, body);
-    return this.admin.getPreferencesMatrix(user.id, user.role);
-  }
 
   // ── Invites ──
   @Get('invites')
@@ -182,7 +158,6 @@ export class AdminController {
     return { success: true };
   }
 
-  // ── Feature toggles ──
   // ── Feature toggles ──
   // Straight to AddonsService, which owns every one of these flags. They used to go
   // through eleven-plus pass-through methods on AdminService, and the three places
@@ -300,20 +275,6 @@ export class AdminController {
   }
 
   // ── Default user settings ──
-  @Get('default-user-settings')
-  getDefaultUserSettings() { return this.admin.getAdminUserDefaults(); }
-
-  @Put('default-user-settings')
-  setDefaultUserSettings(@CurrentUser() user: User, @Body() body: AdminDefaultUserSettingsDto, @Req() req: Request) {
-    try {
-      this.admin.setAdminUserDefaults(body as unknown as Record<string, unknown>);
-      this.audit.writeAudit({ userId: user.id, action: 'admin.default_user_settings_update', ip: getClientIp(req), details: body as Record<string, unknown> });
-      return this.admin.getAdminUserDefaults();
-    } catch (err) {
-      throw new HttpException({ error: err instanceof Error ? err.message : String(err) }, 400);
-    }
-  }
-
   // ── Dev-only: test notification (404 outside development, mirroring the conditional mount) ──
   @Post('dev/test-notification')
   @HttpCode(200)

--- a/server/src/nest/admin/admin.service.ts
+++ b/server/src/nest/admin/admin.service.ts
@@ -27,7 +27,6 @@ import { AddonsService } from '../addons/addons.service';
 import { SettingsService } from '../settings/settings.service';
 import { PasskeyService } from '../auth/passkey.service';
 import { AuthService } from '../auth/auth.service';
-import { PackingService } from '../packing/packing.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { PERMISSION_ACTIONS } from '../permissions/permissions.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -73,7 +72,6 @@ export class AdminService {
     private readonly settings: SettingsService,
     private readonly addons: AddonsService,
     private readonly passkeys: PasskeyService,
-    private readonly packing: PackingService,
     private readonly auth: AuthService,
     private readonly permissions: PermissionsService,
     private readonly notifications: NotificationsService,
@@ -570,64 +568,6 @@ export class AdminService {
     this.db.run('DELETE FROM invite_tokens WHERE id = ?', id);
     return {};
   }
-
-  // ── Feature toggles ────────────────────────────────────────────────────────
-  // Bag-tracking and the collab features are owned by AddonsService (finding
-  // `admin-1`). The three places flags read `=== 'true'` — fail-closed, matching
-  // AddonsService.getBagTracking(). They read `!== 'false'` (fail-open) before
-  // the 2026-08 quirk fix; a migration backfills 'true' for installs that never
-  // touched the switches, so nobody loses a feature on upgrade.
-
-  getBagTracking() { return this.addons.getBagTracking(); }
-  updateBagTracking(enabled: unknown) { return this.addons.updateBagTracking(enabled as boolean); }
-  getCollabFeatures() { return this.addons.getCollabFeatures(); }
-  updateCollabFeatures(body: unknown) { return this.addons.updateCollabFeatures(body as Parameters<AddonsService['updateCollabFeatures']>[0]); }
-
-  getPlacesPhotos() {
-    const row = this.db.get<{ value: string }>("SELECT value FROM app_settings WHERE key = 'places_photos_enabled'");
-    return { enabled: row?.value === 'true' };
-  }
-
-  updatePlacesPhotos(enabled: boolean) {
-    this.db.run("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('places_photos_enabled', ?)", enabled ? 'true' : 'false');
-    return { enabled: !!enabled };
-  }
-
-  getPlacesAutocomplete() {
-    const row = this.db.get<{ value: string }>("SELECT value FROM app_settings WHERE key = 'places_autocomplete_enabled'");
-    return { enabled: row?.value === 'true' };
-  }
-
-  updatePlacesAutocomplete(enabled: boolean) {
-    this.db.run("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('places_autocomplete_enabled', ?)", enabled ? 'true' : 'false');
-    return { enabled: !!enabled };
-  }
-
-  getPlacesDetails() {
-    const row = this.db.get<{ value: string }>("SELECT value FROM app_settings WHERE key = 'places_details_enabled'");
-    return { enabled: row?.value === 'true' };
-  }
-
-  updatePlacesDetails(enabled: boolean) {
-    this.db.run("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('places_details_enabled', ?)", enabled ? 'true' : 'false');
-    return { enabled: !!enabled };
-  }
-
-  // ── Packing templates ──────────────────────────────────────────────────────
-  // The SQL lives in PackingService, which owns all three template tables (see
-  // its "Admin Template CRUD" block).
-
-  listPackingTemplates() { return this.packing.listPackingTemplates(); }
-  getPackingTemplate(id: string) { return this.packing.getPackingTemplate(id); }
-  createPackingTemplate(name: unknown, userId: number) { return this.packing.createPackingTemplate(name as string, userId); }
-  updatePackingTemplate(id: string, body: unknown) { return this.packing.updatePackingTemplate(id, body as Parameters<PackingService['updatePackingTemplate']>[1]); }
-  deletePackingTemplate(id: string) { return this.packing.deletePackingTemplate(id); }
-  createTemplateCategory(templateId: string, name: unknown) { return this.packing.createTemplateCategory(templateId, name as string); }
-  updateTemplateCategory(templateId: string, catId: string, body: unknown) { return this.packing.updateTemplateCategory(templateId, catId, body as Parameters<PackingService['updateTemplateCategory']>[2]); }
-  deleteTemplateCategory(templateId: string, catId: string) { return this.packing.deleteTemplateCategory(templateId, catId); }
-  createTemplateItem(templateId: string, catId: string, name: unknown) { return this.packing.createTemplateItem(templateId, catId, name as string); }
-  updateTemplateItem(templateId: string, itemId: string, body: unknown) { return this.packing.updateTemplateItem(templateId, itemId, body as Parameters<PackingService['updateTemplateItem']>[2]); }
-  deleteTemplateItem(templateId: string, itemId: string) { return this.packing.deleteTemplateItem(templateId, itemId); }
 
   // ── Addons ─────────────────────────────────────────────────────────────────
 

--- a/server/src/nest/admin/admin.service.ts
+++ b/server/src/nest/admin/admin.service.ts
@@ -21,10 +21,8 @@ import { prepareLlmAddonConfigForWrite, maskLlmAddonConfig } from '../llm-parse/
 import { getPhotoProviderConfig } from '../memories/memories.helpers';
 import { validatePassword } from '../common/passwordPolicy';
 import { UserCleanupService } from '../auth/user-cleanup.service';
-import { NotificationPreferencesService } from '../notifications/notification-preferences.service';
 import { DatabaseService } from '../database/database.service';
 import { AddonsService } from '../addons/addons.service';
-import { SettingsService } from '../settings/settings.service';
 import { PasskeyService } from '../auth/passkey.service';
 import { AuthService } from '../auth/auth.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -69,14 +67,12 @@ const VERSION_FAILURE_TTL = 60_000;
 export class AdminService {
   constructor(
     private readonly db: DatabaseService,
-    private readonly settings: SettingsService,
     private readonly addons: AddonsService,
     private readonly passkeys: PasskeyService,
     private readonly auth: AuthService,
     private readonly permissions: PermissionsService,
     private readonly notifications: NotificationsService,
     private readonly userCleanup: UserCleanupService,
-    private readonly notifPrefs: NotificationPreferencesService,
   ) {}
 
   // ── User CRUD ──────────────────────────────────────────────────────────────
@@ -318,50 +314,6 @@ export class AdminService {
     return { entries, total, limit, offset };
   }
 
-  // ── OIDC Settings ──────────────────────────────────────────────────────────
-
-  getOidcSettings() {
-    const get = (key: string) =>
-      this.db.get<{ value: string }>('SELECT value FROM app_settings WHERE key = ?', key)?.value || '';
-    const secret = decrypt_api_key(get('oidc_client_secret'));
-    return {
-      issuer: get('oidc_issuer'),
-      client_id: get('oidc_client_id'),
-      client_secret_set: !!secret,
-      display_name: get('oidc_display_name'),
-      oidc_only: get('oidc_only') === 'true',
-      discovery_url: get('oidc_discovery_url'),
-    };
-  }
-
-  updateOidcSettings(data: {
-    issuer?: string;
-    client_id?: string;
-    client_secret?: string;
-    display_name?: string;
-    discovery_url?: string;
-  }): { error?: string; status?: number; success?: boolean } {
-    // Lockout prevention: can't remove OIDC config when password login is disabled
-    if ((data.issuer === '' || data.client_id === '') && !this.auth.resolveAuthToggles().password_login) {
-      return {
-        error: 'Cannot remove SSO configuration while password login is disabled. Enable password login first.',
-        status: 400,
-      };
-    }
-
-    const set = (key: string, val: string) =>
-      this.db.run('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)', key, val || '');
-    // All five writes are one SSO config — a partial apply would leave the
-    // instance with an issuer but no client id (or vice versa).
-    this.db.transaction(() => {
-      set('oidc_issuer', data.issuer ?? '');
-      set('oidc_client_id', data.client_id ?? '');
-      if (data.client_secret !== undefined) set('oidc_client_secret', maybe_encrypt_api_key(data.client_secret) ?? '');
-      set('oidc_display_name', data.display_name ?? '');
-      set('oidc_discovery_url', data.discovery_url ?? '');
-    });
-    return { success: true };
-  }
 
   // ── Demo Baseline ──────────────────────────────────────────────────────────
 
@@ -790,8 +742,4 @@ export class AdminService {
 
   // ── Settings + notification preference helpers (non-admin-service modules) ──
 
-  getAdminUserDefaults() { return this.settings.getAdminUserDefaults(); }
-  setAdminUserDefaults(body: Record<string, unknown>) { return this.settings.setAdminUserDefaults(body); }
-  getPreferencesMatrix(userId: number, role: string) { return this.notifPrefs.getPreferencesMatrix(userId, role, 'admin'); }
-  setAdminPreferences(userId: number, body: unknown) { return this.notifPrefs.setAdminPreferences(userId, body as Parameters<NotificationPreferencesService['setAdminPreferences']>[1]); }
 }

--- a/server/src/nest/notifications/notifications.controller.ts
+++ b/server/src/nest/notifications/notifications.controller.ts
@@ -22,6 +22,9 @@ import {
   NotificationRespondDto,
 } from './notifications.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { NotificationPreferencesService } from './notification-preferences.service';
+import { AdminNotificationPreferencesDto } from '../admin/admin.dto';
 import { CurrentUser } from '../auth/current-user.decorator';
 
 // The masked placeholder the client sends instead of a stored secret (8× U+2022).
@@ -197,5 +200,32 @@ export class NotificationsController {
       throw new HttpException({ error: 'Invalid id' }, 400);
     }
     return id;
+  }
+}
+
+/**
+ * /api/admin/notification-preferences — the admin-scope row of the preference matrix.
+ *
+ * Two routes that sat on AdminController and reached NotificationPreferencesService
+ * through a pair of pass-through methods on AdminService. The owner is here; the
+ * 'admin' scope argument they always passed is now written once, at the only place
+ * that uses it.
+ */
+@Controller('api/admin/notification-preferences')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminNotificationPreferencesController {
+  constructor(private readonly prefs: NotificationPreferencesService) {}
+
+  @Get()
+  get(@CurrentUser() user: User) {
+    return this.prefs.getPreferencesMatrix(user.id, user.role, 'admin');
+  }
+
+  @Put()
+  set(@CurrentUser() user: User, @Body() body: AdminNotificationPreferencesDto) {
+    this.prefs.setAdminPreferences(user.id, body);
+    // Answer with the refreshed matrix rather than the raw write result — the admin
+    // panel renders straight from this response.
+    return this.prefs.getPreferencesMatrix(user.id, user.role, 'admin');
   }
 }

--- a/server/src/nest/notifications/notifications.module.ts
+++ b/server/src/nest/notifications/notifications.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { NotificationsController } from './notifications.controller';
+import { AdminNotificationPreferencesController, NotificationsController } from './notifications.controller';
 import { NotificationsMcp } from './notifications.mcp';
 import { NotificationsService } from './notifications.service';
 import { NotificationPreferencesService } from './notification-preferences.service';
@@ -17,7 +17,7 @@ import { AuthModule } from '../auth/auth.module';
  *  the plugin RPC surface, HostSurfaceRpc). */
 @Module({
   imports: [AuthModule, MailerModule],
-  controllers: [NotificationsController],
+  controllers: [NotificationsController, AdminNotificationPreferencesController],
   providers: [NotificationsService, NotificationPreferencesService, WebhookService, NtfyService, NotificationsMcp],
   exports: [NotificationsService, NotificationPreferencesService],
 })

--- a/server/src/nest/oidc/oidc.controller.ts
+++ b/server/src/nest/oidc/oidc.controller.ts
@@ -1,8 +1,15 @@
-import { Controller, Get, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, Put, Query, Req, Res, UseGuards } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { readEnv } from '../../app-config';
 import { OidcService, OIDC_STATE_TTL_MS } from './oidc.service';
 import { cookieOptions } from '../common/cookie';
+import { AdminGuard } from '../auth/admin.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { User } from '../../types';
+import { AuditService } from '../audit/audit.service';
+import { getClientIp } from '../audit/client-ip';
+import { AdminOidcUpdateDto } from '../admin/admin.dto';
 
 const OIDC_STATE_COOKIE = 'trek_oidc_state';
 
@@ -163,5 +170,46 @@ export class OidcController {
     }
     this.oidc.setAuthCookie(res, result.token, req);
     res.json({ token: result.token });
+  }
+}
+
+/**
+ * /api/admin/oidc — the SSO configuration.
+ *
+ * Two routes that sat on AdminController with their SQL in AdminService, for a domain
+ * that already had a module. They read and write the same five app_settings keys the
+ * login flow next door consumes, so they belong here; the lockout guard that refuses
+ * to remove the config while password login is off lives with them in OidcService.
+ *
+ * The path, the {error,status} envelope and the audit action are unchanged.
+ */
+@Controller('api/admin/oidc')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminOidcController {
+  constructor(
+    private readonly oidc: OidcService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Get()
+  get() {
+    return this.oidc.getOidcSettings();
+  }
+
+  @Put()
+  update(@CurrentUser() user: User, @Body() body: AdminOidcUpdateDto, @Req() req: Request) {
+    const result = this.oidc.updateOidcSettings(body);
+    if (result.error) {
+      throw new HttpException({ error: result.error }, result.status || 400);
+    }
+    // Only whether an issuer was set, never the value: the details column is readable
+    // by every admin and the issuer identifies the customer's IdP tenant.
+    this.audit.writeAudit({
+      userId: user.id,
+      action: 'admin.oidc_update',
+      ip: getClientIp(req),
+      details: { issuer_set: !!body.issuer },
+    });
+    return { success: true };
   }
 }

--- a/server/src/nest/oidc/oidc.module.ts
+++ b/server/src/nest/oidc/oidc.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
-import { OidcController } from './oidc.controller';
+import { AdminOidcController, OidcController } from './oidc.controller';
+import { AuditModule } from '../audit/audit.module';
 import { OidcService } from './oidc.service';
 import { AuthModule } from '../auth/auth.module';
 import { TripMembershipModule } from '../trip-membership/trip-membership.module';
 
 @Module({
-  imports: [AuthModule, TripMembershipModule],
-  controllers: [OidcController],
+  imports: [AuthModule, TripMembershipModule, AuditModule],
+  controllers: [OidcController, AdminOidcController],
   providers: [OidcService],
 })
 export class OidcModule {}

--- a/server/src/nest/oidc/oidc.service.ts
+++ b/server/src/nest/oidc/oidc.service.ts
@@ -8,7 +8,7 @@ import type { Request, Response } from 'express';
 import { readEnv, getAppUrl } from '../../app-config';
 import { JWT_SECRET, SESSION_DURATION_SECONDS } from '../../config';
 import { User } from '../../types';
-import { decrypt_api_key } from '../common/crypto/apiKeyCrypto';
+import { decrypt_api_key, maybe_encrypt_api_key } from '../common/crypto/apiKeyCrypto';
 import { TripMembershipService } from '../trip-membership/trip-membership.service';
 import { setAuthCookie } from '../common/cookie';
 import { AuthService } from '../auth/auth.service';
@@ -619,5 +619,54 @@ export class OidcService implements OnModuleDestroy {
 
   touchLastLogin(userId: number): void {
     this.db.prepare('UPDATE users SET last_login = CURRENT_TIMESTAMP, login_count = login_count + 1 WHERE id = ?').run(userId);
+  }
+
+  // ── OIDC settings ──────────────────────────────────────────────────────────
+  // Moved here from AdminService, which held the SQL for a domain that already had a
+  // module of its own. The lockout guard below is the reason this cannot be a plain
+  // settings write: removing the SSO config while password login is off would lock
+  // every user out of the instance.
+
+  getOidcSettings() {
+    const get = (key: string) =>
+      this.db.get<{ value: string }>('SELECT value FROM app_settings WHERE key = ?', key)?.value || '';
+    const secret = decrypt_api_key(get('oidc_client_secret'));
+    return {
+      issuer: get('oidc_issuer'),
+      client_id: get('oidc_client_id'),
+      client_secret_set: !!secret,
+      display_name: get('oidc_display_name'),
+      oidc_only: get('oidc_only') === 'true',
+      discovery_url: get('oidc_discovery_url'),
+    };
+  }
+
+  updateOidcSettings(data: {
+    issuer?: string;
+    client_id?: string;
+    client_secret?: string;
+    display_name?: string;
+    discovery_url?: string;
+  }): { error?: string; status?: number; success?: boolean } {
+    // Lockout prevention: can't remove OIDC config when password login is disabled
+    if ((data.issuer === '' || data.client_id === '') && !this.auth.resolveAuthToggles().password_login) {
+      return {
+        error: 'Cannot remove SSO configuration while password login is disabled. Enable password login first.',
+        status: 400,
+      };
+    }
+
+    const set = (key: string, val: string) =>
+      this.db.run('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)', key, val || '');
+    // All five writes are one SSO config — a partial apply would leave the
+    // instance with an issuer but no client id (or vice versa).
+    this.db.transaction(() => {
+      set('oidc_issuer', data.issuer ?? '');
+      set('oidc_client_id', data.client_id ?? '');
+      if (data.client_secret !== undefined) set('oidc_client_secret', maybe_encrypt_api_key(data.client_secret) ?? '');
+      set('oidc_display_name', data.display_name ?? '');
+      set('oidc_discovery_url', data.discovery_url ?? '');
+    });
+    return { success: true };
   }
 }

--- a/server/src/nest/packing/admin-packing-templates.controller.ts
+++ b/server/src/nest/packing/admin-packing-templates.controller.ts
@@ -1,0 +1,116 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpException, Param, Post, Put, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import { PackingService } from './packing.service';
+import { AdminTemplateNameDto } from '../admin/admin.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { getClientIp } from '../audit/client-ip';
+import { AuditService } from '../audit/audit.service';
+import type { User } from '../../types';
+
+/** Throw the legacy {error,status} envelope when a service call reports failure. */
+function ok<T>(result: T): Exclude<T, { error: string }> {
+  if (result && typeof result === 'object' && 'error' in (result as Record<string, unknown>)) {
+    const r = result as unknown as { error: string; status?: number };
+    throw new HttpException({ error: r.error }, r.status ?? 400);
+  }
+  return result as Exclude<T, { error: string }>;
+}
+
+/**
+ * /api/admin/packing-templates — the admin CRUD for packing templates.
+ *
+ * These twelve routes sat on AdminController and reached PackingService through
+ * eleven pass-through methods on AdminService that did nothing but forward and cast.
+ * PackingService already owns all three template tables, so the routes belong here:
+ * the pass-through block is gone, and there is one owner instead of a controller in
+ * one domain calling a service in another through a third.
+ *
+ * The path, the admin gate, the {error,status} envelope, the create-201-vs-rest-200
+ * split and the audit-log writes are unchanged — this is a move, not a redesign.
+ */
+@Controller('api/admin/packing-templates')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminPackingTemplatesController {
+  constructor(
+    private readonly packing: PackingService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Get()
+  list() {
+    return { templates: this.packing.listPackingTemplates() };
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return ok(this.packing.getPackingTemplate(id));
+  }
+
+  @Post()
+  @HttpCode(201)
+  create(@CurrentUser() user: User, @Body() body: AdminTemplateNameDto, @Req() req: Request) {
+    const result = ok(this.packing.createPackingTemplate(body.name, user.id));
+    this.audit.writeAudit({
+      userId: user.id,
+      action: 'admin.packing_template_create',
+      resource: String((result.template as { id?: number } | undefined)?.id ?? ''),
+      ip: getClientIp(req),
+      details: { name: body.name },
+    });
+    return result;
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() body: AdminTemplateNameDto) {
+    return ok(this.packing.updatePackingTemplate(id, body));
+  }
+
+  @Delete(':id')
+  remove(@CurrentUser() user: User, @Param('id') id: string, @Req() req: Request) {
+    const result = ok(this.packing.deletePackingTemplate(id));
+    this.audit.writeAudit({
+      userId: user.id,
+      action: 'admin.packing_template_delete',
+      resource: String(id),
+      ip: getClientIp(req),
+      details: { name: result.name },
+    });
+    return { success: true };
+  }
+
+  @Post(':id/categories')
+  @HttpCode(201)
+  createCategory(@Param('id') id: string, @Body() body: AdminTemplateNameDto) {
+    return ok(this.packing.createTemplateCategory(id, body.name));
+  }
+
+  @Put(':templateId/categories/:catId')
+  updateCategory(@Param('templateId') templateId: string, @Param('catId') catId: string, @Body() body: AdminTemplateNameDto) {
+    return ok(this.packing.updateTemplateCategory(templateId, catId, body));
+  }
+
+  @Delete(':templateId/categories/:catId')
+  deleteCategory(@Param('templateId') templateId: string, @Param('catId') catId: string) {
+    ok(this.packing.deleteTemplateCategory(templateId, catId));
+    return { success: true };
+  }
+
+  @Post(':templateId/categories/:catId/items')
+  @HttpCode(201)
+  createItem(@Param('templateId') templateId: string, @Param('catId') catId: string, @Body() body: AdminTemplateNameDto) {
+    return ok(this.packing.createTemplateItem(templateId, catId, body.name));
+  }
+
+  @Put(':templateId/items/:itemId')
+  updateItem(@Param('templateId') templateId: string, @Param('itemId') itemId: string, @Body() body: AdminTemplateNameDto) {
+    return ok(this.packing.updateTemplateItem(templateId, itemId, body));
+  }
+
+  @Delete(':templateId/items/:itemId')
+  deleteItem(@Param('templateId') templateId: string, @Param('itemId') itemId: string) {
+    ok(this.packing.deleteTemplateItem(templateId, itemId));
+    return { success: true };
+  }
+}

--- a/server/src/nest/packing/packing.module.ts
+++ b/server/src/nest/packing/packing.module.ts
@@ -1,19 +1,21 @@
 import { Module } from '@nestjs/common';
 import { PackingController } from './packing.controller';
+import { AdminPackingTemplatesController } from './admin-packing-templates.controller';
 import { PackingMcp } from './packing.mcp';
 import { PackingService } from './packing.service';
 import { PackingRpc } from './packing.rpc';
 import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
 import { RealtimeModule } from '../realtime/realtime.module';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { AuditModule } from '../audit/audit.module';
 import { AuthModule } from '../auth/auth.module';
 
 /** Packing domain (S2 — Phase 2 trip sub-domain). Registered in AppModule.
  *  Exports PackingService for in-container consumers (TripsService bundle,
  *  PackingRpc). */
 @Module({
-  imports: [PermissionsModule, AuthModule, RealtimeModule, PluginGuardsModule],
-  controllers: [PackingController],
+  imports: [PermissionsModule, AuthModule, RealtimeModule, PluginGuardsModule, AuditModule],
+  controllers: [PackingController, AdminPackingTemplatesController],
   providers: [PackingService, PackingMcp, PackingRpc],
   exports: [PackingService],
 })

--- a/server/src/nest/settings/settings.controller.ts
+++ b/server/src/nest/settings/settings.controller.ts
@@ -1,9 +1,14 @@
-import { Body, Controller, Get, HttpCode, HttpException, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpException, Post, Put, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
 import { MASKED_SETTING_VALUE } from '@trek/shared';
 import type { User } from '../../types';
 import { SettingsService } from './settings.service';
 import { SettingUpsertDto, SettingsBulkDto } from './settings.dto';
+import { AdminDefaultUserSettingsDto } from '../admin/admin.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { AuditService } from '../audit/audit.service';
+import { getClientIp } from '../audit/client-ip';
 import { CurrentUser } from '../auth/current-user.decorator';
 
 /**
@@ -43,6 +48,45 @@ export class SettingsController {
     } catch (err) {
       console.error('Error saving settings:', err);
       throw new HttpException({ error: 'Error saving settings' }, 500);
+    }
+  }
+}
+
+/**
+ * /api/admin/default-user-settings — the defaults a new account starts with.
+ *
+ * These two routes sat on AdminController and reached SettingsService through a pair
+ * of pass-through methods on AdminService that did nothing but forward. The owner is
+ * here, so the routes are too; the path and both response shapes are unchanged.
+ */
+@Controller('api/admin/default-user-settings')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminDefaultUserSettingsController {
+  constructor(
+    private readonly settings: SettingsService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Get()
+  get() {
+    return this.settings.getAdminUserDefaults();
+  }
+
+  @Put()
+  update(@CurrentUser() user: User, @Body() body: AdminDefaultUserSettingsDto, @Req() req: Request) {
+    try {
+      this.settings.setAdminUserDefaults(body as unknown as Record<string, unknown>);
+      this.audit.writeAudit({
+        userId: user.id,
+        action: 'admin.default_user_settings_update',
+        ip: getClientIp(req),
+        details: body as Record<string, unknown>,
+      });
+      // Answer with the stored defaults, not the request body: the service normalises
+      // and drops unknown keys, and the admin panel renders straight from this.
+      return this.settings.getAdminUserDefaults();
+    } catch (err) {
+      throw new HttpException({ error: err instanceof Error ? err.message : String(err) }, 400);
     }
   }
 }

--- a/server/src/nest/settings/settings.module.ts
+++ b/server/src/nest/settings/settings.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
-import { SettingsController } from './settings.controller';
+import { AdminDefaultUserSettingsController, SettingsController } from './settings.controller';
+import { AuthModule } from '../auth/auth.module';
+import { AuditModule } from '../audit/audit.module';
 import { SettingsService } from './settings.service';
 
 /** Exports SettingsService for in-container consumers (admin, share, llm-parse). */
 @Module({
-  controllers: [SettingsController],
+  // AuthModule for the admin gate on the defaults routes.
+  imports: [AuthModule, AuditModule],
+  controllers: [SettingsController, AdminDefaultUserSettingsController],
   providers: [SettingsService],
   exports: [SettingsService],
 })

--- a/server/tests/e2e/admin.e2e.test.ts
+++ b/server/tests/e2e/admin.e2e.test.ts
@@ -85,6 +85,12 @@ vi.mock('../../src/nest/notifications/notification-preferences.service', async (
 vi.mock('../../src/nest/notifications/notifications.bridge', () => ({ send: vi.fn().mockResolvedValue(undefined) }));
 
 import { AdminModule } from '../../src/nest/admin/admin.module';
+// The admin surface is no longer one module: oidc, the account defaults and the admin
+// preference matrix moved to the domains that own them, so the app has to assemble
+// them too or those routes 404 here while working in production.
+import { OidcModule } from '../../src/nest/oidc/oidc.module';
+import { SettingsModule } from '../../src/nest/settings/settings.module';
+import { NotificationsModule } from '../../src/nest/notifications/notifications.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
 import { ZodValidationPipe } from '../../src/nest/common/zod-validation.pipe';
 
@@ -93,7 +99,7 @@ describe('Admin e2e (real auth + admin guard + temp SQLite)', () => {
   let app: Awaited<ReturnType<typeof build>>;
 
   async function build() {
-    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, RealtimeModule, AdminModule] }).compile();
+    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, RealtimeModule, AdminModule, OidcModule, SettingsModule, NotificationsModule] }).compile();
     const nest = moduleRef.createNestApplication();
     nest.use(cookieParser());
     // Mirror the production APP_PIPE (app.module.ts): DTO-typed bodies validate

--- a/server/tests/helpers/module-providers.ts
+++ b/server/tests/helpers/module-providers.ts
@@ -19,3 +19,10 @@ export function expectRegisteredProvider(moduleClass: object, provider: object):
   expect(Array.isArray(providers)).toBe(true);
   expect(providers).toEqual(expect.arrayContaining([provider]));
 }
+
+/** The same check for a module's `controllers: []`, with the same soundness caveat. */
+export function expectRegisteredController(moduleClass: object, controller: object): void {
+  const controllers = Reflect.getMetadata('controllers', moduleClass) as unknown[] | undefined;
+  expect(Array.isArray(controllers)).toBe(true);
+  expect(controllers).toEqual(expect.arrayContaining([controller]));
+}

--- a/server/tests/unit/nest/addons.service.test.ts
+++ b/server/tests/unit/nest/addons.service.test.ts
@@ -296,3 +296,50 @@ describe('AddonsService addon/feature flags', () => {
     expect(dbMock._stmt.run).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The three places flags moved here from AdminService, where they were raw
+ * app_settings SQL sitting next to flags that already delegated to this service.
+ * They are fail-CLOSED (`=== 'true'`), matching getBagTracking: unset used to read as
+ * ON (`!== 'false'`), and a migration backfills 'true' for existing installs so
+ * nobody loses a feature on upgrade.
+ */
+describe('AddonsService places flags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const cases = [
+    ['getPlacesPhotos', 'updatePlacesPhotos', 'places_photos_enabled'],
+    ['getPlacesAutocomplete', 'updatePlacesAutocomplete', 'places_autocomplete_enabled'],
+    ['getPlacesDetails', 'updatePlacesDetails', 'places_details_enabled'],
+  ] as const;
+
+  it('ADDONS-SVC-080 an unset flag reads as OFF, and anything but the literal true does too', () => {
+    for (const [getter, , key] of cases) {
+      dbMock._stmt.get.mockReturnValueOnce(undefined);
+      expect(svc()[getter]()).toEqual({ enabled: false });
+      expect(dbMock.prepare).toHaveBeenLastCalledWith('SELECT value FROM app_settings WHERE key = ?');
+      expect(dbMock._stmt.get).toHaveBeenLastCalledWith(key);
+
+      dbMock._stmt.get.mockReturnValueOnce({ value: 'garbage' });
+      expect(svc()[getter]()).toEqual({ enabled: false });
+    }
+  });
+
+  it('ADDONS-SVC-081 a stored "true" reads as ON', () => {
+    for (const [getter] of cases) {
+      dbMock._stmt.get.mockReturnValueOnce({ value: 'true' });
+      expect(svc()[getter]()).toEqual({ enabled: true });
+    }
+  });
+
+  it('ADDONS-SVC-082 the setters persist the literal string and echo the boolean back', () => {
+    for (const [, setter, key] of cases) {
+      expect(svc()[setter](true)).toEqual({ enabled: true });
+      expect(dbMock._stmt.run).toHaveBeenLastCalledWith(key, 'true');
+      expect(svc()[setter](false)).toEqual({ enabled: false });
+      expect(dbMock._stmt.run).toHaveBeenLastCalledWith(key, 'false');
+    }
+  });
+});

--- a/server/tests/unit/nest/admin-default-user-settings.controller.test.ts
+++ b/server/tests/unit/nest/admin-default-user-settings.controller.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The account defaults, after the two routes moved off AdminController next to
+ * SettingsService, which owns them. Same path, same audit action, same 400 envelope on
+ * a rejected write — these cases came over with the routes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpException } from '@nestjs/common';
+import { AdminDefaultUserSettingsController } from '../../../src/nest/settings/settings.controller';
+import { SettingsModule } from '../../../src/nest/settings/settings.module';
+import type { SettingsService } from '../../../src/nest/settings/settings.service';
+import type { AuditService } from '../../../src/nest/audit/audit.service';
+import type { User } from '../../../src/types';
+import { expectRegisteredController } from '../../helpers/module-providers';
+
+const user = { id: 1, role: 'admin' } as User;
+const req = { headers: {}, socket: {} } as never;
+const writeAudit = vi.fn();
+
+function controller(over: Partial<SettingsService> = {}) {
+  const settings = {
+    getAdminUserDefaults: vi.fn(() => ({ theme: 'dark' })),
+    setAdminUserDefaults: vi.fn(),
+    ...over,
+  } as unknown as SettingsService;
+  return { c: new AdminDefaultUserSettingsController(settings, { writeAudit } as unknown as AuditService), settings };
+}
+
+const thrown = (run: () => unknown) => {
+  try {
+    run();
+    return null;
+  } catch (e) {
+    return e instanceof HttpException ? { status: e.getStatus(), body: e.getResponse() } : e;
+  }
+};
+
+describe('AdminDefaultUserSettingsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('DEFAULTS-001 GET returns the stored defaults verbatim', () => {
+    expect(controller().c.get()).toEqual({ theme: 'dark' });
+  });
+
+  it('DEFAULTS-002 PUT writes, audits, and answers with the STORED defaults', () => {
+    const { c, settings } = controller();
+    // Not the request body: the service normalises and drops unknown keys, and the
+    // admin panel renders straight from this response.
+    expect(c.update(user, { theme: 'light' } as never, req)).toEqual({ theme: 'dark' });
+    expect(settings.setAdminUserDefaults).toHaveBeenCalledWith({ theme: 'light' });
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 1, action: 'admin.default_user_settings_update', details: { theme: 'light' } }),
+    );
+  });
+
+  it('DEFAULTS-003 a rejected write is a 400 carrying the message, and is not audited', () => {
+    const { c } = controller({
+      setAdminUserDefaults: vi.fn(() => {
+        throw new Error('unknown setting: nope');
+      }),
+    } as Partial<SettingsService>);
+    expect(thrown(() => c.update(user, { nope: 1 } as never, req))).toEqual({
+      status: 400,
+      body: { error: 'unknown setting: nope' },
+    });
+    expect(writeAudit).not.toHaveBeenCalled();
+  });
+
+  it('DEFAULTS-004 a non-Error throw is stringified rather than swallowed', () => {
+    const { c } = controller({
+      setAdminUserDefaults: vi.fn(() => {
+        throw 'plain string';
+      }),
+    } as Partial<SettingsService>);
+    expect(thrown(() => c.update(user, {} as never, req))).toEqual({ status: 400, body: { error: 'plain string' } });
+  });
+
+  it('DEFAULTS-005 the class is listed in its module controllers', () => {
+    expectRegisteredController(SettingsModule, AdminDefaultUserSettingsController);
+  });
+});

--- a/server/tests/unit/nest/admin-notification-preferences.controller.test.ts
+++ b/server/tests/unit/nest/admin-notification-preferences.controller.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The admin-scope preference matrix, after the two routes moved off AdminController
+ * next to NotificationPreferencesService, which owns it. The 'admin' scope argument
+ * they always passed is now written once, at the only place that uses it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AdminNotificationPreferencesController } from '../../../src/nest/notifications/notifications.controller';
+import { NotificationsModule } from '../../../src/nest/notifications/notifications.module';
+import type { NotificationPreferencesService } from '../../../src/nest/notifications/notification-preferences.service';
+import type { User } from '../../../src/types';
+import { expectRegisteredController } from '../../helpers/module-providers';
+
+const admin = { id: 1, role: 'admin' } as User;
+
+function controller() {
+  const prefs = {
+    getPreferencesMatrix: vi.fn(() => ({ rows: [{ event: 'trip_reminder' }] })),
+    setAdminPreferences: vi.fn(),
+  } as unknown as NotificationPreferencesService;
+  return { c: new AdminNotificationPreferencesController(prefs), prefs };
+}
+
+describe('AdminNotificationPreferencesController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ADMINPREF-001 GET asks for the admin scope, not the user one', () => {
+    const { c, prefs } = controller();
+    expect(c.get(admin)).toEqual({ rows: [{ event: 'trip_reminder' }] });
+    expect(prefs.getPreferencesMatrix).toHaveBeenCalledWith(1, 'admin', 'admin');
+  });
+
+  it('ADMINPREF-002 PUT persists, then answers with the REFRESHED matrix', () => {
+    const { c, prefs } = controller();
+    // The admin panel renders straight from this response, so returning the write
+    // result instead of a fresh read would leave it showing stale rows.
+    expect(c.set(admin, { trip_reminder: { email: true } } as never)).toEqual({ rows: [{ event: 'trip_reminder' }] });
+    expect(prefs.setAdminPreferences).toHaveBeenCalledWith(1, { trip_reminder: { email: true } });
+    expect(prefs.getPreferencesMatrix).toHaveBeenCalledWith(1, 'admin', 'admin');
+  });
+
+  it('ADMINPREF-003 the acting user drives the lookup, never a body field', () => {
+    const { c, prefs } = controller();
+    c.get({ id: 7, role: 'admin' } as User);
+    expect(prefs.getPreferencesMatrix).toHaveBeenCalledWith(7, 'admin', 'admin');
+  });
+
+  it('ADMINPREF-004 the class is listed in its module controllers', () => {
+    expectRegisteredController(NotificationsModule, AdminNotificationPreferencesController);
+  });
+});

--- a/server/tests/unit/nest/admin-packing-templates.controller.test.ts
+++ b/server/tests/unit/nest/admin-packing-templates.controller.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The admin packing-template CRUD, after it moved off AdminController into the packing
+ * domain that owns the three template tables. Same paths, same {error,status}
+ * envelope, same create-201 split, same audit actions — these cases came over from
+ * admin.controller.test.ts with the routes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpException } from '@nestjs/common';
+import { AdminPackingTemplatesController } from '../../../src/nest/packing/admin-packing-templates.controller';
+import { PackingModule } from '../../../src/nest/packing/packing.module';
+import type { PackingService } from '../../../src/nest/packing/packing.service';
+import type { AuditService } from '../../../src/nest/audit/audit.service';
+import type { User } from '../../../src/types';
+import { expectRegisteredController } from '../../helpers/module-providers';
+
+const user = { id: 1, role: 'admin' } as User;
+const req = { headers: {}, socket: {} } as never;
+const writeAudit = vi.fn();
+
+function controller(over: Partial<PackingService> = {}) {
+  const packing = {
+    listPackingTemplates: vi.fn(() => [{ id: 1 }]),
+    getPackingTemplate: vi.fn(() => ({ template: { id: 1 } })),
+    createPackingTemplate: vi.fn(() => ({ template: { id: 9 } })),
+    updatePackingTemplate: vi.fn(() => ({ template: { id: 1 } })),
+    deletePackingTemplate: vi.fn(() => ({ name: 'Beach' })),
+    createTemplateCategory: vi.fn(() => ({ category: { id: 2 } })),
+    updateTemplateCategory: vi.fn(() => ({ category: { id: 2 } })),
+    deleteTemplateCategory: vi.fn(() => ({ ok: true })),
+    createTemplateItem: vi.fn(() => ({ item: { id: 3 } })),
+    updateTemplateItem: vi.fn(() => ({ item: { id: 3 } })),
+    deleteTemplateItem: vi.fn(() => ({ ok: true })),
+    ...over,
+  } as unknown as PackingService;
+  return { c: new AdminPackingTemplatesController(packing, { writeAudit } as unknown as AuditService), packing };
+}
+
+const thrown = (run: () => unknown) => {
+  try {
+    run();
+    return null;
+  } catch (e) {
+    return e instanceof HttpException ? { status: e.getStatus(), body: e.getResponse() } : e;
+  }
+};
+
+describe('AdminPackingTemplatesController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('PACKTPL-001 list wraps the service result in the { templates } envelope', () => {
+    expect(controller().c.list()).toEqual({ templates: [{ id: 1 }] });
+  });
+
+  it('PACKTPL-002 a service {error,status} becomes that HTTP status, not a 200 body', () => {
+    const { c } = controller({ getPackingTemplate: vi.fn(() => ({ error: 'not found', status: 404 })) } as Partial<PackingService>);
+    expect(thrown(() => c.get('9'))).toEqual({ status: 404, body: { error: 'not found' } });
+  });
+
+  it('PACKTPL-003 an error without a status defaults to 400', () => {
+    const { c } = controller({ createTemplateCategory: vi.fn(() => ({ error: 'name required' })) } as Partial<PackingService>);
+    expect(thrown(() => c.createCategory('1', { name: '' }))).toEqual({ status: 400, body: { error: 'name required' } });
+  });
+
+  it('PACKTPL-004 create audits with the new template id', () => {
+    const { c, packing } = controller();
+    expect(c.create(user, { name: 'Beach' }, req)).toEqual({ template: { id: 9 } });
+    expect(packing.createPackingTemplate).toHaveBeenCalledWith('Beach', 1);
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'admin.packing_template_create', resource: '9', details: { name: 'Beach' } }),
+    );
+  });
+
+  it('PACKTPL-005 delete audits the removed name and answers { success: true }', () => {
+    const { c } = controller();
+    expect(c.remove(user, '1', req)).toEqual({ success: true });
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'admin.packing_template_delete', resource: '1', details: { name: 'Beach' } }),
+    );
+  });
+
+  it('PACKTPL-006 the nested category and item routes forward their ids in order', () => {
+    const { c, packing } = controller();
+    c.createCategory('1', { name: 'Clothes' });
+    expect(packing.createTemplateCategory).toHaveBeenCalledWith('1', 'Clothes');
+    c.updateCategory('1', '2', { name: 'Warm' });
+    expect(packing.updateTemplateCategory).toHaveBeenCalledWith('1', '2', { name: 'Warm' });
+    expect(c.deleteCategory('1', '2')).toEqual({ success: true });
+    c.createItem('1', '2', { name: 'Socks' });
+    expect(packing.createTemplateItem).toHaveBeenCalledWith('1', '2', 'Socks');
+    c.updateItem('1', '3', { name: 'Wool socks' });
+    expect(packing.updateTemplateItem).toHaveBeenCalledWith('1', '3', { name: 'Wool socks' });
+    expect(c.deleteItem('1', '3')).toEqual({ success: true });
+  });
+
+  it('PACKTPL-007 the delete routes answer { success: true } rather than the service payload', () => {
+    // The client branches on `success`; leaking the raw service result here would be a
+    // silent shape change for every caller.
+    const { c } = controller();
+    expect(c.deleteCategory('1', '2')).toEqual({ success: true });
+    expect(c.deleteItem('1', '3')).toEqual({ success: true });
+  });
+
+  it('PACKTPL-008 the class is listed in its module controllers', () => {
+    expectRegisteredController(PackingModule, AdminPackingTemplatesController);
+  });
+});

--- a/server/tests/unit/nest/admin.controller.test.ts
+++ b/server/tests/unit/nest/admin.controller.test.ts
@@ -84,10 +84,6 @@ describe('AdminController permissions + oidc + misc', () => {
     expect(c.savePermissions(user, { permissions: {} }, req)).toEqual({ success: true, permissions: {}, skipped: ['bad'] });
   });
 
-  it('oidc update maps error, else audits', () => {
-    expect(thrown(() => adminCtl(svc({ updateOidcSettings: vi.fn().mockReturnValue({ error: 'bad issuer', status: 400 }) } as Partial<AdminService>)).updateOidc(user, {}, req))).toEqual({ status: 400, body: { error: 'bad issuer' } });
-    expect(adminCtl(svc({ updateOidcSettings: vi.fn().mockReturnValue({}) } as Partial<AdminService>)).updateOidc(user, { issuer: 'https://idp' }, req)).toEqual({ success: true });
-  });
 
   it('save-demo-baseline maps error, else returns message', () => {
     expect(thrown(() => adminCtl(svc({ saveDemoBaseline: vi.fn().mockReturnValue({ error: 'not demo', status: 400 }) } as Partial<AdminService>)).saveDemoBaseline(user, req))).toEqual({ status: 400, body: { error: 'not demo' } });
@@ -138,12 +134,6 @@ describe('AdminController addons + sessions + jwt + defaults', () => {
     expect(adminCtl(svc({ rotateJwtSecret: vi.fn().mockReturnValue({}) } as Partial<AdminService>)).rotateJwtSecret(user, req)).toEqual({ success: true });
   });
 
-  it('default-user-settings: sets + audits', () => {
-    const setAdminUserDefaults = vi.fn();
-    const c = adminCtl(svc({ setAdminUserDefaults, getAdminUserDefaults: vi.fn().mockReturnValue({ theme: 'dark' }) } as Partial<AdminService>));
-    expect(c.setDefaultUserSettings(user, { theme: 'dark' }, req)).toEqual({ theme: 'dark' });
-    expect(setAdminUserDefaults).toHaveBeenCalled();
-  });
 });
 
 describe('AdminController error envelope fallbacks', () => {
@@ -151,14 +141,7 @@ describe('AdminController error envelope fallbacks', () => {
     expect(thrown(() => adminCtl(svc({ createUser: vi.fn().mockReturnValue({ error: 'boom' }) } as Partial<AdminService>)).createUser(user, {}, req))).toEqual({ status: 400, body: { error: 'boom' } });
   });
 
-  it('updateOidc defaults to 400 when the service error omits a status', () => {
-    expect(thrown(() => adminCtl(svc({ updateOidcSettings: vi.fn().mockReturnValue({ error: 'nope' }) } as Partial<AdminService>)).updateOidc(user, {}, req))).toEqual({ status: 400, body: { error: 'nope' } });
-  });
 
-  it('updateOidc audits issuer_set=false when no issuer is supplied', () => {
-    expect(adminCtl(svc({ updateOidcSettings: vi.fn().mockReturnValue({}) } as Partial<AdminService>)).updateOidc(user, {}, req)).toEqual({ success: true });
-    expect(writeAudit).toHaveBeenCalledWith(expect.objectContaining({ action: 'admin.oidc_update', details: { issuer_set: false } }));
-  });
 });
 
 describe('AdminController read-only getters', () => {
@@ -167,22 +150,13 @@ describe('AdminController read-only getters', () => {
     expect(adminCtl(svc({ getStats: vi.fn().mockReturnValue({ users: 3 }) } as Partial<AdminService>)).stats()).toEqual({ users: 3 });
     expect(adminCtl(svc({ getPermissions: vi.fn().mockReturnValue({ a: 1 }) } as Partial<AdminService>)).permissions()).toEqual({ a: 1 });
     expect(adminCtl(svc({ getAuditLog: vi.fn().mockReturnValue({ entries: [] }) } as Partial<AdminService>)).auditLog({})).toEqual({ entries: [] });
-    expect(adminCtl(svc({ getOidcSettings: vi.fn().mockReturnValue({ issuer: 'x' }) } as Partial<AdminService>)).getOidc()).toEqual({ issuer: 'x' });
     expect(adminCtl(svc({ checkVersion: vi.fn().mockResolvedValue({ current: '1' }) } as Partial<AdminService>)).versionCheck()).resolves.toEqual({ current: '1' });
-    expect(adminCtl(svc({ getPreferencesMatrix: vi.fn().mockReturnValue({ rows: [] }) } as Partial<AdminService>)).getNotificationPrefs(user)).toEqual({ rows: [] });
     expect(adminCtl(svc({ listInvites: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listInvites()).toEqual({ invites: [{ id: 1 }] });
     expect(adminCtl(svc({ listAddons: vi.fn().mockReturnValue([{ id: 'mcp' }]) } as Partial<AdminService>)).listAddons()).toEqual({ addons: [{ id: 'mcp' }] });
     expect(adminCtl(svc({ listMcpTokens: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listMcpTokens()).toEqual({ tokens: [{ id: 1 }] });
     expect(adminCtl(svc({ listOAuthSessions: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listOAuthSessions()).toEqual({ sessions: [{ id: 1 }] });
-    expect(adminCtl(svc({ getAdminUserDefaults: vi.fn().mockReturnValue({ theme: 'dark' }) } as Partial<AdminService>)).getDefaultUserSettings()).toEqual({ theme: 'dark' });
   });
 
-  it('setNotificationPrefs persists then returns the refreshed matrix', () => {
-    const setAdminPreferences = vi.fn();
-    const c = adminCtl(svc({ setAdminPreferences, getPreferencesMatrix: vi.fn().mockReturnValue({ rows: [1] }) } as Partial<AdminService>));
-    expect(c.setNotificationPrefs(user, { x: 1 })).toEqual({ rows: [1] });
-    expect(setAdminPreferences).toHaveBeenCalledWith(user.id, { x: 1 });
-  });
 
   it('githubReleases falls back to default paging when no query is given', async () => {
     const getGithubReleases = vi.fn().mockResolvedValue([{ tag: 'v1' }]);
@@ -204,18 +178,6 @@ describe('AdminController tokens + sessions', () => {
   });
 });
 
-describe('AdminController default-user-settings error path', () => {
-  it('400 with an Error message when setAdminUserDefaults throws an Error', () => {
-    const c = adminCtl(svc({ setAdminUserDefaults: vi.fn(() => { throw new Error('bad default'); }) } as Partial<AdminService>));
-    expect(thrown(() => c.setDefaultUserSettings(user, { theme: 'x' }, req))).toEqual({ status: 400, body: { error: 'bad default' } });
-  });
-
-  it('400 stringifies a non-Error throw', () => {
-    const c = adminCtl(svc({ setAdminUserDefaults: vi.fn(() => { throw 'plain string'; }) } as Partial<AdminService>));
-    expect(thrown(() => c.setDefaultUserSettings(user, { theme: 'x' }, req))).toEqual({ status: 400, body: { error: 'plain string' } });
-  });
-
-});
 
 describe('AdminController dev test-notification', () => {
   it('404 outside development', async () => {

--- a/server/tests/unit/nest/admin.controller.test.ts
+++ b/server/tests/unit/nest/admin.controller.test.ts
@@ -5,6 +5,7 @@ import type { Request } from 'express';
 vi.mock('../../../src/nest/audit/client-ip', () => ({ getClientIp: vi.fn(() => '1.2.3.4') }));
 vi.mock('../../../src/nest/audit/audit-log.logger', () => ({ LOG_LEVEL: 'error', logInfo: vi.fn(), logDebug: vi.fn(), logError: vi.fn(), logWarn: vi.fn() }));
 
+import type { AddonsService } from '../../../src/nest/addons/addons.service';
 import { AdminController } from '../../../src/nest/admin/admin.controller';
 import type { AdminService } from '../../../src/nest/admin/admin.service';
 import type { PluginRuntimeService } from '../../../src/nest/plugins/plugin-runtime.service';
@@ -27,8 +28,22 @@ const audit = { writeAudit } as unknown as AuditService;
 // (same behavior as the old services/notificationService path mock).
 const sendNotification = vi.fn().mockResolvedValue(undefined);
 const notifications = { send: sendNotification } as unknown as NotificationsService;
-const adminCtl = (s: AdminService, rt?: PluginRuntimeService) =>
-  new AdminController(s, rt as unknown as PluginRuntimeService, audit, notifications);
+/** The flags live on AddonsService now; the toggle routes reach it directly. */
+const addonsStub = () => ({
+  getBagTracking: vi.fn(() => ({ enabled: false })),
+  updateBagTracking: vi.fn((enabled: boolean) => ({ enabled })),
+  getPlacesPhotos: vi.fn(() => ({ enabled: false })),
+  updatePlacesPhotos: vi.fn((enabled: boolean) => ({ enabled })),
+  getPlacesAutocomplete: vi.fn(() => ({ enabled: false })),
+  updatePlacesAutocomplete: vi.fn((enabled: boolean) => ({ enabled })),
+  getPlacesDetails: vi.fn(() => ({ enabled: false })),
+  updatePlacesDetails: vi.fn((enabled: boolean) => ({ enabled })),
+  getCollabFeatures: vi.fn(() => ({ chat: false })),
+  updateCollabFeatures: vi.fn(() => ({ features: { chat: true }, changed: true })),
+}) as unknown as AddonsService;
+
+const adminCtl = (s: AdminService, rt?: PluginRuntimeService, addons: AddonsService = addonsStub()) =>
+  new AdminController(s, addons, rt as unknown as PluginRuntimeService, audit, notifications);
 function thrown(fn: () => unknown): { status: number; body: unknown } {
   try { fn(); } catch (err) {
     if (err instanceof NotFoundException) return { status: 404, body: err.getResponse() };
@@ -80,7 +95,10 @@ describe('AdminController permissions + oidc + misc', () => {
   });
 });
 
-describe('AdminController invites + feature toggles', () => {
+// The feature toggles and the packing-template CRUD moved to the addons and packing
+// domains; their cases live in admin-feature-toggles.controller.test.ts and
+// admin-packing-templates.controller.test.ts.
+describe('AdminController invites', () => {
   it('invites: create 201 + audit, delete maps error', () => {
     const c = adminCtl(svc({ createInvite: vi.fn().mockReturnValue({ invite: { id: 5 }, inviteId: 5, uses: 1, expiresInDays: 7 }) } as Partial<AdminService>));
     expect(c.createInvite(user, {}, req)).toEqual({ invite: { id: 5 } });
@@ -88,31 +106,9 @@ describe('AdminController invites + feature toggles', () => {
     expect(thrown(() => adminCtl(svc({ deleteInvite: vi.fn().mockReturnValue({ error: 'not found', status: 404 }) } as Partial<AdminService>)).deleteInvite(user, '5', req))).toEqual({ status: 404, body: { error: 'not found' } });
   });
 
-  it('places-photos: updates + audits', () => {
-    expect(adminCtl(svc({ updatePlacesPhotos: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>)).updatePlacesPhotos(user, { enabled: true }, req)).toEqual({ enabled: true });
-  });
 
-  it('collab-features update invalidates MCP sessions only when a flag actually flipped (#1414)', () => {
-    const invalidateMcpSessions = vi.fn();
-    const c = adminCtl(svc({ updateCollabFeatures: vi.fn().mockReturnValue({ features: { chat: true }, changed: true }), invalidateMcpSessions } as Partial<AdminService>));
-    expect(c.updateCollabFeatures(user, { chat: true }, req)).toEqual({ chat: true });
-    expect(invalidateMcpSessions).toHaveBeenCalled();
-
-    const noopInvalidate = vi.fn();
-    const noop = adminCtl(svc({ updateCollabFeatures: vi.fn().mockReturnValue({ features: { chat: true }, changed: false }), invalidateMcpSessions: noopInvalidate } as Partial<AdminService>));
-    expect(noop.updateCollabFeatures(user, { chat: true }, req)).toEqual({ chat: true });
-    expect(noopInvalidate).not.toHaveBeenCalled();
-  });
 });
 
-describe('AdminController packing templates', () => {
-  it('get 404, create 201, delete audits', () => {
-    expect(thrown(() => adminCtl(svc({ getPackingTemplate: vi.fn().mockReturnValue({ error: 'not found', status: 404 }) } as Partial<AdminService>)).getPackingTemplate('9'))).toEqual({ status: 404, body: { error: 'not found' } });
-    expect(adminCtl(svc({ createPackingTemplate: vi.fn().mockReturnValue({ id: 3, name: 'Beach' }) } as Partial<AdminService>)).createPackingTemplate(user, { name: 'Beach' })).toEqual({ id: 3, name: 'Beach' });
-    expect(adminCtl(svc({ deletePackingTemplate: vi.fn().mockReturnValue({ name: 'Beach' }) } as Partial<AdminService>)).deletePackingTemplate(user, '3', req)).toEqual({ success: true });
-    expect(adminCtl(svc({ createTemplateItem: vi.fn().mockReturnValue({ id: 7 }) } as Partial<AdminService>)).createTemplateItem('3', '4', { name: 'Towel' })).toEqual({ id: 7 });
-  });
-});
 
 describe('AdminController addons + sessions + jwt + defaults', () => {
   it('addon update audits + invalidates MCP sessions only when the MCP surface changed (#1414)', async () => {
@@ -175,12 +171,6 @@ describe('AdminController read-only getters', () => {
     expect(adminCtl(svc({ checkVersion: vi.fn().mockResolvedValue({ current: '1' }) } as Partial<AdminService>)).versionCheck()).resolves.toEqual({ current: '1' });
     expect(adminCtl(svc({ getPreferencesMatrix: vi.fn().mockReturnValue({ rows: [] }) } as Partial<AdminService>)).getNotificationPrefs(user)).toEqual({ rows: [] });
     expect(adminCtl(svc({ listInvites: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listInvites()).toEqual({ invites: [{ id: 1 }] });
-    expect(adminCtl(svc({ getBagTracking: vi.fn().mockReturnValue({ enabled: false }) } as Partial<AdminService>)).getBagTracking()).toEqual({ enabled: false });
-    expect(adminCtl(svc({ getPlacesPhotos: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>)).getPlacesPhotos()).toEqual({ enabled: true });
-    expect(adminCtl(svc({ getPlacesAutocomplete: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>)).getPlacesAutocomplete()).toEqual({ enabled: true });
-    expect(adminCtl(svc({ getPlacesDetails: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>)).getPlacesDetails()).toEqual({ enabled: true });
-    expect(adminCtl(svc({ getCollabFeatures: vi.fn().mockReturnValue({ chat: false }) } as Partial<AdminService>)).getCollabFeatures()).toEqual({ chat: false });
-    expect(adminCtl(svc({ listPackingTemplates: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listPackingTemplates()).toEqual({ templates: [{ id: 1 }] });
     expect(adminCtl(svc({ listAddons: vi.fn().mockReturnValue([{ id: 'mcp' }]) } as Partial<AdminService>)).listAddons()).toEqual({ addons: [{ id: 'mcp' }] });
     expect(adminCtl(svc({ listMcpTokens: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listMcpTokens()).toEqual({ tokens: [{ id: 1 }] });
     expect(adminCtl(svc({ listOAuthSessions: vi.fn().mockReturnValue([{ id: 1 }]) } as Partial<AdminService>)).listOAuthSessions()).toEqual({ sessions: [{ id: 1 }] });
@@ -204,33 +194,7 @@ describe('AdminController read-only getters', () => {
   });
 });
 
-describe('AdminController feature toggles + audit', () => {
-  it('bag-tracking updates and audits', () => {
-    const c = adminCtl(svc({ updateBagTracking: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>));
-    expect(c.updateBagTracking(user, { enabled: true }, req)).toEqual({ enabled: true });
-    expect(writeAudit).toHaveBeenCalledWith(expect.objectContaining({ action: 'admin.bag_tracking' }));
-  });
 
-  it('places-autocomplete: updates + audits', () => {
-    expect(adminCtl(svc({ updatePlacesAutocomplete: vi.fn().mockReturnValue({ enabled: false }) } as Partial<AdminService>)).updatePlacesAutocomplete(user, { enabled: false }, req)).toEqual({ enabled: false });
-  });
-
-  it('places-details: updates + audits', () => {
-    expect(adminCtl(svc({ updatePlacesDetails: vi.fn().mockReturnValue({ enabled: true }) } as Partial<AdminService>)).updatePlacesDetails(user, { enabled: true }, req)).toEqual({ enabled: true });
-  });
-});
-
-describe('AdminController packing template sub-routes', () => {
-  it('update/delete templates, categories and items map errors + return success', () => {
-    expect(adminCtl(svc({ updatePackingTemplate: vi.fn().mockReturnValue({ id: 3 }) } as Partial<AdminService>)).updatePackingTemplate('3', {})).toEqual({ id: 3 });
-    expect(adminCtl(svc({ createTemplateCategory: vi.fn().mockReturnValue({ id: 4 }) } as Partial<AdminService>)).createTemplateCategory('3', { name: 'Tops' })).toEqual({ id: 4 });
-    expect(adminCtl(svc({ updateTemplateCategory: vi.fn().mockReturnValue({ id: 4 }) } as Partial<AdminService>)).updateTemplateCategory('3', '4', {})).toEqual({ id: 4 });
-    expect(adminCtl(svc({ deleteTemplateCategory: vi.fn().mockReturnValue({}) } as Partial<AdminService>)).deleteTemplateCategory('3', '4')).toEqual({ success: true });
-    expect(adminCtl(svc({ updateTemplateItem: vi.fn().mockReturnValue({ id: 7 }) } as Partial<AdminService>)).updateTemplateItem('7', {})).toEqual({ id: 7 });
-    expect(adminCtl(svc({ deleteTemplateItem: vi.fn().mockReturnValue({}) } as Partial<AdminService>)).deleteTemplateItem('7')).toEqual({ success: true });
-    expect(thrown(() => adminCtl(svc({ deleteTemplateItem: vi.fn().mockReturnValue({ error: 'gone', status: 404 }) } as Partial<AdminService>)).deleteTemplateItem('9'))).toEqual({ status: 404, body: { error: 'gone' } });
-  });
-});
 
 describe('AdminController tokens + sessions', () => {
   it('mcp token + oauth session deletes return success and map errors', () => {
@@ -282,5 +246,51 @@ describe('AdminController dev test-notification', () => {
     process.env.NODE_ENV = 'development';
     (sendNotification as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce('weird');
     await expect(adminCtl(svc()).devTestNotification(user, { event: 'trip_reminder' })).rejects.toMatchObject({ response: { error: 'weird' } });
+  });
+});
+
+// The feature toggles now go straight to AddonsService — these cases used to assert
+// the same thing through AdminService pass-throughs that no longer exist.
+describe('AdminController feature toggles', () => {
+  it('ADMIN-TOGGLE-001 each toggle forwards to AddonsService and writes its own audit action', () => {
+    const addons = addonsStub();
+    const c = adminCtl(svc(), undefined, addons);
+    const cases: Array<[() => unknown, string, keyof AddonsService]> = [
+      [() => c.updateBagTracking(user, { enabled: true }, req), 'admin.bag_tracking', 'updateBagTracking'],
+      [() => c.updatePlacesPhotos(user, { enabled: true }, req), 'admin.places_photos', 'updatePlacesPhotos'],
+      [() => c.updatePlacesAutocomplete(user, { enabled: true }, req), 'admin.places_autocomplete', 'updatePlacesAutocomplete'],
+      [() => c.updatePlacesDetails(user, { enabled: true }, req), 'admin.places_details', 'updatePlacesDetails'],
+    ];
+    for (const [run, action, method] of cases) {
+      writeAudit.mockClear();
+      expect(run()).toEqual({ enabled: true });
+      expect(addons[method]).toHaveBeenCalledWith(true);
+      expect(writeAudit).toHaveBeenCalledWith(expect.objectContaining({ action, details: { enabled: true } }));
+    }
+  });
+
+  it('ADMIN-TOGGLE-002 the getters return the AddonsService value verbatim', () => {
+    const c = adminCtl(svc());
+    expect(c.getBagTracking()).toEqual({ enabled: false });
+    expect(c.getPlacesPhotos()).toEqual({ enabled: false });
+    expect(c.getPlacesAutocomplete()).toEqual({ enabled: false });
+    expect(c.getPlacesDetails()).toEqual({ enabled: false });
+    expect(c.getCollabFeatures()).toEqual({ chat: false });
+  });
+
+  it('ADMIN-TOGGLE-003 collab-features invalidates MCP sessions only when a flag flipped (#1414)', () => {
+    const invalidateMcpSessions = vi.fn();
+    const c = adminCtl(svc({ invalidateMcpSessions } as Partial<AdminService>));
+    expect(c.updateCollabFeatures(user, { chat: true }, req)).toEqual({ chat: true });
+    expect(invalidateMcpSessions).toHaveBeenCalled();
+
+    const noopInvalidate = vi.fn();
+    const noop = adminCtl(
+      svc({ invalidateMcpSessions: noopInvalidate } as Partial<AdminService>),
+      undefined,
+      { ...addonsStub(), updateCollabFeatures: vi.fn(() => ({ features: { chat: true }, changed: false })) } as unknown as AddonsService,
+    );
+    expect(noop.updateCollabFeatures(user, { chat: true }, req)).toEqual({ chat: true });
+    expect(noopInvalidate).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/nest/admin.service.test.ts
+++ b/server/tests/unit/nest/admin.service.test.ts
@@ -82,14 +82,12 @@ const userCleanup = new UserCleanupService(dbs);
 const auth = new AuthService(dbs, permissions, new AtlasService(dbs), new TripMembershipService(dbs), webauthn, userCleanup);
 const svc = new AdminService(
   dbs,
-  new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
   auth,
   permissions,
   makeNotificationsService(dbs, realtime),
   userCleanup,
-  makeNotificationPreferencesService(dbs),
 );
 
 // Legacy free-function names bound to the service, so the moved cases below read
@@ -372,32 +370,6 @@ describe('getAuditLog — JSON details', () => {
 
 // ── OIDC Settings ─────────────────────────────────────────────────────────────
 
-describe('OIDC Settings', () => {
-  it('ADMIN-SVC-047 — getOidcSettings returns default empty values when no OIDC configured', () => {
-    const result = getOidcSettings() as any;
-    expect(result.issuer).toBe('');
-    expect(result.client_id).toBe('');
-    expect(result.oidc_only).toBe(false);
-    expect(result.client_secret_set).toBe(false);
-    expect(result.display_name).toBe('');
-    expect(result.discovery_url).toBe('');
-  });
-
-  it('ADMIN-SVC-048 — updateOidcSettings persists issuer and client_id, then getOidcSettings returns them', () => {
-    updateOidcSettings({ issuer: 'https://auth.example.com', client_id: 'my-client' });
-    const result = getOidcSettings() as any;
-    expect(result.issuer).toBe('https://auth.example.com');
-    expect(result.client_id).toBe('my-client');
-  });
-
-  it('ADMIN-SVC-049 — updateOidcSettings does not write oidc_only (replaced by granular toggles)', () => {
-    updateOidcSettings({ issuer: 'https://auth.example.com', client_id: 'my-client' });
-    const result = getOidcSettings() as any;
-    // oidc_only is no longer managed by updateOidcSettings; use password_login/oidc_login toggles
-    expect(result.oidc_only).toBe(false);
-  });
-});
-
 // ── saveDemoBaseline ──────────────────────────────────────────────────────────
 
 describe('saveDemoBaseline', () => {
@@ -622,12 +594,5 @@ describe('admin quirk fixes (post-fold)', () => {
     const sessions = svc.listOAuthSessions() as any[];
     expect(sessions).toHaveLength(1);
     expect(sessions[0].scopes).toBeNull();
-  });
-
-  it('ADMIN-SVC-075 — updateOidcSettings applies all five writes atomically', () => {
-    const result = svc.updateOidcSettings({ issuer: 'https://idp', client_id: 'cid', display_name: 'IdP' }) as any;
-    expect(result.success).toBe(true);
-    const settings = svc.getOidcSettings();
-    expect(settings).toMatchObject({ issuer: 'https://idp', client_id: 'cid', display_name: 'IdP' });
   });
 });

--- a/server/tests/unit/nest/admin.service.test.ts
+++ b/server/tests/unit/nest/admin.service.test.ts
@@ -85,7 +85,6 @@ const svc = new AdminService(
   new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
-  new PackingService(dbs, permissions, realtime),
   auth,
   permissions,
   makeNotificationsService(dbs, realtime),
@@ -592,19 +591,6 @@ describe('admin.bridge', () => {
 // ── Quirk fixes landed after the 2026-08 fold ─────────────────────────────────
 
 describe('admin quirk fixes (post-fold)', () => {
-  it('ADMIN-SVC-071 — the three places toggles are fail-closed (=== true), matching bag-tracking', () => {
-    // Unset used to read as ON (`!== 'false'`); a migration backfills 'true' for
-    // existing installs so nobody loses a feature on upgrade.
-    expect(svc.getPlacesPhotos()).toEqual({ enabled: false });
-    expect(svc.getPlacesAutocomplete()).toEqual({ enabled: false });
-    expect(svc.getPlacesDetails()).toEqual({ enabled: false });
-
-    svc.updatePlacesPhotos(true);
-    expect(svc.getPlacesPhotos()).toEqual({ enabled: true });
-
-    testDb.prepare("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('places_details_enabled', 'garbage')").run();
-    expect(svc.getPlacesDetails()).toEqual({ enabled: false });
-  });
 
   it('ADMIN-SVC-072 — updateUser rejects an empty username/email instead of silently no-opping', () => {
     const { user } = createUser(testDb);

--- a/server/tests/unit/nest/admin.version-notification.test.ts
+++ b/server/tests/unit/nest/admin.version-notification.test.ts
@@ -65,14 +65,12 @@ const userCleanup = new UserCleanupService(dbs);
 const auth = new AuthService(dbs, permissions, new AtlasService(dbs), new TripMembershipService(dbs), webauthn, userCleanup);
 const svc = new AdminService(
   dbs,
-  new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
   auth,
   permissions,
   makeNotificationsService(dbs, realtime),
   userCleanup,
-  makeNotificationPreferencesService(dbs),
 );
 const checkAndNotifyVersion = () => svc.checkAndNotifyVersion();
 

--- a/server/tests/unit/nest/admin.version-notification.test.ts
+++ b/server/tests/unit/nest/admin.version-notification.test.ts
@@ -68,7 +68,6 @@ const svc = new AdminService(
   new SettingsService(dbs),
   new AddonsService(dbs),
   new PasskeyService(dbs, auth, webauthn),
-  new PackingService(dbs, permissions, realtime),
   auth,
   permissions,
   makeNotificationsService(dbs, realtime),

--- a/server/tests/unit/nest/oidc.service.test.ts
+++ b/server/tests/unit/nest/oidc.service.test.ts
@@ -827,3 +827,69 @@ describe('wrapper methods', () => {
     expect(setAuthCookieMock).toHaveBeenCalledWith(res, 'jwt', req);
   });
 });
+
+// The SSO configuration read/write moved here from AdminService, which held the SQL
+// for a domain that already had a module. Same cases, same service, new owner.
+describe('OIDC settings', () => {
+  it('ADMIN-SVC-047 — getOidcSettings returns default empty values when no OIDC configured', () => {
+    const result = svc.getOidcSettings() as any;
+    expect(result.issuer).toBe('');
+    expect(result.client_id).toBe('');
+    expect(result.oidc_only).toBe(false);
+    expect(result.client_secret_set).toBe(false);
+    expect(result.display_name).toBe('');
+    expect(result.discovery_url).toBe('');
+  });
+
+  it('ADMIN-SVC-048 — updateOidcSettings persists issuer and client_id, then getOidcSettings returns them', () => {
+    svc.updateOidcSettings({ issuer: 'https://auth.example.com', client_id: 'my-client' });
+    const result = svc.getOidcSettings() as any;
+    expect(result.issuer).toBe('https://auth.example.com');
+    expect(result.client_id).toBe('my-client');
+  });
+
+  it('ADMIN-SVC-049 — updateOidcSettings does not write oidc_only (replaced by granular toggles)', () => {
+    svc.updateOidcSettings({ issuer: 'https://auth.example.com', client_id: 'my-client' });
+    const result = svc.getOidcSettings() as any;
+    // oidc_only is no longer managed by updateOidcSettings; use password_login/oidc_login toggles
+    expect(result.oidc_only).toBe(false);
+  });
+
+  it('ADMIN-SVC-075 — updateOidcSettings applies all five writes atomically', () => {
+    const result = svc.updateOidcSettings({ issuer: 'https://idp', client_id: 'cid', display_name: 'IdP' }) as any;
+    expect(result.success).toBe(true);
+    const settings = svc.getOidcSettings();
+    expect(settings).toMatchObject({ issuer: 'https://idp', client_id: 'cid', display_name: 'IdP' });
+  });
+});
+
+describe('OIDC settings — the lockout guard', () => {
+  it('OIDC-SETTINGS-050 refuses to clear the config while password login is off', () => {
+    // Clearing the issuer with password login disabled locks every user out of the
+    // instance: no SSO to log in through, and no password form either.
+    const toggles = vi.spyOn(auth, 'resolveAuthToggles').mockReturnValue({ password_login: false } as never);
+    expect(svc.updateOidcSettings({ issuer: '', client_id: 'x' })).toMatchObject({ status: 400 });
+    expect(svc.updateOidcSettings({ issuer: 'x', client_id: '' })).toMatchObject({ status: 400 });
+    expect((svc.updateOidcSettings({ issuer: '', client_id: '' }) as { error?: string }).error).toMatch(/password login/i);
+    toggles.mockRestore();
+  });
+
+  it('OIDC-SETTINGS-051 allows the same clear once password login is back on', () => {
+    const toggles = vi.spyOn(auth, 'resolveAuthToggles').mockReturnValue({ password_login: true } as never);
+    expect(svc.updateOidcSettings({ issuer: '', client_id: '' })).toEqual({ success: true });
+    toggles.mockRestore();
+  });
+
+  it('OIDC-SETTINGS-052 an omitted client_secret keeps the stored one, an empty string clears it', () => {
+    const toggles = vi.spyOn(auth, 'resolveAuthToggles').mockReturnValue({ password_login: true } as never);
+    svc.updateOidcSettings({ issuer: 'https://idp', client_id: 'c', client_secret: 'shh' });
+    expect(svc.getOidcSettings().client_secret_set).toBe(true);
+    // Omitted: the write skips the column entirely rather than blanking it, which is
+    // what lets the admin panel save the form without re-typing the secret.
+    svc.updateOidcSettings({ issuer: 'https://idp', client_id: 'c' });
+    expect(svc.getOidcSettings().client_secret_set).toBe(true);
+    svc.updateOidcSettings({ issuer: 'https://idp', client_id: 'c', client_secret: '' });
+    expect(svc.getOidcSettings().client_secret_set).toBe(false);
+    toggles.mockRestore();
+  });
+});


### PR DESCRIPTION
Five surfaces leave `AdminController`: the twelve packing-template routes (to `packing/`), the three `places` feature flags (raw `app_settings` SQL that belonged in `AddonsService`), the account defaults (to `settings/`), the admin preference matrix (to `notifications/`) and the SSO config (to `oidc/`). Fifteen pass-through methods on `AdminService` are gone with them, along with its `PackingService`, `SettingsService` and `NotificationPreferencesService` dependencies.

Three routes deliberately stay, and the reason is the same each time — a module cycle. `AuthModule` imports `AuditModule`, so an admin-gated controller in `AuditModule` cannot exist (audit-log). `PluginGuardsModule` imports `AddonsModule` precisely because it is a leaf, so the toggles keep their routes on Admin and only their flags moved. The addon CRUD cascades into `PluginRuntimeService`. All three are recorded in the code.

Two findings on the way: the OIDC lockout guard — which refuses to clear the SSO config while password login is off — had no test at all, and the admin e2e app assembles `AdminModule` alone, so the moved routes 404'd there while working in production.