### PR TITLE
feat(dayplan): per-segment travel mode for boundary legs (#1281 follow-up)

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -455,7 +455,9 @@ export const assignmentsApi = {
   setParticipants: (tripId: number | string, id: number, userIds: number[]) => apiClient.put(`/trips/${tripId}/assignments/${id}/participants`, { user_ids: userIds } satisfies AssignmentParticipantsRequest).then(r => r.data),
   updateTime: (tripId: number | string, id: number, times: AssignmentTimeRequest) => apiClient.put(`/trips/${tripId}/assignments/${id}/time`, times).then(r => r.data),
   // Per-segment travel mode (#1281): mode of the leg leaving this stop (null = inherit day default).
-  updateTransport: (tripId: number | string, id: number, mode: string | null, direction: 'outgoing' | 'incoming' = 'outgoing') => apiClient.put(`/trips/${tripId}/assignments/${id}/transport`, { transport_mode: mode, direction } satisfies AssignmentTransportRequest).then(r => r.data),
+  // direction defaults to 'outgoing' server-side, so only send it for the incoming (boundary-leg) case
+  // and keep the outgoing payload byte-for-byte identical to the pre-#1281 shape.
+  updateTransport: (tripId: number | string, id: number, mode: string | null, direction: 'outgoing' | 'incoming' = 'outgoing') => apiClient.put(`/trips/${tripId}/assignments/${id}/transport`, (direction === 'incoming' ? { transport_mode: mode, direction } : { transport_mode: mode }) satisfies Partial<AssignmentTransportRequest>).then(r => r.data),
 }
 
 export const packingApi = {

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -455,7 +455,7 @@ export const assignmentsApi = {
   setParticipants: (tripId: number | string, id: number, userIds: number[]) => apiClient.put(`/trips/${tripId}/assignments/${id}/participants`, { user_ids: userIds } satisfies AssignmentParticipantsRequest).then(r => r.data),
   updateTime: (tripId: number | string, id: number, times: AssignmentTimeRequest) => apiClient.put(`/trips/${tripId}/assignments/${id}/time`, times).then(r => r.data),
   // Per-segment travel mode (#1281): mode of the leg leaving this stop (null = inherit day default).
-  updateTransport: (tripId: number | string, id: number, mode: string | null) => apiClient.put(`/trips/${tripId}/assignments/${id}/transport`, { transport_mode: mode } satisfies AssignmentTransportRequest).then(r => r.data),
+  updateTransport: (tripId: number | string, id: number, mode: string | null, direction: 'outgoing' | 'incoming' = 'outgoing') => apiClient.put(`/trips/${tripId}/assignments/${id}/transport`, { transport_mode: mode, direction } satisfies AssignmentTransportRequest).then(r => r.data),
 }
 
 export const packingApi = {

--- a/client/src/components/Map/RouteCalculator.ts
+++ b/client/src/components/Map/RouteCalculator.ts
@@ -92,14 +92,14 @@ export async function calculateRoute(
  * hotel and the first/last located waypoint exist; passing nulls leaves `runs`
  * untouched. The shared first/last waypoint is repeated so the polylines join.
  */
-export function withHotelBookends(
-  runs: Waypoint[][],
-  firstWay: Waypoint | undefined,
-  lastWay: Waypoint | undefined,
-  startHotel: Waypoint | null,
-  endHotel: Waypoint | null,
-): Waypoint[][] {
-  const out: Waypoint[][] = []
+export function withHotelBookends<T extends { lat: number; lng: number }>(
+  runs: T[][],
+  firstWay: T | undefined,
+  lastWay: T | undefined,
+  startHotel: T | null,
+  endHotel: T | null,
+): T[][] {
+  const out: T[][] = []
   if (startHotel && firstWay) out.push([startHotel, firstWay])
   out.push(...runs)
   if (endHotel && lastWay) out.push([lastWay, endHotel])

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -1293,6 +1293,30 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
       { label: t('dayplan.transportMode.useDefault'), icon: RotateCcw, onClick: () => setLegMode(assignmentId, dayId, null) },
     ])
   }
+
+  // Set the mode of the leg ENTERING this stop (a booking arrival or the morning
+  // hotel bookend). Optimistic, then persisted with direction:'incoming'.
+  const setIncomingLegMode = (assignmentId: number, dayId: number, mode: string | null) => {
+    const key = String(dayId)
+    if (assignments[key]) {
+      tripActions.setAssignments({
+        ...assignments,
+        [key]: assignments[key].map(a => (a.id === assignmentId ? { ...a, incoming_leg_transport_mode: mode } : a)),
+      })
+    }
+    assignmentsApi.updateTransport(tripId, assignmentId, mode, 'incoming').catch((err: unknown) => {
+      toast.error(err instanceof Error ? err.message : t('common.unknownError'))
+      tripActions.refreshDays(tripId)
+    })
+  }
+
+  const openIncomingLegModeMenu = (e: React.MouseEvent, assignmentId: number, dayId: number) => {
+    ctxMenu.open(e, [
+      ...routeProfileOptions.map(o => ({ label: o.label, icon: modeIcon(o.key), onClick: () => setIncomingLegMode(assignmentId, dayId, o.key) })),
+      { divider: true },
+      { label: t('dayplan.transportMode.useDefault'), icon: RotateCcw, onClick: () => setIncomingLegMode(assignmentId, dayId, null) },
+    ])
+  }
   return (
     <div data-touch-drag={dragDisabled ? undefined : ''} style={{ display: 'flex', flexDirection: 'column', height: '100%', position: 'relative', fontFamily: "var(--font-system)" }}>
       {/* Toolbar */}
@@ -1614,9 +1638,15 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                       handleMergedDrop(day.id, 'note', Number(noteId), lastItem.type, lastItem.data.id, true)
                   }}
                 >
-                  {hotelLegs[day.id]?.top && (
-                    <HotelRouteConnector seg={hotelLegs[day.id]!.top!.seg} name={hotelLegs[day.id]!.top!.name} profile={routeProfile} placement="top" />
-                  )}
+                  {hotelLegs[day.id]?.top && (() => {
+                    const firstPlaceId = merged.find(i => i.type === 'place')?.data.id
+                    const connector = <HotelRouteConnector seg={hotelLegs[day.id]!.top!.seg} name={hotelLegs[day.id]!.top!.name} profile={routeProfile} placement="top" />
+                    return canEditDays && firstPlaceId != null ? (
+                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openIncomingLegModeMenu(e, Number(firstPlaceId), day.id)} style={{ cursor: 'pointer' }}>
+                        {connector}
+                      </div>
+                    ) : connector
+                  })()}
                   {daySchedule.byPosition[day.id]?.start.map(si => <PluginDayScheduleRow key={`${si.pluginId}:${si.id}`} item={si} />)}
                   {merged.length === 0 && !dayNoteUi ? (
                     <div
@@ -2217,7 +2247,15 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                             </div>
                           )}
                           {daySchedule.byReservation[day.id]?.[res.id]?.map(si => <PluginDayScheduleRow key={`${si.pluginId}:${si.id}`} item={si} />)}
-                          {routeLegs[day.id]?.[res.id] && <RouteConnector seg={routeLegs[day.id]![res.id]} profile={routeProfile} />}
+                          {routeLegs[day.id]?.[res.id] && (() => {
+                            const nextPlaceId = merged.slice(idx + 1).find(i => i.type === 'place')?.data.id
+                            const connector = <RouteConnector seg={routeLegs[day.id]![res.id]} profile={routeProfile} />
+                            return canEditDays && nextPlaceId != null ? (
+                              <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openIncomingLegModeMenu(e, Number(nextPlaceId), day.id)} style={{ cursor: 'pointer' }}>
+                                {connector}
+                              </div>
+                            ) : connector
+                          })()}
                           </React.Fragment>
                         )
                       }
@@ -2343,9 +2381,15 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                     })
                   )}
                   {daySchedule.byPosition[day.id]?.end.map(si => <PluginDayScheduleRow key={`${si.pluginId}:${si.id}`} item={si} />)}
-                  {hotelLegs[day.id]?.bottom && (
-                    <HotelRouteConnector seg={hotelLegs[day.id]!.bottom!.seg} name={hotelLegs[day.id]!.bottom!.name} profile={routeProfile} placement="bottom" />
-                  )}
+                  {hotelLegs[day.id]?.bottom && (() => {
+                    const lastPlaceId = [...merged].reverse().find(i => i.type === 'place')?.data.id
+                    const connector = <HotelRouteConnector seg={hotelLegs[day.id]!.bottom!.seg} name={hotelLegs[day.id]!.bottom!.name} profile={routeProfile} placement="bottom" />
+                    return canEditDays && lastPlaceId != null ? (
+                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openLegModeMenu(e, Number(lastPlaceId), day.id)} style={{ cursor: 'pointer' }}>
+                        {connector}
+                      </div>
+                    ) : connector
+                  })()}
                   {/* Drop-Zone am Listenende — immer vorhanden als Drop-Target */}
                   <div
                     style={{ minHeight: 12, padding: '2px 8px' }}

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -38,6 +38,7 @@ import { noteSurface } from './noteSurface'
 import { findTodayDayId } from './today'
 import { markdownLinkComponents } from '../shared/markdownLink'
 import { RouteConnector, HotelRouteConnector } from './DayPlanSidebarRouteConnector'
+import { resolveLegMode } from './legMode'
 import { usePluginDaySchedule, usePluginDayTints, dayTintBackground, dayTinted, PluginDayScheduleRow, formatScheduleMinutes } from '../Plugins/PluginDaySchedule'
 import { MobileAddPlaceButton } from './DayPlanSidebarMobileAddPlaceButton'
 import { DayPlanSidebarToolbar } from './DayPlanSidebarToolbar'
@@ -482,8 +483,8 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
       // Each run point carries the ORIGIN assignment's per-segment travel mode
       // (#1281): the leg from this point to the next is routed with `mode` (null =
       // inherit the day default). Transport endpoints carry no mode → day default.
-      const runs: { id: number; lat: number; lng: number; mode?: string | null }[][] = []
-      let cur: { id: number; lat: number; lng: number; mode?: string | null }[] = []
+      const runs: { id: number; lat: number; lng: number; isPlace: boolean; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null }[][] = []
+      let cur: { id: number; lat: number; lng: number; isPlace: boolean; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null }[] = []
       // A run is only a real drive when it holds an actual place. Two back-to-back
       // transports (e.g. two flights on one day) would otherwise pair the first's
       // arrival with the second's departure into a phantom airport→airport leg — the
@@ -491,7 +492,7 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
       let curHasPlace = false
       for (const it of merged) {
         if (it.type === 'place' && it.data.place?.lat && it.data.place?.lng) {
-          cur.push({ id: it.data.id, lat: it.data.place.lat, lng: it.data.place.lng, mode: it.data.leg_transport_mode ?? null })
+          cur.push({ id: it.data.id, lat: it.data.place.lat, lng: it.data.place.lng, isPlace: true, leg_transport_mode: it.data.leg_transport_mode ?? null, incoming_leg_transport_mode: it.data.incoming_leg_transport_mode ?? null })
           curHasPlace = true
         } else if (it.type === 'transport') {
           const r = it.data
@@ -499,11 +500,11 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
           if (from || to) {
             // Located transport: route to its departure point, break the run (the
             // flight/train itself isn't driven), and let its arrival start the next.
-            if (from) cur.push({ id: r.id, lat: from.lat, lng: from.lng })
+            if (from) cur.push({ id: r.id, lat: from.lat, lng: from.lng, isPlace: false })
             if (cur.length >= 2 && curHasPlace) runs.push(cur)
             cur = []
             curHasPlace = false
-            if (to) cur.push({ id: r.id, lat: to.lat, lng: to.lng })
+            if (to) cur.push({ id: r.id, lat: to.lat, lng: to.lng, isPlace: false })
           } else if (cur.length > 0 && !(r.type === 'car' && getSpanPhase(r, dayId) === 'middle')) {
             // No location: ignore for routing, but attribute the through-leg to the
             // booking so its distance/duration shows under it (purely cosmetic).
@@ -529,10 +530,10 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
       // whether each is a place and its time so the bookend decision can drop a leg that isn't
       // real: a check-in hotel never drove to a departure airport (#1321), and a place timed before
       // check-in / after check-out means you weren't at the hotel then (#1465).
-      const wayPts: { lat: number; lng: number; isPlace: boolean; time: string | null }[] = []
+      const wayPts: { lat: number; lng: number; isPlace: boolean; time: string | null; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null }[] = []
       for (const it of merged) {
         if (it.type === 'place' && it.data.place?.lat && it.data.place?.lng) {
-          wayPts.push({ lat: it.data.place.lat, lng: it.data.place.lng, isPlace: true, time: it.data.place?.place_time ?? null })
+          wayPts.push({ lat: it.data.place.lat, lng: it.data.place.lng, isPlace: true, time: it.data.place?.place_time ?? null, leg_transport_mode: it.data.leg_transport_mode ?? null, incoming_leg_transport_mode: it.data.incoming_leg_transport_mode ?? null })
         } else if (it.type === 'transport') {
           const { from, to } = getTransportRouteEndpoints(it.data, dayId)
           if (from) wayPts.push({ lat: from.lat, lng: from.lng, isPlace: false, time: null })
@@ -577,7 +578,7 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
           // profile+coords, so per-leg calls stay cheap (a single-mode day reuses
           // the same entries) and each leg is tagged with the mode it was drawn in.
           for (let i = 0; i < run.length - 1; i++) {
-            const seg = await legBetween({ lat: run[i].lat, lng: run[i].lng }, { lat: run[i + 1].lat, lng: run[i + 1].lng }, dayId, run[i].mode || dfMode)
+            const seg = await legBetween({ lat: run[i].lat, lng: run[i].lng }, { lat: run[i + 1].lat, lng: run[i + 1].lng }, dayId, resolveLegMode(run[i], run[i + 1], dfMode))
             if (seg) dayLegs[run[i].id] = seg
             else if (controller.signal.aborted) return
           }
@@ -585,11 +586,11 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
         if (Object.keys(dayLegs).length) legsByDay[dayId] = dayLegs
         const hotel: { top?: { seg: RouteSegment; name: string }; bottom?: { seg: RouteSegment; name: string } } = {}
         if (wantTop) {
-          const seg = await legBetween({ lat: startHotel!.place_lat as number, lng: startHotel!.place_lng as number }, { lat: firstWay!.lat, lng: firstWay!.lng }, dayId, dfMode)
+          const seg = await legBetween({ lat: startHotel!.place_lat as number, lng: startHotel!.place_lng as number }, { lat: firstWay!.lat, lng: firstWay!.lng }, dayId, resolveLegMode({ isPlace: false }, firstWay!, dfMode))
           if (seg) hotel.top = { seg, name: hotelName(startHotel!) }
         }
         if (wantBottom) {
-          const seg = await legBetween({ lat: lastWay!.lat, lng: lastWay!.lng }, { lat: endHotel!.place_lat as number, lng: endHotel!.place_lng as number }, dayId, dfMode)
+          const seg = await legBetween({ lat: lastWay!.lat, lng: lastWay!.lng }, { lat: endHotel!.place_lat as number, lng: endHotel!.place_lng as number }, dayId, resolveLegMode(lastWay!, { isPlace: false }, dfMode))
           if (seg) hotel.bottom = { seg, name: hotelName(endHotel!) }
         }
         if (controller.signal.aborted) return

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -189,7 +189,7 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
   const [routeLegs, setRouteLegs] = useState<Record<number, Record<number, RouteSegment>>>({})
   // Hotel bookend legs keyed by day id. Desktop keys only the selected day; mobile
   // keys every day whose Route toggle is on, so each shows its own bookends (#1374).
-  const [hotelLegs, setHotelLegs] = useState<Record<number, { top?: { seg: RouteSegment; name: string }; bottom?: { seg: RouteSegment; name: string } }>>({})
+  const [hotelLegs, setHotelLegs] = useState<Record<number, { top?: { seg: RouteSegment; name: string; targetId?: number }; bottom?: { seg: RouteSegment; name: string; targetId?: number } }>>({})
   // Mobile only: days the user tapped "Route" on. Their leg distances show inline in
   // the expanded day, so seeing distances doesn't require selecting the day (which
   // closes the mobile sheet) — #1374.
@@ -530,10 +530,10 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
       // whether each is a place and its time so the bookend decision can drop a leg that isn't
       // real: a check-in hotel never drove to a departure airport (#1321), and a place timed before
       // check-in / after check-out means you weren't at the hotel then (#1465).
-      const wayPts: { lat: number; lng: number; isPlace: boolean; time: string | null; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null }[] = []
+      const wayPts: { lat: number; lng: number; isPlace: boolean; time: string | null; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null; id?: number }[] = []
       for (const it of merged) {
         if (it.type === 'place' && it.data.place?.lat && it.data.place?.lng) {
-          wayPts.push({ lat: it.data.place.lat, lng: it.data.place.lng, isPlace: true, time: it.data.place?.place_time ?? null, leg_transport_mode: it.data.leg_transport_mode ?? null, incoming_leg_transport_mode: it.data.incoming_leg_transport_mode ?? null })
+          wayPts.push({ lat: it.data.place.lat, lng: it.data.place.lng, isPlace: true, time: it.data.place?.place_time ?? null, leg_transport_mode: it.data.leg_transport_mode ?? null, incoming_leg_transport_mode: it.data.incoming_leg_transport_mode ?? null, id: it.data.id })
         } else if (it.type === 'transport') {
           const { from, to } = getTransportRouteEndpoints(it.data, dayId)
           if (from) wayPts.push({ lat: from.lat, lng: from.lng, isPlace: false, time: null })
@@ -551,7 +551,7 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
     legsAbortRef.current = controller
     ;(async () => {
       const legsByDay: Record<number, Record<number, RouteSegment>> = {}
-      const hotelByDay: Record<number, { top?: { seg: RouteSegment; name: string }; bottom?: { seg: RouteSegment; name: string } }> = {}
+      const hotelByDay: Record<number, { top?: { seg: RouteSegment; name: string; targetId?: number }; bottom?: { seg: RouteSegment; name: string; targetId?: number } }> = {}
 
       // One cached OSRM/plugin call per waypoint pair; shares RouteCalculator's cache.
       // tripId/dayId ride along for plugin route profiles (the server access-checks them).
@@ -584,14 +584,14 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
           }
         }
         if (Object.keys(dayLegs).length) legsByDay[dayId] = dayLegs
-        const hotel: { top?: { seg: RouteSegment; name: string }; bottom?: { seg: RouteSegment; name: string } } = {}
+        const hotel: { top?: { seg: RouteSegment; name: string; targetId?: number }; bottom?: { seg: RouteSegment; name: string; targetId?: number } } = {}
         if (wantTop) {
           const seg = await legBetween({ lat: startHotel!.place_lat as number, lng: startHotel!.place_lng as number }, { lat: firstWay!.lat, lng: firstWay!.lng }, dayId, resolveLegMode({ isPlace: false }, firstWay!, dfMode))
-          if (seg) hotel.top = { seg, name: hotelName(startHotel!) }
+          if (seg) hotel.top = { seg, name: hotelName(startHotel!), targetId: firstWay!.isPlace ? firstWay!.id : undefined }
         }
         if (wantBottom) {
           const seg = await legBetween({ lat: lastWay!.lat, lng: lastWay!.lng }, { lat: endHotel!.place_lat as number, lng: endHotel!.place_lng as number }, dayId, resolveLegMode(lastWay!, { isPlace: false }, dfMode))
-          if (seg) hotel.bottom = { seg, name: hotelName(endHotel!) }
+          if (seg) hotel.bottom = { seg, name: hotelName(endHotel!), targetId: lastWay!.isPlace ? lastWay!.id : undefined }
         }
         if (controller.signal.aborted) return
         if (hotel.top || hotel.bottom) hotelByDay[dayId] = hotel
@@ -1639,10 +1639,10 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                   }}
                 >
                   {hotelLegs[day.id]?.top && (() => {
-                    const firstPlaceId = merged.find(i => i.type === 'place')?.data.id
+                    const targetId = hotelLegs[day.id]?.top?.targetId
                     const connector = <HotelRouteConnector seg={hotelLegs[day.id]!.top!.seg} name={hotelLegs[day.id]!.top!.name} profile={routeProfile} placement="top" />
-                    return canEditDays && firstPlaceId != null ? (
-                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openIncomingLegModeMenu(e, Number(firstPlaceId), day.id)} style={{ cursor: 'pointer' }}>
+                    return canEditDays && targetId != null ? (
+                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openIncomingLegModeMenu(e, targetId, day.id)} style={{ cursor: 'pointer' }}>
                         {connector}
                       </div>
                     ) : connector
@@ -2248,7 +2248,7 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                           )}
                           {daySchedule.byReservation[day.id]?.[res.id]?.map(si => <PluginDayScheduleRow key={`${si.pluginId}:${si.id}`} item={si} />)}
                           {routeLegs[day.id]?.[res.id] && (() => {
-                            const nextPlaceId = merged.slice(idx + 1).find(i => i.type === 'place')?.data.id
+                            const nextPlaceId = merged.slice(idx + 1).find(i => i.type === 'place' && i.data.place?.lat && i.data.place?.lng)?.data.id
                             const connector = <RouteConnector seg={routeLegs[day.id]![res.id]} profile={routeProfile} />
                             return canEditDays && nextPlaceId != null ? (
                               <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openIncomingLegModeMenu(e, Number(nextPlaceId), day.id)} style={{ cursor: 'pointer' }}>
@@ -2382,10 +2382,10 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                   )}
                   {daySchedule.byPosition[day.id]?.end.map(si => <PluginDayScheduleRow key={`${si.pluginId}:${si.id}`} item={si} />)}
                   {hotelLegs[day.id]?.bottom && (() => {
-                    const lastPlaceId = [...merged].reverse().find(i => i.type === 'place')?.data.id
+                    const targetId = hotelLegs[day.id]?.bottom?.targetId
                     const connector = <HotelRouteConnector seg={hotelLegs[day.id]!.bottom!.seg} name={hotelLegs[day.id]!.bottom!.name} profile={routeProfile} placement="bottom" />
-                    return canEditDays && lastPlaceId != null ? (
-                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openLegModeMenu(e, Number(lastPlaceId), day.id)} style={{ cursor: 'pointer' }}>
+                    return canEditDays && targetId != null ? (
+                      <div role="button" tabIndex={0} title={t('dayplan.transportMode.change')} onClick={e => openLegModeMenu(e, targetId, day.id)} style={{ cursor: 'pointer' }}>
                         {connector}
                       </div>
                     ) : connector

--- a/client/src/components/Planner/legMode.test.ts
+++ b/client/src/components/Planner/legMode.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLegMode } from './legMode';
+
+const P = (o?: Partial<{ leg_transport_mode: string | null; incoming_leg_transport_mode: string | null }>) =>
+  ({ isPlace: true, ...o });
+const B = () => ({ isPlace: false });
+
+describe('resolveLegMode', () => {
+  it('origin place with outgoing mode wins', () => {
+    expect(resolveLegMode(P({ leg_transport_mode: 'cycling' }), P(), 'walking')).toBe('cycling');
+  });
+  it('origin place, no override -> day default', () => {
+    expect(resolveLegMode(P(), P(), 'driving')).toBe('driving');
+  });
+  it('non-place origin -> destination incoming override', () => {
+    expect(resolveLegMode(B(), P({ incoming_leg_transport_mode: 'transit' }), 'walking')).toBe('transit');
+  });
+  it('non-place origin, no incoming override -> day default', () => {
+    expect(resolveLegMode(B(), P(), 'walking')).toBe('walking');
+  });
+  it('no place endpoint at all -> day default', () => {
+    expect(resolveLegMode(B(), B(), 'walking')).toBe('walking');
+  });
+  it('incoming is inert when origin is a place', () => {
+    expect(resolveLegMode(P(), P({ incoming_leg_transport_mode: 'transit' }), 'walking')).toBe('walking');
+  });
+  it('undefined dest falls back to day default for a non-place origin', () => {
+    expect(resolveLegMode(B(), undefined, 'walking')).toBe('walking');
+  });
+});

--- a/client/src/components/Planner/legMode.ts
+++ b/client/src/components/Planner/legMode.ts
@@ -1,0 +1,22 @@
+export type LegPoint = {
+  isPlace: boolean;
+  leg_transport_mode?: string | null;
+  incoming_leg_transport_mode?: string | null;
+};
+
+/**
+ * Travel mode of the leg from `origin` to `dest`. The mode is owned by the leg's
+ * place endpoint: the origin's outgoing override wins when the origin is a place;
+ * otherwise the destination's incoming override applies (only meaningful when the
+ * origin is not a place - a booking arrival or the morning hotel); otherwise the
+ * day default. The incoming value is inert whenever the origin is a place.
+ */
+export function resolveLegMode(
+  origin: LegPoint,
+  dest: LegPoint | undefined,
+  dayDefault: string,
+): string {
+  if (origin.isPlace) return origin.leg_transport_mode ?? dayDefault;
+  if (dest?.isPlace) return dest.incoming_leg_transport_mode ?? dayDefault;
+  return dayDefault;
+}

--- a/client/src/hooks/useRouteCalculation.ts
+++ b/client/src/hooks/useRouteCalculation.ts
@@ -4,6 +4,7 @@ import { useSettingsStore } from '../store/settingsStore'
 import { calculateRouteWithLegs, withHotelBookends, type RouteProfileKey } from '../components/Map/RouteCalculator'
 import { getTransportRouteEndpoints } from '../utils/dayMerge'
 import { getDayBookendHotels, shouldDrawMorningLeg, shouldDrawEveningLeg } from '../utils/dayOrder'
+import { resolveLegMode } from '../components/Planner/legMode'
 import type { TripStoreState } from '../store/tripStore'
 import type { RouteSegment, RouteResult, RouteVia, Accommodation } from '../types'
 
@@ -73,13 +74,15 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
 
     // Build a unified list of places + transports sorted by effective position.
     type Entry =
-      | { kind: 'place'; lat: number; lng: number; pos: number; time: string | null; mode: string | null }
+      | { kind: 'place'; lat: number; lng: number; pos: number; time: string | null; mode: string | null; incoming: string | null }
       | { kind: 'transport'; from: { lat: number; lng: number } | null; to: { lat: number; lng: number } | null; pos: number }
     const entries: Entry[] = [
       ...da.filter(a => a.place?.lat && a.place?.lng).map(a => ({
         kind: 'place' as const, lat: a.place.lat!, lng: a.place.lng!, pos: a.order_index, time: a.place?.place_time ?? null,
         // Per-segment travel mode (#1281): mode of the leg leaving this place.
         mode: (a as { leg_transport_mode?: string | null }).leg_transport_mode ?? null,
+        // Boundary-leg mode (#1281 follow-up): mode of the leg arriving at this place.
+        incoming: (a as { incoming_leg_transport_mode?: string | null }).incoming_leg_transport_mode ?? null,
       })),
       ...dayTransports.map(r => {
         const { from, to } = getTransportRouteEndpoints(r, dayId)
@@ -102,19 +105,20 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
     // back-to-back transports (e.g. two flights on one day) would otherwise pair the
     // first's arrival point with the second's departure point into a phantom
     // [airport → airport] road route — that is the flight itself, not a drive (#1394).
-    const runs: { lat: number; lng: number; mode?: string | null }[][] = []
-    let currentRun: { lat: number; lng: number; mode?: string | null }[] = []
+    type RunPoint = { lat: number; lng: number; isPlace: boolean; leg_transport_mode?: string | null; incoming_leg_transport_mode?: string | null }
+    const runs: RunPoint[][] = []
+    let currentRun: RunPoint[] = []
     let runHasPlace = false
     for (const entry of entries) {
       if (entry.kind === 'place') {
-        currentRun.push({ lat: entry.lat, lng: entry.lng, mode: entry.mode })
+        currentRun.push({ lat: entry.lat, lng: entry.lng, isPlace: true, leg_transport_mode: entry.mode, incoming_leg_transport_mode: entry.incoming })
         runHasPlace = true
       } else if (entry.from || entry.to) {
-        if (entry.from) currentRun.push(entry.from)
+        if (entry.from) currentRun.push({ ...entry.from, isPlace: false })
         if (currentRun.length >= 2 && runHasPlace) runs.push(currentRun)
         currentRun = []
         runHasPlace = false
-        if (entry.to) currentRun.push(entry.to)
+        if (entry.to) currentRun.push({ ...entry.to, isPlace: false })
       }
     }
     if (currentRun.length >= 2 && runHasPlace) runs.push(currentRun)
@@ -127,13 +131,16 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
     const bookends = day && optimizeFromAccommodation !== false
       ? getDayBookendHotels(day, allDays, accommodations)
       : null
-    const flatPts: { lat: number; lng: number }[] = []
+    const flatPts: RunPoint[] = []
     for (const e of entries) {
-      if (e.kind === 'place') flatPts.push({ lat: e.lat, lng: e.lng })
-      else { if (e.from) flatPts.push(e.from); if (e.to) flatPts.push(e.to) }
+      if (e.kind === 'place') flatPts.push({ lat: e.lat, lng: e.lng, isPlace: true, leg_transport_mode: e.mode, incoming_leg_transport_mode: e.incoming })
+      else { if (e.from) flatPts.push({ ...e.from, isPlace: false }); if (e.to) flatPts.push({ ...e.to, isPlace: false }) }
     }
-    const hotelPt = (a?: Accommodation) =>
-      a && a.place_lat != null && a.place_lng != null ? { lat: a.place_lat, lng: a.place_lng } : null
+    // A hotel bookend point is not a place-assignment, so isPlace: false — resolveLegMode
+    // falls through to the day default for hotel-adjacent legs unless the place endpoint
+    // carries its own override.
+    const hotelPt = (a?: Accommodation): RunPoint | null =>
+      a && a.place_lat != null && a.place_lng != null ? { lat: a.place_lat, lng: a.place_lng, isPlace: false } : null
     // Only draw a hotel bookend when the leg is a real drive. You start/end the day at a hotel
     // when you slept there / sleep there tonight; on the hotel's own check-in or check-out day
     // the leg holds only when the edge stop is a PLACE timed after check-in / before check-out
@@ -147,7 +154,7 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
       e ? { isPlace: e.kind === 'place', time: e.kind === 'place' ? e.time : null } : undefined
     const drawMorning = !!bookends && !!day && shouldDrawMorningLeg(bookends, day, edgeInfo(firstStop))
     const drawEvening = !!bookends && !!day && shouldDrawEveningLeg(bookends, day, edgeInfo(lastStop))
-    const runsWithHotel: { lat: number; lng: number; mode?: string | null }[][] = withHotelBookends(
+    const runsWithHotel: RunPoint[][] = withHotelBookends(
       runs,
       flatPts[0],
       flatPts[flatPts.length - 1],
@@ -199,7 +206,7 @@ export function useRouteCalculation(tripStore: TripStoreState, selectedDayId: nu
           }
         }
         for (let i = 0; i < run.length - 1; i++) {
-          const mode = run[i].mode || dayDefaultMode
+          const mode = resolveLegMode(run[i], run[i + 1], dayDefaultMode)
           const straight = (): [number, number][] => [[run[i].lat, run[i].lng], [run[i + 1].lat, run[i + 1].lng]]
           try {
             const r = await calculateRouteWithLegs([{ lat: run[i].lat, lng: run[i].lng }, { lat: run[i + 1].lat, lng: run[i + 1].lng }], { signal: controller.signal, profile: mode, tripId, dayId })

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3772,17 +3772,6 @@ function runMigrations(db: Database.Database): void {
         if (!err.message?.includes('duplicate column name')) throw err;
       }
     },
-    // Per-segment travel mode for boundary legs: a leg whose ORIGIN is not a place
-    // (booking arrival, morning hotel) stores its mode on the DESTINATION stop.
-    // NULL = inherit the day default. INERT whenever the previous timeline element
-    // is itself a place (that place's outgoing leg_transport_mode wins).
-    () => {
-      try {
-        db.exec('ALTER TABLE day_assignments ADD COLUMN incoming_leg_transport_mode TEXT');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) throw err;
-      }
-    },
     // School holidays are a visual Vacay calendar layer. Keep them separate from
     // public holidays so applyHolidayCalendars never removes vacation entries for
     // school-break dates. Appended LAST: this branch was cut before #1435/#1281
@@ -3875,6 +3864,20 @@ function runMigrations(db: Database.Database): void {
     () => {
       const hasColor = db.prepare("SELECT 1 FROM pragma_table_info('day_notes') WHERE name = 'color'").get();
       if (!hasColor) db.exec('ALTER TABLE day_notes ADD COLUMN color TEXT');
+    },
+
+    // Per-segment travel mode for boundary legs: a leg whose ORIGIN is not a place
+    // (booking arrival, morning hotel) stores its mode on the DESTINATION stop.
+    // NULL = inherit the day default. INERT whenever the previous timeline element
+    // is itself a place (that place's outgoing leg_transport_mode wins).
+    // Appended LAST: the array is index-addressed against schema_version, so a slot
+    // inserted anywhere above this line is simply skipped on every existing database.
+    () => {
+      try {
+        db.exec('ALTER TABLE day_assignments ADD COLUMN incoming_leg_transport_mode TEXT');
+      } catch (err: any) {
+        if (!err.message?.includes('duplicate column name')) throw err;
+      }
     },
   ];
 

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3772,6 +3772,17 @@ function runMigrations(db: Database.Database): void {
         if (!err.message?.includes('duplicate column name')) throw err;
       }
     },
+    // Per-segment travel mode for boundary legs: a leg whose ORIGIN is not a place
+    // (booking arrival, morning hotel) stores its mode on the DESTINATION stop.
+    // NULL = inherit the day default. INERT whenever the previous timeline element
+    // is itself a place (that place's outgoing leg_transport_mode wins).
+    () => {
+      try {
+        db.exec('ALTER TABLE day_assignments ADD COLUMN incoming_leg_transport_mode TEXT');
+      } catch (err: any) {
+        if (!err.message?.includes('duplicate column name')) throw err;
+      }
+    },
     // School holidays are a visual Vacay calendar layer. Keep them separate from
     // public holidays so applyHolidayCalendars never removes vacation entries for
     // school-break dates. Appended LAST: this branch was cut before #1435/#1281

--- a/server/src/nest/assignments/assignments.controller.ts
+++ b/server/src/nest/assignments/assignments.controller.ts
@@ -175,7 +175,9 @@ export class AssignmentOpsController {
     if (!this.assignments.getAssignmentForTrip(id, tripId)) {
       throw new HttpException({ error: 'Assignment not found' }, 404);
     }
-    const assignment = this.assignments.setLegTransportMode(id, body.transport_mode ?? null);
+    const assignment = body.direction === 'incoming'
+      ? this.assignments.setIncomingLegTransportMode(id, body.transport_mode ?? null)
+      : this.assignments.setLegTransportMode(id, body.transport_mode ?? null);
     this.assignments.broadcast(tripId, 'assignment:updated', { assignment }, socketId);
     return { assignment };
   }

--- a/server/src/nest/assignments/assignments.service.ts
+++ b/server/src/nest/assignments/assignments.service.ts
@@ -272,6 +272,17 @@ export class AssignmentsService {
     return this.getAssignmentWithPlace(Number(id));
   }
 
+  /**
+   * Set the travel mode of the leg arriving at this stop (#1281 boundary legs).
+   * Mirrors setLegTransportMode but targets incoming_leg_transport_mode; inert
+   * when the previous timeline element is a place (the column is only read for
+   * non-place origins like a booking arrival or a morning hotel departure).
+   */
+  setIncomingLegTransportMode(id: string | number, mode: string | null) {
+    this.dbs.run('UPDATE day_assignments SET incoming_leg_transport_mode = ? WHERE id = ?', mode ?? null, id);
+    return this.getAssignmentWithPlace(Number(id));
+  }
+
   setParticipants(assignmentId: string | number, userIds: number[]) {
     this.dbs.transaction(() => {
       this.dbs.run('DELETE FROM assignment_participants WHERE assignment_id = ?', assignmentId);

--- a/server/src/nest/assignments/assignments.service.ts
+++ b/server/src/nest/assignments/assignments.service.ts
@@ -90,6 +90,7 @@ export class AssignmentsService {
       assignment_time: a.assignment_time ?? null,
       assignment_end_time: a.assignment_end_time ?? null,
       leg_transport_mode: a.leg_transport_mode ?? null,
+      incoming_leg_transport_mode: a.incoming_leg_transport_mode ?? null,
       participants,
       created_at: a.created_at,
       place: {

--- a/server/src/nest/common/rowShape.ts
+++ b/server/src/nest/common/rowShape.ts
@@ -19,6 +19,7 @@ export function formatAssignmentWithPlace(a: AssignmentRow, tags: Partial<Tag>[]
     assignment_time: a.assignment_time ?? null,
     assignment_end_time: a.assignment_end_time ?? null,
     leg_transport_mode: a.leg_transport_mode ?? null,
+    incoming_leg_transport_mode: a.incoming_leg_transport_mode ?? null,
     participants: participants || [],
     created_at: a.created_at,
     place: {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -111,6 +111,7 @@ export interface DayAssignment {
   assignment_time?: string | null;
   assignment_end_time?: string | null;
   leg_transport_mode?: string | null;
+  incoming_leg_transport_mode?: string | null;
   created_at?: string;
 }
 

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -124,4 +124,74 @@ describe('incoming_leg_transport_mode read-path parity', () => {
     const a = foundDay.assignments.find((x: any) => x.id === assignmentId);
     expect(a.incoming_leg_transport_mode).toBe('transit');
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Write path — PUT .../transport gains `direction` (outgoing|incoming).
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('PUT /assignments/:id/transport direction', () => {
+    it('defaults to outgoing (back-compat)', async () => {
+      const { user } = createUser(testDb2);
+      const trip = createTrip(testDb2, user.id);
+      const day = createDay(testDb2, trip.id, { date: '2025-06-01' });
+      const place = createPlace(testDb2, trip.id, { name: 'Test Place' });
+
+      const create = await request(app)
+        .post(`/api/trips/${trip.id}/days/${day.id}/assignments`)
+        .set('Cookie', authCookie(user.id))
+        .send({ place_id: place.id });
+      const assignmentId = create.body.assignment.id;
+
+      const res = await request(app)
+        .put(`/api/trips/${trip.id}/assignments/${assignmentId}/transport`)
+        .set('Cookie', authCookie(user.id))
+        .send({ transport_mode: 'cycling' });
+      expect(res.status).toBe(200);
+
+      const row = testDb2.prepare('SELECT leg_transport_mode, incoming_leg_transport_mode FROM day_assignments WHERE id = ?').get(assignmentId);
+      expect(row.leg_transport_mode).toBe('cycling');
+      expect(row.incoming_leg_transport_mode).toBeNull();
+    });
+
+    it("direction: 'incoming' writes the incoming column", async () => {
+      const { user } = createUser(testDb2);
+      const trip = createTrip(testDb2, user.id);
+      const day = createDay(testDb2, trip.id, { date: '2025-06-01' });
+      const place = createPlace(testDb2, trip.id, { name: 'Test Place' });
+
+      const create = await request(app)
+        .post(`/api/trips/${trip.id}/days/${day.id}/assignments`)
+        .set('Cookie', authCookie(user.id))
+        .send({ place_id: place.id });
+      const assignmentId = create.body.assignment.id;
+
+      const res = await request(app)
+        .put(`/api/trips/${trip.id}/assignments/${assignmentId}/transport`)
+        .set('Cookie', authCookie(user.id))
+        .send({ transport_mode: 'transit', direction: 'incoming' });
+      expect(res.status).toBe(200);
+
+      const row = testDb2.prepare('SELECT incoming_leg_transport_mode FROM day_assignments WHERE id = ?').get(assignmentId);
+      expect(row.incoming_leg_transport_mode).toBe('transit');
+    });
+
+    it('rejects an invalid direction with 400', async () => {
+      const { user } = createUser(testDb2);
+      const trip = createTrip(testDb2, user.id);
+      const day = createDay(testDb2, trip.id, { date: '2025-06-01' });
+      const place = createPlace(testDb2, trip.id, { name: 'Test Place' });
+
+      const create = await request(app)
+        .post(`/api/trips/${trip.id}/days/${day.id}/assignments`)
+        .set('Cookie', authCookie(user.id))
+        .send({ place_id: place.id });
+      const assignmentId = create.body.assignment.id;
+
+      const res = await request(app)
+        .put(`/api/trips/${trip.id}/assignments/${assignmentId}/transport`)
+        .set('Cookie', authCookie(user.id))
+        .send({ transport_mode: 'walking', direction: 'sideways' });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -32,6 +32,27 @@ describe('incoming_leg_transport_mode migration', () => {
     const cols = testDb.prepare(`PRAGMA table_info(day_assignments)`).all() as { name: string }[];
     expect(cols.map(c => c.name)).toContain('incoming_leg_transport_mode');
   });
+
+  // The case above starts from an empty database and runs every migration, so it
+  // passes wherever this one sits in the array. Existing installs replay only the
+  // slots above their schema_version, which is why the migration has to be the
+  // trailing entry: from anywhere but the end it is silently skipped on upgrade.
+  it('still lands on a database that already holds every earlier migration', () => {
+    const upgraded = new Database(':memory:');
+    upgraded.exec('PRAGMA foreign_keys = ON');
+    createTables(upgraded);
+    runMigrations(upgraded);
+
+    const { version } = upgraded.prepare('SELECT version FROM schema_version').get() as { version: number };
+    upgraded.exec('ALTER TABLE day_assignments DROP COLUMN incoming_leg_transport_mode');
+    upgraded.prepare('UPDATE schema_version SET version = ?').run(version - 1);
+
+    runMigrations(upgraded);
+
+    const cols = upgraded.prepare(`PRAGMA table_info(day_assignments)`).all() as { name: string }[];
+    expect(cols.map(c => c.name)).toContain('incoming_leg_transport_mode');
+    upgraded.close();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -193,5 +193,43 @@ describe('incoming_leg_transport_mode read-path parity', () => {
         .send({ transport_mode: 'walking', direction: 'sideways' });
       expect(res.status).toBe(400);
     });
+
+    it('outgoing and incoming leg modes on one stop persist independently', async () => {
+      const { user } = createUser(testDb2);
+      const trip = createTrip(testDb2, user.id);
+      const day = createDay(testDb2, trip.id, { date: '2025-06-01' });
+      const place = createPlace(testDb2, trip.id, { name: 'Test Place' });
+
+      const create = await request(app)
+        .post(`/api/trips/${trip.id}/days/${day.id}/assignments`)
+        .set('Cookie', authCookie(user.id))
+        .send({ place_id: place.id });
+      const assignmentId = create.body.assignment.id;
+
+      await request(app)
+        .put(`/api/trips/${trip.id}/assignments/${assignmentId}/transport`)
+        .set('Cookie', authCookie(user.id))
+        .send({ transport_mode: 'cycling' })
+        .expect(200);
+
+      await request(app)
+        .put(`/api/trips/${trip.id}/assignments/${assignmentId}/transport`)
+        .set('Cookie', authCookie(user.id))
+        .send({ transport_mode: 'transit', direction: 'incoming' })
+        .expect(200);
+
+      const row = testDb2.prepare('SELECT leg_transport_mode, incoming_leg_transport_mode FROM day_assignments WHERE id = ?').get(assignmentId);
+      expect(row.leg_transport_mode).toBe('cycling');
+      expect(row.incoming_leg_transport_mode).toBe('transit');
+
+      const res = await request(app)
+        .get(`/api/trips/${trip.id}/days`)
+        .set('Cookie', authCookie(user.id));
+      expect(res.status).toBe(200);
+      const foundDay = res.body.days.find((d: any) => d.id === day.id);
+      const a = foundDay.assignments.find((x: any) => x.id === assignmentId);
+      expect(a.leg_transport_mode).toBe('cycling');
+      expect(a.incoming_leg_transport_mode).toBe('transit');
+    });
   });
 });

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -1,7 +1,12 @@
 /**
- * Migration test for incoming_leg_transport_mode on day_assignments.
+ * Migration test for incoming_leg_transport_mode on day_assignments, plus
+ * read-path parity: the field must survive both the single-assignment
+ * projection and the day-LIST projection.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import type { Application } from 'express';
+import type { INestApplication } from '@nestjs/common';
 
 const Database = require('better-sqlite3');
 
@@ -26,5 +31,97 @@ describe('incoming_leg_transport_mode migration', () => {
   it('adds a nullable incoming_leg_transport_mode column to day_assignments', () => {
     const cols = testDb.prepare(`PRAGMA table_info(day_assignments)`).all() as { name: string }[];
     expect(cols.map(c => c.name)).toContain('incoming_leg_transport_mode');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read-path parity (day-LIST endpoint) — mirrors the harness in
+// tests/integration/assignments.test.ts verbatim.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { testDb2, dbMock } = vi.hoisted(() => {
+  const Database2 = require('better-sqlite3');
+  const db = new Database2(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: (placeId: number) => {
+      const place: any = db.prepare(`SELECT p.*, c.name as category_name, c.color as category_color, c.icon as category_icon FROM places p LEFT JOIN categories c ON p.category_id = c.id WHERE p.id = ?`).get(placeId);
+      if (!place) return null;
+      const tags = db.prepare(`SELECT t.* FROM tags t JOIN place_tags pt ON t.id = pt.tag_id WHERE pt.place_id = ?`).all(placeId);
+      return { ...place, category: place.category_id ? { id: place.category_id, name: place.category_name, color: place.category_color, icon: place.category_icon } : null, tags };
+    },
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb2: db, dbMock: mock };
+});
+
+vi.mock('../../src/db/database', () => dbMock);
+vi.mock('../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+  SESSION_DURATION: '24h',
+  SESSION_DURATION_MS: 86400000,
+  SESSION_DURATION_SECONDS: 86400,
+  DEFAULT_LANGUAGE: 'en',
+}));
+vi.mock('../../src/websocket', () => ({ broadcast: vi.fn(), broadcastToUser: vi.fn() }));
+
+import { buildApp } from '../../src/bootstrap';
+import { resetTestDb, resetRateLimits } from '../helpers/test-db';
+import { createUser, createTrip, createDay, createPlace } from '../helpers/factories';
+import { authCookie } from '../helpers/auth';
+
+describe('incoming_leg_transport_mode read-path parity', () => {
+  let nestApp: INestApplication;
+  let app: Application;
+
+  beforeAll(async () => {
+    createTables(testDb2);
+    runMigrations(testDb2);
+    nestApp = await buildApp();
+    app = nestApp.getHttpAdapter().getInstance();
+  });
+
+  beforeEach(() => {
+    resetTestDb(testDb2);
+    resetRateLimits(nestApp);
+  });
+
+  afterAll(async () => {
+    await nestApp.close();
+    testDb2.close();
+  });
+
+  it('round-trips incoming_leg_transport_mode through the day-LIST endpoint', async () => {
+    const { user } = createUser(testDb2);
+    const trip = createTrip(testDb2, user.id);
+    const day = createDay(testDb2, trip.id, { date: '2025-06-01' });
+    const place = createPlace(testDb2, trip.id, { name: 'Test Place' });
+
+    const create = await request(app)
+      .post(`/api/trips/${trip.id}/days/${day.id}/assignments`)
+      .set('Cookie', authCookie(user.id))
+      .send({ place_id: place.id });
+    expect(create.status).toBe(201);
+    const assignmentId = create.body.assignment.id;
+
+    testDb2.prepare('UPDATE day_assignments SET incoming_leg_transport_mode = ? WHERE id = ?').run('transit', assignmentId);
+
+    const res = await request(app)
+      .get(`/api/trips/${trip.id}/days`)
+      .set('Cookie', authCookie(user.id));
+    expect(res.status).toBe(200);
+    const foundDay = res.body.days.find((d: any) => d.id === day.id);
+    const a = foundDay.assignments.find((x: any) => x.id === assignmentId);
+    expect(a.incoming_leg_transport_mode).toBe('transit');
   });
 });

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Migration test for incoming_leg_transport_mode on day_assignments.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const Database = require('better-sqlite3');
+
+import { createTables } from '../../src/db/schema';
+import { runMigrations } from '../../src/db/migrations';
+
+let testDb: any;
+
+beforeAll(() => {
+  testDb = new Database(':memory:');
+  testDb.exec('PRAGMA journal_mode = WAL');
+  testDb.exec('PRAGMA foreign_keys = ON');
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+describe('incoming_leg_transport_mode migration', () => {
+  it('adds a nullable incoming_leg_transport_mode column to day_assignments', () => {
+    const cols = testDb.prepare(`PRAGMA table_info(day_assignments)`).all() as { name: string }[];
+    expect(cols.map(c => c.name)).toContain('incoming_leg_transport_mode');
+  });
+});

--- a/shared/src/assignment/assignment.schema.ts
+++ b/shared/src/assignment/assignment.schema.ts
@@ -43,6 +43,10 @@ export const assignmentSchema = z.object({
   // Per-segment travel mode (#1281): the transport mode of the leg LEAVING this
   // stop for the next one. null = inherit the day's default_transport_mode.
   leg_transport_mode: z.string().nullable().optional(),
+  // Per-segment travel mode of the leg ENTERING this stop when its origin is
+  // not a place (booking arrival / morning hotel). null = inherit the day default.
+  // Inert when the previous timeline element is a place.
+  incoming_leg_transport_mode: z.string().nullable().optional(),
   participants: z.array(assignmentParticipantSchema).optional(),
   created_at: z.string().optional(),
   place: assignmentPlaceSchema,

--- a/shared/src/assignment/assignment.schema.ts
+++ b/shared/src/assignment/assignment.schema.ts
@@ -83,6 +83,9 @@ export const assignmentTransportRequestSchema = z.object({
   // The legacy route read `body.transport_mode ?? null`, so an absent key
   // behaves like an explicit null — keep it optional on the wire.
   transport_mode: z.string().nullable().optional(),
+  // Which leg this write targets: the one leaving this stop (default, and the
+  // legacy behaviour) or the one arriving at it (#1281 boundary legs).
+  direction: z.enum(['outgoing', 'incoming']).default('outgoing'),
 });
 export type AssignmentTransportRequest = z.infer<typeof assignmentTransportRequestSchema>;
 


### PR DESCRIPTION
Follow-up to the per-segment travel mode from #1651. After living with that feature across a multi-city trip, the mode picker only attaches to a leg whose **origin is a place** — so four kinds of legs that are still drawn on the day plan stay read-only:

1. the first ground leg after a transport booking (ferry/train/bus arrival → next stop),
2. the same after a transit booking,
3. the evening accommodation bookend (last stop → the day's hotel),
4. the morning accommodation bookend (the day's hotel → first stop).

The mode of those legs couldn't be changed, and (1), (2) and (4) always drew in the day default because there was nowhere to store an override — `leg_transport_mode` on `day_assignments` means "the leg *leaving* this stop", and their origin isn't a place.

## Approach

A leg's mode is owned by whichever end is a real stop:

- origin is a place → its existing outgoing `leg_transport_mode` (unchanged),
- origin isn't a place but the destination is → a new **`incoming_leg_transport_mode`** on the destination stop.

That one nullable column covers cases 1, 2 and 4 (destination-owns-incoming); case 3 already had a place origin and just needed the connector wired up. Everything stays on `day_assignments`, so there's a single storage location and read path, and resolution is one shared helper (`resolveLegMode(origin, dest, dayDefault)`) used by both the sidebar and the map route-calc; the mobile timeline consumes the segments they produce.

## What's in it

- migration: `incoming_leg_transport_mode TEXT` (nullable, guarded) — existing itineraries are unchanged.
- read path: projected in both `getAssignmentWithPlace` and `rowShape.ts::formatAssignmentWithPlace` (the list projection).
- write path: `PUT /assignments/:id/transport` gains an optional `direction: 'outgoing' | 'incoming'` (defaults to `'outgoing'`, so existing callers are untouched); a `setIncomingLegTransportMode` service method mirrors the outgoing one.
- resolution: `resolveLegMode` in the day sidebar and the map route calc — boundary legs now draw in their resolved mode.
- UI: the mode menu is exposed on the booking connector (writes the next stop's incoming), the morning hotel connector (first stop's incoming) and the evening hotel connector (last stop's outgoing). The menus always target the leg's real located endpoint, so a coordinate-less edge stop or a booking edge gets no menu rather than a silent mis-write.
- tests: migration, list-endpoint parity, the `direction` API (default-outgoing back-compat, incoming write, invalid-direction 400), the resolver's semantics, and outgoing/incoming independence on one stop.

## Known limitation (intentional)

A leg with **no place endpoint on either side** still can't carry a mode — there's nowhere to store it:

- booking → booking (e.g. a ferry arrival straight into a train) isn't drawn today anyway (the `curHasPlace` gate), so no change there;
- hotel → booking (a morning hotel straight to a departure, no stop between) **is** drawn but stays in the day default, uneditable — its endpoint isn't a place, so the connector shows no mode menu. Uncommon but real; left as an inert leg rather than growing the schema for it.

A follow-up PR will add a "public transport" option to the same per-segment menu that pre-fills the transit-journey search from the leg (origin/destination/departure); it builds on this one's connector-menu plumbing, so it'll come after this lands.
