### PR TITLE
ci: retarget Dependabot pull requests onto dev instead of labelling them

### DIFF
--- a/.github/workflows/enforce-target-branch.yml
+++ b/.github/workflows/enforce-target-branch.yml
@@ -68,6 +68,38 @@ jobs:
               return;
             }
 
+            // Dependabot cannot be pointed at dev. `target-branch` in dependabot.yml
+            // applies to version updates only; security updates always open against
+            // the default branch, and security updates are all this repository gets
+            // (there is no dependabot.yml). Labelling them meant close-stale-wrong-branch
+            // shut them 24 hours later, which is how 13 of them died. Retarget instead:
+            // a bot cannot click "Edit" the way the comment below asks a human to.
+            if (context.payload.pull_request.user.login === 'dependabot[bot]') {
+              try {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  base: 'dev',
+                });
+                if (labels.includes('wrong-base-branch')) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    name: 'wrong-base-branch',
+                  });
+                }
+                console.log('Retargeted the Dependabot PR onto dev.');
+                return;
+              } catch (err) {
+                // Retargeting can fail when the branch was cut from main and dev has
+                // moved on. Fall through to the normal path so a human sees it rather
+                // than the check passing on a PR that is still aimed at main.
+                console.log(`Could not retarget the Dependabot PR: ${err.message}`);
+              }
+            }
+
             // Base is main — check if this user is a maintainer
             let permission = 'none';
             try {


### PR DESCRIPTION
## Description

Dependabot keeps opening against `main`, the branch check labels those pull requests `wrong-base-branch`, and `close-stale-wrong-branch` shuts them 24 hours later. Thirteen of the seventeen Dependabot pull requests in this repository died that way. The four that made it were retargeted by hand.

It cannot be fixed with configuration. `target-branch` in `dependabot.yml` applies to version updates only; security updates always open against the default branch ([options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), [dependabot-core#2767](https://github.com/dependabot/dependabot-core/issues/2767)). Security updates are all this repository gets, because there is no `dependabot.yml` at all, so every one of them lands on `main` regardless of what we write there. Adding a config with `target-branch: dev` would only switch on a second, much broader stream of version updates while the security ones kept arriving on `main`.

So the check retargets them instead. The comment it otherwise leaves asks the author to click Edit and change the base, which a bot cannot do.

If retargeting fails, because the branch was cut from `main` and `dev` has moved on far enough to conflict, it falls through to the existing labelling path so a human sees it rather than the check quietly passing on a pull request still aimed at `main`.

Two things worth knowing:

- **This only takes effect once it is on `main`.** `pull_request_target` loads the workflow from the pull request's base branch, and these arrive on `main`. Merging here arms it for the next `dev` to `main` merge, not before.
- Nothing else changes. Human pull requests targeting `main` are still labelled and still fail the check exactly as before, and `bypass-branch-check` and the `wiki/` exemption are untouched.

## Related Issue or Discussion

No issue. Maintenance of our own CI, raised while triaging the open Dependabot pull request #1918, which had to be retargeted by hand like the three before it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI / repository maintenance

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
