### PR TITLE
feat: enable environment proxy support in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN mkdir -p /app/data/logs /app/uploads/files /app/uploads/covers /app/uploads/
     chown -h node:node /app/server/uploads /app/server/data
 
 ENV NODE_ENV=production
+ENV NODE_USE_ENV_PROXY=1
 ENV PORT=3000
 ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
 #      - COOKIE_SECURE=false # Escape hatch: force session cookies over plain HTTP even in production. Not recommended.
 #      - TRUST_PROXY=1 # Trusted proxy count for X-Forwarded-For / X-Forwarded-Proto. Required for FORCE_HTTPS to work.
 #      - ALLOW_INTERNAL_NETWORK=false # Set to true if Immich or other services are hosted on your local network (RFC-1918 IPs). Loopback and link-local addresses remain blocked regardless.
+#      - HTTP_PROXY=${HTTP_PROXY:-} # Optional. Proxy URL for outbound HTTP requests (e.g. http://192.168.1.10:7890)
+#      - HTTPS_PROXY=${HTTPS_PROXY:-} # Optional. Proxy URL for outbound HTTPS requests
+#      - NO_PROXY=${NO_PROXY:-localhost,127.0.0.1} # Optional. Comma-separated hosts and domains that bypass the outbound proxy
 #      - APP_URL=https://trek.example.com # Public base URL — required when OIDC is enabled (must match the redirect URI registered with your IdP); also used as base URL for links in email notifications
 #      - OIDC_ISSUER=https://auth.example.com # OpenID Connect provider URL
 #      - OIDC_CLIENT_ID=trek # OpenID Connect client ID

--- a/wiki/Environment-Variables.md
+++ b/wiki/Environment-Variables.md
@@ -97,7 +97,23 @@ translations are added to TREK.
 
 ---
 
-## HTTPS / Proxy
+## Outbound HTTP(S) Proxy
+
+TREK can route supported outbound HTTP(S) requests through a proxy by setting the standard variables below. Outbound
+proxying is disabled by default.
+
+| Variable      | Description                                                   | Default |
+|---------------|---------------------------------------------------------------|---------|
+| `HTTP_PROXY`  | Proxy URL for outbound HTTP requests                          | —       |
+| `HTTPS_PROXY` | Proxy URL for outbound HTTPS requests                         | —       |
+| `NO_PROXY`    | Comma-separated hosts or domains that should bypass the proxy | —       |
+
+> **Note:** Proxy environment variables apply to requests made through Node.js's default HTTP dispatcher. Requests
+> handled by TREK's SSRF protection use a dedicated dispatcher and do not use the environment proxy.
+
+---
+
+## HTTPS / Reverse Proxy
 
 These three variables work together behind a TLS-terminating reverse proxy. See [Reverse-Proxy](Reverse-Proxy) for the
 full explanation.

--- a/wiki/Environment-Variables.md
+++ b/wiki/Environment-Variables.md
@@ -111,6 +111,13 @@ proxying is disabled by default.
 > **Note:** Proxy environment variables apply to requests made through Node.js's default HTTP dispatcher. Requests
 > handled by TREK's SSRF protection use a dedicated dispatcher and do not use the environment proxy.
 
+> **Container only.** Node ignores these variables unless it is started with `NODE_USE_ENV_PROXY=1`, and the official
+> image sets that for you. On a source or Proxmox install, and on Helm where the chart's ConfigMap only passes through
+> the keys it knows, set `NODE_USE_ENV_PROXY=1` alongside them or nothing will change.
+
+> **Set `NO_PROXY`.** Without it every request goes to the proxy, including the ones TREK makes to itself, such as the
+> container health check. `localhost,127.0.0.1` is a sensible minimum; add your own hosts as needed.
+
 ---
 
 ## HTTPS / Reverse Proxy


### PR DESCRIPTION
﻿  ## Description

  Enable environment-based outbound proxy support for TREK container deployments.

  Node.js `fetch` does not use `HTTP_PROXY`, `HTTPS_PROXY`, or `NO_PROXY` by default. This PR enables Node.js environment proxy
  support in the container image by setting `NODE_USE_ENV_PROXY=1`.

  It also:

  - Adds optional, commented proxy variables to `docker-compose.yml`
  - Documents `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
  - Keeps outbound proxying disabled unless proxy variables are explicitly configured

  Requests handled by TREK's SSRF protection use a dedicated dispatcher and are not affected by the environment proxy.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Documentation update

  ## Checklist

  - [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
  - [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-
  date)
  - [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
  - [x] I have tested my changes locally
  - [ ] I have added/updated tests that prove my fix is effective or that my feature works
  - [x] I have updated documentation if needed

  ## Testing

  - Successfully built the container image for `linux/amd64` and `linux/arm64`
  - Verified the multi-architecture image manifest
  - Verified that proxy configuration remains disabled by default
  - Verified Compose and Markdown changes with `git diff --check`

  Automated tests were not added because this change only enables Node.js's built-in environment proxy support at the container
  runtime level.

## Related Issue or Discussion

Addresses discussion #1754 ("Add Proxy Settings"), which reports exactly this: `HTTP_PROXY` / `HTTPS_PROXY` set on the container have no effect, because Node ignores them unless it is started with `NODE_USE_ENV_PROXY=1`.

_Added by a maintainer while triaging: the reference was missing from the original description._