### PR TITLE
test(mobile): follow the export sheet's rename

### DIFF
--- a/client/tests/unit/mobile/trip/MExportSheet.test.tsx
+++ b/client/tests/unit/mobile/trip/MExportSheet.test.tsx
@@ -60,9 +60,10 @@ describe('MExportSheet', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('FE-MOB-EXPSH-002: lists the three export routes and names the ics after the trip', () => {
+  it('FE-MOB-EXPSH-002: lists the export routes and names the ics after the trip', () => {
     renderSheet()
-    expect(screen.getByRole('dialog', { name: 'Export Calendar' })).toBeInTheDocument()
+    // Renamed from "Export Calendar": the sheet carries the PDF and GPX exports too.
+    expect(screen.getByRole('dialog', { name: 'Export' })).toBeInTheDocument()
     expect(screen.getByText('PDF')).toBeInTheDocument()
     expect(screen.getByText('Export day plan as PDF')).toBeInTheDocument()
     expect(screen.getByText('Download .ics')).toBeInTheDocument()

--- a/client/tests/unit/mobile/trip/MMehrSheet.test.tsx
+++ b/client/tests/unit/mobile/trip/MMehrSheet.test.tsx
@@ -105,7 +105,7 @@ describe('MMehrSheet', () => {
   it('FE-MOB-MEHR-009: the action rows open the share, export and edit sheets', () => {
     const { shell } = renderSheet()
     fireEvent.click(screen.getByRole('button', { name: 'Share Trip' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Export Calendar' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
     fireEvent.click(screen.getByRole('button', { name: 'Edit Trip' }))
     expect(shell.openSheet).toHaveBeenNthCalledWith(1, 'members')
     expect(shell.openSheet).toHaveBeenNthCalledWith(2, 'export')


### PR DESCRIPTION
## Description

`dev` is red. #1907 renamed the mobile export sheet from **Export Calendar** to **Export** (it carries the PDF and now GPX exports, so the old name was wrong), but two suites still look the sheet up by its accessible name:

```
tests/unit/mobile/trip/MExportSheet.test.tsx
  → Unable to find an accessible element with the role "dialog" and name "Export Calendar"
tests/unit/mobile/trip/MMehrSheet.test.tsx
  → Unable to find an accessible element with the role "button" and name "Export Calendar"
```

They live under `client/tests/` rather than beside the component in `src/`, which is why the targeted runs while building #1907 did not include them and only CI caught it, after that PR had already merged.

Every PR opened against `dev` now shows these two failures, so this is worth landing on its own rather than riding along with a feature branch.

## Related Issue or Discussion

Follow-up to #1907

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
