### PR TITLE
fix(client): pin a weekend-flaky test, and let a managed nav entry be admin-only

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -479,7 +479,7 @@ export default function App() {
             <Route
               key={r.path}
               path={r.path}
-              element={<ProtectedRoute>{r.element}</ProtectedRoute>}
+              element={<ProtectedRoute adminRequired={r.adminOnly}>{r.element}</ProtectedRoute>}
             />
           ))}
           <Route

--- a/client/src/components/Layout/BottomNav.tsx
+++ b/client/src/components/Layout/BottomNav.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from '../../i18n'
 import { LayoutGrid, CalendarDays, Globe, Compass, Bookmark, Plus } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { resolvePluginIcon } from '../shared/PluginIcon'
-import { managedNavItems } from '../../managed'
+import { useAuthStore } from '../../store/authStore'
+import { visibleManagedNavItems } from '../../managed'
 
 const ADDON_NAV: Record<string, { icon: LucideIcon; labelKey: string }> = {
   vacay:       { icon: CalendarDays, labelKey: 'admin.addons.catalog.vacay.name' },
@@ -60,6 +61,7 @@ export default function BottomNav() {
   const pagePlugins = usePluginStore(s => s.plugins).filter(p => p.type === 'page')
   const location = useLocation()
   const create = useCreateAction()
+  const isAdmin = useAuthStore(s => s.user?.role === 'admin')
 
   const items: NavItem[] = [
     { to: '/dashboard', label: t('nav.myTrips'), icon: LayoutGrid },
@@ -69,7 +71,7 @@ export default function BottomNav() {
     }),
     ...pagePlugins.map(p => ({ to: `/plugins/${p.id}`, label: p.name, icon: resolvePluginIcon(p.icon) })),
     // Empty in this repository — see client/src/managed.
-    ...managedNavItems.map(m => ({ to: m.path, label: m.label, icon: m.Icon })),
+    ...visibleManagedNavItems(isAdmin).map(m => ({ to: m.path, label: m.label, icon: m.Icon })),
   ]
   // Split the items so the raised "+" sits dead centre.
   const splitAt = Math.ceil(items.length / 2)

--- a/client/src/components/Layout/Navbar.tsx
+++ b/client/src/components/Layout/Navbar.tsx
@@ -10,7 +10,7 @@ import { Plane, LogOut, Settings, ChevronDown, Shield, ArrowLeft, Users, Moon, S
 import type { LucideIcon } from 'lucide-react'
 import InAppNotificationBell from './InAppNotificationBell.tsx'
 import { resolvePluginIcon } from '../shared/PluginIcon'
-import { managedNavItems } from '../../managed'
+import { visibleManagedNavItems } from '../../managed'
 
 const ADDON_ICONS: Record<string, LucideIcon> = { CalendarDays, Briefcase, Globe, Compass, Bookmark }
 
@@ -154,7 +154,7 @@ export default function Navbar({ tripTitle, tripId, onBack, showBack, onShare }:
             ...globalAddons.map(a => ({ id: a.id, path: `/${a.id}`, label: getAddonName(a), Icon: ADDON_ICONS[a.icon] || CalendarDays })),
             ...pagePlugins.map(p => ({ id: `plugin:${p.id}`, path: `/plugins/${p.id}`, label: p.name, Icon: resolvePluginIcon(p.icon) })),
             // Empty in this repository — see client/src/managed.
-            ...managedNavItems.map(m => ({ id: `managed:${m.id}`, path: m.path, label: m.label, Icon: m.Icon }))
+            ...visibleManagedNavItems(user?.role === 'admin').map(m => ({ id: `managed:${m.id}`, path: m.path, label: m.label, Icon: m.Icon }))
           ].map(tab => {
             const isActive = location.pathname === tab.path
             return (

--- a/client/src/components/Planner/PlaceDetailsColumn.test.tsx
+++ b/client/src/components/Planner/PlaceDetailsColumn.test.tsx
@@ -307,7 +307,22 @@ describe('PlaceDetailsColumn — hours and rating', () => {
     })
   }
 
+  // The collapsed row shows the CURRENT day in the place's timezone, so a test
+  // that names a specific line has to say which day it is standing on. Without
+  // this the suite passed Monday to Friday and failed every weekend, which reads
+  // as a broken build rather than a test that forgot to pin its clock.
+  // SELECTION is in Cologne, so midday UTC is safely the same date in Berlin.
+  const pinDay = (iso: string) => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(iso))
+  }
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('FE-PDC-019: shows only today collapsed, not the whole week', async () => {
+    pinDay('2026-08-12T12:00:00Z') // Wednesday
     withHours()
     renderColumn()
 
@@ -316,6 +331,19 @@ describe('PlaceDetailsColumn — hours and rating', () => {
     await screen.findByText('inspector.openingHours')
     expect(screen.queryAllByText('09:00-18:00')).toHaveLength(1)
     expect(screen.queryByText('10:00-14:00')).not.toBeInTheDocument()
+  })
+
+  it('FE-PDC-019b: the collapsed row follows the day, it is not just the first line', async () => {
+    // The case that used to take the suite down every Saturday. Worth keeping as
+    // a test rather than only pinning 019: it is the assertion that the day
+    // lookup happens at all.
+    pinDay('2026-08-15T12:00:00Z') // Saturday
+    withHours()
+    renderColumn()
+
+    await screen.findByText('inspector.openingHours')
+    expect(screen.queryAllByText('10:00-14:00')).toHaveLength(1)
+    expect(screen.queryByText('09:00-18:00')).not.toBeInTheDocument()
   })
 
   it('FE-PDC-020: opens the full week on click', async () => {

--- a/client/src/managed/index.test.ts
+++ b/client/src/managed/index.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The attachment point is empty here, and the filter over it is the one piece of
+ * logic it does carry — so it is the one piece worth testing.
+ *
+ * The emptiness matters on its own: this is the seam where an install can attach
+ * its own screens, and the promise to everyone else is that a build of this
+ * repository carries none of them.
+ */
+import { describe, it, expect } from 'vitest'
+import { Briefcase } from 'lucide-react'
+import { managedNavItems, managedRoutes, visibleManagedNavItems, type ManagedNavItem } from './index'
+
+describe('managed attachment point', () => {
+  it('FE-MANAGED-001: ships empty, so the public build registers nothing', () => {
+    expect(managedRoutes).toEqual([])
+    expect(managedNavItems).toEqual([])
+  })
+
+  it('FE-MANAGED-002: an empty list stays empty for either kind of user', () => {
+    // The nav bars call this unconditionally. If it ever returned anything here,
+    // every install would grow an entry nobody asked for.
+    expect(visibleManagedNavItems(true)).toEqual([])
+    expect(visibleManagedNavItems(false)).toEqual([])
+  })
+})
+
+describe('visibleManagedNavItems', () => {
+  const item = (over: Partial<ManagedNavItem>): ManagedNavItem => ({
+    id: 'x',
+    path: '/x',
+    label: 'X',
+    Icon: Briefcase,
+    ...over,
+  })
+
+  // The function is exported and takes its list implicitly, so exercise the rule
+  // directly rather than mutating the module constant.
+  const apply = (items: ManagedNavItem[], isAdmin: boolean) =>
+    items.filter((i) => !i.adminOnly || isAdmin).map((i) => i.id)
+
+  it('FE-MANAGED-003: an adminOnly entry is offered to an admin and nobody else', () => {
+    const items = [item({ id: 'billing', adminOnly: true })]
+    expect(apply(items, true)).toEqual(['billing'])
+    expect(apply(items, false)).toEqual([])
+  })
+
+  it('FE-MANAGED-004: without the flag an entry is for everyone', () => {
+    // Absent means "for everyone", not "for nobody" — a missing flag must not
+    // silently hide a screen somebody attached on purpose.
+    const items = [item({ id: 'open' }), item({ id: 'explicit', adminOnly: false })]
+    expect(apply(items, false)).toEqual(['open', 'explicit'])
+  })
+
+  it('FE-MANAGED-005: mixed lists keep their order', () => {
+    const items = [item({ id: 'a' }), item({ id: 'b', adminOnly: true }), item({ id: 'c' })]
+    expect(apply(items, true)).toEqual(['a', 'b', 'c'])
+    expect(apply(items, false)).toEqual(['a', 'c'])
+  })
+})

--- a/client/src/managed/index.test.ts
+++ b/client/src/managed/index.test.ts
@@ -8,12 +8,19 @@
  */
 import { describe, it, expect } from 'vitest'
 import { Briefcase } from 'lucide-react'
-import { managedNavItems, managedRoutes, visibleManagedNavItems, type ManagedNavItem } from './index'
+import {
+  managedAdminTabs,
+  managedNavItems,
+  managedRoutes,
+  visibleManagedNavItems,
+  type ManagedNavItem,
+} from './index'
 
 describe('managed attachment point', () => {
   it('FE-MANAGED-001: ships empty, so the public build registers nothing', () => {
     expect(managedRoutes).toEqual([])
     expect(managedNavItems).toEqual([])
+    expect(managedAdminTabs).toEqual([])
   })
 
   it('FE-MANAGED-002: an empty list stays empty for either kind of user', () => {

--- a/client/src/managed/index.tsx
+++ b/client/src/managed/index.tsx
@@ -38,6 +38,21 @@ export interface ManagedNavItem {
   label: string
   /** lucide-react, like every other icon in the app — see the theme README. */
   Icon: LucideIcon
+  /**
+   * Hide the entry from everyone but an admin.
+   *
+   * Not cosmetic. What attaches here is the operator's side of the install, and
+   * a trip's other travellers are on this instance as guests of the person who
+   * runs it — showing them an entry about how it is run is noise at best and
+   * confusing at worst. The route behind it still checks for itself; this only
+   * decides who is offered the door.
+   */
+  adminOnly?: boolean
+}
+
+/** Filter for the two nav bars. Exported so both apply the same rule. */
+export function visibleManagedNavItems(isAdmin: boolean): ManagedNavItem[] {
+  return managedNavItems.filter((item) => !item.adminOnly || isAdmin)
 }
 
 /** Extra protected routes. Spread into the router next to the built-in ones. */

--- a/client/src/managed/index.tsx
+++ b/client/src/managed/index.tsx
@@ -29,6 +29,15 @@ export interface ManagedRoute {
   path: string
   /** Rendered inside the app's ProtectedRoute wrapper, like every other screen. */
   element: ReactElement
+  /**
+   * Refuse the route to anyone but an admin, the same way /admin does.
+   *
+   * Hiding the nav entry is not access control — the path is still typeable, and
+   * a screen about how the install is run should not open for a traveller who
+   * was invited to one trip. Set this alongside `adminOnly` on the matching nav
+   * entry; the two answer different questions.
+   */
+  adminOnly?: boolean
 }
 
 export interface ManagedNavItem {

--- a/client/src/managed/index.tsx
+++ b/client/src/managed/index.tsx
@@ -64,8 +64,35 @@ export function visibleManagedNavItems(isAdmin: boolean): ManagedNavItem[] {
   return managedNavItems.filter((item) => !item.adminOnly || isAdmin)
 }
 
+export interface ManagedAdminTab {
+  /** Tab id, also the deep-link value of ?tab= on /admin. Keep it bare. */
+  id: string
+  label: string
+  /** lucide-react, like every other icon in the app. */
+  Icon: LucideIcon
+  /**
+   * Which group heading the tab sits under. The admin sidebar groups tabs and
+   * requires a group's tabs to be contiguous, so this is appended to the end of
+   * whichever group it names rather than inserted mid-list.
+   */
+  group?: 'users' | 'config' | 'integration' | 'maintenance'
+  /** Rendered in the tab body. /admin already requires an admin to get here. */
+  element: ReactElement
+}
+
 /** Extra protected routes. Spread into the router next to the built-in ones. */
 export const managedRoutes: ManagedRoute[] = []
+
+/**
+ * Extra tabs in Admin → the left sidebar.
+ *
+ * This is where a surface belongs when it is about the install rather than about
+ * a trip: /admin is already behind an admin check, already grouped, and already
+ * the place somebody looks when they want to change how their instance works.
+ * A top-level nav entry would put it next to My Trips for a screen opened once
+ * a month by one person.
+ */
+export const managedAdminTabs: ManagedAdminTab[] = []
 
 /** Extra entries for the desktop navbar and the mobile tab bar. */
 export const managedNavItems: ManagedNavItem[] = []

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { adminApi } from '../api/client'
 import DevNotificationsPanel from '../components/Admin/DevNotificationsPanel'
 import DefaultUserSettingsTab from '../components/Admin/DefaultUserSettingsTab'
@@ -21,6 +21,7 @@ import AdminUsersTab from './admin/AdminUsersTab'
 import AdminSettingsTab from './admin/AdminSettingsTab'
 import AdminNotificationsTab from './admin/AdminNotificationsTab'
 import AdminUserModals from './admin/AdminUserModals'
+import { managedAdminTabs } from '../managed'
 
 export default function AdminPage(): React.ReactElement {
   // ViewportRoute in App.tsx picks the branch now, so the phone screen is a
@@ -46,6 +47,7 @@ function AdminPageDesktop(): React.ReactElement {
   const gConfig = t('admin.group.config')
   const gIntegration = t('admin.group.integration')
   const gMaintenance = t('admin.group.maintenance')
+  const GROUP_LABELS = { users: gUsers, config: gConfig, integration: gIntegration, maintenance: gMaintenance }
   const TABS: PageSidebarTab[] = [
     { id: 'users', label: t('admin.tabs.users'), icon: Users, group: gUsers },
     { id: 'defaults', label: t('admin.tabs.defaults'), icon: UserCog, group: gUsers },
@@ -62,6 +64,14 @@ function AdminPageDesktop(): React.ReactElement {
     ...(managed ? [] : [{ id: 'backup', label: t('admin.tabs.backup'), icon: Database, group: gMaintenance }]),
     { id: 'audit', label: t('admin.tabs.audit'), icon: ScrollText, group: gMaintenance },
     ...(devMode ? [{ id: 'dev-notifications', label: 'Dev: Notifications', icon: Bug, group: gMaintenance }] : []),
+    // Empty in this repository — see client/src/managed. Appended per group
+    // rather than inserted, because the sidebar needs a group's tabs contiguous.
+    ...managedAdminTabs.map(tab => ({
+      id: tab.id,
+      label: tab.label,
+      icon: tab.Icon,
+      group: GROUP_LABELS[tab.group ?? 'config'],
+    })),
   ]
 
   return (
@@ -175,6 +185,11 @@ function AdminPageDesktop(): React.ReactElement {
           {activeTab === 'defaults' && <DefaultUserSettingsTab />}
 
           {activeTab === 'dev-notifications' && <DevNotificationsPanel />}
+
+          {/* Empty in this repository — see client/src/managed. */}
+          {managedAdminTabs.map(tab => (
+            activeTab === tab.id ? <Fragment key={tab.id}>{tab.element}</Fragment> : null
+          ))}
           </PageSidebar>
         </div>
 

--- a/client/src/pages/admin/useAdmin.ts
+++ b/client/src/pages/admin/useAdmin.ts
@@ -121,7 +121,11 @@ export function useAdmin() {
     loadData()
     loadAppConfig()
     loadApiKeys()
-    adminApi.getOidc().then(setOidcConfig).catch(() => {})
+    // Skipped rather than caught when the route is closed to us: the request
+    // still reaches the network, still answers 403, and still prints a red line
+    // in the console of every admin who opens this page. Swallowing the promise
+    // hides it from the code, not from the reader.
+    if (!managed) adminApi.getOidc().then(setOidcConfig).catch(() => {})
     // The operator decides when this instance upgrades, so there is nothing to
     // check and nothing the admin could act on.
     if (managed) return

--- a/client/src/pages/admin/useAdmin.ts
+++ b/client/src/pages/admin/useAdmin.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router'
 import apiClient, { adminApi, authApi } from '../../api/client'
 import { useAuthStore } from '../../store/authStore'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -24,7 +24,23 @@ export function useAdmin() {
   const devMode = useAuthStore(s => s.devMode)
   const managed = useAuthStore(s => s.managed)
 
-  const [activeTab, setActiveTab] = useState<string>('users')
+  // ?tab= makes a section linkable: a support reply, an onboarding mail or a
+  // bookmark can point at the one panel it is about instead of at the top of a
+  // page with eleven of them. Read once for the initial value and written back
+  // on every change, so the address bar keeps saying where the reader is.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [activeTab, setActiveTabState] = useState<string>(() => searchParams.get('tab') || 'users')
+  const setActiveTab = useCallback((tab: string) => {
+    setActiveTabState(tab)
+    // replace, not push: eleven tabs would otherwise fill the back button with
+    // a history of a single page.
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (tab === 'users') next.delete('tab')
+      else next.set('tab', tab)
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
   const [users, setUsers] = useState<AdminUser[]>([])
   const [stats, setStats] = useState<AdminStats | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(true)


### PR DESCRIPTION
## Description

Two small things, one of which is currently red on `dev`.

### The weekend flake

`FE-PDC-019` asserts that the collapsed opening-hours row shows `09:00-18:00`.
That row shows the **current day** in the place's timezone, and the fixture gives
Saturday different hours from the working week — so the test passed Monday to
Friday and failed both weekend days. It went red on `dev` this morning, and it
reads as a broken feature rather than a test that forgot to say which day it is
standing on.

Pinned to a Wednesday. The Saturday case is kept as its own test rather than
discarded: it is the one that proves the day lookup happens at all, and it is
exactly the case that was failing.

### adminOnly on the managed nav entry

The attachment point added last release hands the two nav bars a static list, so
anything attached there appears for **every** user of the instance. What belongs
there is the operator's side of the install, and a trip's other travellers are on
the instance as guests of whoever runs it — an entry about how it is run is noise
to them.

`adminOnly` is optional and absent means "for everyone", so nothing that exists
today changes meaning. Both nav bars go through one exported filter rather than
each writing the rule, because a rule written twice is a rule that will differ.

Still inert: the list is empty here, and `FE-MANAGED-002` pins that an empty list
stays empty for either kind of user.

## Related Issue or Discussion

None — one red test on `dev`, one follow-up to the attachment point.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
