### PR TITLE
fix(tests): generate trip days in UTC so a DST shift can't drop or repeat one

### DIFF
--- a/server/tests/helpers/factories.ts
+++ b/server/tests/helpers/factories.ts
@@ -99,7 +99,11 @@ export function createTrip(
     const end = new Date(overrides.end_date);
     const tripId = result.lastInsertRowid as number;
     let dayNumber = 1;
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    // Step in UTC. A date-only ISO string parses as UTC midnight, but setDate()
+    // advances local wall-clock time — 23h or 25h across a DST transition — so the
+    // instant drifts off midnight and toISOString() then reports the wrong day:
+    // one is dropped in autumn, one repeated in spring. CI runs UTC and never sees it.
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
       const dateStr = d.toISOString().slice(0, 10);
       db.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, ?)').run(tripId, dayNumber++, dateStr);
     }


### PR DESCRIPTION
## Description

`server/tests/helpers/factories.ts` builds a trip's day rows by parsing date-only ISO strings — which JS parses as **UTC** midnight — and then stepping the cursor with `setDate()`, which advances **local** wall-clock time. Between DST transitions that step is exactly 24h so it reads fine; across one it is 23h or 25h, the instant drifts off midnight, and `toISOString().slice(0, 10)` reports the wrong day: one is dropped in autumn and one repeated in spring.

This fails on `dev` today. `TRIP-SVC-015` already builds a trip over `2025-11-01..2025-11-03`, which straddles the US fall-back, so on any machine in a DST-observing zone:

```
AssertionError: expected [ { id: 1, trip_id: 1, …(5) }, …(3) ] to have a length of 5 but got 4
 ❯ tests/unit/nest/trips.service.test.ts:315:21
```

CI runs UTC, where the loop happens to be correct, so this is invisible on GitHub and only affects contributors running the suite locally.

The fix is one line — `setUTCDate(d.getUTCDate() + 1)`. One file, +5/-1.

## Related Issue or Discussion

Raised in `#github-pr` on Discord before opening.

No linked issue: nothing in the tracker covers this, and the timezone issues that exist (#1453, #1768, #1222) are all user-facing runtime behaviour. This is test-only with no runtime impact, so a `[BUG]` report seemed the wrong shape — happy to file one if you'd prefer the PR link to it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works — see note below
- [ ] I have updated documentation if needed *(n/a)*

**On the tests checkbox:** the change *is* in the test layer, and the proving test already exists — `TRIP-SVC-015` goes red → green with it. I deliberately did not add a new test: one pinning this behaviour would pass in UTC both before and after the fix, so it would catch nothing in CI. Glad to add one that stubs the timezone if you'd rather have it explicit.

**Test plan**

- `npx vitest run tests/unit/nest/trips.service.test.ts` — 47/47 (was 46/47)
- `npm run test --workspace=server` — 396 files, 7550 tests, green
