### PR TITLE
fix(vacay): let a day stranded by a weekend-config change be cleared

### DIFF
--- a/client/src/components/Vacay/VacayCalendar.test.tsx
+++ b/client/src/components/Vacay/VacayCalendar.test.tsx
@@ -270,6 +270,54 @@ describe('VacayCalendar', () => {
     expect(toggleEntry).toHaveBeenCalledWith('2025-01-01', 42, 0.5, 'comp')
   })
 
+  it('FE-COMP-VACAYCALENDAR-006e: a blocked weekend day without an entry stays inert', async () => {
+    const user = userEvent.setup()
+    const toggleEntry = vi.fn().mockResolvedValue(undefined)
+
+    seedStore(useVacayStore, {
+      selectedYear: 2025,
+      entries: [],
+      companyHolidays: [],
+      holidays: {},
+      plan: { ...basePlan, block_weekends: true, company_holidays_enabled: false },
+      users: [],
+      selectedUserId: 42,
+      toggleEntry,
+    })
+
+    render(<VacayCalendar />)
+
+    // Month 3 → '2025-01-04', a Saturday.
+    await user.click(screen.getByText('click-3'))
+
+    expect(toggleEntry).not.toHaveBeenCalled()
+  })
+
+  it('FE-COMP-VACAYCALENDAR-006f: a day stranded by a weekend-config change can still be cleared (#1897)', async () => {
+    const user = userEvent.setup()
+    const toggleEntry = vi.fn().mockResolvedValue(undefined)
+
+    seedStore(useVacayStore, {
+      selectedYear: 2025,
+      entries: [{ date: '2025-01-04', user_id: 42, fraction: 1, kind: 'vacation' }],
+      companyHolidays: [],
+      holidays: {},
+      plan: { ...basePlan, block_weekends: true, company_holidays_enabled: false },
+      users: [],
+      selectedUserId: 42,
+      toggleEntry,
+    })
+
+    render(<VacayCalendar />)
+
+    // The half-day modifier must not turn the clear into a conversion — the server
+    // only allows the delete on a blocked day.
+    await user.click(screen.getByRole('button', { name: 'Half day' }))
+    await user.click(screen.getByText('click-3'))
+
+    expect(toggleEntry).toHaveBeenCalledWith('2025-01-04', 42, 1, 'vacation')
+  })
+
   it('FE-COMP-VACAYCALENDAR-007: cell click on public holiday toggles vacation entry', async () => {
     const user = userEvent.setup()
     const toggleEntry = vi.fn().mockResolvedValue(undefined)

--- a/client/src/components/Vacay/VacayCalendar.tsx
+++ b/client/src/components/Vacay/VacayCalendar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback, useEffect } from 'react'
 import { useVacayStore } from '../../store/vacayStore'
+import { useAuthStore } from '../../store/authStore'
 import { useTranslation } from '../../i18n'
 import { isWeekend } from './holidays'
 import { inGridWindow, windowMonths } from '../../vacay/yearWindow'
@@ -15,6 +16,7 @@ export type SharedDayMark = { color: string; name: string; fraction?: number; co
 export default function VacayCalendar() {
   const { t, locale } = useTranslation()
   const { selectedYear, selectedUserId, entries, companyHolidays, toggleEntry, toggleCompanyHoliday, plan, users, holidays, sharedCalendars, yearSettings } = useVacayStore()
+  const currentUserId = useAuthStore(s => s.user?.id)
   const [mode, setMode] = useState<VacayMode>('vacation')
   // Half-day is a per-person modifier on the vacation action, not a mode: with it
   // on, clicking a day logs (or converts) it as a 0.5 day for the selected person.
@@ -92,10 +94,19 @@ export default function VacayCalendar() {
       await toggleCompanyHoliday(dateStr)
       return
     }
-    if (blockWeekends && isWeekend(dateStr, weekendDays)) return
+    if (blockWeekends && isWeekend(dateStr, weekendDays)) {
+      // A day already logged when the weekend config changed under it (#1897) keeps
+      // counting against the entitlement, so clearing it stays possible — with the
+      // entry's own fraction/kind, since the server only allows the delete on a
+      // blocked day, not a conversion. Logging a new one stays blocked.
+      const own = entryMap[dateStr]?.find(e => e.user_id === (selectedUserId ?? currentUserId))
+      if (!own) return
+      await toggleEntry(dateStr, selectedUserId || undefined, (own.fraction ?? 1) === 0.5 ? 0.5 : 1, own.kind ?? 'vacation')
+      return
+    }
     if (companyHolidaysEnabled && companyHolidaySet.has(dateStr)) return
     await toggleEntry(dateStr, selectedUserId || undefined, halfDay ? 0.5 : 1, compDay ? 'comp' : 'vacation')
-  }, [mode, halfDay, compDay, toggleEntry, toggleCompanyHoliday, companyHolidaySet, blockWeekends, weekendDays, companyHolidaysEnabled, selectedUserId])
+  }, [mode, halfDay, compDay, toggleEntry, toggleCompanyHoliday, companyHolidaySet, blockWeekends, weekendDays, companyHolidaysEnabled, selectedUserId, currentUserId, entryMap])
 
   // Cells with a half day or a shared overlay report a hover, so the tooltip
   // appears exactly when there's something to explain. Fixed-positioned at the

--- a/client/src/components/Vacay/VacayMonthCard.test.tsx
+++ b/client/src/components/Vacay/VacayMonthCard.test.tsx
@@ -86,6 +86,17 @@ describe('VacayMonthCard', () => {
     expect(cell.style.cursor).toBe('default')
   })
 
+  it('FE-COMP-VACAYMONTHCARD-006a: a blocked weekend cell that still holds an entry stays clickable (#1897)', () => {
+    const props = {
+      ...baseProps,
+      entryMap: { '2025-01-05': [{ date: '2025-01-05', user_id: 1, person_color: '#6366f1' }] },
+    }
+    render(<VacayMonthCard {...props} />)
+    const daySpan = screen.getByText('5')
+    const cell = daySpan.closest('div') as HTMLElement
+    expect(cell.style.cursor).toBe('pointer')
+  })
+
   it('FE-COMP-VACAYMONTHCARD-007: Company holiday cell shows amber fill', () => {
     const props = {
       ...baseProps,

--- a/client/src/components/Vacay/VacayMonthCard.tsx
+++ b/client/src/components/Vacay/VacayMonthCard.tsx
@@ -108,7 +108,9 @@ export default function VacayMonthCard({
           const isCompany = companyHolidaysEnabled && companyHolidaySet.has(dateStr)
           const dayEntries = entryMap[dateStr] || []
           const hasEntries = dayEntries.length > 0
-          const isBlocked = (weekend && blockWeekends) || (isCompany && !companyMode)
+          // A blocked weekend day that still carries an entry (#1897) stays clickable —
+          // the click clears the stranded day rather than logging a new one.
+          const isBlocked = (weekend && blockWeekends && !hasEntries) || (isCompany && !companyMode)
           const isToday = dateStr === todayStr
           const plain = !hasEntries && holidayMarkers.length === 0 && !isCompany
 

--- a/client/src/mobile/screens/vacay/useMVacay.ts
+++ b/client/src/mobile/screens/vacay/useMVacay.ts
@@ -181,10 +181,19 @@ export function useMVacay() {
       await toggleCompanyHoliday(dateStr)
       return
     }
-    if (blockWeekends && isWeekend(dateStr, weekendDays)) return
+    if (blockWeekends && isWeekend(dateStr, weekendDays)) {
+      // A day already logged when the weekend config changed under it (#1897) keeps
+      // counting against the entitlement, so clearing it stays possible — with the
+      // entry's own fraction/kind, since the server only allows the delete on a
+      // blocked day, not a conversion. Logging a new one stays blocked.
+      const own = entryMap[dateStr]?.find(e => e.user_id === (selectedUserId ?? currentUser?.id))
+      if (!own) return
+      await toggleEntry(dateStr, selectedUserId || undefined, (own.fraction ?? 1) === 0.5 ? 0.5 : 1, own.kind ?? 'vacation')
+      return
+    }
     if (companyHolidaysEnabled && companyHolidaySet.has(dateStr)) return
     await toggleEntry(dateStr, selectedUserId || undefined, halfDay ? 0.5 : 1, compDay ? 'comp' : 'vacation')
-  }, [view, mode, halfDay, compDay, companyHolidaysEnabled, blockWeekends, weekendDays, companyHolidaySet, toggleEntry, toggleCompanyHoliday, selectedUserId])
+  }, [view, mode, halfDay, compDay, companyHolidaysEnabled, blockWeekends, weekendDays, companyHolidaySet, toggleEntry, toggleCompanyHoliday, selectedUserId, currentUser?.id, entryMap])
 
   // Entitlement stepper: never below what is already used this year
   // (carried-over days cover the difference when used > entitlement).

--- a/client/tests/unit/mobile/vacay/useMVacay.test.tsx
+++ b/client/tests/unit/mobile/vacay/useMVacay.test.tsx
@@ -424,4 +424,22 @@ describe('useMVacay', () => {
     act(() => { result.current.goBack(); });
     expect(navigateMock).toHaveBeenCalledWith('/dashboard');
   });
+
+  it('FE-MOB-MVAC-026: a day stranded by a weekend-config change can still be cleared (#1897)', async () => {
+    const toggleEntry = vi.fn(async (_date: string, _userId?: number, _fraction?: 0.5 | 1, _kind?: 'vacation' | 'comp') => {});
+    // 2026-06-13 is a Saturday; alice logged it before Saturday became a weekend.
+    const entry: VacayEntry = { date: '2026-06-13', user_id: 1, fraction: 0.5, kind: 'comp' };
+    act(() => { useVacayStore.setState({ toggleEntry, entries: [entry] }); });
+    const { result } = await mount();
+    act(() => { result.current.toggleView(); });
+
+    await act(async () => { await result.current.handleDayTap('2026-06-13'); });
+    // Cleared with the entry's own fraction/kind, ignoring the toolbar modifiers —
+    // the server only allows the delete on a blocked day, not a conversion.
+    expect(toggleEntry).toHaveBeenCalledWith('2026-06-13', 1, 0.5, 'comp');
+
+    // A weekend day nobody logged stays inert.
+    await act(async () => { await result.current.handleDayTap('2026-06-14'); });
+    expect(toggleEntry).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Description
Clicking a vacation day that a weekend-config change had turned into a weekend day did
nothing: `VacayCalendar.tsx:95` and `useMVacay.ts:184` returned early on every click on a
configured weekend day. The server is deliberately more permissive — `vacay.service.ts:1085-1092`
runs the delete branch *before* the `weekendBlocked` check ("removing a stray entry on a
blocked day stays possible"), refusing only conversions and new inserts. Since `usedDays`
(`vacay.service.ts:194-205`) counts every entry in the window regardless of weekday, the day
kept consuming entitlement with no way to clear it short of reverting the setting, deleting
the day, and re-applying it.

Both cell handlers now let a click through on a blocked weekend day when the acting person
already has an entry there, sending that entry's own `fraction`/`kind` so the server takes
its delete branch instead of the conversion branch (which would 400 if the Half-day or Comp
modifier were on). Logging a new weekend day stays blocked. `VacayMonthCard`'s `isBlocked`
no longer marks such cells `cursor: default`, so the affordance matches the behavior.

Fixed on the client because that is the layer that was wrong — the server already allows
this removal and pins it with `VACAY-SVC-033i`/`033j`.

Automatic credit-back when the weekend config changes is intentionally out of scope: it
silently deletes user data, and the issue itself flags that past days probably should not be
credited back.

## Related Issue or Discussion
Closes #1897

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally 
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed