### PR TITLE
feat(mcp): MCP tools for per-leg and day-default transport modes

### DIFF
--- a/server/src/nest/assignments/assignments.mcp.ts
+++ b/server/src/nest/assignments/assignments.mcp.ts
@@ -117,7 +117,7 @@ export class AssignmentsMcp {
 
   @Tool({
     name: 'set_leg_transport_mode',
-    description: 'Set the travel mode of a route leg for a place assignment. Use direction "outgoing" (default) for the common case: the leg leaving this stop toward the next. Use direction "incoming" ONLY when this stop\'s arriving leg originates from something that is not itself a place assignment (e.g. a flight/train booking arrival, or a morning hotel departure) – setting "incoming" on an ordinary place-to-place leg is stored but has no effect on route rendering, because it targets a column that is only read for non-place origins. transport_mode is a route profile key (e.g. "driving", "walking", "cycling", "transit"); null clears it so the leg inherits the day default.',
+    description: 'Set the travel mode of a route leg for a place assignment. Use direction "outgoing" (default) for the common case: the leg leaving this stop toward the next. Use direction "incoming" ONLY when this stop\'s arriving leg originates from something that is not itself a place assignment (e.g. a flight/train booking arrival, or a morning hotel departure) – setting "incoming" on an ordinary place-to-place leg is stored but has no effect on route rendering, because it targets a column that is only read for non-place origins. transport_mode is a route profile key: "driving", "walking", "cycling", or a plugin profile written as "plugin:<pluginId>/<profileId>". Any other value is stored but drawn as a driving route. null clears it so the leg inherits the day default.',
     inputSchema: {
       tripId: z.number().int().positive(),
       assignmentId: z.number().int().positive(),

--- a/server/src/nest/assignments/assignments.mcp.ts
+++ b/server/src/nest/assignments/assignments.mcp.ts
@@ -116,6 +116,35 @@ export class AssignmentsMcp {
   }
 
   @Tool({
+    name: 'set_leg_transport_mode',
+    description: 'Set the travel mode of a route leg for a place assignment. Use direction "outgoing" (default) for the common case: the leg leaving this stop toward the next. Use direction "incoming" ONLY when this stop\'s arriving leg originates from something that is not itself a place assignment (e.g. a flight/train booking arrival, or a morning hotel departure) – setting "incoming" on an ordinary place-to-place leg is stored but has no effect on route rendering, because it targets a column that is only read for non-place origins. transport_mode is a route profile key (e.g. "driving", "walking", "cycling", "transit"); null clears it so the leg inherits the day default.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      assignmentId: z.number().int().positive(),
+      transport_mode: z.string().nullable().optional().describe('Route profile key (e.g. "driving"), or null to inherit the day default'),
+      direction: z.enum(['outgoing', 'incoming']).default('outgoing').describe('Which leg to set: "outgoing" (leaving this stop, default) or "incoming" (arriving at it)'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'places', mode: 'write' },
+  })
+  async setLegTransportMode(
+    { tripId, assignmentId, transport_mode, direction }: {
+      tripId: number; assignmentId: number; transport_mode?: string | null; direction?: 'outgoing' | 'incoming';
+    },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.assignments.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
+    if (!this.assignments.getAssignmentForTrip(assignmentId, tripId)) return errorResult('Assignment not found.');
+    const assignment = direction === 'incoming'
+      ? this.assignments.setIncomingLegTransportMode(assignmentId, transport_mode ?? null)
+      : this.assignments.setLegTransportMode(assignmentId, transport_mode ?? null);
+    this.guards.safeBroadcast(tripId, 'assignment:updated', { assignment });
+    return ok({ assignment });
+  }
+
+  @Tool({
     name: 'move_assignment',
     description: 'Move a place assignment to a different day.',
     inputSchema: {

--- a/server/src/nest/days/days.mcp.ts
+++ b/server/src/nest/days/days.mcp.ts
@@ -104,6 +104,30 @@ export class DaysMcp {
     return ok({ success: true });
   }
 
+  @Tool({
+    name: 'set_day_default_transport_mode',
+    description: 'Set the whole-day default travel mode for a day. transport_mode is a route profile key (e.g. "driving", "walking", "cycling", "transit"); null clears the default. Per-segment leg modes still override this.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      dayId: z.number().int().positive(),
+      transport_mode: z.string().nullable().optional().describe('Route profile key (e.g. "driving"), or null to clear the day default'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async setDayDefaultTransportMode(
+    { tripId, dayId, transport_mode }: { tripId: number; dayId: number; transport_mode?: string | null },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
+    if (!this.days.getDay(dayId, tripId)) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
+    const day = this.days.setDefaultTransportMode(dayId, transport_mode ?? null);
+    this.guards.safeBroadcast(tripId, 'day:updated', { day });
+    return ok({ day });
+  }
+
   @ResourceTemplate({
     name: 'trip-days',
     uriTemplate: 'trek://trips/{tripId}/days',

--- a/server/src/nest/days/days.mcp.ts
+++ b/server/src/nest/days/days.mcp.ts
@@ -106,7 +106,7 @@ export class DaysMcp {
 
   @Tool({
     name: 'set_day_default_transport_mode',
-    description: 'Set the whole-day default travel mode for a day. transport_mode is a route profile key (e.g. "driving", "walking", "cycling", "transit"); null clears the default. Per-segment leg modes still override this.',
+    description: 'Set the whole-day default travel mode for a day. transport_mode is a route profile key: "driving", "walking", "cycling", or a plugin profile written as "plugin:<pluginId>/<profileId>". Any other value is stored but drawn as a driving route. null clears the default. Per-segment leg modes still override this.',
     inputSchema: {
       tripId: z.number().int().positive(),
       dayId: z.number().int().positive(),

--- a/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
+++ b/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
@@ -182,3 +182,115 @@ describe('Tool: set_leg_transport_mode', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// set_day_default_transport_mode
+// ---------------------------------------------------------------------------
+
+describe('Tool: set_day_default_transport_mode', () => {
+  it('sets the day default transport mode', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: day.id, transport_mode: 'driving' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.day.default_transport_mode).toBe('driving');
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'day:updated', expect.any(Object));
+    });
+  });
+
+  it('clears the day default with null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    testDb.prepare('UPDATE days SET default_transport_mode = ? WHERE id = ?').run('driving', day.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: day.id, transport_mode: null },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.day.default_transport_mode).toBeNull();
+    });
+  });
+
+  it('returns the day with its populated assignments array', async () => {
+    // setDefaultTransportMode returns { ...day, assignments }; exercise the non-empty case (panel item 4).
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: day.id, transport_mode: 'driving' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(Array.isArray(data.day.assignments)).toBe(true);
+      expect(data.day.assignments).toHaveLength(1);
+      expect(data.day.assignments[0].id).toBe(assignment.id);
+    });
+  });
+
+  it('rejects a day belonging to another trip (cross-trip join)', async () => {
+    const { user } = createUser(testDb);
+    const trip1 = createTrip(testDb, user.id);
+    const trip2 = createTrip(testDb, user.id);
+    const day2 = createDay(testDb, trip2.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip1.id, dayId: day2.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns error when day not found', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: 99999, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns access denied for non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const day = createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: day.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_day_default_transport_mode',
+        arguments: { tripId: trip.id, dayId: day.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
+++ b/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for MCP leg-mode tools: set_leg_transport_mode,
+ * set_day_default_transport_mode.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb } from '../../helpers/test-db';
+import { createUser, createTrip, createDay, createPlace, createDayAssignment } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  broadcastMock.mockClear();
+  delete process.env.DEMO_MODE;
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
+  const h = await createMcpHarness({ userId, withResources: false });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// set_leg_transport_mode
+// ---------------------------------------------------------------------------
+
+describe('Tool: set_leg_transport_mode', () => {
+  it('sets the outgoing leg mode (default direction)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'cycling' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.assignment.leg_transport_mode).toBe('cycling');
+      expect(data.assignment.incoming_leg_transport_mode ?? null).toBeNull(); // outgoing must not touch incoming (panel item 4)
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'assignment:updated', expect.any(Object));
+    });
+  });
+
+  it('sets the incoming leg mode without clobbering the outgoing column (column independence)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+    // Seed the outgoing column so we prove incoming does NOT touch it (panel item 4).
+    testDb.prepare('UPDATE day_assignments SET leg_transport_mode = ? WHERE id = ?').run('driving', assignment.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'transit', direction: 'incoming' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.assignment.incoming_leg_transport_mode).toBe('transit');
+      expect(data.assignment.leg_transport_mode).toBe('driving'); // outgoing untouched
+    });
+  });
+
+  it('rejects an assignment belonging to another trip (cross-trip join)', async () => {
+    // Proves the `AND d.trip_id = ?` join in getAssignmentForTrip; a 99999 id cannot.
+    const { user } = createUser(testDb);
+    const trip1 = createTrip(testDb, user.id);
+    const trip2 = createTrip(testDb, user.id);
+    const day2 = createDay(testDb, trip2.id);
+    const place2 = createPlace(testDb, trip2.id);
+    const assignment2 = createDayAssignment(testDb, day2.id, place2.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip1.id, assignmentId: assignment2.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('clears the leg mode with null (inherit day default)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+    testDb.prepare('UPDATE day_assignments SET leg_transport_mode = ? WHERE id = ?').run('cycling', assignment.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: null },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.assignment.leg_transport_mode).toBeNull();
+    });
+  });
+
+  it('returns error when assignment not found', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: 99999, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns access denied for non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_leg_transport_mode',
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'walking' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
+++ b/server/tests/unit/mcp/tools-leg-transport-mode.test.ts
@@ -70,6 +70,9 @@ describe('Tool: set_leg_transport_mode', () => {
     const day = createDay(testDb, trip.id);
     const place = createPlace(testDb, trip.id);
     const assignment = createDayAssignment(testDb, day.id, place.id);
+    // Seed the incoming column so the assertion below proves it survives; the factory
+    // leaves it NULL, so without this it would pass whether or not the tool touched it.
+    testDb.prepare('UPDATE day_assignments SET incoming_leg_transport_mode = ? WHERE id = ?').run('walking', assignment.id);
 
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({
@@ -78,7 +81,7 @@ describe('Tool: set_leg_transport_mode', () => {
       });
       const data = parseToolResult(result) as any;
       expect(data.assignment.leg_transport_mode).toBe('cycling');
-      expect(data.assignment.incoming_leg_transport_mode ?? null).toBeNull(); // outgoing must not touch incoming (panel item 4)
+      expect(data.assignment.incoming_leg_transport_mode).toBe('walking'); // outgoing must not touch incoming (panel item 4)
       expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'assignment:updated', expect.any(Object));
     });
   });
@@ -95,10 +98,10 @@ describe('Tool: set_leg_transport_mode', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({
         name: 'set_leg_transport_mode',
-        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'transit', direction: 'incoming' },
+        arguments: { tripId: trip.id, assignmentId: assignment.id, transport_mode: 'walking', direction: 'incoming' },
       });
       const data = parseToolResult(result) as any;
-      expect(data.assignment.incoming_leg_transport_mode).toBe('transit');
+      expect(data.assignment.incoming_leg_transport_mode).toBe('walking');
       expect(data.assignment.leg_transport_mode).toBe('driving'); // outgoing untouched
     });
   });

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -68,11 +68,13 @@ Requires `trips:read` or `trips:write` scope.
 | `update_day` | Set or clear a day's title. |
 | `create_day` | Add a new day to a trip with optional date and notes. |
 | `delete_day` | Delete a day from a trip. |
+| `set_day_default_transport_mode` | Set the whole-day default travel mode. Per-leg modes still override it. Pass `null` to clear. |
 | `assign_place_to_day` | Pin a place to a specific day in the itinerary. Requires `places:write`. |
 | `unassign_place` | Remove a place assignment from a day. Requires `places:write`. |
 | `reorder_day_assignments` | Reorder places within a day by providing assignment IDs in order. Requires `places:write`. |
 | `update_assignment_time` | Set start/end times for a place assignment (e.g. `"09:00"` – `"11:30"`). Pass `null` to clear. Requires `places:write`. |
 | `move_assignment` | Move a place assignment to a different day. Requires `places:write`. |
+| `set_leg_transport_mode` | Set the travel mode of a route leg for a place assignment. `direction` `"outgoing"` (default) targets the leg leaving the stop, `"incoming"` the arriving one. Pass `null` to inherit the day default. Requires `places:write`. |
 | `get_assignment_participants` | Get users participating in a specific place assignment. |
 | `set_assignment_participants` | Set participants for a place assignment (replaces current list). |
 


### PR DESCRIPTION
## Description

Follow-up to the per-segment travel modes (#1281) and the boundary-leg modes in #1890. Those let each leg of a day carry its own transport mode, and the whole day carry a default; but the only way to set those from an MCP client was a raw DB write. This PR closes that gap with two MCP tools that wrap the exact service methods the REST routes already use.

- **`set_leg_transport_mode`** – sets a leg's travel mode for a place assignment. `direction` `"outgoing"` (default) targets the leg leaving the stop; `"incoming"` targets the arriving leg for a non-place origin (a booking arrival or a morning hotel departure), mirroring the `PUT :tripId/assignments/:id/transport` route's `direction` branch.
- **`set_day_default_transport_mode`** – sets (or clears, with `null`) a day's whole-day default mode, mirroring `PUT :tripId/days/:id/transport`.

Both are pure adapters: no new business logic, no schema or API change. They call `AssignmentsService.setLegTransportMode` / `setIncomingLegTransportMode` and `DaysService.setDefaultTransportMode` respectively, with the same `?? null` coalescing, the same trip-access / `day_edit` permission checks, the same demo-user gate, and the same `assignment:updated` / `day:updated` broadcasts as the REST handlers.

## Related Issue or Discussion

Continues the per-segment transport feature line: the modes introduced in #1281 and the boundary-leg modes shipped in #1890. This PR adds the MCP surface for setting those same modes (the REST + UI paths already exist); it introduces no new user-facing behaviour, only a programmatic way to reach the existing setters.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Approach

The tools live on the existing `AssignmentsMcp` and `DaysMcp` controllers next to their siblings and follow the same shape exactly: inline Zod `inputSchema`, `TOOL_ANNOTATIONS_WRITE`, and the declarative access markers (`{ group: 'places', mode: 'write' }` for the leg tool, `{ group: 'trips', mode: 'write' }` for the day tool). `transport_mode` stays a loose nullable string, matching `assignmentTransportRequestSchema` / `dayTransportRequestSchema` in `@trek/shared` – the same source of truth the REST routes derive from, including `direction: z.enum(['outgoing','incoming']).default('outgoing')`.

The `set_leg_transport_mode` description states plainly that `"incoming"` only affects rendering when the leg's origin is not itself a place assignment, so an MCP caller does not silently set an inert mode on an ordinary place-to-place leg.

(Note for reviewers: the inline `z.*` `inputSchema` in `*.mcp.ts` is the established house convention across every MCP controller in this repo – it is not an omission of a `@trek/shared` contract.)

## What's in it

- `assignments.mcp.ts`: `set_leg_transport_mode` (branches on `direction`).
- `days.mcp.ts`: `set_day_default_transport_mode` (inline not-found result, matching this file's convention).
- tests (`tools-leg-transport-mode.test.ts`): outgoing and incoming set only their own column (column independence), `null` clears / inherits, `direction` defaults to outgoing, day-default returns its populated `assignments` array, plus cross-trip rejection, not-found, non-member access denial, and demo-user block for both tools.

Scoped to the MCP server surface; no schema, API, or i18n changes. Server typecheck clean, lint clean, the full `tests/unit/mcp` suite passes (756 tests).

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my feature works
- [ ] I have updated documentation if needed <!-- MCP.md points to the wiki; add a wiki tool entry if the maintainers want one -->
