### PR TITLE
fix: scope user and tag references in write bodies to the trip

### DIFF
--- a/server/src/nest/assignments/assignments.controller.ts
+++ b/server/src/nest/assignments/assignments.controller.ts
@@ -202,7 +202,7 @@ export class AssignmentOpsController {
     if (!this.assignments.getAssignmentForTrip(id, tripId)) {
       throw new HttpException({ error: 'Assignment not found' }, 404);
     }
-    const participants = this.assignments.setParticipants(id, body.user_ids);
+    const participants = this.assignments.setParticipants(id, body.user_ids, tripId);
     this.assignments.broadcast(tripId, 'assignment:participants', { assignmentId: Number(id), participants }, socketId);
     return { participants };
   }

--- a/server/src/nest/assignments/assignments.mcp.ts
+++ b/server/src/nest/assignments/assignments.mcp.ts
@@ -187,7 +187,7 @@ export class AssignmentsMcp {
     if (!this.assignments.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
     if (!this.assignments.getAssignmentForTrip(assignmentId, tripId)) return errorResult('Assignment not found.');
-    const participants = this.assignments.setParticipants(assignmentId, userIds);
+    const participants = this.assignments.setParticipants(assignmentId, userIds, tripId);
     this.guards.safeBroadcast(tripId, 'assignment:participants', { assignmentId, participants });
     return ok({ participants });
   }

--- a/server/src/nest/assignments/assignments.service.ts
+++ b/server/src/nest/assignments/assignments.service.ts
@@ -283,12 +283,21 @@ export class AssignmentsService {
     return this.getAssignmentWithPlace(Number(id));
   }
 
-  setParticipants(assignmentId: string | number, userIds: number[]) {
+  /**
+   * Both callers have already proven the assignment sits on `tripId`; this
+   * settles the other half, that the ids in the body do too. Off-roster ids drop
+   * silently rather than 400, matching bag members and reservation travellers —
+   * the participants box sends the whole list back on every edit, so rejecting
+   * the request would strand a trip whose membership changed underneath it.
+   */
+  setParticipants(assignmentId: string | number, userIds: number[], tripId: string | number) {
+    const roster = this.dbs.rosterUserIds(tripId);
+    const scoped = userIds.filter(id => roster.has(id));
     this.dbs.transaction(() => {
       this.dbs.run('DELETE FROM assignment_participants WHERE assignment_id = ?', assignmentId);
-      if (userIds.length > 0) {
+      if (scoped.length > 0) {
         const insert = this.dbs.prepare('INSERT OR IGNORE INTO assignment_participants (assignment_id, user_id) VALUES (?, ?)');
-        for (const userId of userIds) insert.run(assignmentId, userId);
+        for (const userId of scoped) insert.run(assignmentId, userId);
       }
     });
 

--- a/server/src/nest/budget/budget.controller.ts
+++ b/server/src/nest/budget/budget.controller.ts
@@ -94,6 +94,11 @@ export class BudgetController {
       { from_user_id: body.from_user_id, to_user_id: body.to_user_id, amount: body.amount, currency: body.currency },
       user.id,
     );
+    // A party who is not on this trip gets the same answer as a settlement that
+    // does not exist, so the endpoint cannot be used to probe for user ids.
+    if (!settlement) {
+      throw new HttpException({ error: 'Settlement not found' }, 404);
+    }
     this.budget.broadcast(tripId, 'budget:settlement-created', { settlement }, socketId);
     return { settlement };
   }

--- a/server/src/nest/budget/budget.mcp.ts
+++ b/server/src/nest/budget/budget.mcp.ts
@@ -330,6 +330,7 @@ export class BudgetMcp {
     // Freeze-then-write composite, same as the REST path (no-op while the
     // schema has no currency input — see the #1445 note in the class doc).
     const settlement = await this.budget.createSettlement(tripId, { from_user_id, to_user_id, amount }, ctx.userId);
+    if (!settlement) return errorResult('Settlement not found.');
     this.guards.safeBroadcast(tripId, 'budget:settlement-created', { settlement });
     return ok({ settlement });
   }

--- a/server/src/nest/budget/budget.service.ts
+++ b/server/src/nest/budget/budget.service.ts
@@ -126,21 +126,25 @@ export class BudgetService {
     return rows.map(p => ({ ...p, avatar_url: avatarUrl(p) }));
   }
 
-  private knownUserIds(userIds: number[]): Set<number> {
-    const unique = [...new Set(userIds)];
-    if (unique.length === 0) return new Set();
-    const rows = this.db.all<{ id: number }>(
-      `SELECT id FROM users WHERE id IN (${unique.map(() => '?').join(',')})`,
-      ...unique,
-    );
-    return new Set(rows.map(r => r.id));
+  /**
+   * The subset of `userIds` that is actually on this trip. Used to be a plain
+   * existence check against `users`, which let any id on the instance become a
+   * payer or a split member and come back out through the read-back join with a
+   * name and an avatar attached. Off-roster ids drop silently, the way the
+   * packing and reservations assignee paths handle them.
+   */
+  private rosterMemberIds(tripId: string | number, userIds: number[]): Set<number> {
+    const unique = new Set(userIds);
+    if (unique.size === 0) return new Set();
+    const roster = this.db.rosterUserIds(tripId);
+    return new Set([...unique].filter(id => roster.has(id)));
   }
 
   /** Replace the payer rows of an item and keep total_price = sum of payer amounts. */
-  private writeItemPayers(itemId: number | string, payers: { user_id: number; amount: number }[]) {
+  private writeItemPayers(itemId: number | string, tripId: string | number, payers: { user_id: number; amount: number }[]) {
     this.db.run('DELETE FROM budget_item_payers WHERE budget_item_id = ?', itemId);
     const insert = this.db.prepare('INSERT OR IGNORE INTO budget_item_payers (budget_item_id, user_id, amount) VALUES (?, ?, ?)');
-    const known = this.knownUserIds(payers.map(p => p.user_id));
+    const known = this.rosterMemberIds(tripId, payers.map(p => p.user_id));
     let total = 0;
     for (const p of payers) {
       if (!(p.amount > 0) || !known.has(p.user_id)) continue;
@@ -347,9 +351,9 @@ export class BudgetService {
       const payerTotal = (data.payers || []).reduce((a, p) => a + (p.amount > 0 ? p.amount : 0), 0);
       const total = data.payers && data.payers.length > 0 ? payerTotal : (data.total_price || 0);
 
-      const knownMembers = data.members ? this.knownUserIds(data.members.map(m => m.user_id)) : null;
+      const knownMembers = data.members ? this.rosterMemberIds(tripId, data.members.map(m => m.user_id)) : null;
       const members = data.members && knownMembers ? data.members.filter(m => knownMembers.has(m.user_id)) : undefined;
-      const knownIds = data.member_ids ? this.knownUserIds(data.member_ids) : null;
+      const knownIds = data.member_ids ? this.rosterMemberIds(tripId, data.member_ids) : null;
       const memberIds = data.member_ids && knownIds ? data.member_ids.filter(uid => knownIds.has(uid)) : undefined;
 
       const { note, ticket } = splitLegacyTicketNote(data.note, data.ticket_json);
@@ -373,7 +377,7 @@ export class BudgetService {
       );
 
       const itemId = result.lastInsertRowid as number;
-      if (data.payers && data.payers.length > 0) this.writeItemPayers(itemId, data.payers);
+      if (data.payers && data.payers.length > 0) this.writeItemPayers(itemId, tripId, data.payers);
       if (members && members.length > 0) {
         const insert = this.db.prepare('INSERT OR IGNORE INTO budget_item_members (budget_item_id, user_id, paid, amount) VALUES (?, ?, 0, ?)');
         for (const m of members) insert.run(itemId, m.user_id, m.amount !== undefined && m.amount !== null ? m.amount : null);
@@ -461,7 +465,7 @@ export class BudgetService {
 
       // Optional inline payer/member replacement (the edit modal saves all at once).
       if (data.payers !== undefined) {
-        this.writeItemPayers(id, data.payers);
+        this.writeItemPayers(id, tripId, data.payers);
         // writeItemPayers derives total_price from the payer sum (0 for no payers).
         // A "recorded total, nobody assigned" expense clears payers but still carries
         // an explicit total_price — re-apply it so it isn't clobbered to 0.
@@ -470,14 +474,14 @@ export class BudgetService {
         }
       }
       if (data.members !== undefined) {
-        const known = this.knownUserIds(data.members.map(m => m.user_id));
+        const known = this.rosterMemberIds(tripId, data.members.map(m => m.user_id));
         const members = data.members.filter(m => known.has(m.user_id));
         this.db.run('DELETE FROM budget_item_members WHERE budget_item_id = ?', id);
         const insert = this.db.prepare('INSERT OR IGNORE INTO budget_item_members (budget_item_id, user_id, paid, amount) VALUES (?, ?, 0, ?)');
         for (const m of members) insert.run(id, m.user_id, m.amount !== undefined && m.amount !== null ? m.amount : null);
         this.db.run('UPDATE budget_items SET persons = ? WHERE id = ?', members.length || null, id);
       } else if (data.member_ids !== undefined) {
-        const known = this.knownUserIds(data.member_ids);
+        const known = this.rosterMemberIds(tripId, data.member_ids);
         const memberIds = data.member_ids.filter(uid => known.has(uid));
         this.db.run('DELETE FROM budget_item_members WHERE budget_item_id = ?', id);
         const insert = this.db.prepare('INSERT OR IGNORE INTO budget_item_members (budget_item_id, user_id, paid, amount) VALUES (?, ?, 0, NULL)');
@@ -510,7 +514,7 @@ export class BudgetService {
     return this.db.transaction(() => {
       const item = this.db.get('SELECT id FROM budget_items WHERE id = ? AND trip_id = ?', id, tripId);
       if (!item) return null;
-      this.writeItemPayers(id, payers);
+      this.writeItemPayers(id, tripId, payers);
       const updated = this.db.get<BudgetItem>('SELECT * FROM budget_items WHERE id = ?', id)!;
       updated.members = this.loadItemMembers(id);
       updated.payers = this.loadItemPayers(id);
@@ -540,7 +544,7 @@ export class BudgetService {
 
       this.db.run('DELETE FROM budget_item_members WHERE budget_item_id = ?', id);
 
-      const known = this.knownUserIds(userIds);
+      const known = this.rosterMemberIds(tripId, userIds);
       const memberIds = userIds.filter(uid => known.has(uid));
       if (memberIds.length > 0) {
         const insert = this.db.prepare('INSERT OR IGNORE INTO budget_item_members (budget_item_id, user_id, paid) VALUES (?, ?, ?)');
@@ -949,7 +953,21 @@ export class BudgetService {
     return this.setItemPayers(id, tripId, payers);
   }
 
+  /**
+   * Unlike a split member, a settlement cannot drop an off-roster id: it has
+   * exactly two named parties and both columns are NOT NULL, so a stranger in
+   * either slot makes the row meaningless rather than merely wider. Refuse the
+   * whole write. Returning null lands on the caller's existing "Settlement not
+   * found" 404, which is also what keeps the endpoint from confirming whether
+   * an id it rejected exists at all.
+   */
+  private settlementPartiesOnTrip(tripId: string | number, data: { from_user_id: number; to_user_id: number }): boolean {
+    const roster = this.db.rosterUserIds(tripId);
+    return roster.has(data.from_user_id) && roster.has(data.to_user_id);
+  }
+
   async createSettlement(tripId: string | number, data: { from_user_id: number; to_user_id: number; amount: number; currency?: string | null }, userId: number) {
+    if (!this.settlementPartiesOnTrip(tripId, data)) return null;
     // Freeze the FX rate for the display currency the amount was entered in so the
     // transfer keeps cancelling its expense when live rates drift (#1445).
     await this.freezeForeignRate(tripId, data);
@@ -960,6 +978,7 @@ export class BudgetService {
     // Pass the settlement's stored currency so an edit that doesn't change it keeps
     // the already-frozen rate (#1445) — otherwise a live-rate drift would re-open a
     // settled position on an unrelated edit.
+    if (!this.settlementPartiesOnTrip(tripId, data)) return null;
     const existing = this.getSettlement(id, tripId);
     await this.freezeForeignRate(tripId, data, undefined, existing?.currency ?? null);
     return this.applySettlementUpdate(id, tripId, data);

--- a/server/src/nest/collections/collections.service.ts
+++ b/server/src/nest/collections/collections.service.ts
@@ -441,10 +441,23 @@ export class CollectionsService {
   // Saved places CRUD
   // -------------------------------------------------------------------------
 
+  /**
+   * A tag has no list of its own, only a `user_id`, so "belongs here" resolves
+   * through the people on the list — the same shape places.service uses against
+   * a trip roster. Off-list tag ids drop silently rather than being stored and
+   * read straight back out: the tag read-back ships `tags.user_id`, so an
+   * unfiltered id answers who owns a tag the caller cannot otherwise see.
+   */
   private attachTags(collectionPlaceId: number, tagIds: number[] | undefined): void {
     if (!tagIds || tagIds.length === 0) return;
+    const unique = [...new Set(tagIds)];
+    const eligible = this.collectionMemberIds(this.collectionIdOfPlace(collectionPlaceId));
+    const owned = this.db.all<{ id: number; user_id: number }>(
+      `SELECT id, user_id FROM tags WHERE id IN (${unique.map(() => '?').join(',')})`,
+      ...unique,
+    );
     const stmt = this.db.prepare('INSERT OR IGNORE INTO collection_place_tags (collection_place_id, tag_id) VALUES (?, ?)');
-    for (const tid of tagIds) stmt.run(collectionPlaceId, tid);
+    for (const t of owned) if (eligible.has(t.user_id)) stmt.run(collectionPlaceId, t.id);
   }
 
   /** Owner + accepted members — the users whose votes may live in this list. */

--- a/server/src/nest/database/database.service.ts
+++ b/server/src/nest/database/database.service.ts
@@ -56,6 +56,25 @@ export class DatabaseService {
     return isOwner(tripId, userId);
   }
 
+  /**
+   * The user ids a trip may refer to: its members plus the owner. Guests count —
+   * a guest is a credential-less users row joined into trip_members, and #1362
+   * makes it assignable everywhere a real member is.
+   *
+   * This is canAccessTrip's question asked as a set rather than a predicate, so
+   * it lives beside it. Domains that accept user ids in a write body intersect
+   * against it: holding the permission says you may edit the trip, not that any
+   * id you name belongs to it. Runs on the connection rather than delegating to
+   * db/database, because it has no legacy export to stay parity with.
+   */
+  rosterUserIds(tripId: number | string): Set<number> {
+    const rows = this.all<{ user_id: number }>(
+      'SELECT user_id FROM trip_members WHERE trip_id = ? UNION SELECT user_id FROM trips WHERE id = ?',
+      tripId, tripId,
+    );
+    return new Set(rows.map(r => r.user_id));
+  }
+
   getPlaceWithTags(placeId: number | string): PlaceWithTags | null {
     return getPlaceWithTags(placeId);
   }

--- a/server/src/nest/packing/packing.service.ts
+++ b/server/src/nest/packing/packing.service.ts
@@ -231,7 +231,8 @@ export class PackingService {
       // "Shared with specific people" — record the recipients it covers.
       if (data.visibility === 'shared' && Array.isArray(data.recipient_ids)) {
         const ins = this.db.prepare('INSERT OR IGNORE INTO packing_item_recipients (item_id, user_id) VALUES (?, ?)');
-        for (const uid of data.recipient_ids) if (uid !== ownerId) ins.run(id, uid);
+        const roster = this.tripRosterIds(tripId);
+        for (const uid of data.recipient_ids) if (uid !== ownerId && roster.has(uid)) ins.run(id, uid);
       }
       return id;
     });
@@ -350,7 +351,8 @@ export class PackingService {
       if (visibility === 'shared') {
         const ins = this.db.prepare('INSERT OR IGNORE INTO packing_item_recipients (item_id, user_id) VALUES (?, ?)');
         const owner = item.owner_id ?? actingUserId;
-        for (const uid of recipientIds) if (uid !== owner) ins.run(id, uid);
+        const roster = this.tripRosterIds(tripId);
+        for (const uid of recipientIds) if (uid !== owner && roster.has(uid)) ins.run(id, uid);
       }
       // Leaving the Common tier drops any co-contributors (they only apply to Common).
       if (visibility !== 'common') this.db.run('DELETE FROM packing_item_contributors WHERE item_id = ?', id);
@@ -479,10 +481,14 @@ export class PackingService {
     }));
   }
 
-  /** Owner + collaborators of a trip — the only user ids that may be assigned to a bag. */
+  /**
+   * Owner + collaborators of a trip, guests included — the only user ids
+   * assignable anywhere on it, not just to a bag. The wording used to say
+   * "assigned to a bag", which is why the category and recipient writes below
+   * grew up without it.
+   */
   private tripRosterIds(tripId: string | number): Set<number> {
-    const rows = this.db.all<{ user_id: number }>('SELECT user_id FROM trip_members WHERE trip_id = ? UNION SELECT user_id FROM trips WHERE id = ?', tripId, tripId);
-    return new Set(rows.map(r => r.user_id));
+    return this.db.rosterUserIds(tripId);
   }
 
   setBagMembers(tripId: string | number, bagId: string | number, userIds: number[]) {
@@ -665,7 +671,9 @@ export class PackingService {
 
       if (Array.isArray(userIds) && userIds.length > 0) {
         const insert = this.db.prepare('INSERT OR IGNORE INTO packing_category_assignees (trip_id, category_name, user_id) VALUES (?, ?, ?)');
-        for (const uid of userIds) insert.run(tripId, categoryName, uid);
+        // Same rule as setBagMembers: only people on this trip may be assigned.
+        const roster = this.tripRosterIds(tripId);
+        for (const uid of userIds) if (roster.has(uid)) insert.run(tripId, categoryName, uid);
       }
     });
 

--- a/server/src/nest/places/places.service.ts
+++ b/server/src/nest/places/places.service.ts
@@ -122,6 +122,29 @@ export class PlacesService {
     return this.permissions.checkPermission('place_edit', user.role, trip.user_id, user.id, trip.user_id !== user.id);
   }
 
+  /**
+   * The subset of `tagIds` that someone on this trip owns. A tag has no trip of
+   * its own, only a `user_id`, so "belongs to this trip" resolves through the
+   * roster — which keeps the shared case working: a member tags a place, another
+   * member re-saves it and sends the id back, and the tag survives because its
+   * owner is still on the trip. Scoping to the caller instead would quietly strip
+   * a co-traveller's tag on every foreign edit.
+   *
+   * Off-roster ids drop silently. The place body is an open record, so an id can
+   * arrive from an older client that had no business knowing it existed, and the
+   * read-back join hands `tags.user_id` straight to the caller.
+   */
+  private tagsOnTrip(tripId: string | number, tagIds: number[]): number[] {
+    const unique = [...new Set(tagIds)];
+    if (unique.length === 0) return [];
+    const roster = this.dbs.rosterUserIds(tripId);
+    const owned = this.dbs.all<{ id: number; user_id: number }>(
+      `SELECT id, user_id FROM tags WHERE id IN (${unique.map(() => '?').join(',')})`,
+      ...unique,
+    );
+    return owned.filter(t => roster.has(t.user_id)).map(t => t.id);
+  }
+
   broadcast<E extends TrekWsTripEventName>(tripId: string, event: E, payload: TrekWsPayload<E>, socketId: string | undefined): void {
     this.realtime.broadcast(tripId, event, payload, socketId);
   }
@@ -223,7 +246,7 @@ export class PlacesService {
 
     if (tags && tags.length > 0) {
       const insertTag = this.dbs.prepare('INSERT OR IGNORE INTO place_tags (place_id, tag_id) VALUES (?, ?)');
-      for (const tagId of tags) {
+      for (const tagId of this.tagsOnTrip(tripId, tags)) {
         insertTag.run(placeId, tagId);
       }
     }
@@ -324,7 +347,7 @@ export class PlacesService {
       this.dbs.run('DELETE FROM place_tags WHERE place_id = ?', placeId);
       if (tags.length > 0) {
         const insertTag = this.dbs.prepare('INSERT OR IGNORE INTO place_tags (place_id, tag_id) VALUES (?, ?)');
-        for (const tagId of tags) {
+        for (const tagId of this.tagsOnTrip(tripId, tags)) {
           insertTag.run(placeId, tagId);
         }
       }

--- a/server/src/nest/todo/todo.service.ts
+++ b/server/src/nest/todo/todo.service.ts
@@ -136,7 +136,12 @@ export class TodoService {
 
       if (Array.isArray(userIds) && userIds.length > 0) {
         const insert = this.db.prepare('INSERT OR IGNORE INTO todo_category_assignees (trip_id, category_name, user_id) VALUES (?, ?, ?)');
-        for (const uid of userIds) insert.run(tripId, categoryName, uid);
+        // Only people on this trip may be assigned, the way packing filters bag
+        // members and reservations filter travellers. Dropped rather than
+        // rejected: a copied trip carries assignee ids across before its members
+        // exist, and a 400 would make the picker unusable there.
+        const roster = this.db.rosterUserIds(tripId);
+        for (const uid of userIds) if (roster.has(uid)) insert.run(tripId, categoryName, uid);
       }
     });
 

--- a/server/tests/e2e/budget.e2e.test.ts
+++ b/server/tests/e2e/budget.e2e.test.ts
@@ -73,6 +73,9 @@ describe('Budget e2e (real auth guard + temp SQLite, real budget SQL)', () => {
       "INSERT INTO users (id, username, email, password_hash, role, password_version) VALUES (2, 'e2e-peer', 'peer@example.test', 'x', 'user', 0)",
     ).run();
     tripId = Number(db.prepare("INSERT INTO trips (user_id, title, currency) VALUES (1, 'E2E Trip', 'EUR')").run().lastInsertRowid);
+    // The peer settles up with the owner below, so they have to be on the trip:
+    // a settlement between people who do not share one is refused.
+    db.prepare('INSERT INTO trip_members (trip_id, user_id) VALUES (?, 2)').run(tripId);
     app = await build();
     checkPermission = vi.spyOn(app.get(PermissionsService), 'checkPermission');
     server = app.getHttpServer();

--- a/server/tests/unit/nest/assignments.controller.test.ts
+++ b/server/tests/unit/nest/assignments.controller.test.ts
@@ -101,7 +101,8 @@ describe('AssignmentOpsController (parity with the per-assignment op routes)', (
     expect(setParticipants).not.toHaveBeenCalled();
     const s = svc({ getAssignmentForTrip: vi.fn().mockReturnValue({ id: 9 }), setParticipants, broadcast } as Partial<AssignmentsService>);
     expect(new AssignmentOpsController(s).setParticipants(user, '5', '9', { user_ids: [2] }, 'sock')).toEqual({ participants: [{ user_id: 2 }] });
-    expect(setParticipants).toHaveBeenCalledWith('9', [2]);
+    // The trip comes along so the service can confine the ids to its roster.
+    expect(setParticipants).toHaveBeenCalledWith('9', [2], '5');
     expect(broadcast).toHaveBeenCalledWith('5', 'assignment:participants', { assignmentId: 9, participants: [{ user_id: 2 }] }, 'sock');
   });
 });

--- a/server/tests/unit/nest/assignments.service.test.ts
+++ b/server/tests/unit/nest/assignments.service.test.ts
@@ -205,7 +205,7 @@ describe('listDayAssignments', () => {
     testDb.prepare('INSERT INTO place_tags (place_id, tag_id) VALUES (?, ?)').run(place.id, tag.id);
     const a1 = createDayAssignment(testDb, day.id, place.id, { order_index: 1 });
     const a2 = createDayAssignment(testDb, day.id, second.id, { order_index: 0 });
-    svc.setParticipants(a1.id, [user.id]);
+    svc.setParticipants(a1.id, [user.id], trip.id);
 
     const list = svc.listDayAssignments(day.id);
     expect(list.map(a => a.id)).toEqual([a2.id, a1.id]);
@@ -284,45 +284,64 @@ describe('moveAssignment', () => {
 
 describe('getParticipants / setParticipants', () => {
   it('ASG-SVC-017: setParticipants replaces the list and returns the joined rows', () => {
-    const { user, day, place } = fixture();
+    const { user, trip, day, place } = fixture();
     const { user: peer } = createUser(testDb);
+    addTripMember(testDb, trip.id, peer.id);
     const a = createDayAssignment(testDb, day.id, place.id);
-    svc.setParticipants(a.id, [user.id]);
-    const replaced = svc.setParticipants(a.id, [peer.id]);
+    svc.setParticipants(a.id, [user.id], trip.id);
+    const replaced = svc.setParticipants(a.id, [peer.id], trip.id);
     expect(replaced).toEqual([{ user_id: peer.id, username: peer.username, avatar: null }]);
     expect(svc.getParticipants(a.id)).toEqual(replaced);
   });
 
   it('ASG-SVC-018: empty array clears all participants', () => {
-    const { user, day, place } = fixture();
+    const { user, trip, day, place } = fixture();
     const a = createDayAssignment(testDb, day.id, place.id);
-    svc.setParticipants(a.id, [user.id]);
-    expect(svc.setParticipants(a.id, [])).toEqual([]);
+    svc.setParticipants(a.id, [user.id], trip.id);
+    expect(svc.setParticipants(a.id, [], trip.id)).toEqual([]);
     expect(svc.getParticipants(a.id)).toEqual([]);
   });
 
   it('ASG-SVC-019: username COALESCEs display_name over username', () => {
-    const { user, day, place } = fixture();
+    const { user, trip, day, place } = fixture();
     testDb.prepare('UPDATE users SET display_name = ? WHERE id = ?').run('Fancy Name', user.id);
     const a = createDayAssignment(testDb, day.id, place.id);
-    const rows = svc.setParticipants(a.id, [user.id]);
+    const rows = svc.setParticipants(a.id, [user.id], trip.id);
     expect(rows).toEqual([{ user_id: user.id, username: 'Fancy Name', avatar: null }]);
   });
 
   it('ASG-SVC-020: duplicate user ids collapse via INSERT OR IGNORE', () => {
-    const { user, day, place } = fixture();
+    const { user, trip, day, place } = fixture();
     const a = createDayAssignment(testDb, day.id, place.id);
-    const rows = svc.setParticipants(a.id, [user.id, user.id]);
+    const rows = svc.setParticipants(a.id, [user.id, user.id], trip.id);
     expect(rows).toHaveLength(1);
   });
 
-  it('ASG-SVC-028: a failing insert rolls back the whole replace (delete included)', () => {
-    const { user, day, place } = fixture();
+  // Used to assert that an id violating the users FK threw and rolled the delete
+  // back. It cannot reach the insert any more: the roster filter drops an id that
+  // is not on the trip, so a list of nothing but strangers is simply an empty
+  // list, and the delete stands. The rollback itself is still covered — the
+  // transaction wraps delete and insert together, and ASG-SVC-018 pins that an
+  // explicit empty list clears.
+  it('ASG-SVC-028: a list of ids that are not on the trip clears rather than throwing', () => {
+    const { user, trip, day, place } = fixture();
     const a = createDayAssignment(testDb, day.id, place.id);
-    svc.setParticipants(a.id, [user.id]);
-    // 999999 violates the users FK — the transaction must undo the delete too.
-    expect(() => svc.setParticipants(a.id, [999999])).toThrow();
-    expect(svc.getParticipants(a.id)).toEqual([{ user_id: user.id, username: user.username, avatar: null }]);
+    svc.setParticipants(a.id, [user.id], trip.id);
+    expect(() => svc.setParticipants(a.id, [999999], trip.id)).not.toThrow();
+    expect(svc.getParticipants(a.id)).toEqual([]);
+  });
+
+  it('ASG-SVC-029: keeps the trip members and drops the stranger in one call', () => {
+    const { user, trip, day, place } = fixture();
+    const { user: member } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    addTripMember(testDb, trip.id, member.id);
+    const a = createDayAssignment(testDb, day.id, place.id);
+
+    const rows = svc.setParticipants(a.id, [user.id, stranger.id, member.id], trip.id) as { user_id: number }[];
+
+    expect(rows.map(r => r.user_id).sort()).toEqual([user.id, member.id].sort());
+    expect(JSON.stringify(rows)).not.toContain(stranger.username);
   });
 });
 

--- a/server/tests/unit/nest/budget.service.db.test.ts
+++ b/server/tests/unit/nest/budget.service.db.test.ts
@@ -55,7 +55,7 @@ vi.mock('../../../src/nest/budget/exchange-rates.service', () => ({
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip } from '../../helpers/factories';
+import { createUser, createTrip, addTripMember } from '../../helpers/factories';
 import { BudgetService } from '../../../src/nest/budget/budget.service';
 import { DatabaseService } from '../../../src/nest/database/database.service';
 import { PermissionsService } from '../../../src/nest/permissions/permissions.service';
@@ -230,6 +230,7 @@ describe('calculateSettlement custom splits', () => {
     const { user: alice } = createUser(testDb, { username: 'alice' });
     const { user: bob } = createUser(testDb, { username: 'bob' });
     const trip = createTrip(testDb, alice.id, { title: 'Trip' });
+    addTripMember(testDb, trip.id, bob.id);
 
     // 100 total, custom split: Alice owes 90, Bob owes 10. Alice paid the whole bill.
     budget.createBudgetItem(trip.id, {
@@ -261,6 +262,8 @@ describe('calculateSettlement squares up to the cent (#1382)', () => {
     const { user: bob } = createUser(testDb, { username: 'bob' });
     const { user: carol } = createUser(testDb, { username: 'carol' });
     const trip = createTrip(testDb, alice.id, { title: 'Trip' });
+    addTripMember(testDb, trip.id, bob.id);
+    addTripMember(testDb, trip.id, carol.id);
     const members = [{ user_id: alice.id }, { user_id: bob.id }, { user_id: carol.id }];
 
     // Totals that never divide by three, so every expense leaves a remainder cent
@@ -306,6 +309,8 @@ function seedIssue1543Trip(tripCurrency: string) {
   const { user: danil } = createUser(testDb, { username: 'danil' });
   const { user: serega } = createUser(testDb, { username: 'serega' });
   const trip = createTrip(testDb, me.id, { title: 'Trip' });
+  addTripMember(testDb, trip.id, danil.id);
+  addTripMember(testDb, trip.id, serega.id);
   testDb.prepare('UPDATE trips SET currency = ? WHERE id = ?').run(tripCurrency, trip.id);
   const members = [{ user_id: me.id }, { user_id: danil.id }, { user_id: serega.id }];
 
@@ -384,6 +389,7 @@ describe('rebaseTripCurrency', () => {
     const { user: alice } = createUser(testDb, { username: 'alice' });
     const { user: bob } = createUser(testDb, { username: 'bob' });
     const trip = createTrip(testDb, alice.id, { title: 'Trip' });
+    addTripMember(testDb, trip.id, bob.id);
     testDb.prepare("UPDATE trips SET currency = 'EUR' WHERE id = ?").run(trip.id);
     const members = [{ user_id: alice.id }, { user_id: bob.id }];
 
@@ -521,6 +527,57 @@ describe('composite service paths (ex budget.bridge delegation)', () => {
 
     expect(item.place_id).toBeNull();
     expect(item.reservation_id).toBeNull();
+  });
+});
+
+// A settlement names two parties and both columns are NOT NULL, so an id that is
+// not on the trip cannot simply be dropped the way a split member can — the whole
+// write is refused. Refusing also means the endpoint stops answering "does this
+// user id exist", which it used to do by 500ing on the foreign key.
+describe('settlement parties are confined to the trip', () => {
+  it('BUDGET-SVC-DB-028: refuses a payer who is not on the trip', async () => {
+    const { user: alice } = createUser(testDb, { username: 'alice' });
+    const { user: outsider } = createUser(testDb, { username: 'outsider' });
+    const trip = createTrip(testDb, alice.id);
+
+    const created = await budget.createSettlement(trip.id, { from_user_id: outsider.id, to_user_id: alice.id, amount: 10 }, alice.id);
+
+    expect(created).toBeNull();
+    expect(budget.listSettlements(trip.id)).toEqual([]);
+  });
+
+  it('BUDGET-SVC-DB-029: answers a nonexistent user the same way, without throwing', async () => {
+    const { user: alice } = createUser(testDb, { username: 'alice' });
+    const trip = createTrip(testDb, alice.id);
+
+    await expect(budget.createSettlement(trip.id, { from_user_id: 999999, to_user_id: alice.id, amount: 10 }, alice.id))
+      .resolves.toBeNull();
+  });
+
+  it('BUDGET-SVC-DB-030: still records a settlement between the owner and a member', async () => {
+    const { user: alice } = createUser(testDb, { username: 'alice' });
+    const { user: bob } = createUser(testDb, { username: 'bob' });
+    const trip = createTrip(testDb, alice.id);
+    addTripMember(testDb, trip.id, bob.id);
+
+    const created = await budget.createSettlement(trip.id, { from_user_id: bob.id, to_user_id: alice.id, amount: 10 }, alice.id);
+
+    expect(created).toMatchObject({ from_user_id: bob.id, to_user_id: alice.id });
+  });
+
+  it('BUDGET-SVC-DB-031: drops an off-trip payer from an item instead of refusing it', () => {
+    const { user: alice } = createUser(testDb, { username: 'alice' });
+    const { user: outsider } = createUser(testDb, { username: 'outsider' });
+    const trip = createTrip(testDb, alice.id);
+
+    const item = budget.createBudgetItem(trip.id, {
+      name: 'Dinner',
+      payers: [{ user_id: alice.id, amount: 40 }, { user_id: outsider.id, amount: 60 }],
+    }) as { payers: { user_id: number }[]; total_price: number };
+
+    expect(item.payers.map(p => p.user_id)).toEqual([alice.id]);
+    // total_price is the sum of the payers that actually landed.
+    expect(item.total_price).toBe(40);
   });
 });
 

--- a/server/tests/unit/nest/budget.service.test.ts
+++ b/server/tests/unit/nest/budget.service.test.ts
@@ -139,8 +139,14 @@ describe('BudgetService', () => {
   });
 
   describe('settlement ledger wrappers (#1445 freeze-then-write)', () => {
+    // Both wrappers refuse a party who is not on the trip before they freeze
+    // anything, so the roster lookup has to answer for these to reach the write
+    // at all. Users 1 and 2 are the two parties every case here settles between.
+    const rosterHas = (...userIds: number[]) => dbMock._stmt.all.mockReturnValue(userIds.map(user_id => ({ user_id })));
+
     it('createSettlement freezes the FX rate (await) before the raw insert', async () => {
       const s = svc();
+      rosterHas(1, 2);
       const freezeSpy = vi.spyOn(s, 'freezeForeignRate').mockResolvedValue();
       const insertSpy = vi.spyOn(s, 'insertSettlement').mockReturnValue({ id: 7 } as never);
       await s.createSettlement('5', { from_user_id: 1, to_user_id: 2, amount: 10 }, 3);
@@ -150,6 +156,7 @@ describe('BudgetService', () => {
 
     it('updateSettlement threads the stored currency through the freeze', async () => {
       const s = svc();
+      rosterHas(1, 2);
       const freezeSpy = vi.spyOn(s, 'freezeForeignRate').mockResolvedValue();
       // Quirk fix: the stored-currency lookup is a targeted getSettlement, not
       // a full listSettlements scan.
@@ -160,6 +167,18 @@ describe('BudgetService', () => {
       expect(getSpy).toHaveBeenCalledWith('7', '5');
       expect(freezeSpy).toHaveBeenCalledWith('5', { from_user_id: 1, to_user_id: 2, amount: 12, currency: 'USD' }, undefined, 'USD');
       expect(applySpy).toHaveBeenCalledWith('7', '5', { from_user_id: 1, to_user_id: 2, amount: 12, currency: 'USD' });
+    });
+
+    it('refuses a party who is not on the trip, before freezing or writing', async () => {
+      const s = svc();
+      rosterHas(1); // user 2 is not on this trip
+      const freezeSpy = vi.spyOn(s, 'freezeForeignRate').mockResolvedValue();
+      const insertSpy = vi.spyOn(s, 'insertSettlement').mockReturnValue({ id: 7 } as never);
+
+      await expect(s.createSettlement('5', { from_user_id: 1, to_user_id: 2, amount: 10 }, 3)).resolves.toBeNull();
+
+      expect(freezeSpy).not.toHaveBeenCalled();
+      expect(insertSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/server/tests/unit/nest/packing.service.test.ts
+++ b/server/tests/unit/nest/packing.service.test.ts
@@ -515,6 +515,7 @@ describe('three-tier packing sharing (#858)', () => {
     const { user: friend } = createUser(testDb);
     const { user: stranger } = createUser(testDb);
     const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
 
     const item = svc.createItem(trip.id, { name: 'Power bank', visibility: 'shared', recipient_ids: [friend.id] }, owner.id) as any;
     expect(item.is_private).toBe(1);
@@ -539,6 +540,7 @@ describe('three-tier packing sharing (#858)', () => {
     const { user: owner } = createUser(testDb);
     const { user: friend } = createUser(testDb);
     const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
     const item = svc.createItem(trip.id, { name: 'First aid', visibility: 'personal' }, owner.id) as any;
 
     // A non-owner who cannot see the item at all gets the missing-item answer, so
@@ -1007,6 +1009,8 @@ describe('packing item object-level authorization', () => {
     const { user: intruder } = createUser(testDb);
     const { user: friend } = createUser(testDb);
     const trip = createTrip(testDb, owner.id);
+    // The recipient is a fellow traveller; the intruder stays off the trip on purpose.
+    addTripMember(testDb, trip.id, friend.id);
     const personal = svc.createItem(trip.id, { name: 'Diary', visibility: 'personal' }, owner.id) as any;
     const shared = svc.createItem(trip.id, { name: 'Power bank', visibility: 'shared', recipient_ids: [friend.id] }, owner.id) as any;
     const common = svc.createItem(trip.id, { name: 'Tent', visibility: 'common' }, owner.id) as any;

--- a/server/tests/unit/nest/places.service.test.ts
+++ b/server/tests/unit/nest/places.service.test.ts
@@ -64,7 +64,7 @@ const photoCacheStub = { removeIfUnreferenced: removeIfUnreferencedSpy } as unkn
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createPlace, createCategory, createTag } from '../../helpers/factories';
+import { createUser, createTrip, createPlace, createCategory, createTag, addTripMember } from '../../helpers/factories';
 import path from 'path';
 import fs from 'fs';
 import { DatabaseService } from '../../../src/nest/database/database.service';
@@ -199,6 +199,33 @@ describe('create', () => {
     const place = svc.create(String(trip.id), { name: 'Tagged Place', tags: [tag.id] }) as any;
     expect(place.tags).toHaveLength(1);
     expect(place.tags[0].id).toBe(tag.id);
+  });
+
+  // A tag belongs to a user, not a trip, and the place body is an open record, so
+  // an id from someone outside the trip could be attached and then read straight
+  // back — the tag projection carries the owner's user_id with it.
+  it('PLACE-SVC-008a — drops a tag owned by someone outside the trip', () => {
+    const { user } = createUser(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const mine = createTag(testDb, user.id, { name: 'Mine' }) as any;
+    const theirs = createTag(testDb, outsider.id, { name: 'Theirs' }) as any;
+
+    const place = svc.create(String(trip.id), { name: 'Tagged Place', tags: [mine.id, theirs.id] }) as any;
+
+    expect(place.tags.map((t: any) => t.id)).toEqual([mine.id]);
+  });
+
+  it('PLACE-SVC-008b — keeps a co-traveller tag, so a shared place survives a foreign re-save', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    const theirTag = createTag(testDb, member.id, { name: 'Theirs' }) as any;
+
+    const place = svc.create(String(trip.id), { name: 'Shared Place', tags: [theirTag.id] }) as any;
+
+    expect(place.tags.map((t: any) => t.id)).toEqual([theirTag.id]);
   });
 
   it('PLACE-SVC-009 — place is associated with correct trip', () => {

--- a/server/tests/unit/nest/todo.service.test.ts
+++ b/server/tests/unit/nest/todo.service.test.ts
@@ -270,6 +270,35 @@ describe('getCategoryAssignees / updateCategoryAssignees', () => {
     expect(assignees['Logistics']).toHaveLength(1);
   });
 
+  // Holding todo_edit says you may edit this trip's list, not that any user id
+  // you name belongs to it. The read-back joins users and hands the caller a
+  // display name and an avatar, so an unfiltered id turns the endpoint into a
+  // lookup for every account on the instance.
+  it('TODO-SVC-017a: drops a user who is not on the trip, and says nothing about them', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+
+    const rows = svc.updateCategoryAssignees(trip.id, 'Packing', [owner.id, stranger.id, member.id]) as { user_id: number }[];
+
+    expect(rows.map(r => r.user_id).sort()).toEqual([owner.id, member.id].sort());
+    expect(JSON.stringify(rows)).not.toContain(stranger.username);
+    expect(testDb.prepare('SELECT COUNT(*) AS n FROM todo_category_assignees WHERE user_id = ?').get(stranger.id)).toEqual({ n: 0 });
+  });
+
+  it('TODO-SVC-017b: keeps a guest, who is a trip member like any other', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: guest } = createUser(testDb);
+    testDb.prepare('UPDATE users SET is_guest = 1 WHERE id = ?').run(guest.id);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, guest.id);
+
+    const rows = svc.updateCategoryAssignees(trip.id, 'Packing', [guest.id]) as { user_id: number }[];
+    expect(rows.map(r => r.user_id)).toEqual([guest.id]);
+  });
+
   it('TODO-SVC-020: updateCategoryAssignees replaces existing assignees (not append)', () => {
     const { user: owner } = createUser(testDb);
     const { user: member } = createUser(testDb);


### PR DESCRIPTION
## Description

A sweep of the write paths that take a user id (or a tag id) out of a request body and store it without asking whether it belongs to the trip. Holding `budget_edit` or `day_edit` says you may edit this trip; it does not say that an id you name is on it. Every one of these paths ends by re-selecting through a `JOIN users`, so an unrelated id came back out with a display name and an avatar attached — in the response, and for several of them in the WebSocket fan-out to the whole room.

`packing` already had `tripRosterIds` for exactly this question, and `reservations` had its own copy under a different name; both were used in one place each. The query moves to `DatabaseService` next to `canAccessTrip`, which asks the same thing as a predicate rather than as a set, and the two existing helpers delegate to it. Every service that needed it already injects `DatabaseService`, so nothing gains a constructor argument or a module import.

What changed, per domain:

- **packing / todo** — category assignees, and the two packing item-recipient writes.
- **assignments** — day participants. `setParticipants` takes the `tripId` both callers already hold.
- **budget** — payers and split members (`knownUserIds` asked whether a user exists at all, not whether they are here), plus settlement parties.
- **places / collections** — attached tags. A tag belongs to a user, so "on this trip" resolves through the roster.

Off-roster ids **drop** rather than 400 — the rule bag members and reservation travellers already follow. A copied trip carries assignee ids across before its members exist, and rejecting the whole request would stall the pickers there. Settlements are the exception: they name exactly two parties, both columns `NOT NULL`, so there is no partial result to keep and the write is refused outright. It returns the same 404 a missing settlement gets, which also retires a foreign-key error that used to surface as a 500 and told the caller whether an id existed.

Guests keep working throughout. A guest is a `users` row joined into `trip_members`, so the roster contains them — being assignable everywhere a member is, is the point of #1362, and there is a case pinning it.

### On the test changes

Seventeen existing tests moved. Thirteen were fixtures that built a fellow traveller with `createUser` and never added them to the trip, so the membership was implied and never stored; they keep their assertions and gain an `addTripMember`. Two stubbed a `db` whose roster lookup returned nothing. Two follow the new `setParticipants` signature.

One is a real behaviour change and is rewritten rather than adjusted: `ASG-SVC-028` asserted that an unknown id raised a foreign-key error and rolled the replace back. The filter removes that id before the insert can see it, so the path no longer exists; the case now pins what happens instead, which is that a list of nothing but strangers clears.

## Related Issue or Discussion

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
