### PR TITLE
Hide permanently closed places from search

### DIFF
--- a/server/src/nest/maps/maps.service.ts
+++ b/server/src/nest/maps/maps.service.ts
@@ -260,6 +260,8 @@ export interface CommonsCandidate {
 interface GooglePlaceResult {
   id: string;
   displayName?: { text: string };
+  /** OPERATIONAL | CLOSED_TEMPORARILY | CLOSED_PERMANENTLY. Absent on non-business results. */
+  businessStatus?: string;
   formattedAddress?: string;
   location?: { latitude: number; longitude: number };
   rating?: number;
@@ -806,6 +808,13 @@ export class MapsService {
       const tags = el.tags || {};
       const name = tags[`name:${osmLang}`] || tags['int_name'] || tags.name || tags.brand || null;
       if (!name) continue; // unnamed POIs aren't useful to add to a plan
+      // A shut-down place is not somewhere to plan a visit (#1341). OSM usually
+      // re-tags one with a `disused:`/`abandoned:` prefix, and those never match
+      // the selectors above — but plenty keep their original tag and gain a marker
+      // instead, and those do come back. `opening_hours=closed`/`off` is the same
+      // statement in the hours field.
+      if (tags.disused === 'yes' || tags.abandoned === 'yes') continue;
+      if (tags.opening_hours === 'closed' || tags.opening_hours === 'off') continue;
       const lat = el.lat ?? el.center?.lat;
       const lng = el.lon ?? el.center?.lon;
       if (lat == null || lng == null) continue;
@@ -1404,7 +1413,7 @@ export class MapsService {
         'Content-Type': 'application/json',
         'X-Goog-Api-Key': apiKey,
         'X-Goog-FieldMask':
-          'places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.websiteUri,places.nationalPhoneNumber,places.types,places.googleMapsUri',
+          'places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.websiteUri,places.nationalPhoneNumber,places.types,places.googleMapsUri,places.businessStatus',
       },
       body: JSON.stringify(searchBody),
     });
@@ -1417,7 +1426,13 @@ export class MapsService {
       throw err;
     }
 
-    const places = (data.places || []).map((p: GooglePlaceResult) => ({
+    // A place that has shut down for good is never the answer to "where should we
+    // go" (#1341). Temporarily closed stays: a restaurant on holiday next month is
+    // still worth planning around. Anything without the field is a non-business
+    // result (a park, a viewpoint) and is kept.
+    const places = (data.places || [])
+      .filter((p: GooglePlaceResult) => p.businessStatus !== 'CLOSED_PERMANENTLY')
+      .map((p: GooglePlaceResult) => ({
       google_place_id: p.id,
       google_ftid: googleFtidFromMapsUrl(p.googleMapsUri),
       name: p.displayName?.text || '',

--- a/server/tests/unit/nest/maps.service.test.ts
+++ b/server/tests/unit/nest/maps.service.test.ts
@@ -804,6 +804,25 @@ describe('searchOverpassPois localized names (#1655)', () => {
     expect(pois[0].name).toBe('Elephant Obelisk');
   });
 
+  it('skips POIs tagged as closed for good (#1341)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          elements: [
+            { type: 'node', id: 1, lat: 41.9, lon: 12.48, tags: { name: 'Gone Forever', tourism: 'attraction', disused: 'yes' } },
+            { type: 'node', id: 2, lat: 41.9, lon: 12.49, tags: { name: 'Ruin', tourism: 'attraction', abandoned: 'yes' } },
+            { type: 'node', id: 3, lat: 41.9, lon: 12.5, tags: { name: 'Shut', tourism: 'attraction', opening_hours: 'closed' } },
+            { type: 'node', id: 4, lat: 41.9, lon: 12.51, tags: { name: 'Open For Business', tourism: 'attraction' } },
+          ],
+        }),
+      }),
+    );
+    const { pois } = await svc.searchOverpassPois('sights', bbox(5), 'en-US');
+    expect(pois.map((p: any) => p.name)).toEqual(['Open For Business']);
+  });
+
   it('falls back to the native name when no localized tag exists', async () => {
     stubOverpass({ name: tags.name, tourism: 'attraction' });
     const { pois } = await svc.searchOverpassPois('sights', bbox(4), 'fr-FR');
@@ -1160,6 +1179,27 @@ describe('searchPlaces (fetch stubbed)', () => {
     expect(place.rating).toBeNull();
     expect(place.website).toBeNull();
     expect(place.phone).toBeNull();
+  });
+
+  it('MAPS-183: drops permanently closed Google results and keeps the rest (#1341)', async () => {
+    mockDbGet.mockReturnValueOnce({ maps_api_key: 'some-key' });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        places: [
+          { id: 'gone', displayName: { text: 'Shuttered Bistro' }, businessStatus: 'CLOSED_PERMANENTLY' },
+          { id: 'holiday', displayName: { text: 'Winter Break Cafe' }, businessStatus: 'CLOSED_TEMPORARILY' },
+          { id: 'open', displayName: { text: 'Still Trading' }, businessStatus: 'OPERATIONAL' },
+          { id: 'park', displayName: { text: 'City Park' } },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await svc.searchPlaces(1, 'bistro');
+    expect(result.places.map((p: any) => p.google_place_id)).toEqual(['holiday', 'open', 'park']);
+    // The field has to be requested or it never arrives to filter on.
+    const mask = (fetchMock.mock.calls[0][1].headers as Record<string, string>)['X-Goog-FieldMask'];
+    expect(mask).toContain('places.businessStatus');
   });
 
   it('MAPS-107: keeps 0 coordinates (equator / prime meridian) instead of nulling them', async () => {


### PR DESCRIPTION
Picks up one of the POI wishes from #1341: closed-down places should not turn up when you search for somewhere to go.

## Google

`businessStatus` was never in the field mask, so the answer was there and we never asked for it. Now requested, and `CLOSED_PERMANENTLY` drops out of the result list.

Two things stay on purpose:

- `CLOSED_TEMPORARILY` — a restaurant shut for a refit or on winter break is still worth putting in a plan for next spring
- results with no `businessStatus` at all — that is a park, a viewpoint, a mountain pass, not a business

## OpenStreetMap

OSM states the same fact in a few different ways. Objects that were re-tagged to `disused:amenity=*` or `abandoned:shop=*` never matched the category selectors to begin with, so those were already invisible. But a lot of mappers keep the original tag and add a marker next to it, and those did come back — `disused=yes`, `abandoned=yes`, and `opening_hours=closed`/`off`, which is the same statement in the hours field.

## The other half of that request

The first item in the same list, place names in the system language, is already implemented — it landed with #1655. `searchOverpassPois` derives the OSM language from the request locale and reads `name:<lang>`, then `int_name`, then the native `name`. The language is part of the cache key, so two users on different locales do not serve each other's names. Nothing to do there.

## Verification

`tsc --noEmit` clean, `eslint` 0 errors (the two warnings in the file predate this), 208 tests green in `maps.service.test.ts`.

New tests: a mixed Google response keeps the temporarily-closed, the operational and the fieldless entry while dropping the permanently closed one, and asserts the field mask actually requests the field — filtering on a field you did not request is a silent no-op. On the OSM side, three differently-tagged closed POIs are dropped and the open one survives.
