### PR TITLE
fix: trip card controls, place URL fields, and per-day reservation ordering

### DIFF
--- a/client/src/components/Journey/JourneyMap.test.tsx
+++ b/client/src/components/Journey/JourneyMap.test.tsx
@@ -550,4 +550,30 @@ describe('JourneyMap', () => {
     expect(colors).not.toContain('#ff0000');
     expect(colors).not.toContain('#ffffff');
   });
+
+  // A string handed to bindTooltip becomes innerHTML. A track name is a place
+  // name off a shared trip and an entry label is a journey title, so both are
+  // written by someone who is not necessarily the person reading the map — and
+  // this component is what the public journey page renders.
+  it('FE-COMP-JOURNEYMAP-044: escapes a track name before it becomes tooltip markup', () => {
+    vi.mocked(L.polyline).mockClear();
+    render(<JourneyMap checkins={[]} entries={entriesWithCoords} tracks={[track({ name: '<img src=x onerror="alert(1)">' })]} />);
+
+    const line = vi.mocked(L.polyline).mock.results
+      .map(r => r.value as any)
+      .find(v => v.bindTooltip.mock.calls.length > 0);
+    const [label] = line.bindTooltip.mock.calls[0];
+    expect(label).not.toContain('<img');
+    expect(label).not.toContain('onerror="');
+    expect(label).toBe('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+  });
+
+  it('FE-COMP-JOURNEYMAP-045: escapes an entry title before it becomes tooltip markup', () => {
+    const hostile = [{ id: 'e9', lat: 48.1, lng: 2.1, title: '<img src=x onerror="alert(1)">', mood: null, entry_date: '2025-06-04' }];
+    render(<JourneyMap checkins={[]} entries={hostile} />);
+
+    const labels = vi.mocked(mockedMarker().bindTooltip).mock.calls.map(c => c[0]);
+    expect(labels.some(l => typeof l === 'string' && l.includes('<img'))).toBe(false);
+    expect(labels).toContain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+  });
 });

--- a/client/src/components/Journey/JourneyMap.tsx
+++ b/client/src/components/Journey/JourneyMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useImperativeHandle, useCallback, type Ref } from 'react'
 import L from 'leaflet'
 import { useSettingsStore } from '../../store/settingsStore'
-import type { JourneyTrack } from '@trek/shared'
+import { escapeHtml, type JourneyTrack } from '@trek/shared'
 
 export interface MapMarkerItem {
   id: string
@@ -212,8 +212,9 @@ function JourneyMap(
       const line = L.polyline(coords, { color, weight: 3.5, opacity: 0.95, lineCap: 'round', lineJoin: 'round' })
       // Same tooltip the markers on this map use, rather than Leaflet's default box:
       // it follows the appearance tokens, so it lands right in dark mode and with
-      // transparency switched off.
-      if (track.name) line.bindTooltip(track.name, { sticky: true, direction: 'top', className: 'map-tooltip' })
+      // transparency switched off. Escaped because a string handed to bindTooltip
+      // becomes innerHTML, and a track name is a place name off a shared trip.
+      if (track.name) line.bindTooltip(escapeHtml(track.name), { sticky: true, direction: 'top', className: 'map-tooltip' })
       line.addTo(map)
       coords.forEach(c => allCoords.push(c))
     }
@@ -243,7 +244,9 @@ function JourneyMap(
       })
 
       const marker = L.marker(pos, { icon }).addTo(map)
-      marker.bindTooltip(item.label, {
+      // Escaped for the same reason as the track tooltip above: the label is an
+      // entry title, and this map is what the public journey page renders.
+      marker.bindTooltip(escapeHtml(item.label), {
         direction: 'top',
         offset: [0, -MARKER_H],
         className: 'map-tooltip',

--- a/client/src/components/Map/MapViewGL.test.tsx
+++ b/client/src/components/Map/MapViewGL.test.tsx
@@ -851,6 +851,23 @@ describe('MapViewGL', () => {
     expect(glMarkers.created[1].lngLat).toEqual([2.12, 48.12])
   })
 
+  // The Leaflet twin of this is FE-COMP-MAPVIEW-074. Both renderers build their
+  // marker as an HTML string, so both need the escape pinned — otherwise it can
+  // be dropped from one of them without a single test going red.
+  it('FE-COMP-MAPVIEWGL-023b: an image_url that passes the prefix check is still escaped', async () => {
+    loadOnAttach()
+    render(<MapViewGL places={[buildMapPlace({
+      id: 13, lat: 48.13, lng: 2.13, image_url: '/uploads/x" onerror="alert(1)" y="',
+    })]} fitKey={1} />)
+    await act(async () => {})
+
+    const marker = glMarkers.created[0].element
+    expect(marker.innerHTML).not.toContain('onerror="alert(1)"')
+    expect(marker.innerHTML).toContain('&quot;')
+    // The escape must not break the ordinary case: the src still resolves.
+    expect(marker.querySelector('img')?.getAttribute('src')).toBe('/uploads/x" onerror="alert(1)" y="')
+  })
+
   it('FE-COMP-MAPVIEWGL-024: the hover card shows name, category and address and follows the cursor', async () => {
     loadOnAttach()
     const places = [buildMapPlace({

--- a/client/src/components/Planner/DayPlanSidebar.test.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.test.tsx
@@ -3332,7 +3332,7 @@ describe('DayPlanSidebar', () => {
     render(<DayPlanSidebar {...makeDefaultProps({ days: [day], places: [place], assignments: { '10': [a] } })} />)
     fireEvent.contextMenu(dragRow(screen.getByText('Louvre')))
     await user.click(screen.getByRole('button', { name: 'Open Website' }))
-    expect(openSpy).toHaveBeenCalledWith('https://louvre.fr', '_blank')
+    expect(openSpy).toHaveBeenCalledWith('https://louvre.fr', '_blank', 'noopener,noreferrer')
 
     fireEvent.contextMenu(dragRow(screen.getByText('Louvre')))
     await user.click(screen.getByRole('button', { name: 'Google Maps' }))

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -4,6 +4,7 @@ declare global { interface Window { __dragData: DragDataPayload | null } }
 
 import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react'
 import { avatarSrc } from '../../utils/avatarSrc'
+import { safeHttpUrl } from '../../utils/safeUrl'
 import { ChevronDown, ChevronRight, ChevronUp, Compass, Navigation, RotateCcw, ExternalLink, Clock, Pencil, GripVertical, Ticket, Plus, FileText, Trash2, Car, Lock, Hotel, Footprints, Route as RouteIcon, Bookmark, TramFront, Zap } from 'lucide-react'
 import { type PickedPlace } from './TransitSearchPanel'
 import { assignmentsApi, reservationsApi, daysApi } from '../../api/client'
@@ -1871,7 +1872,7 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                               ctxMenu.open(e, [
                                 canEditDays && onEditPlace && { label: t('common.edit'), icon: Pencil, onClick: () => onEditPlace(place, assignment.id) },
                                 canEditDays && onRemoveAssignment && { label: t('planner.removeFromDay'), icon: Trash2, onClick: () => onRemoveAssignment(day.id, assignment.id) },
-                                place.website && { label: t('inspector.website'), icon: ExternalLink, onClick: () => window.open(place.website, '_blank') },
+                                safeHttpUrl(place.website) && { label: t('inspector.website'), icon: ExternalLink, onClick: () => window.open(safeHttpUrl(place.website)!, '_blank', 'noopener,noreferrer') },
                                 ...navTargets.map(target => ({ label: target.label, icon: Navigation, onClick: () => openNavigationTarget(target) })),
                                 collectionsEnabled && { label: t('inspector.saveToCollection'), icon: Bookmark, onClick: () => useSaveToCollectionStore.getState().open(placeToSaveTarget(place)) },
                                 { divider: true },

--- a/client/src/components/Planner/PlaceInspector.test.tsx
+++ b/client/src/components/Planner/PlaceInspector.test.tsx
@@ -953,7 +953,7 @@ describe('PlaceInspector', () => {
 
     fireEvent.click(screen.getByText('Open Website').closest('button')!);
     expect(open).toHaveBeenCalledTimes(2);
-    expect(open.mock.calls[1]).toEqual(['https://example.org', '_blank']);
+    expect(open.mock.calls[1]).toEqual(['https://example.org', '_blank', 'noopener,noreferrer']);
     vi.unstubAllGlobals();
   });
 

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { avatarSrc } from '../../utils/avatarSrc'
+import { safeHttpUrl } from '../../utils/safeUrl'
 import { openFile } from '../../utils/fileDownload'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -318,6 +319,10 @@ export default function PlaceInspector({
     detailLng,
     googleDetails?.open_now,
   )
+  // Allow-listed rather than passed straight through: window.open runs a
+  // javascript: URL in this origin, and the stored value predates the check the
+  // server does on the way in now.
+  const websiteUrl = safeHttpUrl(place.website) ?? safeHttpUrl(googleDetails?.website)
   // Prefer the place's stored ftid; if it has none yet, use the one just fetched from Google.
   const navigationTargets = getNavigationTargets(
     place ? { ...place, google_ftid: place.google_ftid || googleDetails?.google_ftid || null } : null,
@@ -513,8 +518,8 @@ export default function PlaceInspector({
               )}
             </>
           )}
-          {(place.website || googleDetails?.website) && (
-            <ActionButton onClick={() => window.open(place.website || googleDetails?.website, '_blank')} variant="ghost" icon={<ExternalLink size={13} />}
+          {websiteUrl && (
+            <ActionButton onClick={() => window.open(websiteUrl, '_blank', 'noopener,noreferrer')} variant="ghost" icon={<ExternalLink size={13} />}
               label={<span className="hidden sm:inline">{t('inspector.website')}</span>} />
           )}
           <div style={{ flex: 1 }} />

--- a/client/src/components/Planner/usePlacesSidebar.test.tsx
+++ b/client/src/components/Planner/usePlacesSidebar.test.tsx
@@ -643,7 +643,7 @@ describe('usePlacesSidebar context menu', () => {
 
     fireEvent.contextMenu(screen.getByTestId('row-3'));
     await user.click(screen.getByRole('button', { name: 'Open Website' }));
-    expect(open).toHaveBeenCalledWith('https://cafe.example', '_blank');
+    expect(open).toHaveBeenCalledWith('https://cafe.example', '_blank', 'noopener,noreferrer');
 
     fireEvent.contextMenu(screen.getByTestId('row-3'));
     await user.click(screen.getByRole('button', { name: 'Google Maps' }));

--- a/client/src/components/Planner/usePlacesSidebar.ts
+++ b/client/src/components/Planner/usePlacesSidebar.ts
@@ -14,6 +14,7 @@ import { useSaveToCollectionStore } from '../../store/saveToCollectionStore'
 import { placeToSaveTarget } from '../Collections/saveTarget'
 import type { Place, Category, Day, AssignmentsMap } from '../../types'
 import { getGoogleMapsUrlForPlace } from './placeGoogleMaps'
+import { safeHttpUrl } from '../../utils/safeUrl'
 
 export interface PlacesSidebarProps {
   tripId: number
@@ -276,7 +277,7 @@ export function usePlacesSidebar(props: PlacesSidebarProps) {
     ctxMenu.open(e, [
       canEditPlaces && { label: t('common.edit'), icon: Pencil, onClick: () => props.onEditPlace(place) },
       selDayId && { label: t('planner.addToDay'), icon: CalendarDays, onClick: () => props.onAssignToDay(place.id, selDayId) },
-      place.website && { label: t('inspector.website'), icon: ExternalLink, onClick: () => window.open(place.website, '_blank') },
+      safeHttpUrl(place.website) && { label: t('inspector.website'), icon: ExternalLink, onClick: () => window.open(safeHttpUrl(place.website)!, '_blank', 'noopener,noreferrer') },
       googleMapsUrl && { label: t('inspector.google'), icon: Navigation, onClick: () => window.open(googleMapsUrl, '_blank') },
       collectionsEnabled && { label: t('inspector.saveToCollection'), icon: Bookmark, onClick: () => useSaveToCollectionStore.getState().open(placeToSaveTarget(place)) },
       { divider: true },

--- a/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
@@ -17,6 +17,7 @@ import PlaceRating from '../../../../components/shared/StarRating'
 import TrackColorPicker from '../../../../components/shared/TrackColorPicker'
 import { resolveTrackColor, inheritedTrackColor } from '../../../../components/Map/trackColors'
 import { avatarSrc } from '../../../../utils/avatarSrc'
+import { safeHttpUrl } from '../../../../utils/safeUrl'
 import { openFile } from '../../../../utils/fileDownload'
 import { getNavigationTargets, openNavigationTarget } from '../../../../components/Planner/placeNavigation'
 import { NavigationMenu } from '../../../../components/shared/NavigationMenu'
@@ -527,9 +528,9 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
                   <MapIcon size={15} strokeWidth={2} />
                 </ActionCircle>
               )}
-              {place.website && (
+              {safeHttpUrl(place.website) && (
                 <ActionCircle
-                  onClick={() => window.open(place.website!, '_blank', 'noopener,noreferrer')}
+                  onClick={() => window.open(safeHttpUrl(place.website)!, '_blank', 'noopener,noreferrer')}
                   label={t('inspector.website')}
                 >
                   <ExternalLink size={15} strokeWidth={2} />

--- a/client/src/pages/DashboardPage.test.tsx
+++ b/client/src/pages/DashboardPage.test.tsx
@@ -1000,4 +1000,59 @@ describe('DashboardPage', () => {
       expect(within(grid()).queryByText('Paris Adventure')).not.toBeInTheDocument();
     });
   });
+
+  // Two people reported in a row that they could not find how to unarchive or
+  // rename a trip. The controls sat at opacity 0 until the card was hovered, and
+  // the archive button carried the same icon whether it would archive or restore.
+  describe('FE-PAGE-DASH-036: the cover controls are findable', () => {
+    const activeOnly = (trips: unknown[]) =>
+      server.use(
+        http.get('/api/trips', ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get('archived')) return HttpResponse.json({ trips: [] });
+          return HttpResponse.json({ trips });
+        }),
+      );
+
+    it('names every action on the card, so none of them is icon-only guesswork', async () => {
+      activeOnly([buildTrip({ title: 'Lisbon 2025', start_date: '2025-05-01', end_date: '2025-05-08' })]);
+      const user = userEvent.setup();
+      render(<DashboardPage />);
+
+      await waitFor(() => expect(screen.getAllByText('Lisbon 2025').length).toBeGreaterThan(0));
+      await user.click(screen.getByText('Completed'));
+      const card = (await screen.findAllByText('Lisbon 2025'))
+        .map(n => n.closest('.trip-card'))
+        .find(Boolean) as HTMLElement;
+      for (const label of ['Edit', 'Duplicate', 'Archive', 'Delete']) {
+        const button = card.querySelector(`[aria-label="${label}"]`) as HTMLElement;
+        expect(button).toBeTruthy();
+        // A tooltip as well as the screen-reader label — the icons alone did not read.
+        expect(button.getAttribute('title')).toBe(label);
+      }
+    });
+
+    it('swaps the archive icon for a restore one once the trip is archived', async () => {
+      const archived = buildTrip({ title: 'Old Rome Trip', start_date: '2024-01-01', end_date: '2024-01-07', is_archived: 1 });
+      server.use(
+        http.get('/api/trips', ({ request }) => {
+          const url = new URL(request.url);
+          return HttpResponse.json({ trips: url.searchParams.get('archived') ? [archived] : [] });
+        }),
+      );
+      const user = userEvent.setup();
+      render(<DashboardPage />);
+
+      await user.click(screen.getByText('Archived'));
+      await waitFor(() => expect(screen.getByText('Old Rome Trip')).toBeInTheDocument());
+
+      const card = screen.getByText('Old Rome Trip').closest('.trip-card') as HTMLElement;
+      const restore = card.querySelector('[aria-label="Restore"]') as HTMLElement;
+      expect(restore).toBeTruthy();
+      // lucide stamps the icon name on the svg, which is how the archive and the
+      // restore variant tell themselves apart.
+      expect(restore.querySelector('svg')?.getAttribute('class')).toContain('archive-restore');
+      expect(card.querySelector('[aria-label="Archive"]')).toBeNull();
+    });
+  });
 });

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -15,7 +15,7 @@ import {
   MS_PER_DAY, daysUntil, getTripStatus,
 } from './dashboard/dashboardModel'
 import {
-  Plus, Edit2, Trash2, Archive, Copy, ArrowRight, MapPin,
+  Plus, Edit2, Trash2, Archive, ArchiveRestore, Copy, ArrowRight, MapPin,
   Plane, Hotel, Utensils, Clock, RefreshCw, ArrowRightLeft, Calendar,
   LayoutGrid, List, Ticket, X, CalendarPlus, ParkingSquare,
 } from 'lucide-react'
@@ -304,6 +304,7 @@ function BoardingPassHero({ trip, bundle, locale, onOpen, onEdit, onCopy, onArch
   const heroPlugins = usePluginStore(s => s.plugins).filter(p => p.type === 'widget' && p.slot === 'hero')
   const stop = (e: React.MouseEvent, fn: () => void) => { e.stopPropagation(); fn() }
   const status = getTripStatus(trip)
+  const archiveLabel = trip.is_archived ? t('dashboard.restore') : t('dashboard.archive')
   const start = splitDate(trip.start_date, locale)
   const end = splitDate(trip.end_date, locale)
 
@@ -404,10 +405,10 @@ function BoardingPassHero({ trip, bundle, locale, onOpen, onEdit, onCopy, onArch
             {badge}
           </div>
           <div className="hero-tools">
-            <button className="hero-tool" aria-label={t('common.edit')} onClick={(e) => stop(e, onEdit)}><Edit2 size={16} /></button>
-            <button className="hero-tool" aria-label={t('dashboard.aria.duplicate')} onClick={(e) => stop(e, onCopy)}><Copy size={16} /></button>
-            <button className="hero-tool" aria-label={trip.is_archived ? t('dashboard.restore') : t('dashboard.archive')} onClick={(e) => stop(e, onArchive)}><Archive size={16} /></button>
-            <button className="hero-tool" aria-label={t('common.delete')} onClick={(e) => stop(e, onDelete)}><Trash2 size={16} /></button>
+            <button className="hero-tool" aria-label={t('common.edit')} title={t('common.edit')} onClick={(e) => stop(e, onEdit)}><Edit2 size={17} strokeWidth={2.2} /></button>
+            <button className="hero-tool" aria-label={t('dashboard.aria.duplicate')} title={t('dashboard.aria.duplicate')} onClick={(e) => stop(e, onCopy)}><Copy size={17} strokeWidth={2.2} /></button>
+            <button className="hero-tool" aria-label={archiveLabel} title={archiveLabel} onClick={(e) => stop(e, onArchive)}>{trip.is_archived ? <ArchiveRestore size={17} strokeWidth={2.2} /> : <Archive size={17} strokeWidth={2.2} />}</button>
+            <button className="hero-tool" aria-label={t('common.delete')} title={t('common.delete')} onClick={(e) => stop(e, onDelete)}><Trash2 size={17} strokeWidth={2.2} /></button>
           </div>
         </div>
 
@@ -535,6 +536,7 @@ function TripCard({ trip, locale, badges, onOpen, onEdit, onCopy, onArchive, onD
 }): React.ReactElement {
   const { t } = useTranslation()
   const status = getTripStatus(trip)
+  const archiveLabel = trip.is_archived ? t('dashboard.restore') : t('dashboard.archive')
   const start = splitDate(trip.start_date, locale)
   const end = splitDate(trip.end_date, locale)
   const until = daysUntil(trip.start_date)
@@ -557,10 +559,10 @@ function TripCard({ trip, locale, badges, onOpen, onEdit, onCopy, onArchive, onD
           : <div style={{ width: '100%', height: '100%', background: tripGradient(trip.id) }} />}
         <div className={`trip-status ${statusClass}`}><span className="indicator" /> {statusLabel}</div>
         <div className="trip-actions">
-          <button className="trip-action-btn" aria-label={t('common.edit')} onClick={(e) => stop(e, onEdit)}><Edit2 size={16} /></button>
-          <button className="trip-action-btn" aria-label={t('dashboard.aria.duplicate')} onClick={(e) => stop(e, onCopy)}><Copy size={16} /></button>
-          <button className="trip-action-btn" aria-label={trip.is_archived ? t('dashboard.restore') : t('dashboard.archive')} onClick={(e) => stop(e, onArchive)}><Archive size={16} /></button>
-          <button className="trip-action-btn" aria-label={t('common.delete')} onClick={(e) => stop(e, onDelete)}><Trash2 size={16} /></button>
+          <button className="trip-action-btn" aria-label={t('common.edit')} title={t('common.edit')} onClick={(e) => stop(e, onEdit)}><Edit2 size={17} strokeWidth={2.2} /></button>
+          <button className="trip-action-btn" aria-label={t('dashboard.aria.duplicate')} title={t('dashboard.aria.duplicate')} onClick={(e) => stop(e, onCopy)}><Copy size={17} strokeWidth={2.2} /></button>
+          <button className="trip-action-btn" aria-label={archiveLabel} title={archiveLabel} onClick={(e) => stop(e, onArchive)}>{trip.is_archived ? <ArchiveRestore size={17} strokeWidth={2.2} /> : <Archive size={17} strokeWidth={2.2} />}</button>
+          <button className="trip-action-btn" aria-label={t('common.delete')} title={t('common.delete')} onClick={(e) => stop(e, onDelete)}><Trash2 size={17} strokeWidth={2.2} /></button>
         </div>
         <div className="trip-cover-content">
           <h3 className="trip-name">{trip.title}</h3>

--- a/client/src/pages/atlas/useAtlas.ts
+++ b/client/src/pages/atlas/useAtlas.ts
@@ -6,7 +6,7 @@ import apiClient, { mapsApi, pluginsApi, type PluginAtlasLayer } from '../../api
 import L from 'leaflet'
 import type { GeoJsonFeatureCollection } from '../../types'
 import { A2_TO_A3, countryStatus, findBucketDuplicate, isBucketDuplicateError, isCountryVisible, normalizeRegionName, withCountryMarkedVisited, wishlistA3Codes, countryColor, type AtlasData, type AtlasPlaceHit, type CountryDetail, type BucketItem } from './atlasModel'
-import { continentForCountry, type VisitStatus } from '@trek/shared'
+import { continentForCountry, escapeHtml, type VisitStatus } from '@trek/shared'
 import { useToast } from '../../components/shared/Toast'
 import { getApiErrorMessage } from '../../types'
 
@@ -941,7 +941,7 @@ export function useAtlas() {
         iconAnchor: [14, 14],
       })
       return L.marker([b.lat!, b.lng!], { icon }).bindTooltip(
-        `<div style="font-size:12px;font-weight:600">${b.name}</div>${b.notes ? `<div style="font-size:10px;opacity:0.7;margin-top:2px">${b.notes}</div>` : ''}`,
+        `<div style="font-size:12px;font-weight:600">${escapeHtml(b.name)}</div>${b.notes ? `<div style="font-size:10px;opacity:0.7;margin-top:2px">${escapeHtml(b.notes)}</div>` : ''}`,
         { className: 'atlas-tooltip', direction: 'top', offset: [0, -14] }
       )
     })

--- a/client/src/styles/dashboard.css
+++ b/client/src/styles/dashboard.css
@@ -191,11 +191,12 @@
 .trek-dash .hero-top { display: flex; justify-content: space-between; align-items: start; }
 .trek-dash .hero-badge {
   display: inline-flex; align-items: center; gap: 8px;
-  background: oklch(1 0 0 / .14);
+  background: oklch(0.22 0.01 260 / .5);
   backdrop-filter: blur(14px) saturate(1.4); -webkit-backdrop-filter: blur(14px) saturate(1.4);
-  border: 1px solid oklch(1 0 0 / .2); padding: 8px 14px 8px 12px;
+  border: 1px solid oklch(1 0 0 / .32); padding: 8px 14px 8px 12px;
   border-radius: 999px; font-size: 12px; font-weight: 500;
   letter-spacing: 0.06em; text-transform: uppercase;
+  box-shadow: 0 2px 8px oklch(0 0 0 / .26);
 }
 .trek-dash .hero-badge .pulse {
   width: 7px; height: 7px; border-radius: 50%;
@@ -208,15 +209,18 @@
   100% { box-shadow: 0 0 0 0 oklch(0.84 0.18 85 / 0); }
 }
 .trek-dash .hero-tools { display: flex; gap: 8px; }
+/* Same story as .trip-action-btn: a dark scrim instead of a white .14 fill, so
+   the tools read against a bright hero photo too. */
 .trek-dash .hero-tool {
-  width: 38px; height: 38px; border-radius: 50%;
-  background: oklch(1 0 0 / .14);
+  width: 40px; height: 40px; border-radius: 50%;
+  background: oklch(0.22 0.01 260 / .5);
   backdrop-filter: blur(14px) saturate(1.4); -webkit-backdrop-filter: blur(14px) saturate(1.4);
-  border: 1px solid oklch(1 0 0 / .2); color: #fff;
+  border: 1px solid oklch(1 0 0 / .32); color: #fff;
+  box-shadow: 0 2px 8px oklch(0 0 0 / .26);
   display: grid; place-items: center; transition: background .15s, transform .12s;
 }
-.trek-dash .hero-tool:hover { background: oklch(1 0 0 / .26); transform: scale(1.05); }
-.trek-dash .hero-tool svg { width: 16px; height: 16px; }
+.trek-dash .hero-tool:hover { background: oklch(0.22 0.01 260 / .78); transform: scale(1.05); }
+.trek-dash .hero-tool svg { width: 17px; height: 17px; }
 .trek-dash .hero-title-block { align-self: end; padding-bottom: 24px; }
 .trek-dash .hero-eyebrow {
   display: inline-flex; align-items: center; gap: 10px;
@@ -435,26 +439,36 @@
 .trek-dash .trip-cover img { width: 100%; height: 100%; object-fit: cover; transition: transform .6s cubic-bezier(.2,.7,.2,1); }
 .trek-dash .trip-card:hover .trip-cover img { transform: scale(1.04); }
 .trek-dash .trip-cover::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, oklch(0 0 0 / 0) 40%, oklch(0 0 0 / .55) 100%); }
+/* Shares the dark scrim of .trip-action-btn so both overlays on the cover read
+   as one set, and the label survives a bright photo behind it. */
 .trek-dash .trip-status {
   position: absolute; top: 16px; left: 16px; z-index: 1;
   display: inline-flex; align-items: center; gap: 7px; padding: 6px 11px 6px 9px;
   border-radius: 999px; font-size: 11.5px; font-weight: 500; letter-spacing: 0.02em;
-  background: oklch(1 0 0 / .18); backdrop-filter: blur(14px) saturate(1.4); -webkit-backdrop-filter: blur(14px) saturate(1.4);
-  border: 1px solid oklch(1 0 0 / .22); color: #fff; text-transform: uppercase;
+  background: oklch(0.22 0.01 260 / .58); backdrop-filter: blur(14px) saturate(1.4); -webkit-backdrop-filter: blur(14px) saturate(1.4);
+  border: 1px solid oklch(1 0 0 / .34); color: #fff; text-transform: uppercase;
+  box-shadow: 0 2px 8px oklch(0 0 0 / .28);
 }
 .trek-dash .trip-status .indicator { width: 6px; height: 6px; border-radius: 50%; background: oklch(0.84 0.16 145); }
 .trek-dash .trip-status.completed .indicator { background: oklch(0.75 0.02 220); }
 .trek-dash .trip-status.upcoming .indicator { background: oklch(0.84 0.18 85); }
 .trek-dash .trip-status.idea .indicator { background: oklch(0.78 0.14 280); }
-.trek-dash .trip-actions { position: absolute; top: 14px; right: 14px; z-index: 1; display: flex; gap: 6px; opacity: 0; transition: opacity .2s; }
+/* The actions used to sit at opacity 0 until the card was hovered, over a white
+   .18 glass fill. Two people in a row reported they never found the archive and
+   rename buttons — invisible at rest, and on a light cover the white-on-white
+   fill hid them even while hovering. They stay on the card now, and the fill is
+   a dark scrim so the white icons carry against any photo. */
+.trek-dash .trip-actions { position: absolute; top: 14px; right: 14px; z-index: 1; display: flex; gap: 6px; opacity: .92; transition: opacity .2s; }
 .trek-dash .trip-card:hover .trip-actions { opacity: 1; }
 .trek-dash .trip-action-btn {
-  width: 36px; height: 36px; border-radius: 50%;
-  background: oklch(1 0 0 / .18); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
-  border: 1px solid oklch(1 0 0 / .22); color: #fff; display: grid; place-items: center; transition: background .15s;
+  width: 38px; height: 38px; border-radius: 50%;
+  background: oklch(0.22 0.01 260 / .58); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+  border: 1px solid oklch(1 0 0 / .34); color: #fff; display: grid; place-items: center;
+  box-shadow: 0 2px 8px oklch(0 0 0 / .28);
+  transition: background .15s, transform .12s;
 }
-.trek-dash .trip-action-btn:hover { background: oklch(1 0 0 / .3); }
-.trek-dash .trip-action-btn svg { width: 16px; height: 16px; }
+.trek-dash .trip-action-btn:hover { background: oklch(0.22 0.01 260 / .82); transform: scale(1.06); }
+.trek-dash .trip-action-btn svg { width: 17px; height: 17px; }
 .trek-dash .trip-cover-content { position: absolute; left: 18px; right: 18px; bottom: 16px; z-index: 1; color: #fff; }
 .trek-dash .trip-name { font-size: 26px; font-weight: 600; letter-spacing: -0.025em; line-height: 1.05; margin: 0; text-shadow: 0 1px 7px oklch(0 0 0 / .3), 0 1px 2px oklch(0 0 0 / .38); }
 .trek-dash .trip-where { margin-top: 4px; font-size: 13px; opacity: .85; display: flex; align-items: center; gap: 6px; }
@@ -686,8 +700,8 @@
   .trek-dash .trips { grid-template-columns: 1fr; gap: 16px; margin-bottom: 28px; }
   .trek-dash .add-trip-card { min-height: 180px; }
 
-  /* Touch devices have no hover — keep the edit/copy/archive/delete actions
-     visible at all times instead of revealing them on hover. */
+  /* Touch devices have no hover state to lift the actions to full strength, so
+     skip the resting dim entirely. */
   .trek-dash .trip-actions { opacity: 1; }
 
   /* Compact list row on mobile — keeps the list view distinct from the grid. The

--- a/client/src/utils/safeUrl.test.ts
+++ b/client/src/utils/safeUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { safeHttpUrl } from './safeUrl'
+
+describe('safeHttpUrl', () => {
+  it('FE-UTIL-SAFEURL-001: passes an ordinary https homepage through', () => {
+    expect(safeHttpUrl('https://louvre.fr/en/visit')).toBe('https://louvre.fr/en/visit')
+  })
+
+  it('FE-UTIL-SAFEURL-002: passes plain http through — plenty of small venues still run it', () => {
+    expect(safeHttpUrl('http://pension-alpenblick.at')).toBe('http://pension-alpenblick.at')
+  })
+
+  it('FE-UTIL-SAFEURL-003: rejects javascript:, which window.open would run in this origin', () => {
+    expect(safeHttpUrl('javascript:fetch("/api/trips")')).toBeNull()
+    expect(safeHttpUrl('JavaScript:alert(1)')).toBeNull()
+    expect(safeHttpUrl('  javascript:alert(1)')).toBeNull()
+  })
+
+  it('FE-UTIL-SAFEURL-004: rejects the other schemes that are not a web page', () => {
+    expect(safeHttpUrl('data:text/html,<script>alert(1)</script>')).toBeNull()
+    expect(safeHttpUrl('vbscript:msgbox(1)')).toBeNull()
+    expect(safeHttpUrl('file:///etc/passwd')).toBeNull()
+  })
+
+  it('FE-UTIL-SAFEURL-005: rejects a bare host, since window.open would treat it as a relative path', () => {
+    expect(safeHttpUrl('louvre.fr')).toBeNull()
+    expect(safeHttpUrl('//evil.example')).toBeNull()
+  })
+
+  it('FE-UTIL-SAFEURL-006: treats absent and empty as nothing to open', () => {
+    expect(safeHttpUrl(null)).toBeNull()
+    expect(safeHttpUrl(undefined)).toBeNull()
+    expect(safeHttpUrl('')).toBeNull()
+  })
+})

--- a/client/src/utils/safeUrl.ts
+++ b/client/src/utils/safeUrl.ts
@@ -1,0 +1,18 @@
+import { placeWebsiteSchema } from '@trek/shared'
+
+/**
+ * Allow-list a URL before handing it to window.open.
+ *
+ * A place's website is a plain string in the older contracts, and it reaches
+ * window.open from the inspector, both sidebar context menus and the mobile
+ * place sheet. `window.open('javascript:…')` does not open a page — it evaluates
+ * the script in a fresh document that inherits this origin, so a co-traveller
+ * with place_edit could plant one and wait for someone to click Website.
+ *
+ * Server-side validation closes the write path. This closes the read path, which
+ * is what covers rows written before that validation existed and instances that
+ * have not updated yet — the same split as safeHexColor.
+ */
+export function safeHttpUrl(value: string | null | undefined): string | null {
+  return typeof value === 'string' && placeWebsiteSchema.safeParse(value).success ? value : null
+}

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3891,6 +3891,24 @@ function runMigrations(db: Database.Database): void {
         db.exec('ALTER TABLE budget_items ADD COLUMN place_id INTEGER REFERENCES places(id) ON DELETE SET NULL DEFAULT NULL');
       }
     },
+    // A reservation_day_positions row only makes sense when its reservation and
+    // its day are on the same trip. The table carries no trip_id and its two
+    // foreign keys only ask that the ids exist, so pairs that never belonged
+    // together could accumulate; the writer refuses them now, and this clears
+    // whatever an older build let through. Appended LAST — the array is
+    // index-addressed against schema_version.
+    () => {
+      db.exec(`
+        DELETE FROM reservation_day_positions
+         WHERE rowid IN (
+           SELECT rdp.rowid
+             FROM reservation_day_positions rdp
+             JOIN reservations r ON r.id = rdp.reservation_id
+             JOIN days d ON d.id = rdp.day_id
+            WHERE d.trip_id <> r.trip_id
+         )
+      `);
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/nest/assignments/assignments.controller.ts
+++ b/server/src/nest/assignments/assignments.controller.ts
@@ -113,9 +113,14 @@ export class DayAssignmentsController {
 /**
  * /api/trips/:tripId/assignments/:id/* — per-assignment ops (move, time,
  * participants), independent of the day path. Same parity rules as above.
+ *
+ * Same guard pair as the day controller, and for the same reason: TripAccessGuard
+ * is what resolves :tripId and what reads @RequirePermission. The per-handler
+ * getAssignmentForTrip calls answer a different question — whether the assignment
+ * sits on the trip in the URL, not whether the caller may be on that trip.
  */
 @Controller('api/trips/:tripId/assignments')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, TripAccessGuard)
 export class AssignmentOpsController {
   constructor(private readonly assignments: AssignmentsService) {}
 
@@ -142,6 +147,9 @@ export class AssignmentOpsController {
 
   @Get(':id/participants')
   participants(@CurrentUser() user: User, @Param('tripId') tripId: string, @Param('id') id: string) {
+    if (!this.assignments.getAssignmentForTrip(id, tripId)) {
+      throw new HttpException({ error: 'Assignment not found' }, 404);
+    }
     return { participants: this.assignments.getParticipants(id) };
   }
 
@@ -191,6 +199,9 @@ export class AssignmentOpsController {
     @Body() body: AssignmentParticipantsDto,
     @Headers('x-socket-id') socketId?: string,
   ) {
+    if (!this.assignments.getAssignmentForTrip(id, tripId)) {
+      throw new HttpException({ error: 'Assignment not found' }, 404);
+    }
     const participants = this.assignments.setParticipants(id, body.user_ids);
     this.assignments.broadcast(tripId, 'assignment:participants', { assignmentId: Number(id), participants }, socketId);
     return { participants };

--- a/server/src/nest/places/places.controller.ts
+++ b/server/src/nest/places/places.controller.ts
@@ -20,7 +20,7 @@ import type { Response } from 'express';
 import { isDemoWriteBlocked, DEMO_WRITE_ERROR } from '../common/demo-write';
 import { RuntimeEnvService } from '../app-config/runtime-env.service';
 import { memoryStorage } from 'multer';
-import { hexColorSchema } from '@trek/shared';
+import { hexColorSchema, placeImageUrlSchema, placeWebsiteSchema } from '@trek/shared';
 import type { User } from '../../types';
 import { PlacesService } from './places.service';
 import { isUpdateConflict } from '../common/conflictResult';
@@ -60,6 +60,25 @@ function validateRouteColor(body: Record<string, unknown>): void {
   if (value === undefined || value === null) return;
   if (typeof value !== 'string' || !hexColorSchema.safeParse(value).success) {
     throw new HttpException({ error: 'route_color must be a hex colour like #4f46e5' }, 400);
+  }
+}
+
+// Same reason as route_color: these two leave the database for a renderer that
+// treats them as a URL — the thumbnail into marker HTML, the homepage into
+// window.open — and the open record means the pipe never sees them.
+function validateUrlFields(body: Record<string, unknown>): void {
+  const image = body.image_url;
+  if (image !== undefined && image !== null) {
+    if (typeof image !== 'string' || !placeImageUrlSchema.safeParse(image).success) {
+      throw new HttpException({ error: 'image_url must be an uploaded path, a photo-proxy path, an inline image or an https URL' }, 400);
+    }
+  }
+  const website = body.website;
+  // '' is how the UI clears the field; treat it like an absent value.
+  if (website !== undefined && website !== null && website !== '') {
+    if (typeof website !== 'string' || !placeWebsiteSchema.safeParse(website).success) {
+      throw new HttpException({ error: 'website must be an http or https URL' }, 400);
+    }
   }
 }
 
@@ -131,6 +150,7 @@ export class PlacesController {
     const trip = this.requireTrip(tripId, user);
     validateLengths(body);
     validateRouteColor(body);
+    validateUrlFields(body);
     this.requireEdit(trip, user);
     const place = this.places.create(tripId, body as never);
     this.places.broadcast(tripId, 'place:created', { place }, socketId);
@@ -428,6 +448,7 @@ export class PlacesController {
     const trip = this.requireTrip(tripId, user);
     validateLengths(body);
     validateRouteColor(body);
+    validateUrlFields(body);
     this.requireEdit(trip, user);
     const result = this.places.update(tripId, id, body as never, ifMatch);
     if (!result) {

--- a/server/src/nest/places/places.mcp.ts
+++ b/server/src/nest/places/places.mcp.ts
@@ -5,6 +5,7 @@ import {
   demoDenied, ok,
 } from '@trek/nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { placeWebsiteSchema } from '@trek/shared';
 import { z } from 'zod';
 import { AuthService } from '../auth/auth.service';
 import { AssignmentsService } from '../assignments/assignments.service';
@@ -63,7 +64,7 @@ export class PlacesMcp {
       google_ftid: z.string().optional().describe('Google Maps feature ID from search_place — enables direct Google Maps links'),
       osm_id: z.string().optional().describe('OpenStreetMap ID from search_place (e.g. "way:12345") — enables opening hours if no Google ID'),
       notes: z.string().max(2000).optional(),
-      website: z.string().max(500).optional(),
+      website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
       price: z.number().nonnegative().optional().describe('Cost of this place/activity (e.g. ticket price, entry fee)'),
       currency: z.string().length(3).optional().describe('ISO 4217 currency code (e.g. "EUR", "USD")'),
@@ -103,7 +104,7 @@ export class PlacesMcp {
       google_ftid: z.string().optional().describe('Google Maps feature ID from search_place — enables direct Google Maps links'),
       osm_id: z.string().optional().describe('OpenStreetMap ID from search_place (e.g. "way:12345")'),
       place_notes: z.string().max(2000).optional().describe('Notes for the place'),
-      website: z.string().max(500).optional(),
+      website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
       assignment_notes: z.string().max(500).optional().describe('Notes for this day assignment'),
       price: z.number().nonnegative().optional().describe('Cost of this place/activity (e.g. ticket price, entry fee)'),
@@ -158,7 +159,7 @@ export class PlacesMcp {
       end_time: z.string().max(50).optional().describe('End time (e.g. "11:00")'),
       duration_minutes: z.number().int().positive().optional(),
       notes: z.string().max(2000).optional(),
-      website: z.string().max(500).optional(),
+      website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
       transport_mode: z.enum(['walking', 'driving', 'cycling', 'transit', 'flight']).optional(),
       osm_id: z.string().optional().describe('OpenStreetMap ID (e.g. "way:12345")'),
@@ -366,7 +367,7 @@ export class PlacesMcp {
       end_time: z.string().max(50).optional().describe('End time (e.g. "11:00")'),
       duration_minutes: z.number().int().positive().optional(),
       notes: z.string().max(2000).optional(),
-      website: z.string().max(500).optional(),
+      website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
       description: z.string().max(2000).optional(),
     },

--- a/server/src/nest/places/places.rpc.ts
+++ b/server/src/nest/places/places.rpc.ts
@@ -1,4 +1,4 @@
-import { placeCreateRequestSchema, placeUpdateRequestSchema } from '@trek/shared';
+import { placeCreateRequestSchema, placeImageUrlSchema, placeUpdateRequestSchema, placeWebsiteSchema } from '@trek/shared';
 import { PluginController, PluginMethod } from '../plugins/host/rpc-kit/decorators';
 import { PluginGuards } from '../plugins/host/plugin-guards.service';
 import { BadParams, ForbiddenResource } from '../plugins/host/rpc-errors';
@@ -17,6 +17,23 @@ const PLACE_EDIT_ACTION = 'place_edit';
  * field the web app refuses with a 400, e.g. a 100k-character place name.
  */
 const PLACE_STR_LIMITS: Record<string, number> = { name: 200, description: 2000, address: 500, notes: 2000 };
+
+/**
+ * The two URL fields the REST controller pins in validateUrlFields. Same reason
+ * they are checked there rather than in the contract: the write schemas are open
+ * records, so a plugin could otherwise store a thumbnail or a homepage the web
+ * app refuses — and both end up somewhere that treats them as a URL.
+ */
+function capUrls(input: Record<string, unknown>): void {
+  const image = input.image_url;
+  if (image !== undefined && image !== null && !placeImageUrlSchema.safeParse(image).success) {
+    throw new BadParams('invalid place: image_url must be an uploaded path, a photo-proxy path, an inline image or an https URL');
+  }
+  const website = input.website;
+  if (website !== undefined && website !== null && website !== '' && !placeWebsiteSchema.safeParse(website).success) {
+    throw new BadParams('invalid place: website must be an http or https URL');
+  }
+}
 
 /**
  * The place surface a plugin may reach (#plugins).
@@ -41,6 +58,7 @@ export class PlacesRpc {
     const parsed = placeCreateRequestSchema.safeParse(params.input);
     if (!parsed.success) throw new BadParams(`invalid place: ${schemaMessage(parsed.error)}`);
     this.guards.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
+    capUrls(parsed.data as Record<string, unknown>);
     this.guards.requireTripEdit(tripId, actor, PLACE_EDIT_ACTION);
     const place = this.places.create(String(tripId), parsed.data as unknown as PlaceCreateInput);
     this.realtime.broadcast(tripId, 'place:created', { place });
@@ -56,6 +74,7 @@ export class PlacesRpc {
     const parsed = placeUpdateRequestSchema.safeParse(params.input);
     if (!parsed.success) throw new BadParams(`invalid place: ${schemaMessage(parsed.error)}`);
     this.guards.capStrings(parsed.data as Record<string, unknown>, PLACE_STR_LIMITS);
+    capUrls(parsed.data as Record<string, unknown>);
     this.guards.requireTripEdit(tripId, actor, PLACE_EDIT_ACTION);
     const place = this.places.update(String(tripId), String(placeId), parsed.data as PlaceUpdateInput);
     if (place === null) throw new ForbiddenResource(`no place ${placeId} on trip ${tripId}`);

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -468,6 +468,13 @@ export class ReservationsMcp {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.reservations.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('reservation_edit', tripId, ctx.userId)) return permissionDenied();
+
+    // The service scopes the write to the trip on its own, so a foreign id is
+    // already harmless — say so rather than reporting a success that moved
+    // nothing, the way the sibling tools above do.
+    if (dayId && !this.days.getDay(dayId, tripId))
+      return errorResult('dayId does not belong to this trip.');
+
     this.reservations.updatePositions(tripId, positions, dayId);
     this.guards.safeBroadcast(tripId, 'reservation:positions', { positions, dayId });
     return ok({ success: true });

--- a/server/src/nest/reservations/reservations.service.ts
+++ b/server/src/nest/reservations/reservations.service.ts
@@ -527,13 +527,26 @@ export class ReservationsService {
     return { reservation, accommodationCreated };
   }
 
-  updatePositions(tripId: string | number, positions: { id: number; day_plan_position: number }[], dayId?: number | string | null) {
+  updatePositions(tripId: string | number, positions: { id: number; day_plan_position?: number }[], dayId?: number | string | null) {
     if (dayId) {
-      // Per-day positions for multi-day reservations
-      const stmt = this.db.prepare('INSERT OR REPLACE INTO reservation_day_positions (reservation_id, day_id, position) VALUES (?, ?, ?)');
+      // Per-day positions for multi-day reservations, scoped the way the legacy
+      // branch below already scopes its update. The table carries no trip_id and
+      // its two foreign keys only ask that the ids exist, so the trip has to come
+      // from the join: the row materialises only when the reservation and the day
+      // agree on it. Doing that in the statement rather than as a pre-check also
+      // makes a stale id a quiet no-op instead of a foreign-key error surfacing
+      // as a 500.
+      const stmt = this.db.prepare(`
+        INSERT OR REPLACE INTO reservation_day_positions (reservation_id, day_id, position)
+        SELECT r.id, d.id, ?
+          FROM reservations r
+          JOIN days d ON d.trip_id = r.trip_id
+         WHERE r.id = ? AND d.id = ? AND r.trip_id = ?
+      `);
       this.db.transaction(() => {
         for (const item of positions) {
-          stmt.run(item.id, dayId, item.day_plan_position);
+          // position is NOT NULL while the wire contract leaves the value optional.
+          stmt.run(item.day_plan_position ?? 0, item.id, dayId, tripId);
         }
       });
     } else {

--- a/server/tests/e2e/assignments.e2e.test.ts
+++ b/server/tests/e2e/assignments.e2e.test.ts
@@ -194,4 +194,92 @@ describe('Assignments e2e (real auth guard + temp SQLite)', () => {
     expect(res.status).toBe(200);
     expect(res.body.assignment).toMatchObject({ id, day_id: 4, order_index: 0 });
   });
+
+  // The per-assignment controller declared @RequirePermission but not the guard
+  // that reads it, so the decorators were inert metadata and :tripId was never
+  // checked against the caller at all. The handlers that ask
+  // getAssignmentForTrip(id, tripId) were happy as long as the assignment sat on
+  // the trip in the URL — which is true for the owner's trip too.
+  describe('a trip the caller cannot see', () => {
+    const FOREIGN_TRIP = 9;
+
+    beforeEach(() => {
+      canAccessTrip.mockImplementation((tripId: unknown) => (Number(tripId) === 5 ? { id: 5, user_id: 1 } : undefined));
+      db.prepare('INSERT OR IGNORE INTO days (id, trip_id) VALUES (30, ?), (31, ?)').run(FOREIGN_TRIP, FOREIGN_TRIP);
+      db.prepare('INSERT OR IGNORE INTO places (id, trip_id, name) VALUES (20, ?, ?)').run(FOREIGN_TRIP, 'Their hotel');
+    });
+
+    const seedForeignAssignment = () =>
+      Number(db.prepare('INSERT INTO day_assignments (day_id, place_id, order_index) VALUES (30, 20, 0)').run().lastInsertRowid);
+
+    it('404s a move instead of reordering their itinerary', async () => {
+      const id = seedForeignAssignment();
+      const res = await request(server)
+        .put(`/api/trips/${FOREIGN_TRIP}/assignments/${id}/move`)
+        .set('Cookie', sessionCookie(1))
+        .send({ new_day_id: 31, order_index: 0 });
+      expect(res.status).toBe(404);
+      expect(db.prepare('SELECT day_id FROM day_assignments WHERE id = ?').get(id)).toEqual({ day_id: 30 });
+    });
+
+    it('404s a time change instead of rewriting their schedule', async () => {
+      const id = seedForeignAssignment();
+      const res = await request(server)
+        .put(`/api/trips/${FOREIGN_TRIP}/assignments/${id}/time`)
+        .set('Cookie', sessionCookie(1))
+        .send({ place_time: '23:00', end_time: null });
+      expect(res.status).toBe(404);
+      expect(db.prepare('SELECT assignment_time FROM day_assignments WHERE id = ?').get(id)).toEqual({ assignment_time: null });
+    });
+
+    it('404s a transport change', async () => {
+      const id = seedForeignAssignment();
+      const res = await request(server)
+        .put(`/api/trips/${FOREIGN_TRIP}/assignments/${id}/transport`)
+        .set('Cookie', sessionCookie(1))
+        .send({ transport_mode: 'driving' });
+      expect(res.status).toBe(404);
+    });
+
+    it('404s setting participants instead of writing to their assignment', async () => {
+      const id = seedForeignAssignment();
+      const res = await request(server)
+        .put(`/api/trips/${FOREIGN_TRIP}/assignments/${id}/participants`)
+        .set('Cookie', sessionCookie(1))
+        .send({ user_ids: [1] });
+      expect(res.status).toBe(404);
+      expect(db.prepare('SELECT COUNT(*) AS n FROM assignment_participants WHERE assignment_id = ?').get(id)).toEqual({ n: 0 });
+    });
+
+    it('404s reading participants instead of disclosing who is on it', async () => {
+      const id = seedForeignAssignment();
+      db.prepare('INSERT INTO assignment_participants (assignment_id, user_id) VALUES (?, 2)').run(id);
+      const res = await request(server)
+        .get(`/api/trips/${FOREIGN_TRIP}/assignments/${id}/participants`)
+        .set('Cookie', sessionCookie(1));
+      expect(res.status).toBe(404);
+    });
+
+    // The guard has to reject an assignment borrowed from elsewhere even when the
+    // caller is legitimately on the trip named in the URL.
+    it('404s an assignment that belongs to another trip than the URL says', async () => {
+      const id = seedForeignAssignment();
+      const res = await request(server)
+        .put(`/api/trips/5/assignments/${id}/participants`)
+        .set('Cookie', sessionCookie(1))
+        .send({ user_ids: [1] });
+      expect(res.status).toBe(404);
+      expect(db.prepare('SELECT COUNT(*) AS n FROM assignment_participants WHERE assignment_id = ?').get(id)).toEqual({ n: 0 });
+    });
+
+    it('403s when the caller is on the trip but lacks day_edit', async () => {
+      const id = seedAssignment();
+      checkPermission.mockReturnValue(false);
+      const res = await request(server)
+        .put(`/api/trips/5/assignments/${id}/time`)
+        .set('Cookie', sessionCookie(1))
+        .send({ place_time: '09:00', end_time: null });
+      expect(res.status).toBe(403);
+    });
+  });
 });

--- a/server/tests/e2e/reservations.e2e.test.ts
+++ b/server/tests/e2e/reservations.e2e.test.ts
@@ -185,4 +185,92 @@ describe('Reservations + accommodations e2e (real auth guard + temp SQLite, real
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: 'place_id, start_day_id, and end_day_id are required' });
   });
+
+  // The per-day branch of updatePositions used to bind the caller's ids straight
+  // into reservation_day_positions without ever looking at the tripId it was
+  // handed, so a request authorised on your own trip could rewrite the ordering
+  // of someone else's. The legacy branch three lines below it always scoped by
+  // trip_id — these pin that the two behave the same way now.
+  describe('positions are confined to the trip in the URL', () => {
+    let foreignTripId: number;
+    let foreignReservationId: number;
+    let foreignDayId: number;
+    let ownDayId: number;
+    // Days are unique per (trip_id, day_number) and this block seeds a fresh pair
+    // for every case, so the numbers have to keep climbing.
+    let dayNumber = 100;
+
+    beforeEach(() => {
+      db.prepare(
+        "INSERT OR IGNORE INTO users (id, username, email, password_hash, role, password_version) VALUES (2, 'victim', 'victim@example.test', 'x', 'user', 0)",
+      ).run();
+      foreignTripId = Number(db.prepare("INSERT INTO trips (user_id, title) VALUES (2, 'Someone else')").run().lastInsertRowid);
+      foreignReservationId = Number(db.prepare("INSERT INTO reservations (trip_id, title, type) VALUES (?, 'Secret', 'other')").run(foreignTripId).lastInsertRowid);
+      dayNumber += 1;
+      foreignDayId = Number(db.prepare("INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, '2026-05-01')").run(foreignTripId, dayNumber).lastInsertRowid);
+      ownDayId = Number(db.prepare("INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, '2026-05-01')").run(tripId, dayNumber).lastInsertRowid);
+    });
+
+    function positionRow(reservationId: number, dayId: number) {
+      return db.prepare('SELECT position FROM reservation_day_positions WHERE reservation_id = ? AND day_id = ?').get(reservationId, dayId);
+    }
+
+    it('writes nothing when both ids belong to another trip', async () => {
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: foreignReservationId, day_plan_position: 999 }], day_id: foreignDayId });
+      expect(res.status).toBe(200);
+      expect(positionRow(foreignReservationId, foreignDayId)).toBeUndefined();
+    });
+
+    it('writes nothing when only the reservation is foreign', async () => {
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: foreignReservationId, day_plan_position: 5 }], day_id: ownDayId });
+      expect(res.status).toBe(200);
+      expect(positionRow(foreignReservationId, ownDayId)).toBeUndefined();
+    });
+
+    it('writes nothing when only the day is foreign', async () => {
+      const ownReservationId = Number(db.prepare("INSERT INTO reservations (trip_id, title, type) VALUES (?, 'Mine', 'other')").run(tripId).lastInsertRowid);
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: ownReservationId, day_plan_position: 5 }], day_id: foreignDayId });
+      expect(res.status).toBe(200);
+      expect(positionRow(ownReservationId, foreignDayId)).toBeUndefined();
+    });
+
+    it('still stores a position when both ids are on the trip', async () => {
+      const ownReservationId = Number(db.prepare("INSERT INTO reservations (trip_id, title, type) VALUES (?, 'Mine', 'other')").run(tripId).lastInsertRowid);
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: ownReservationId, day_plan_position: 3 }], day_id: ownDayId });
+      expect(res.status).toBe(200);
+      expect(positionRow(ownReservationId, ownDayId)).toEqual({ position: 3 });
+    });
+
+    // An id that exists nowhere used to raise a foreign-key error, which the
+    // exception filter turned into a 500 — telling the caller apart from the
+    // 200 a real id returns, for any id on the instance.
+    it('answers a nonexistent reservation the same way it answers a foreign one', async () => {
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: 999999, day_plan_position: 1 }], day_id: ownDayId });
+      expect(res.status).toBe(200);
+    });
+
+    it('does not fall over when day_plan_position is omitted', async () => {
+      const ownReservationId = Number(db.prepare("INSERT INTO reservations (trip_id, title, type) VALUES (?, 'Mine', 'other')").run(tripId).lastInsertRowid);
+      const res = await request(server)
+        .put(`/api/trips/${tripId}/reservations/positions`)
+        .set('Cookie', sessionCookie(1))
+        .send({ positions: [{ id: ownReservationId }], day_id: ownDayId });
+      expect(res.status).toBe(200);
+    });
+  });
 });

--- a/server/tests/integration/leg-mode-incoming.test.ts
+++ b/server/tests/integration/leg-mode-incoming.test.ts
@@ -41,24 +41,34 @@ describe('incoming_leg_transport_mode migration', () => {
     // skipped on every one of them. Undoing what the LAST migration did and
     // rewinding one version is the only way to prove it still runs.
     //
-    // >>> Appending a migration? Re-point the DROP below at the column yours
-    // >>> adds. That is the whole maintenance cost of this guard.
-    const TRAILING_TABLE = 'budget_items';
-    const TRAILING_COLUMN = 'place_id';
-
+    // >>> Appending a migration? Re-point the "undo" below at whatever yours
+    // >>> does. That is the whole maintenance cost of this guard. The current
+    // >>> trailing slot deletes reservation_day_positions rows whose reservation
+    // >>> and day sit on different trips, so undoing it means putting one back.
     const upgraded = new Database(':memory:');
     upgraded.exec('PRAGMA foreign_keys = ON');
     createTables(upgraded);
     runMigrations(upgraded);
 
     const { version } = upgraded.prepare('SELECT version FROM schema_version').get() as { version: number };
-    upgraded.exec(`ALTER TABLE ${TRAILING_TABLE} DROP COLUMN ${TRAILING_COLUMN}`);
+
+    upgraded.prepare("INSERT INTO users (id, username, email, password_hash) VALUES (1, 'a', 'a@test.local', 'x')").run();
+    upgraded.prepare("INSERT INTO users (id, username, email, password_hash) VALUES (2, 'b', 'b@test.local', 'x')").run();
+    const tripA = upgraded.prepare("INSERT INTO trips (user_id, title) VALUES (1, 'A')").run().lastInsertRowid;
+    const tripB = upgraded.prepare("INSERT INTO trips (user_id, title) VALUES (2, 'B')").run().lastInsertRowid;
+    const reservationOnA = upgraded.prepare("INSERT INTO reservations (trip_id, title, type) VALUES (?, 'r', 'other')").run(tripA).lastInsertRowid;
+    const dayOnA = upgraded.prepare("INSERT INTO days (trip_id, day_number, date) VALUES (?, 1, '2026-01-01')").run(tripA).lastInsertRowid;
+    const dayOnB = upgraded.prepare("INSERT INTO days (trip_id, day_number, date) VALUES (?, 1, '2026-01-01')").run(tripB).lastInsertRowid;
+    const insertPosition = upgraded.prepare('INSERT INTO reservation_day_positions (reservation_id, day_id, position) VALUES (?, ?, ?)');
+    insertPosition.run(reservationOnA, dayOnB, 1); // the mismatched pair the migration clears
+    insertPosition.run(reservationOnA, dayOnA, 2); // a legitimate one it must leave alone
+
     upgraded.prepare('UPDATE schema_version SET version = ?').run(version - 1);
 
     runMigrations(upgraded);
 
-    const cols = upgraded.prepare(`PRAGMA table_info(${TRAILING_TABLE})`).all() as { name: string }[];
-    expect(cols.map(c => c.name)).toContain(TRAILING_COLUMN);
+    const rows = upgraded.prepare('SELECT day_id FROM reservation_day_positions ORDER BY day_id').all() as { day_id: number }[];
+    expect(rows).toEqual([{ day_id: Number(dayOnA) }]);
     expect(upgraded.prepare('SELECT version FROM schema_version').get()).toEqual({ version });
     upgraded.close();
   });

--- a/server/tests/unit/db/migration-hygiene.test.ts
+++ b/server/tests/unit/db/migration-hygiene.test.ts
@@ -135,6 +135,8 @@ const ALLOWED_DESTRUCTIVE: Record<string, string> = {
     'Atlas enclave fix: DELETE ... WHERE place_id IN (places inside specific enclave boxes) — invalidate stale region cache; re-resolved on next request.',
   'DELETE FROM visited_regions':
     'Atlas geoBoundaries swap (#1119): DELETE ... WHERE id = ? — after UPDATE OR IGNORE re-codes a manually-marked region to its current code, drop only the single leftover row whose UNIQUE(user_id, region_code) collision caused the update to be skipped (a duplicate of a region the user already has).',
+  'DELETE FROM reservation_day_positions':
+    'DELETE ... WHERE the row joins a reservation and a day sitting on different trips. The table has no trip_id and its two foreign keys only require the ids to exist, so a pair that never belonged together was storable; the writer scopes to the trip now and this clears what earlier builds allowed. Bounded by the join — a row whose reservation and day agree on their trip is untouched.',
 };
 
 describe('migration hygiene — destructive operation guard', () => {

--- a/server/tests/unit/nest/assignments.controller.test.ts
+++ b/server/tests/unit/nest/assignments.controller.test.ts
@@ -78,8 +78,10 @@ describe('AssignmentOpsController (parity with the per-assignment op routes)', (
     expect(reconcile).toHaveBeenCalledWith('5', 'sock');
   });
 
-  it('GET /:id/participants returns participants (access-only)', () => {
-    const s = svc({ getParticipants: vi.fn().mockReturnValue([{ user_id: 2 }]) } as Partial<AssignmentsService>);
+  it('GET /:id/participants 404 when the assignment is on another trip, else returns participants (access-only)', () => {
+    expect(thrown(() => new AssignmentOpsController(svc({ getAssignmentForTrip: vi.fn().mockReturnValue(undefined) } as Partial<AssignmentsService>)).participants(user, '5', '9')))
+      .toEqual({ status: 404, body: { error: 'Assignment not found' } });
+    const s = svc({ getAssignmentForTrip: vi.fn().mockReturnValue({ id: 9 }), getParticipants: vi.fn().mockReturnValue([{ user_id: 2 }]) } as Partial<AssignmentsService>);
     expect(new AssignmentOpsController(s).participants(user, '5', '9')).toEqual({ participants: [{ user_id: 2 }] });
   });
 
@@ -92,9 +94,13 @@ describe('AssignmentOpsController (parity with the per-assignment op routes)', (
     expect(reconcile).toHaveBeenCalledWith('5', 'sock');
   });
 
-  it('PUT /:id/participants sets + broadcasts (non-array bodies are the Zod pipe\'s 400, covered in e2e)', () => {
+  it('PUT /:id/participants 404 on a foreign assignment, else sets + broadcasts (non-array bodies are the Zod pipe\'s 400, covered in e2e)', () => {
     const setParticipants = vi.fn().mockReturnValue([{ user_id: 2 }]); const broadcast = vi.fn();
-    expect(new AssignmentOpsController(svc({ setParticipants, broadcast } as Partial<AssignmentsService>)).setParticipants(user, '5', '9', { user_ids: [2] }, 'sock')).toEqual({ participants: [{ user_id: 2 }] });
+    expect(thrown(() => new AssignmentOpsController(svc({ getAssignmentForTrip: vi.fn().mockReturnValue(undefined), setParticipants } as Partial<AssignmentsService>)).setParticipants(user, '5', '9', { user_ids: [2] })))
+      .toEqual({ status: 404, body: { error: 'Assignment not found' } });
+    expect(setParticipants).not.toHaveBeenCalled();
+    const s = svc({ getAssignmentForTrip: vi.fn().mockReturnValue({ id: 9 }), setParticipants, broadcast } as Partial<AssignmentsService>);
+    expect(new AssignmentOpsController(s).setParticipants(user, '5', '9', { user_ids: [2] }, 'sock')).toEqual({ participants: [{ user_id: 2 }] });
     expect(setParticipants).toHaveBeenCalledWith('9', [2]);
     expect(broadcast).toHaveBeenCalledWith('5', 'assignment:participants', { assignmentId: 9, participants: [{ user_id: 2 }] }, 'sock');
   });

--- a/server/tests/unit/nest/places.controller.test.ts
+++ b/server/tests/unit/nest/places.controller.test.ts
@@ -301,6 +301,59 @@ describe('PlacesController (parity with the legacy /api/trips/:tripId/places rou
     });
   });
 
+  // image_url and website leave the database for something that treats them as a
+  // URL — the thumbnail into hand-built marker HTML, the homepage into
+  // window.open. The write body is an open record, so the Zod pipe never sees
+  // either one; they are checked here for the same reason route_color is.
+  describe('image_url and website', () => {
+    const imageErr = { status: 400, body: { error: 'image_url must be an uploaded path, a photo-proxy path, an inline image or an https URL' } };
+    const siteErr = { status: 400, body: { error: 'website must be an http or https URL' } };
+    const ctl = (over: Partial<PlacesService> = {}) => new PlacesController(svc(over), new RuntimeEnvService());
+
+    it('400s an image_url the marker builders were never meant to receive, before the permission check', () => {
+      const canEdit = vi.fn().mockReturnValue(false); // would 403 if it got that far
+      for (const image_url of [
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'http://insecure.example/p.png',
+        '//evil.example/p.png',
+        123,
+      ]) {
+        expect(thrown(() => ctl({ canEdit }).update(user, '5', '9', { image_url }))).toEqual(imageErr);
+      }
+      expect(thrown(() => ctl({ canEdit }).create(user, '5', { name: 'T', image_url: 'javascript:alert(1)' }))).toEqual(imageErr);
+      expect(canEdit).not.toHaveBeenCalled();
+    });
+
+    it('keeps accepting every shape the app actually stores', () => {
+      const update = vi.fn().mockReturnValue({ id: 9 });
+      for (const image_url of [
+        '/uploads/places/eiffel.jpg',
+        '/api/maps/place-photo/abc123',
+        'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+        'https://images.example/photo.jpg',
+        null,
+      ]) {
+        expect(ctl({ update } as Partial<PlacesService>).update(user, '5', '9', { image_url })).toEqual({ place: { id: 9 } });
+      }
+    });
+
+    it('400s a website that window.open would not treat as a page', () => {
+      const canEdit = vi.fn().mockReturnValue(false);
+      for (const website of ['javascript:fetch("/api/trips")', 'data:text/html,x', 'louvre.fr', 42]) {
+        expect(thrown(() => ctl({ canEdit }).update(user, '5', '9', { website }))).toEqual(siteErr);
+      }
+      expect(canEdit).not.toHaveBeenCalled();
+    });
+
+    it('accepts http and https, and treats the empty string as clearing the field', () => {
+      const update = vi.fn().mockReturnValue({ id: 9 });
+      for (const website of ['https://louvre.fr', 'http://pension.at', '', null]) {
+        expect(ctl({ update } as Partial<PlacesService>).update(user, '5', '9', { website })).toEqual({ place: { id: 9 } });
+      }
+    });
+  });
+
   it('PUT /:id forwards the base-version token and 409s on a conflict (#1135)', () => {
     const update = vi.fn().mockReturnValue({ conflict: true, server: { id: 9, name: 'Theirs' } });
     const onUpdated = vi.fn(); const broadcast = vi.fn();

--- a/shared/src/collection/collection.schema.ts
+++ b/shared/src/collection/collection.schema.ts
@@ -1,4 +1,4 @@
-import { placeCategorySchema, placeRatingVoteSchema } from '../place/place.schema';
+import { placeCategorySchema, placeImageUrlSchema, placeRatingVoteSchema, placeWebsiteSchema } from '../place/place.schema';
 import { tagSchema } from '../tag/tag.schema';
 
 import { z } from 'zod';
@@ -53,6 +53,9 @@ export const collectionPlaceSchema = z.object({
   price: z.number().nullable().optional(),
   currency: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
+  // Deliberately open on the way out, pinned on the way in (see the save/update
+  // request schemas below): rows written before the request-side check existed
+  // still have to round-trip.
   image_url: z.string().nullable().optional(),
   google_place_id: z.string().nullable().optional(),
   google_ftid: z.string().nullable().optional(),
@@ -150,11 +153,11 @@ export const collectionSavePlaceRequestSchema = z.object({
   price: z.number().nullable().optional(),
   currency: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
-  image_url: z.string().nullable().optional(),
+  image_url: placeImageUrlSchema.nullable().optional(),
   google_place_id: z.string().nullable().optional(),
   google_ftid: z.string().nullable().optional(),
   osm_id: z.string().nullable().optional(),
-  website: z.string().nullable().optional(),
+  website: placeWebsiteSchema.nullable().optional(),
   phone: z.string().nullable().optional(),
   status: collectionStatusSchema.optional(),
   links: collectionLinksSchema.optional(),
@@ -203,7 +206,7 @@ export const collectionPlaceUpdateRequestSchema = z.object({
   // Replace the place's per-collection label assignments (omit to leave unchanged).
   label_ids: z.array(z.number()).optional(),
   // Custom thumbnail (#1136): null clears it (falls back to the auto-fetched photo).
-  image_url: z.string().nullable().optional(),
+  image_url: placeImageUrlSchema.nullable().optional(),
 });
 export type CollectionPlaceUpdateRequest = z.infer<typeof collectionPlaceUpdateRequestSchema>;
 

--- a/shared/src/place/place.schema.ts
+++ b/shared/src/place/place.schema.ts
@@ -20,6 +20,34 @@ const open = z.record(z.string(), z.unknown());
 export const hexColorSchema = z.string().regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
 
 /**
+ * The four shapes a place thumbnail is ever allowed to take: a file we stored, a
+ * photo-proxy path, an inline thumbnail, or a remote https image.
+ *
+ * The map markers build their HTML as a string, so what lands here is one input
+ * away from a renderer that forgets to escape. Pinning the scheme on the way in
+ * means a stored value cannot carry anything a future consumer has to defend
+ * against — the escaping in the marker builders stops being the only thing
+ * standing between the database and the DOM.
+ */
+export const placeImageUrlSchema = z.string().max(2048).refine(
+  v =>
+    v.startsWith('/uploads/')
+    || v.startsWith('/api/maps/place-photo/')
+    || /^data:image\/(png|jpe?g|webp|gif|avif);base64,/i.test(v)
+    || /^https:\/\//i.test(v),
+  { message: 'must be an uploaded path, a photo-proxy path, an inline image or an https URL' },
+);
+
+/**
+ * A place's homepage. It reaches window.open() on the client, where a
+ * javascript: value would run in this origin rather than opening a page.
+ */
+export const placeWebsiteSchema = z.string().max(500).refine(
+  v => /^https?:\/\//i.test(v),
+  { message: 'must be an http or https URL' },
+);
+
+/**
  * Embedded category as returned on a place — a trimmed projection of the
  * categories row (id/name/color/icon), built inline by placeService and
  * getPlaceWithTags. `null` when the place has no category_id.


### PR DESCRIPTION
## Description

Three things from one pass over the dashboard and the trip write paths.

**Trip card controls.** The edit / duplicate / archive / delete buttons on a trip cover sat at `opacity: 0` until the card was hovered, over a white translucent fill. Two people reported in a row that they could not find how to unarchive or rename a trip: the controls were invisible at rest, and on a light cover the white-on-white fill hid them even while hovering. They stay on the card now, the fill is a dark scrim so the white icons carry against any photo, and the archive button shows a restore icon once the trip is archived — mobile already did that, desktop now matches. The status pill and the hero badge move to the same scrim so the overlays on a cover read as one set. Every button gains a `title` alongside its `aria-label`.

**Place URL fields.** `image_url` and `website` were unconstrained strings on every write path. Both leave the database for something that treats them as a URL — the thumbnail into hand-built marker HTML, the homepage into `window.open` — so they are pinned on the way in now: in the shared contract, and on all three write surfaces (REST, plugin RPC, MCP) so none of them accepts what the others refuse. On the read side `safeHttpUrl` covers rows written before the check existed, the same split `safeHexColor` already uses. The entity schemas stay open, so existing rows still round-trip.

**Per-day reservation ordering.** The per-day branch of `updatePositions` did not scope its write to the trip, unlike the legacy branch three lines below it. It is scoped in the statement now, which also turns a stale id into a quiet no-op instead of a foreign-key error surfacing as a 500 — and makes an omitted `day_plan_position` behave, which the wire contract has always allowed. A migration clears rows whose reservation and day disagree on their trip.

Alongside, two consistency fixes in the same area: the per-assignment routes pick up the trip access guard the day routes already carry, and the Leaflet journey map escapes entry titles and track names before they become tooltip markup, which its GL twin already did.

## Related Issue or Discussion

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
