### PR TITLE
feat(share): allow guest note and attachment submissions via public share links

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,11 @@
+# SDD Progress Ledger: Public Guest Notes
+
+**Plan:** `docs/superpowers/plans/2026-08-18-public-guest-notes.md`
+**Branch:** `feature/public-guest-notes`
+
+## Tasks
+- [x] Task 1: Database Migration & Schema Types (commit `671fe81d`, 33/33 tests passing)
+- [x] Task 2: Backend Share Service & Guest Note Endpoint (commit `86557ef9`, 69/69 tests passing)
+- [x] Task 3: Client API & Share Modal Toggle (commit `e5539a00`, 29/29 tests passing, 23 locales supported)
+- [x] Task 4: Public Share Page Guest Note Modal & Submission (commit `cb50d59b`, 33/33 tests passing, 23 locales supported)
+- [x] Task 5: Collab Notes Guest Badge & Display (commit `21845f4f`, 61/61 tests passing)

--- a/.superpowers/sdd/task-1-brief.md
+++ b/.superpowers/sdd/task-1-brief.md
@@ -1,0 +1,34 @@
+# Task 1: Database Migration & Schema Types
+
+**Files:**
+- Modify: `server/src/db/migrations.ts`
+- Modify: `server/src/db/schema.ts`
+- Modify: `server/src/types.ts`
+- Modify: `shared/src/collab/collab.schema.ts`
+- Modify: `shared/src/share/share.schema.ts`
+- Test: `server/tests/integration/share.test.ts`
+
+**Interfaces:**
+- Consumes: Existing SQLite database connection and migration runner.
+- Produces:
+  - `CollabNote.guest_name?: string | null`
+  - `SharePermissions.allow_guest_notes?: boolean`
+  - `ShareTokenInfo.allow_guest_notes: boolean`
+
+## Requirements:
+1. In `server/src/db/migrations.ts`, append a new migration function to `migrations` array:
+   - Add column `allow_guest_notes INTEGER DEFAULT 0` to `share_tokens`.
+   - Add column `guest_name TEXT DEFAULT NULL` to `collab_notes`.
+   - Protect statements with try/catch to be non-fatal on partial databases.
+2. In `server/src/db/schema.ts`:
+   - Add `allow_guest_notes INTEGER DEFAULT 0` to `CREATE TABLE IF NOT EXISTS share_tokens`.
+   - Add `guest_name TEXT DEFAULT NULL` to `CREATE TABLE IF NOT EXISTS collab_notes`.
+3. In `server/src/types.ts`:
+   - Update `CollabNote`: add `guest_name?: string | null;`.
+   - Update `SharePermissions`: add `allow_guest_notes?: boolean;`.
+   - Update `ShareTokenInfo`: add `allow_guest_notes: boolean;`.
+4. In `shared/src/collab/collab.schema.ts` and `shared/src/share/share.schema.ts`:
+   - Update schemas/types to include `guest_name` and `allow_guest_notes`.
+5. Test:
+   - Add test in `server/tests/integration/share.test.ts` or relevant test file.
+   - Run tests with `npm --prefix server test` to verify database migrations and types pass.

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -1,0 +1,39 @@
+﻿# Task 1 Report: Database Migration & Schema Types
+
+## Status: COMPLETE
+
+### Commit:
+- `671fe81d06639401110b6f13ff9fb93fb89c2e62`: `feat(db): add allow_guest_notes and guest_name columns`
+
+### Summary of Changes:
+1. **Database Migrations (`server/src/db/migrations.ts`)**:
+   - Added a new migration function at the end of the `migrations` array to alter tables:
+     - `ALTER TABLE share_tokens ADD COLUMN allow_guest_notes INTEGER DEFAULT 0;`
+     - `ALTER TABLE collab_notes ADD COLUMN guest_name TEXT DEFAULT NULL;`
+   - Protected statements with try/catch to maintain resilience on partial databases.
+
+2. **Database Schema (`server/src/db/schema.ts`)**:
+   - Added `CREATE TABLE IF NOT EXISTS share_tokens` with `allow_guest_notes INTEGER DEFAULT 0` and index `idx_share_tokens_token`.
+   - Updated `CREATE TABLE IF NOT EXISTS collab_notes` with column `guest_name TEXT DEFAULT NULL`.
+
+3. **Server TypeScript Types (`server/src/types.ts`)**:
+   - Updated `CollabNote` interface to include `guest_name?: string | null;`.
+   - Added and exported `SharePermissions` (`allow_guest_notes?: boolean;`) and `ShareTokenInfo` (`allow_guest_notes: boolean;`).
+
+4. **Server Share Service (`server/src/services/shareService.ts`)**:
+   - Updated `SharePermissions` and `ShareTokenInfo` imports.
+   - Updated `createOrUpdateShareLink` to persist `allow_guest_notes` (default `false`).
+   - Updated `getShareLink` to return `allow_guest_notes: boolean`.
+   - Updated `getSharedTripData` permissions payload to include `allow_guest_notes: boolean`.
+
+5. **Shared Schemas (`shared/src/collab/collab.schema.ts`, `shared/src/share/share.schema.ts`)**:
+   - Updated `collabNoteCreateRequestSchema` to include `guest_name: z.string().optional()`.
+   - Updated `shareLinkRequestSchema` to include `allow_guest_notes: z.boolean().optional()`.
+   - Rebuilt `@trek/shared` package successfully.
+
+6. **Tests & Verification**:
+   - Added unit test cases in `server/tests/unit/shared-contract.test.ts` for Zod schema validation.
+   - Added integration tests in `server/tests/integration/share.test.ts` verifying schema columns, `createOrUpdateShareLink`, `getShareLink`, `getSharedTripData`, and inserting collab notes with `guest_name`.
+   - Ran `npm --prefix server test -- tests/integration/share.test.ts tests/unit/shared-contract.test.ts` -> 33 tests passed (0 failures).
+   - Ran `npm --prefix server run typecheck` -> Passed with 0 errors.
+   - Ran `npm run lint:check --workspace=server` and `npm run lint --workspace=shared` -> Passed with 0 errors.

--- a/.superpowers/sdd/task-2-brief.md
+++ b/.superpowers/sdd/task-2-brief.md
@@ -1,0 +1,49 @@
+# Task 2: Backend Share Service & Guest Note Endpoint
+
+**Files:**
+- Modify: `server/src/services/shareService.ts`
+- Modify: `server/src/services/collabService.ts`
+- Modify: `server/src/nest/share/share.controller.ts`
+- Modify: `server/src/nest/share/share.service.ts`
+- Test: `server/tests/e2e/share.e2e.test.ts` (or `server/tests/integration/share.test.ts`)
+
+**Interfaces:**
+- Consumes: `createOrUpdateShareLink`, `getSharedTripData`, `formatNote`, `NOTE_UPLOAD` multer interceptor/config.
+- Produces: `POST /api/shared/:token/notes` endpoint returning `{ success: true, note: CollabNote }`, and updated `GET /api/shared/:token` returning `noteCategories: string[]` and `permissions.allow_guest_notes`.
+
+## Requirements:
+1. In `server/src/services/collabService.ts`:
+   - Update `createNote` to accept `guest_name?: string` and persist it into `collab_notes.guest_name`.
+2. In `server/src/services/shareService.ts`:
+   - In `getSharedTripData(token)`:
+     - Query distinct categories from `collab_notes` for that trip:
+       ```typescript
+       const noteCatRows = db.prepare('SELECT DISTINCT category FROM collab_notes WHERE trip_id = ? AND category IS NOT NULL').all(tripId) as { category: string }[];
+       const noteCategories = noteCatRows.length > 0 ? noteCatRows.map(r => r.category) : ['General'];
+       ```
+     - Return `noteCategories` in the response payload.
+     - Include `allow_guest_notes: !!shareRow.allow_guest_notes` in `permissions`.
+3. In `server/src/nest/share/share.controller.ts` (and `share.service.ts` if helper methods are needed):
+   - In `TripShareController.create`:
+     - Accept `allow_guest_notes?: boolean` in the body and pass it to `share.createOrUpdate`.
+   - In `SharedController`:
+     - Add `POST :token/notes` endpoint.
+     - Use `FileInterceptor('file', NOTE_UPLOAD)` to handle file upload (reuse the `NOTE_UPLOAD` configuration from `collab.controller.ts` or export/import it).
+     - Validation:
+       - Validate token exists and `expires_at` is valid in `share_tokens`.
+       - Check `allow_guest_notes === 1`. If not, throw `HttpException({ error: 'Guest note submissions are disabled for this link' }, 403)`.
+       - Validate `guest_name` and `title` are required non-empty strings (throw 400 if missing).
+       - Sanitize / trim fields.
+     - Action:
+       - Call `collabService.createNote(tripId, shareRow.created_by, { title, content, category, guest_name })`.
+       - If `file` is uploaded: call `collabService.addNoteFile(tripId, note.id, file)` to save file to `trip_files`.
+       - Re-fetch formatted note via `collabService.getFormattedNoteById(note.id)`.
+       - Broadcast WebSocket event `collab:note:created` with `{ note: formattedNote }` to the trip.
+       - Send notification to trip owner via `collabService.notifyCollab(tripId, ...)` or notification service.
+       - Return HTTP 201 with `{ success: true, note: formattedNote }`.
+4. Tests:
+   - Add integration / E2E tests in `server/tests/integration/share.test.ts` or `server/tests/e2e/share.e2e.test.ts` to test:
+     - Rejection (403) when `allow_guest_notes` is false.
+     - Rejection (400) when required fields are missing.
+     - Success (201) when valid, with category and file attachment, verifying returned note and attachment.
+   - Run tests to verify all tests pass.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,52 @@
+# Task 2 Report: Backend Share Service & Guest Note Endpoint
+
+**Status:** Completed  
+**Commit:** `86557ef965028ed24909a5793b19e80361fe608d`  
+**Date:** 2026-08-18  
+
+---
+
+## 1. Summary of Work
+
+Implemented backend support for guest note submissions on shared trips:
+- **`collabService.ts`**: Updated `createNote` to accept optional `guest_name?: string` and persist it into SQLite `collab_notes.guest_name`.
+- **`shareService.ts`**:
+  - Updated `getSharedTripData(token)` to query distinct `noteCategories` for the shared trip (defaulting to `['General']` if empty) and return it in the payload.
+  - Ensured `permissions.allow_guest_notes` is returned based on `share_tokens.allow_guest_notes`.
+  - Added `getValidShareToken(token)` helper to retrieve unexpired share token records.
+- **`collab.controller.ts`**: Exported `NOTE_UPLOAD` configuration (50MB limit, file type filters) for reuse in the share controller.
+- **`share.service.ts`**: Added `createGuestNote` and `getValidShareToken` methods in the Nest `ShareService` wrapper, integrating note persistence, optional file upload (`trip_files`), real-time WebSocket event broadcast (`collab:note:created`), and trip-wide notification dispatch.
+- **`share.controller.ts`**:
+  - Updated `TripShareController.create` to accept `allow_guest_notes?: boolean` and forward it to `share.createOrUpdate`.
+  - Added public unauthenticated `POST /api/shared/:token/notes` endpoint supporting multipart file upload with `FileInterceptor('file', NOTE_UPLOAD)`.
+  - Enforced validations: 404 on invalid/expired token, 403 when `allow_guest_notes` is disabled, 400 on missing or whitespace-only `guest_name` and `title`. Returns HTTP 201 with `{ success: true, note: formattedNote }`.
+
+---
+
+## 2. Test Verification
+
+Added comprehensive tests covering unit, integration, and e2e layers:
+1. **`server/tests/unit/nest/share.controller.test.ts`**:
+   - `POST :token/notes 404 for an invalid or expired token`
+   - `POST :token/notes 403 when allow_guest_notes is false / disabled`
+   - `POST :token/notes 400 when guest_name or title is missing or empty`
+   - `POST :token/notes creates guest note and returns 201 with { success: true, note }`
+2. **`server/tests/unit/nest/share.service.test.ts`**:
+   - Tests delegation for `getValidShareToken`
+   - `createGuestNote` without file attachments (persists, broadcasts `collab:note:created`, notifies)
+   - `createGuestNote` with file attachments (attaches file to note, broadcasts, notifies)
+3. **`server/tests/e2e/share.e2e.test.ts`**:
+   - E2E route testing for `POST /api/shared/:token/notes` (404, 403, 400, 201).
+4. **`server/tests/integration/share.test.ts`**:
+   - `SHARE-027 — getSharedTripData returns noteCategories and allow_guest_notes in permissions`
+   - `SHARE-028 — POST /api/shared/:token/notes returns 404 for invalid/expired token`
+   - `SHARE-029 — POST /api/shared/:token/notes returns 403 when allow_guest_notes is false`
+   - `SHARE-030 — POST /api/shared/:token/notes returns 400 when title or guest_name is missing/empty`
+   - `SHARE-031 — POST /api/shared/:token/notes creates note with guest_name and returns 201 with success: true and note`
+   - `SHARE-032 — POST /api/shared/:token/notes handles file upload attachment and returns 201 with attachments`
+   - `SHARE-033 — POST /api/trips/:tripId/share-link sets allow_guest_notes flag`
+
+### Test Suite Output:
+- Unit & integration & e2e share test suites: **4 test files, 69 tests passed (100% pass)**.
+- Server TypeScript typecheck (`tsc --noEmit`): **0 errors**.
+- Server ESLint: **0 errors**.

--- a/.superpowers/sdd/task-3-brief.md
+++ b/.superpowers/sdd/task-3-brief.md
@@ -1,0 +1,28 @@
+# Task 3: Client API & Share Modal Toggle
+
+**Files:**
+- Modify: `client/src/api/client.ts`
+- Modify: `client/src/components/Trips/TripMembersModal.tsx`
+- Modify: `client/src/i18n/locales/en.json` (and any other locale files if present)
+- Test: `client/src/components/Trips/TripMembersModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `shareApi.createLink`, `shareApi.getLink`.
+- Produces: `shareApi.addGuestNote(token: string, formData: FormData)`, updated `TripMembersModal` with `allow_guest_notes` toggle in `ShareLinkSection`.
+
+## Requirements:
+1. In `client/src/api/client.ts`:
+   - Update `shareApi`:
+     - In `createLink(tripId, perms)`: Ensure `allow_guest_notes?: boolean` is supported in `perms`.
+     - In `getLink(tripId)`: Ensure returned type includes `allow_guest_notes?: boolean`.
+     - Add `addGuestNote: (token: string, formData: FormData) => postMultipart<{ success: boolean; note: any }>(`/api/shared/${token}/notes`, formData)` or helper function using `fetch` to send FormData to `/api/shared/:token/notes`.
+2. In `client/src/components/Trips/TripMembersModal.tsx`:
+   - In `ShareLinkSection`:
+     - Update initial `perms` state to include `allow_guest_notes: false`.
+     - In `useEffect` when fetching link info, set `allow_guest_notes: d.allow_guest_notes ?? false`.
+     - Add permission checkbox button for `allow_guest_notes` with label `t('share.permGuestNotes')`.
+3. In `client/src/i18n/locales/` (e.g. `en.json` and any other locales):
+   - Add `"share.permGuestNotes"` translation string, e.g. `"Allow guest notes"` (or `"Izinkan catatan tamu"` for Indonesian if id.json exists).
+4. Tests:
+   - Add/update tests in `client/src/components/Trips/TripMembersModal.test.tsx` verifying that `allow_guest_notes` toggle renders, toggles, and updates via `shareApi.createLink`.
+   - Run `npm --prefix client test -- TripMembersModal.test.tsx` and typecheck `npm --prefix client run typecheck`.

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,33 @@
+# Task 3: Client API & Share Modal Toggle — Report
+
+## Summary of Changes
+1. **API Client (`client/src/api/client.ts`)**:
+   - Added `ShareLinkInfo` interface supporting `allow_guest_notes?: boolean`.
+   - Updated `shareApi.createLink` signature with `ShareLinkRequest | Record<string, boolean>`.
+   - Updated `shareApi.getLink` return type to `Promise<ShareLinkInfo>`.
+   - Added `shareApi.addGuestNote(token: string, formData: FormData)` method using `postMultipart` to post multipart note data to `/api/shared/:token/notes`.
+
+2. **Trip Members Modal (`client/src/components/Trips/TripMembersModal.tsx`)**:
+   - Added `allow_guest_notes: false` to default `perms` state.
+   - Updated `useEffect` link fetching logic to load `allow_guest_notes: d.allow_guest_notes ?? false`.
+   - Added permission pill button for `allow_guest_notes` with translation key `t('share.permGuestNotes')`.
+
+3. **Translations & i18n (`shared/src/i18n/*/share.ts`)**:
+   - Added `'share.permGuestNotes'` translation key across all 23 supported locales (including `en`, `id`, `de`, `es`, `fr`, etc.).
+   - Verified strict i18n file and key parity with `npm --prefix shared run i18n:parity:strict`.
+   - Rebuilt `@trek/shared` package.
+
+4. **Testing (`client/src/components/Trips/TripMembersModal.test.tsx`)**:
+   - Added `FE-COMP-MEMBERS-028`: verifies `allow_guest_notes` pill renders and clicking it calls `shareApi.createLink` with `allow_guest_notes: true`.
+   - Added `FE-COMP-MEMBERS-029`: verifies `allow_guest_notes` initialises properly when fetched from existing share link info.
+
+## Verification Results
+- `npm --prefix client test -- TripMembersModal.test.tsx`: 29/29 tests passed.
+- `npm --prefix client run typecheck`: 0 errors (clean).
+- `npm --prefix shared run typecheck`: 0 errors (clean).
+- `npm --prefix shared test`: 34/34 test files passed (139 tests).
+- `npm --prefix shared run i18n:parity:strict`: File parity: OK, Key parity: OK.
+
+## Git Commit
+- Commit hash: `e5539a00`
+- Message: `feat(share): add allow_guest_notes toggle and addGuestNote client api`

--- a/.superpowers/sdd/task-4-brief.md
+++ b/.superpowers/sdd/task-4-brief.md
@@ -1,0 +1,53 @@
+# Task 4: Public Share Page Guest Note Modal & Submission
+
+**Files:**
+- Create: `client/src/components/shared/GuestAddNoteModal.tsx`
+- Modify: `client/src/pages/SharedTripPage.tsx`
+- Modify: `client/src/pages/sharedTrip/useSharedTrip.ts`
+- Modify: `shared/src/i18n/*/share.ts` (add translations for guest modal and add note button across all 23 locales)
+- Test: `client/src/pages/SharedTripPage.test.tsx` (and `client/src/components/shared/GuestAddNoteModal.test.tsx` if creating a dedicated test file)
+
+**Interfaces:**
+- Consumes: `shareApi.addGuestNote`, `data.permissions.allow_guest_notes`, `data.noteCategories`.
+- Produces: `GuestAddNoteModal` component, Action Button on `SharedTripPage`.
+
+## Requirements:
+1. Create `client/src/components/shared/GuestAddNoteModal.tsx`:
+   - Props:
+     - `isOpen: boolean`
+     - `onClose: () => void`
+     - `token: string`
+     - `categories: string[]`
+     - `t: (key: string, params?: Record<string, string | number>) => string`
+   - UI Fields:
+     - Guest Name (required text input)
+     - Category (select dropdown populated with `categories`, defaulting to the first item or `'General'`)
+     - Title (required text input)
+     - Content (multiline textarea)
+     - Attach File (file input with selected file name display, size validation <= 50MB, clear file button)
+     - Submit button with loading state spinner
+   - Action:
+     - Constructs `FormData` with `guest_name`, `title`, `content`, `category`, and optional `file`.
+     - Calls `shareApi.addGuestNote(token, formData)`.
+     - Shows success toast on completion, resets form fields, and closes the modal.
+     - Handles errors cleanly with error toast / error message.
+2. In `client/src/pages/SharedTripPage.tsx`:
+   - Read `permissions?.allow_guest_notes` and `noteCategories` (or `data.noteCategories || ['General']`) from `data`.
+   - When `permissions?.allow_guest_notes` is true, render a prominent button:
+     - Floating Action Button (FAB) or Header Action Button: `➕ {t('share.addNote') || 'Kirim Catatan / Ide'}`.
+     - Clicking opens `GuestAddNoteModal`.
+3. In `shared/src/i18n/*/share.ts`:
+   - Add i18n keys for all 23 locales:
+     - `'share.addNote'`: e.g. `"Add note"` / `"Tambah catatan"`
+     - `'share.guestNoteSuccess'`: e.g. `"Note sent successfully!"` / `"Catatan berhasil dikirim!"`
+     - `'share.guestName'`: e.g. `"Your name"` / `"Nama Anda"`
+     - `'share.noteTitle'`: e.g. `"Note title"` / `"Judul catatan"`
+     - `'share.noteContent'`: e.g. `"Note details (optional)"` / `"Isi catatan (opsional)"`
+     - `'share.noteCategory'`: e.g. `"Category"` / `"Kategori"`
+     - `'share.attachFile'`: e.g. `"Attach file / photo"` / `"Lampirkan file / foto"`
+     - `'share.fileTooLarge'`: e.g. `"File size exceeds 50MB limit"` / `"Ukuran file melebihi batas 50MB"`
+     - `'share.sendNote'`: e.g. `"Send Note"` / `"Kirim Catatan"`
+   - Run strict i18n parity check `npm --prefix shared run i18n:parity:strict` and build shared package `npm --prefix shared run build`.
+4. Tests:
+   - Update/add tests in `client/src/pages/SharedTripPage.test.tsx` verifying that when `allow_guest_notes` is true, the button is rendered and opening the modal allows submitting a note with `shareApi.addGuestNote`.
+   - Verify `npm --prefix client test -- SharedTripPage.test.tsx` and `npm --prefix client run typecheck`.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,64 @@
+# Task 4: Public Share Page Guest Note Modal & Submission — Report
+
+## Summary of Changes
+
+1. **Guest Add Note Modal (`client/src/components/shared/GuestAddNoteModal.tsx`)**:
+   - Implemented `GuestAddNoteModal` component with props: `isOpen`, `onClose`, `token`, `categories`, `t`.
+   - UI input fields:
+     - Guest Name (required text input)
+     - Category (dropdown populated from `categories` prop, defaulting to first item or 'General')
+     - Note Title (required text input)
+     - Content (multiline textarea)
+     - File attachment input with file size limit validation (<= 50MB), filename & size badge display, and remove attachment button
+     - Submit button with loading spinner state
+   - Action & error handling:
+     - Builds `FormData` with `guest_name`, `title`, optional `content`, `category`, and optional `file`.
+     - Submits via `shareApi.addGuestNote(token, formData)`.
+     - Displays success toast, resets form fields, and closes modal on completion.
+     - Displays error toast and retains input values on API errors.
+
+2. **Public Share Page Integration (`client/src/pages/SharedTripPage.tsx`, `client/src/pages/sharedTrip/useSharedTrip.ts`)**:
+   - Updated `useSharedTrip` to expose `token`, `showAddNoteModal`, and `setShowAddNoteModal`.
+   - In `SharedTripPage.tsx`, conditionally renders a prominent Floating Action Button (FAB) `➕ {t('share.addNote')}` when `permissions.allow_guest_notes` is true.
+   - Connected button click to open `GuestAddNoteModal`, passing note categories from the shared payload.
+
+3. **Internationalization Parity (`shared/src/i18n/*/share.ts`)**:
+   - Added translation keys across all 23 supported locales (`en`, `id`, `de`, `es`, `fr`, `it`, `nl`, `pl`, `br`, `ru`, `uk`, `cs`, `hu`, `sv`, `tr`, `ar`, `ja`, `ko`, `zh`, `zh-TW`, `ca`, `gr`, `vi`):
+     - `share.addNote`
+     - `share.guestNoteSuccess`
+     - `share.guestName`
+     - `share.noteTitle`
+     - `share.noteContent`
+     - `share.noteCategory`
+     - `share.attachFile`
+     - `share.fileTooLarge`
+     - `share.sendNote`
+   - Rebuilt shared package with `npm --prefix shared run build`.
+   - Verified strict parity with `npm --prefix shared run i18n:parity:strict` (File parity: OK, Key parity: OK).
+
+4. **Testing (`client/src/components/shared/GuestAddNoteModal.test.tsx`, `client/src/pages/SharedTripPage.test.tsx`)**:
+   - Added unit test suite in `GuestAddNoteModal.test.tsx` covering:
+     - `FE-COMP-GUEST-NOTE-001`: Hidden when `isOpen` is false
+     - `FE-COMP-GUEST-NOTE-002`: Field rendering when open
+     - `FE-COMP-GUEST-NOTE-003`: Category selection and default item
+     - `FE-COMP-GUEST-NOTE-004`: Default category fallback to 'General'
+     - `FE-COMP-GUEST-NOTE-005`: Button validation when required fields empty
+     - `FE-COMP-GUEST-NOTE-006`: Successful multipart form submission
+     - `FE-COMP-GUEST-NOTE-007`: Attaching and removing file attachments
+     - `FE-COMP-GUEST-NOTE-008`: File size validation exceeding 50MB
+     - `FE-COMP-GUEST-NOTE-009`: API error handling
+   - Added page integration tests in `SharedTripPage.test.tsx`:
+     - `FE-PAGE-SHARED-021`: Add note button rendered when `allow_guest_notes: true`
+     - `FE-PAGE-SHARED-022`: Add note button hidden when `allow_guest_notes: false`
+     - `FE-PAGE-SHARED-023`: Opening modal and submitting note to `POST /api/shared/:token/notes`
+
+## Verification Results
+- `npm --prefix client test -- GuestAddNoteModal.test.tsx SharedTripPage.test.tsx`: 33/33 passed (100%).
+- `npm --prefix client run typecheck`: 0 errors (clean).
+- `npm --prefix shared run i18n:parity:strict`: File parity: OK, Key parity: OK.
+- `npm --prefix shared run typecheck`: 0 errors (clean).
+- `npm --prefix shared test`: 34/34 test files passed (139 tests).
+
+## Git Commit
+- Commit hash: `cb50d59b`
+- Message: `feat(share): add guest note submission modal on public share page`

--- a/.superpowers/sdd/task-5-brief.md
+++ b/.superpowers/sdd/task-5-brief.md
@@ -1,0 +1,28 @@
+# Task 5: Collab Notes Guest Badge & Display
+
+**Files:**
+- Modify: `client/src/components/Collab/CollabNotesCard.tsx`
+- Modify: `client/src/components/Collab/CollabNotesFormModal.tsx`
+- Modify: `client/src/components/Collab/CollabNotes.types.ts`
+- Modify: `shared/src/i18n/*/collab.ts` (if guest label or badge translation needed across all 23 locales)
+- Test: `client/src/components/Collab/CollabNotes.test.tsx`
+
+**Interfaces:**
+- Consumes: `note.guest_name`, `CollabNote`.
+- Produces: Guest badge and author display in Collab Notes card and modals.
+
+## Requirements:
+1. In `client/src/components/Collab/CollabNotes.types.ts`:
+   - Ensure `CollabNote` interface includes `guest_name?: string | null;`.
+2. In `client/src/components/Collab/CollabNotesCard.tsx`:
+   - If `note.guest_name` is present:
+     - Render a guest badge beside the title or in the header (e.g. `👤 {note.guest_name}` or `👤 Tamu: {note.guest_name}`).
+     - In author avatar / tooltip: reflect that the note was created by guest `{note.guest_name}`.
+3. In `client/src/components/Collab/CollabNotesFormModal.tsx` and `CollabNotes.tsx`:
+   - Ensure viewing/editing a guest note shows the guest attribution clearly.
+4. In `shared/src/i18n/*/collab.ts` (if adding translation key like `collab.notes.guestBadge` / `collab.notes.guest`):
+   - Add translation key across all 23 locales.
+   - Run strict i18n parity check and build shared package.
+5. Tests:
+   - Add/update tests in `client/src/components/Collab/CollabNotes.test.tsx` verifying that a note with `guest_name` renders the guest badge properly.
+   - Run client tests and typechecks (`npm --prefix client test -- CollabNotes.test.tsx`, `npm --prefix client run typecheck`).

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,35 @@
+﻿# Task 5 Report: Collab Notes Guest Badge & Display
+
+**Status:** Completed
+**Branch:** `feature/public-guest-notes`
+**Commit:** `21845f4f` (`feat(collab): add guest badge and attribution to collab notes`)
+
+## Summary of Changes
+
+1. **`client/src/components/Collab/CollabNotes.types.ts`**:
+   - Added optional `guest_name?: string | null` field to the `CollabNote` interface.
+
+2. **`client/src/components/Collab/CollabNotesCard.tsx`**:
+   - Integrated guest badge rendering beside note title/category when `note.guest_name` is present (`UserRound` icon + guest name pill).
+   - Updated author resolution and tooltip attribution so notes authored by guests reflect the guest name and guest attribution (`{name} ({guestLabel})`).
+
+3. **`client/src/components/Collab/CollabNotesFormModal.tsx`**:
+   - Added guest badge pill display in the modal header when editing a note created by a guest.
+
+4. **`client/src/components/Collab/CollabNotes.tsx`**:
+   - Added guest badge display in `ViewNoteModal` alongside category tags when viewing a note created by a guest.
+
+5. **`client/src/components/Collab/CollabNotes.test.tsx`**:
+   - Added test cases `FE-COMP-NOTES-058` through `FE-COMP-NOTES-061` verifying:
+     - Guest badge rendering on note card.
+     - Author tooltip attribution for guest-authored notes.
+     - Guest badge display in full note view modal (`ViewNoteModal`).
+     - Guest attribution badge in edit modal (`NoteFormModal`).
+
+## Verification
+
+- **Client Tests (`CollabNotes.test.tsx`)**: 61/61 passed.
+- **Related Guest Tests (`GuestAddNoteModal.test.tsx`, `SharedTripPage.test.tsx`)**: 33/33 passed.
+- **Client Typecheck (`npm --prefix client run typecheck`)**: Passed with 0 errors.
+- **Client Linter (`npm --prefix client run lint`)**: Passed with 0 errors.
+- **Shared Package Build & Strict Parity (`npm --prefix shared run build; npm --prefix shared run typecheck; npm --prefix shared run i18n:parity:strict`)**: Passed (File parity: OK, Key parity: OK).

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -11,7 +11,7 @@ import {
   type SettingUpsertRequest, type SettingsBulkRequest,
   type JourneyCreateRequest, type JourneyAddTripRequest,
   type JourneyReorderEntriesRequest, type JourneyProviderPhotosRequest,
-  type JourneyShareLinkRequest,
+  type JourneyShareLinkRequest, type ShareLinkRequest,
   type RegisterRequest, type LoginRequest, type ForgotPasswordRequest,
   type ResetPasswordRequest, type ChangePasswordRequest,
   type MfaVerifyLoginRequest, type MfaEnableRequest, type McpTokenCreateRequest,
@@ -981,11 +981,23 @@ export const backupApi = {
   setAutoSettings: (settings: Record<string, unknown>) => apiClient.put('/backup/auto-settings', settings).then(r => r.data),
 }
 
+export interface ShareLinkInfo {
+  token: string | null
+  share_map?: boolean
+  share_bookings?: boolean
+  share_packing?: boolean
+  share_budget?: boolean
+  share_collab?: boolean
+  allow_guest_notes?: boolean
+  [key: string]: unknown
+}
+
 export const shareApi = {
-  getLink: (tripId: number | string) => apiClient.get(`/trips/${tripId}/share-link`).then(r => r.data),
-  createLink: (tripId: number | string, perms?: Record<string, boolean>) => apiClient.post(`/trips/${tripId}/share-link`, perms || {}).then(r => r.data),
+  getLink: (tripId: number | string): Promise<ShareLinkInfo> => apiClient.get(`/trips/${tripId}/share-link`).then(r => r.data),
+  createLink: (tripId: number | string, perms?: ShareLinkRequest | Record<string, boolean>) => apiClient.post(`/trips/${tripId}/share-link`, perms || {}).then(r => r.data),
   deleteLink: (tripId: number | string) => apiClient.delete(`/trips/${tripId}/share-link`).then(r => r.data),
   getSharedTrip: (token: string) => apiClient.get(`/shared/${token}`).then(r => r.data),
+  addGuestNote: (token: string, formData: FormData) => postMultipart<{ success: boolean; note: any }>(`/shared/${token}/notes`, formData),
 }
 
 // Public transit routing (#1065) — Transitous/MOTIS proxied through the server.

--- a/client/src/components/Collab/CollabNotes.test.tsx
+++ b/client/src/components/Collab/CollabNotes.test.tsx
@@ -1267,4 +1267,93 @@ describe('CollabNotes', () => {
     await screen.findByText('Unpinned');
     expect(document.body.innerHTML.indexOf('Pinned')).toBeLessThan(document.body.innerHTML.indexOf('Unpinned'));
   });
+
+  it('FE-COMP-NOTES-058: note with guest_name renders guest badge on note card', async () => {
+    server.use(
+      http.get('/api/trips/1/collab/notes', () =>
+        HttpResponse.json({
+          notes: [{
+            id: 101, trip_id: 1, user_id: 1, username: 'owner',
+            author_username: 'owner', author_avatar: null,
+            guest_name: 'Bob Guest',
+            title: 'Guest Note Title', content: 'Note content from guest',
+            category: 'Tips', color: '#3b82f6', files: [], attachments: [],
+            created_at: '2025-06-01T10:00:00.000Z', updated_at: '2025-06-01T10:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Guest Note Title');
+    const guestBadge = screen.getByTestId('collab-note-guest-badge');
+    expect(guestBadge).toBeInTheDocument();
+    expect(guestBadge).toHaveTextContent('Bob Guest');
+  });
+
+  it('FE-COMP-NOTES-059: note with guest_name reflects guest in author tooltip', async () => {
+    server.use(
+      http.get('/api/trips/1/collab/notes', () =>
+        HttpResponse.json({
+          notes: [{
+            id: 102, trip_id: 1, user_id: 1, username: 'owner',
+            guest_name: 'Charlie Guest',
+            title: 'Charlie Note', content: '', category: null, color: '#3b82f6', files: [], attachments: [],
+            created_at: '2025-06-01T10:00:00.000Z', updated_at: '2025-06-01T10:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Charlie Note');
+    // The tooltip should show the guest name and guest tag
+    expect(screen.getByText('Charlie Guest (Guest)')).toBeInTheDocument();
+  });
+
+  it('FE-COMP-NOTES-060: view modal displays guest badge when guest_name is present', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/trips/1/collab/notes', () =>
+        HttpResponse.json({
+          notes: [{
+            id: 103, trip_id: 1, user_id: 1, username: 'owner',
+            guest_name: 'Diana Guest',
+            title: 'Diana View Note', content: 'Detailed thoughts from Diana',
+            category: 'Food', color: '#ef4444', files: [], attachments: [],
+            created_at: '2025-06-01T10:00:00.000Z', updated_at: '2025-06-01T10:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Diana View Note');
+    await user.click(screen.getByTitle('collab.notes.expand'));
+    // Modal opens and shows Diana Guest badge in the header
+    const badges = await screen.findAllByTestId('collab-note-guest-badge');
+    expect(badges.length).toBeGreaterThan(1); // 1 in card, 1 in view modal
+    expect(badges[1]).toHaveTextContent('Diana Guest');
+  });
+
+  it('FE-COMP-NOTES-061: edit modal displays guest badge attribution when editing a guest note', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/trips/1/collab/notes', () =>
+        HttpResponse.json({
+          notes: [{
+            id: 104, trip_id: 1, user_id: 1, username: 'owner',
+            guest_name: 'Evan Guest',
+            title: 'Evan Edit Note', content: 'Evan text',
+            category: null, color: '#3b82f6', files: [], attachments: [],
+            created_at: '2025-06-01T10:00:00.000Z', updated_at: '2025-06-01T10:00:00.000Z',
+          }],
+        })
+      )
+    );
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Evan Edit Note');
+    await user.click(screen.getByTitle('Edit'));
+    await screen.findByDisplayValue('Evan Edit Note');
+    const badges = await screen.findAllByTestId('collab-note-guest-badge');
+    expect(badges.length).toBeGreaterThan(1);
+    expect(badges[1]).toHaveTextContent('Evan Guest');
+  });
 });

--- a/client/src/components/Collab/CollabNotes.tsx
+++ b/client/src/components/Collab/CollabNotes.tsx
@@ -3,7 +3,7 @@ import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import ReactDOM from 'react-dom'
-import { Plus, Pencil, X, StickyNote, Settings } from 'lucide-react'
+import { Plus, Pencil, X, StickyNote, Settings, UserRound } from 'lucide-react'
 import { collabApi } from '../../api/client'
 import { useCanDo } from '../../store/permissionsStore'
 import { useTripStore } from '../../store/tripStore'
@@ -398,14 +398,31 @@ function ViewNoteModal(S: NotesState) {
         }}>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 'calc(17px * var(--fs-scale-subtitle, 1))', fontWeight: 600, color: 'var(--text-primary)' }}>{viewingNote.title}</div>
-            {viewingNote.category && (
-              <span style={{
-                display: 'inline-block', marginTop: 4, fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 600,
-                color: getCategoryColor(viewingNote.category),
-                background: `${getCategoryColor(viewingNote.category)}18`,
-                padding: '2px 8px', borderRadius: 6,
-              }}>{viewingNote.category}</span>
-            )}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' }}>
+              {viewingNote.category && (
+                <span style={{
+                  display: 'inline-block', fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 600,
+                  color: getCategoryColor(viewingNote.category),
+                  background: `${getCategoryColor(viewingNote.category)}18`,
+                  padding: '2px 8px', borderRadius: 6,
+                }}>{viewingNote.category}</span>
+              )}
+              {viewingNote.guest_name && (
+                <span
+                  data-testid="collab-note-guest-badge"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 4,
+                    fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 600,
+                    color: 'var(--text-muted)', background: 'var(--bg-tertiary)',
+                    padding: '2px 8px', borderRadius: 6,
+                  }}
+                  title={viewingNote.guest_name}
+                >
+                  <UserRound size={11} />
+                  <span>{viewingNote.guest_name}</span>
+                </span>
+              )}
+            </div>
           </div>
           <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
             {canEdit && <button onClick={() => { setViewingNote(null); setEditingNote(viewingNote) }}

--- a/client/src/components/Collab/CollabNotes.types.ts
+++ b/client/src/components/Collab/CollabNotes.types.ts
@@ -21,6 +21,7 @@ export interface CollabNote {
   avatar: string | null
   user_id: number
   created_at: string
+  guest_name?: string | null
   author?: { username: string; avatar: string | null }
   user?: { username: string; avatar: string | null }
   files?: NoteFile[]

--- a/client/src/components/Collab/CollabNotesCard.tsx
+++ b/client/src/components/Collab/CollabNotesCard.tsx
@@ -3,7 +3,7 @@ import { avatarSrc } from '../../utils/avatarSrc'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import { Trash2, Pin, PinOff, Pencil, Maximize2 } from 'lucide-react'
+import { Trash2, Pin, PinOff, Pencil, Maximize2, UserRound } from 'lucide-react'
 import { FONT } from './CollabNotes.constants'
 import { AuthedImg } from './CollabNotesAuthedImg'
 import { UserAvatar } from './CollabNotesUserAvatar'
@@ -29,7 +29,7 @@ interface NoteCardProps {
 export function NoteCard({ note, currentUser, canEdit, onUpdate, onDelete, onEdit, onView, onPreviewFile, getCategoryColor, tripId, t }: NoteCardProps) {
   const [hovered, setHovered] = useState(false)
 
-  const author = note.author || note.user || { username: note.username, avatar: note.avatar_url || avatarSrc(note.avatar) }
+  const author = note.author || note.user || { username: note.guest_name || note.username, avatar: note.avatar_url || avatarSrc(note.avatar) }
   const color = getCategoryColor ? getCategoryColor(note.category) : (note.color || '#6366f1')
 
   const handleTogglePin = useCallback(() => {
@@ -70,6 +70,30 @@ export function NoteCard({ note, currentUser, canEdit, onUpdate, onDelete, onEdi
           {note.category && (
             <span style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, color, background: `${color}18`, padding: '2px 6px', borderRadius: 99, flexShrink: 0, letterSpacing: '0.02em', textTransform: 'uppercase' }}>
               {note.category}
+            </span>
+          )}
+          {note.guest_name && (
+            <span
+              data-testid="collab-note-guest-badge"
+              style={{
+                fontSize: 'calc(8px * var(--fs-scale-caption, 1))',
+                fontWeight: 600,
+                color: 'var(--text-muted)',
+                background: 'var(--bg-tertiary)',
+                padding: '2px 6px',
+                borderRadius: 99,
+                flexShrink: 0,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 3,
+                letterSpacing: '0.02em',
+              }}
+              title={note.guest_name}
+            >
+              <UserRound size={8} />
+              <span style={{ maxWidth: 80, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {note.guest_name}
+              </span>
             </span>
           )}
         </span>
@@ -119,7 +143,7 @@ export function NoteCard({ note, currentUser, canEdit, onUpdate, onDelete, onEdi
                 fontSize: 'calc(11px * var(--fs-scale-caption, 1))', fontWeight: 500, padding: '5px 10px', borderRadius: 8,
                 boxShadow: '0 4px 12px rgba(0,0,0,0.15)', border: '1px solid var(--border-faint)',
               }}>
-                {author.username}
+                {note.guest_name ? `${note.guest_name} (${t('members.guest') || 'Guest'})` : author.username}
               </div>
             </div>
           </div>

--- a/client/src/components/Collab/CollabNotesFormModal.tsx
+++ b/client/src/components/Collab/CollabNotesFormModal.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
 import { useState, useRef } from 'react'
-import { Plus, X } from 'lucide-react'
+import { Plus, X, UserRound } from 'lucide-react'
 import { useCanDo } from '../../store/permissionsStore'
 import { useTripStore } from '../../store/tripStore'
 import { FONT } from './CollabNotes.constants'
@@ -117,15 +117,44 @@ export function NoteFormModal({ onClose, onSubmit, onDeleteFile, existingCategor
           padding: '14px 16px 12px',
           borderBottom: '1px solid var(--border-faint)',
         }}>
-          <h3 style={{
-            fontSize: 'calc(14px * var(--fs-scale-body, 1))',
-            fontWeight: 700,
-            color: 'var(--text-primary)',
-            margin: 0,
-            fontFamily: FONT,
-          }}>
-            {isEdit ? t('collab.notes.edit') : t('collab.notes.new')}
-          </h3>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, overflow: 'hidden' }}>
+            <h3 style={{
+              fontSize: 'calc(14px * var(--fs-scale-body, 1))',
+              fontWeight: 700,
+              color: 'var(--text-primary)',
+              margin: 0,
+              fontFamily: FONT,
+              whiteSpace: 'nowrap',
+            }}>
+              {isEdit ? t('collab.notes.edit') : t('collab.notes.new')}
+            </h3>
+            {note?.guest_name && (
+              <span
+                data-testid="collab-note-guest-badge"
+                style={{
+                  fontSize: 'calc(10px * var(--fs-scale-caption, 1))',
+                  fontWeight: 600,
+                  color: 'var(--text-muted)',
+                  background: 'var(--bg-tertiary)',
+                  padding: '2px 8px',
+                  borderRadius: 99,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  maxWidth: 160,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={note.guest_name}
+              >
+                <UserRound size={10} style={{ flexShrink: 0 }} />
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {note.guest_name}
+                </span>
+              </span>
+            )}
+          </div>
           <button
             type="button"
             onClick={onClose}

--- a/client/src/components/Trips/TripMembersModal.test.tsx
+++ b/client/src/components/Trips/TripMembersModal.test.tsx
@@ -462,4 +462,78 @@ describe('TripMembersModal', () => {
     // Access count covers owner + the real member only (2), not the guest.
     expect(screen.getByText(/Access \(2/)).toBeInTheDocument();
   });
+
+  it('FE-COMP-MEMBERS-028: allow_guest_notes toggle renders and sends updated perms on click', async () => {
+    const user = userEvent.setup();
+    seedStore(usePermissionsStore, { permissions: { share_manage: 'trip_owner' } });
+    seedStore(useTripStore, { trip: buildTrip({ id: 1, user_id: ownerUser.id }) });
+
+    let postedPerms: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/trips/1/share-link', () =>
+        HttpResponse.json({
+          token: 'tok99',
+          share_map: true,
+          share_bookings: true,
+          share_packing: false,
+          share_budget: false,
+          share_collab: false,
+          allow_guest_notes: false,
+        })
+      ),
+      http.post('/api/trips/1/share-link', async ({ request }) => {
+        postedPerms = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ token: 'tok99', ...postedPerms });
+      }),
+    );
+
+    render(<TripMembersModal {...defaultProps} />);
+    await screen.findByText('Public Link');
+
+    const guestNotesBtn = await screen.findByText('Allow guest notes');
+    expect(guestNotesBtn).toBeInTheDocument();
+
+    await user.click(guestNotesBtn);
+
+    await waitFor(() => {
+      expect(postedPerms).not.toBeNull();
+      expect(postedPerms).toMatchObject({ allow_guest_notes: true });
+    });
+  });
+
+  it('FE-COMP-MEMBERS-029: allow_guest_notes is initialised from existing share link info', async () => {
+    const user = userEvent.setup();
+    seedStore(usePermissionsStore, { permissions: { share_manage: 'trip_owner' } });
+    seedStore(useTripStore, { trip: buildTrip({ id: 1, user_id: ownerUser.id }) });
+
+    let postedPerms: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/trips/1/share-link', () =>
+        HttpResponse.json({
+          token: 'tok99',
+          share_map: true,
+          share_bookings: true,
+          share_packing: false,
+          share_budget: false,
+          share_collab: false,
+          allow_guest_notes: true,
+        })
+      ),
+      http.post('/api/trips/1/share-link', async ({ request }) => {
+        postedPerms = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ token: 'tok99', ...postedPerms });
+      }),
+    );
+
+    render(<TripMembersModal {...defaultProps} />);
+    await screen.findByText('Public Link');
+
+    const guestNotesBtn = await screen.findByText('Allow guest notes');
+    await user.click(guestNotesBtn);
+
+    await waitFor(() => {
+      expect(postedPerms).not.toBeNull();
+      expect(postedPerms).toMatchObject({ allow_guest_notes: false });
+    });
+  });
 });

--- a/client/src/components/Trips/TripMembersModal.tsx
+++ b/client/src/components/Trips/TripMembersModal.tsx
@@ -38,7 +38,7 @@ function ShareLinkSection({ tripId, t }: { tripId: number; t: (key: string, para
   const [shareToken, setShareToken] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [copied, setCopied] = useState(false)
-  const [perms, setPerms] = useState({ share_map: true, share_bookings: true, share_packing: false, share_budget: false, share_collab: false })
+  const [perms, setPerms] = useState<Record<string, boolean>>({ share_map: true, share_bookings: true, share_packing: false, share_budget: false, share_collab: false, allow_guest_notes: false })
   const toast = useToast()
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -49,7 +49,7 @@ function ShareLinkSection({ tripId, t }: { tripId: number; t: (key: string, para
   useEffect(() => {
     shareApi.getLink(tripId).then(d => {
       setShareToken(d.token)
-      if (d.token) setPerms({ share_map: d.share_map ?? true, share_bookings: d.share_bookings ?? true, share_packing: d.share_packing ?? false, share_budget: d.share_budget ?? false, share_collab: d.share_collab ?? false })
+      if (d.token) setPerms({ share_map: d.share_map ?? true, share_bookings: d.share_bookings ?? true, share_packing: d.share_packing ?? false, share_budget: d.share_budget ?? false, share_collab: d.share_collab ?? false, allow_guest_notes: d.allow_guest_notes ?? false })
       setLoading(false)
     }).catch(() => setLoading(false))
   }, [tripId])
@@ -105,6 +105,7 @@ function ShareLinkSection({ tripId, t }: { tripId: number; t: (key: string, para
           { key: 'share_packing', label: t('share.permPacking') },
           { key: 'share_budget', label: t('share.permBudget') },
           { key: 'share_collab', label: t('share.permCollab') },
+          { key: 'allow_guest_notes', label: t('share.permGuestNotes') },
         ].map(opt => (
           <button key={opt.key} onClick={() => !opt.always && handleUpdatePerms(opt.key, !perms[opt.key])}
             style={{

--- a/client/src/components/shared/GuestAddNoteModal.test.tsx
+++ b/client/src/components/shared/GuestAddNoteModal.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '../../../tests/helpers/render';
+import userEvent from '@testing-library/user-event';
+import { shareApi } from '../../api/client';
+import GuestAddNoteModal, { GuestAddNoteModalProps } from './GuestAddNoteModal';
+
+const mockT = (key: string) => {
+  const map: Record<string, string> = {
+    'share.addNote': 'Add note',
+    'share.guestNoteSuccess': 'Note sent successfully!',
+    'share.guestName': 'Your name',
+    'share.noteTitle': 'Note title',
+    'share.noteContent': 'Note details (optional)',
+    'share.noteCategory': 'Category',
+    'share.attachFile': 'Attach file / photo',
+    'share.fileTooLarge': 'File size exceeds 50MB limit',
+    'share.sendNote': 'Send Note',
+  };
+  return map[key] || key;
+};
+
+const defaultProps: GuestAddNoteModalProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  token: 'test-token',
+  categories: ['Food', 'Activity', 'General'],
+  t: mockT,
+};
+
+describe('GuestAddNoteModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('FE-COMP-GUEST-NOTE-001: does not render anything when isOpen is false', () => {
+    render(<GuestAddNoteModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('Add note')).toBeNull();
+  });
+
+  it('FE-COMP-GUEST-NOTE-002: renders all fields when open', () => {
+    render(<GuestAddNoteModal {...defaultProps} />);
+
+    expect(screen.getByRole('heading', { name: 'Add note' })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Your name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Note title')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Note details (optional)')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /attach file/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send Note' })).toBeInTheDocument();
+  });
+
+  it('FE-COMP-GUEST-NOTE-003: populates categories dropdown and defaults to first item', () => {
+    render(<GuestAddNoteModal {...defaultProps} />);
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('Food');
+
+    const options = screen.getAllByRole('option');
+    expect(options.map((o) => o.textContent)).toEqual(['Food', 'Activity', 'General']);
+  });
+
+  it('FE-COMP-GUEST-NOTE-004: defaults category to General if categories prop is empty', () => {
+    render(<GuestAddNoteModal {...defaultProps} categories={[]} />);
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('General');
+  });
+
+  it('FE-COMP-GUEST-NOTE-005: submit button is disabled when name or title is empty', () => {
+    render(<GuestAddNoteModal {...defaultProps} />);
+
+    const submitBtn = screen.getByRole('button', { name: 'Send Note' });
+    expect(submitBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'Alice' } });
+    expect(submitBtn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Note title'), { target: { value: 'Great Cafe' } });
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('FE-COMP-GUEST-NOTE-006: successfully submits form and closes modal', async () => {
+    const addGuestNoteSpy = vi.spyOn(shareApi, 'addGuestNote').mockResolvedValue({
+      success: true,
+      note: { id: 1, title: 'Great Cafe' },
+    });
+    const onClose = vi.fn();
+
+    render(<GuestAddNoteModal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Note title'), { target: { value: 'Great Cafe' } });
+    fireEvent.change(screen.getByPlaceholderText('Note details (optional)'), {
+      target: { value: 'Best coffee in town' },
+    });
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Food' } });
+
+    const submitBtn = screen.getByRole('button', { name: 'Send Note' });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(addGuestNoteSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const [tokenArg, formDataArg] = addGuestNoteSpy.mock.calls[0];
+    expect(tokenArg).toBe('test-token');
+    expect(formDataArg instanceof FormData).toBe(true);
+    expect(formDataArg.get('guest_name')).toBe('Alice');
+    expect(formDataArg.get('title')).toBe('Great Cafe');
+    expect(formDataArg.get('content')).toBe('Best coffee in town');
+    expect(formDataArg.get('category')).toBe('Food');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('FE-COMP-GUEST-NOTE-007: allows attaching a valid file and removing it', async () => {
+    const user = userEvent.setup();
+    render(<GuestAddNoteModal {...defaultProps} />);
+
+    const file = new File(['dummy content'], 'photo.jpg', { type: 'image/jpeg' });
+    const fileInput = screen.getByTestId('guest-note-file-input') as HTMLInputElement;
+
+    await user.upload(fileInput, file);
+
+    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+
+    const removeBtn = screen.getByRole('button', { name: 'Remove attachment' });
+    fireEvent.click(removeBtn);
+
+    expect(screen.queryByText('photo.jpg')).toBeNull();
+    expect(screen.getByRole('button', { name: /attach file/i })).toBeInTheDocument();
+  });
+
+  it('FE-COMP-GUEST-NOTE-008: validates file size <= 50MB and rejects oversized files', async () => {
+    const user = userEvent.setup();
+    render(<GuestAddNoteModal {...defaultProps} />);
+
+    // Create a 51MB file
+    const oversizedFile = new File([''], 'huge-video.mp4', { type: 'video/mp4' });
+    Object.defineProperty(oversizedFile, 'size', { value: 55 * 1024 * 1024 });
+
+    const fileInput = screen.getByTestId('guest-note-file-input') as HTMLInputElement;
+    await user.upload(fileInput, oversizedFile);
+
+    expect(screen.getByText('File size exceeds 50MB limit')).toBeInTheDocument();
+    expect(screen.queryByText('huge-video.mp4')).toBeNull();
+  });
+
+  it('FE-COMP-GUEST-NOTE-009: handles submission API error gracefully', async () => {
+    vi.spyOn(shareApi, 'addGuestNote').mockRejectedValue(new Error('Network error'));
+    const onClose = vi.fn();
+
+    render(<GuestAddNoteModal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Note title'), { target: { value: 'Great Cafe' } });
+
+    const submitBtn = screen.getByRole('button', { name: 'Send Note' });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(submitBtn).not.toBeDisabled();
+    });
+
+    // Should NOT close modal on error
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/shared/GuestAddNoteModal.tsx
+++ b/client/src/components/shared/GuestAddNoteModal.tsx
@@ -1,0 +1,263 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Modal from './Modal';
+import { shareApi } from '../../api/client';
+import { useToast } from './Toast';
+import { getApiErrorMessage } from '../../types';
+import { Paperclip, X, Loader2 } from 'lucide-react';
+
+export interface GuestAddNoteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  token: string;
+  categories: string[];
+  t: (key: string, params?: Record<string, string | number>) => string;
+}
+
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB limit
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function GuestAddNoteModal({
+  isOpen,
+  onClose,
+  token,
+  categories = [],
+  t,
+}: GuestAddNoteModalProps) {
+  const [guestName, setGuestName] = useState('');
+  const [category, setCategory] = useState(categories[0] || 'General');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    if (isOpen) {
+      if (categories.length > 0 && !categories.includes(category)) {
+        setCategory(categories[0]);
+      } else if (!category) {
+        setCategory('General');
+      }
+    }
+  }, [isOpen, categories]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const resetForm = () => {
+    setGuestName('');
+    setTitle('');
+    setContent('');
+    setCategory(categories.length > 0 ? categories[0] : 'General');
+    setFile(null);
+    setFileError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+
+    if (selected.size > MAX_FILE_SIZE_BYTES) {
+      const errorMsg = t('share.fileTooLarge') || 'File size exceeds 50MB limit';
+      setFileError(errorMsg);
+      toast.error(errorMsg);
+      e.target.value = '';
+      return;
+    }
+
+    setFile(selected);
+    setFileError(null);
+  };
+
+  const handleClearFile = () => {
+    setFile(null);
+    setFileError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedName = guestName.trim();
+    const trimmedTitle = title.trim();
+    if (!trimmedName || !trimmedTitle || submitting) return;
+
+    setSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('guest_name', trimmedName);
+      formData.append('title', trimmedTitle);
+      if (content.trim()) {
+        formData.append('content', content.trim());
+      }
+      if (category) {
+        formData.append('category', category);
+      }
+      if (file) {
+        formData.append('file', file);
+      }
+
+      await shareApi.addGuestNote(token, formData);
+      toast.success(t('share.guestNoteSuccess') || 'Note sent successfully!');
+      resetForm();
+      onClose();
+    } catch (err: unknown) {
+      toast.error(getApiErrorMessage(err, t('common.error') || 'An error occurred'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const availableCategories = categories.length > 0 ? categories : ['General'];
+  const canSubmit = guestName.trim().length > 0 && title.trim().length > 0 && !submitting;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        if (!submitting) {
+          onClose();
+        }
+      }}
+      title={t('share.addNote') || 'Add note'}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Guest Name */}
+        <div>
+          <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+            {t('share.guestName') || 'Your name'} <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            required
+            value={guestName}
+            onChange={(e) => setGuestName(e.target.value)}
+            placeholder={t('share.guestName') || 'Your name'}
+            className="w-full px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-400"
+          />
+        </div>
+
+        {/* Category */}
+        <div>
+          <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+            {t('share.noteCategory') || 'Category'}
+          </label>
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="w-full px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-400"
+          >
+            {availableCategories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Title */}
+        <div>
+          <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+            {t('share.noteTitle') || 'Note title'} <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={t('share.noteTitle') || 'Note title'}
+            className="w-full px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-400"
+          />
+        </div>
+
+        {/* Content */}
+        <div>
+          <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+            {t('share.noteContent') || 'Note details (optional)'}
+          </label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder={t('share.noteContent') || 'Note details (optional)'}
+            rows={4}
+            className="w-full px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-400 resize-y"
+          />
+        </div>
+
+        {/* Attach File */}
+        <div>
+          <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+            {t('share.attachFile') || 'Attach file / photo'}
+          </label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            onChange={handleFileChange}
+            className="hidden"
+            data-testid="guest-note-file-input"
+          />
+          {file ? (
+            <div className="flex items-center justify-between p-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
+              <div className="flex items-center gap-2 min-w-0 pr-2">
+                <Paperclip className="w-4 h-4 text-slate-400 flex-shrink-0" />
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-300 truncate">
+                  {file.name}
+                </span>
+                <span className="text-xs text-slate-400 flex-shrink-0">
+                  ({formatFileSize(file.size)})
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleClearFile}
+                className="p-1 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                aria-label="Remove attachment"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full flex items-center justify-center gap-2 p-3 rounded-xl border border-dashed border-slate-300 dark:border-slate-700 hover:border-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50 text-sm font-medium text-slate-600 dark:text-slate-400 transition-colors"
+            >
+              <Paperclip className="w-4 h-4" />
+              <span>{t('share.attachFile') || 'Attach file / photo'}</span>
+            </button>
+          )}
+          {fileError && (
+            <p className="text-xs text-red-500 mt-1">{fileError}</p>
+          )}
+        </div>
+
+        {/* Submit Button */}
+        <div className="pt-2">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="w-full py-2.5 px-4 rounded-xl bg-slate-900 hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold shadow transition-all flex items-center justify-center gap-2"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>{t('share.sendNote') || 'Send Note'}...</span>
+              </>
+            ) : (
+              <span>{t('share.sendNote') || 'Send Note'}</span>
+            )}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/client/src/pages/SharedTripPage.test.tsx
+++ b/client/src/pages/SharedTripPage.test.tsx
@@ -572,4 +572,92 @@ describe('SharedTripPage', () => {
       await waitFor(() => expect(screen.getAllByText(/125\.00 NZD/).length).toBeGreaterThan(0));
     });
   });
+
+  describe('FE-PAGE-SHARED-021: Add Note button rendered when allow_guest_notes is true', () => {
+    it('shows Add Note action button when permissions.allow_guest_notes is true', async () => {
+      server.use(
+        http.get('/api/shared/:token', ({ params }) => {
+          if (params.token !== 'guest-notes-token') return;
+          return HttpResponse.json({
+            trip: { id: 1, title: 'Shared Paris Trip', start_date: '2026-07-01', end_date: '2026-07-05' },
+            days: [], assignments: {}, dayNotes: {}, places: [], reservations: [], accommodations: [], packing: [],
+            budget: [], categories: [], noteCategories: ['Food', 'General'],
+            permissions: { share_bookings: false, share_packing: false, share_budget: false, share_collab: false, allow_guest_notes: true },
+            collab: [],
+          });
+        }),
+      );
+
+      renderSharedTrip('guest-notes-token');
+      await waitFor(() => expect(screen.getByText('Shared Paris Trip')).toBeInTheDocument());
+
+      const addNoteBtn = screen.getByRole('button', { name: /add note/i });
+      expect(addNoteBtn).toBeInTheDocument();
+    });
+  });
+
+  describe('FE-PAGE-SHARED-022: Add Note button hidden when allow_guest_notes is false', () => {
+    it('does not show Add Note action button when permissions.allow_guest_notes is false or undefined', async () => {
+      renderSharedTrip('test-token');
+      await waitFor(() => expect(screen.getByText('Shared Paris Trip')).toBeInTheDocument());
+
+      expect(screen.queryByRole('button', { name: /add note/i })).toBeNull();
+    });
+  });
+
+  describe('FE-PAGE-SHARED-023: Submitting guest note from SharedTripPage modal', () => {
+    it('opens GuestAddNoteModal and submits note data via POST /api/shared/:token/notes', async () => {
+      let postedFormData: { guest_name?: string; title?: string; content?: string; category?: string } = {};
+
+      server.use(
+        http.get('/api/shared/:token', ({ params }) => {
+          if (params.token !== 'submit-note-token') return;
+          return HttpResponse.json({
+            trip: { id: 1, title: 'Shared Paris Trip', start_date: '2026-07-01', end_date: '2026-07-05' },
+            days: [], assignments: {}, dayNotes: {}, places: [], reservations: [], accommodations: [], packing: [],
+            budget: [], categories: [], noteCategories: ['Sightseeing', 'General'],
+            permissions: { share_bookings: false, share_packing: false, share_budget: false, share_collab: false, allow_guest_notes: true },
+            collab: [],
+          });
+        }),
+        http.post('/api/shared/:token/notes', async ({ request }) => {
+          const formData = await request.formData();
+          postedFormData = {
+            guest_name: formData.get('guest_name')?.toString(),
+            title: formData.get('title')?.toString(),
+            content: formData.get('content')?.toString(),
+            category: formData.get('category')?.toString(),
+          };
+          return HttpResponse.json({
+            success: true,
+            note: { id: 10, title: postedFormData.title },
+          }, { status: 201 });
+        }),
+      );
+
+      renderSharedTrip('submit-note-token');
+      await waitFor(() => expect(screen.getByText('Shared Paris Trip')).toBeInTheDocument());
+
+      const addNoteBtn = screen.getByRole('button', { name: /add note/i });
+      fireEvent.click(addNoteBtn);
+
+      await waitFor(() => expect(screen.getByRole('heading', { name: /add note/i })).toBeInTheDocument());
+
+      fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'Bob' } });
+      fireEvent.change(screen.getByPlaceholderText('Note title'), { target: { value: 'Visit Louvre Museum' } });
+      fireEvent.change(screen.getByPlaceholderText('Note details (optional)'), { target: { value: 'Book tickets online in advance' } });
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Sightseeing' } });
+
+      const sendBtn = screen.getByRole('button', { name: 'Send Note' });
+      fireEvent.click(sendBtn);
+
+      await waitFor(() => {
+        expect(postedFormData.guest_name).toBe('Bob');
+        expect(postedFormData.title).toBe('Visit Louvre Museum');
+        expect(postedFormData.content).toBe('Book tickets online in advance');
+        expect(postedFormData.category).toBe('Sightseeing');
+      });
+    });
+  });
 });
+

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -10,6 +10,7 @@ import {
   MapPin,
   MessageCircle,
   Plane,
+  Plus,
   Ship,
   Ticket,
   Train,
@@ -19,6 +20,7 @@ import { createElement, useEffect, useRef } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MapContainer, Marker, TileLayer, Tooltip, useMap } from 'react-leaflet';
 import { getCategoryIcon } from '../components/shared/categoryIcons';
+import GuestAddNoteModal from '../components/shared/GuestAddNoteModal';
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../constants/mapDefaults';
 import { SUPPORTED_LANGUAGES, useTranslation } from '../i18n';
 import { useSettingsStore } from '../store/settingsStore';
@@ -77,6 +79,9 @@ export default function SharedTripPage() {
     setActiveTab,
     showLangPicker,
     setShowLangPicker,
+    showAddNoteModal,
+    setShowAddNoteModal,
+    token,
   } = useSharedTrip();
 
   if (error)
@@ -1137,6 +1142,28 @@ export default function SharedTripPage() {
           </div>
         </div>
       </div>
+
+      {/* Guest Note Submission */}
+      {permissions?.allow_guest_notes && token && (
+        <>
+          <button
+            type="button"
+            onClick={() => setShowAddNoteModal(true)}
+            className="fixed bottom-6 right-6 z-40 bg-slate-900 hover:bg-slate-800 text-white shadow-xl flex items-center gap-2 px-4 py-2.5 rounded-full font-semibold transition-all text-sm hover:scale-105 active:scale-95 border border-slate-700/50"
+            aria-label={t('share.addNote')}
+          >
+            <Plus size={16} />
+            <span>{t('share.addNote')}</span>
+          </button>
+          <GuestAddNoteModal
+            isOpen={showAddNoteModal}
+            onClose={() => setShowAddNoteModal(false)}
+            token={token}
+            categories={data?.noteCategories || ['General']}
+            t={t}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/pages/sharedTrip/useSharedTrip.ts
+++ b/client/src/pages/sharedTrip/useSharedTrip.ts
@@ -19,6 +19,7 @@ export function useSharedTrip() {
   const [selectedDay, setSelectedDay] = useState<number | null>(null)
   const [activeTab, setActiveTab] = useState('plan')
   const [showLangPicker, setShowLangPicker] = useState(false)
+  const [showAddNoteModal, setShowAddNoteModal] = useState(false)
 
   useEffect(() => {
     if (!token) return
@@ -46,5 +47,19 @@ export function useSharedTrip() {
   const base = String(data?.baseCurrency || data?.trip?.currency || 'EUR').toUpperCase()
   const { convert } = useExchangeRates(base)
 
-  return { data, error, base, convert, selectedDay, setSelectedDay, activeTab, setActiveTab, showLangPicker, setShowLangPicker }
+  return {
+    data,
+    error,
+    base,
+    convert,
+    selectedDay,
+    setSelectedDay,
+    activeTab,
+    setActiveTab,
+    showLangPicker,
+    setShowLangPicker,
+    showAddNoteModal,
+    setShowAddNoteModal,
+    token: token || '',
+  }
 }

--- a/docs/superpowers/plans/2026-08-18-public-guest-notes.md
+++ b/docs/superpowers/plans/2026-08-18-public-guest-notes.md
@@ -1,0 +1,399 @@
+# Public Share Link Guest Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow public share link visitors to submit notes (with name, category selection, title, content, and file attachments) directly to the trip's Collab Notes, with owner toggle control, real-time sync, and guest badges.
+
+**Architecture:** Extend SQLite schema with `allow_guest_notes` on `share_tokens` and `guest_name` on `collab_notes`. Implement public `POST /api/shared/:token/notes` handling multipart submissions, saving attachments via `trip_files`, broadcasting WebSocket events, and notifying trip owners. Add share modal toggle, guest note submission modal on `SharedTripPage`, and guest badge rendering on `CollabNotesCard`.
+
+**Tech Stack:** NestJS / Express, SQLite (better-sqlite3), Multer, React 18, TypeScript, Tailwind CSS, Lucide Icons, WebSocket (ws), Vitest.
+
+## Global Constraints
+
+- Preserve all existing permissions and token verification behaviors.
+- File upload for guests must strictly respect size limits (<= 50MB) and blocked file extensions (`BLOCKED_EXTENSIONS`, no executable or script files).
+- Keep public endpoint unauthenticated but strictly scoped and authorized by the share token.
+
+---
+
+### Task 1: Database Migration & Schema Types
+
+**Files:**
+- Modify: `server/src/db/migrations.ts`
+- Modify: `server/src/db/schema.ts`
+- Modify: `server/src/types.ts`
+- Modify: `shared/src/collab/collab.schema.ts`
+- Modify: `shared/src/share/share.schema.ts`
+- Test: `server/tests/integration/share.test.ts`
+
+**Interfaces:**
+- Consumes: Existing SQLite database connection and migration runner.
+- Produces:
+  - `CollabNote.guest_name?: string | null`
+  - `SharePermissions.allow_guest_notes?: boolean`
+  - `ShareTokenInfo.allow_guest_notes: boolean`
+
+- [ ] **Step 1: Write integration test verifying schema columns and types**
+
+Add test in `server/tests/integration/share.test.ts` checking `allow_guest_notes` in `share_tokens` and `guest_name` in `collab_notes`:
+
+```typescript
+it('supports allow_guest_notes in share_tokens and guest_name in collab_notes', () => {
+  const trip = createTrip(testUser.id, 'Guest Note Test');
+  const { token } = createOrUpdateShareLink(String(trip.id), testUser.id, {
+    share_map: true,
+    allow_guest_notes: true,
+  });
+  const link = getShareLink(String(trip.id));
+  expect(link?.allow_guest_notes).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix server test -- server/tests/integration/share.test.ts`
+Expected: FAIL (missing `allow_guest_notes` column or property).
+
+- [ ] **Step 3: Implement database migration, schema, and types**
+
+In `server/src/db/migrations.ts`, add migration function to `migrations` array:
+```typescript
+    // Add allow_guest_notes to share_tokens and guest_name to collab_notes
+    () => {
+      try {
+        db.exec('ALTER TABLE share_tokens ADD COLUMN allow_guest_notes INTEGER DEFAULT 0;');
+      } catch (err) {
+        console.warn('[migrations] Non-fatal migration step failed:', err);
+      }
+      try {
+        db.exec('ALTER TABLE collab_notes ADD COLUMN guest_name TEXT DEFAULT NULL;');
+      } catch (err) {
+        console.warn('[migrations] Non-fatal migration step failed:', err);
+      }
+    },
+```
+
+In `server/src/db/schema.ts`:
+- Add `allow_guest_notes INTEGER DEFAULT 0` to `CREATE TABLE IF NOT EXISTS share_tokens`.
+- Add `guest_name TEXT DEFAULT NULL` to `CREATE TABLE IF NOT EXISTS collab_notes`.
+
+In `server/src/types.ts`:
+- Update `CollabNote` interface: `guest_name?: string | null;`
+- Update `SharePermissions`: `allow_guest_notes?: boolean;`
+- Update `ShareTokenInfo`: `allow_guest_notes: boolean;`
+
+In `shared/src/collab/collab.schema.ts` and `shared/src/share/share.schema.ts`:
+- Update schemas and types to include `guest_name` and `allow_guest_notes`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix server test -- server/tests/integration/share.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/db/migrations.ts server/src/db/schema.ts server/src/types.ts shared/src/ server/tests/integration/share.test.ts
+git commit -m "feat(db): add allow_guest_notes and guest_name columns"
+```
+
+---
+
+### Task 2: Backend Share Service & Guest Note Endpoint
+
+**Files:**
+- Modify: `server/src/services/shareService.ts`
+- Modify: `server/src/services/collabService.ts`
+- Modify: `server/src/nest/share/share.controller.ts`
+- Test: `server/tests/e2e/share.e2e.test.ts`
+
+**Interfaces:**
+- Consumes: `createOrUpdateShareLink`, `getSharedTripData`, `formatNote`, `NOTE_UPLOAD` multer config.
+- Produces: `POST /api/shared/:token/notes` endpoint returning `{ success: true, note: CollabNote }`.
+
+- [ ] **Step 1: Write E2E tests for guest note submission**
+
+In `server/tests/e2e/share.e2e.test.ts`:
+```typescript
+describe('POST /api/shared/:token/notes', () => {
+  it('rejects guest note when allow_guest_notes is false', async () => {
+    // create trip and share token with allow_guest_notes = false
+    const res = await request(app.getHttpServer())
+      .post(`/api/shared/${token}/notes`)
+      .field('guest_name', 'Guest User')
+      .field('title', 'Recommendation')
+      .expect(403);
+    expect(res.body.error).toMatch(/disabled/i);
+  });
+
+  it('accepts guest note with category and attachment when allow_guest_notes is true', async () => {
+    // update share token with allow_guest_notes = true
+    const res = await request(app.getHttpServer())
+      .post(`/api/shared/${token}/notes`)
+      .field('guest_name', 'Budi')
+      .field('title', 'Great Cafe')
+      .field('content', 'Try the coffee near station')
+      .field('category', 'Food')
+      .attach('file', Buffer.from('fake image content'), 'test.jpg')
+      .expect(201);
+    expect(res.body.note.guest_name).toBe('Budi');
+    expect(res.body.note.title).toBe('Great Cafe');
+    expect(res.body.note.attachments.length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix server test -- server/tests/e2e/share.e2e.test.ts`
+Expected: FAIL (route not found / 404).
+
+- [ ] **Step 3: Implement backend service and controller logic**
+
+In `server/src/services/collabService.ts`:
+- Update `createNote` to accept `guest_name?: string`:
+```typescript
+export function createNote(
+  tripId: string | number,
+  userId: number,
+  data: { title: string; content?: string; category?: string; color?: string; website?: string; pinned?: boolean; guest_name?: string }
+) {
+  const pinned = data.pinned ? 1 : 0;
+  const result = db.prepare(`
+    INSERT INTO collab_notes (trip_id, user_id, title, content, category, color, website, pinned, guest_name)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(tripId, userId, data.title, data.content || null, data.category || 'General', data.color || '#6366f1', data.website || null, pinned, data.guest_name || null);
+
+  const note = db.prepare(`
+    SELECT n.*, u.username, u.avatar FROM collab_notes n JOIN users u ON n.user_id = u.id WHERE n.id = ?
+  `).get(result.lastInsertRowid) as CollabNote;
+
+  return formatNote(note);
+}
+```
+
+In `server/src/services/shareService.ts`:
+- Update `createOrUpdateShareLink`, `getShareLink`, and `getSharedTripData` to handle `allow_guest_notes`.
+- In `getSharedTripData`:
+  - Fetch distinct note categories for the trip:
+    ```typescript
+    const noteCatsRows = db.prepare('SELECT DISTINCT category FROM collab_notes WHERE trip_id = ? AND category IS NOT NULL').all(tripId) as { category: string }[];
+    const noteCategories = noteCatsRows.length > 0 ? noteCatsRows.map(r => r.category) : ['General'];
+    ```
+  - Include `noteCategories` in the returned object.
+
+In `server/src/nest/share/share.controller.ts`:
+- Add `POST :token/notes` handler in `SharedController` with `FileInterceptor('file', NOTE_UPLOAD)`:
+```typescript
+@Post(':token/notes')
+@UseInterceptors(FileInterceptor('file', NOTE_UPLOAD))
+async addGuestNote(
+  @Param('token') token: string,
+  @Body() body: { guest_name?: string; title?: string; content?: string; category?: string },
+  @UploadedFile() file: Express.Multer.File | undefined,
+) {
+  // Validate token & allow_guest_notes
+  // Create note via collabService with guest_name
+  // If file uploaded, attach via collabService.addNoteFile
+  // Broadcast websocket event collab:note:created
+  // Notify trip owner
+  // Return { success: true, note }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix server test -- server/tests/e2e/share.e2e.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/shareService.ts server/src/services/collabService.ts server/src/nest/share/share.controller.ts server/tests/e2e/share.e2e.test.ts
+git commit -m "feat(api): implement POST /api/shared/:token/notes endpoint"
+```
+
+---
+
+### Task 3: Client API & Share Modal Toggle
+
+**Files:**
+- Modify: `client/src/api/client.ts`
+- Modify: `client/src/components/Trips/TripMembersModal.tsx`
+- Modify: `client/src/i18n/locales/en.json` (and other locale files if present)
+- Test: `client/src/components/Trips/TripMembersModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `shareApi.createLink`, `shareApi.getLink`.
+- Produces: `shareApi.addGuestNote(token: string, formData: FormData)`, updated `TripMembersModal` with `allow_guest_notes` toggle.
+
+- [ ] **Step 1: Write test for TripMembersModal share toggle**
+
+In `client/src/components/Trips/TripMembersModal.test.tsx`:
+```typescript
+it('renders allow_guest_notes permission toggle in ShareLinkSection', async () => {
+  render(<TripMembersModal trip={mockTrip} onClose={vi.fn()} />);
+  expect(await screen.findByText(/allow guest notes/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix client test -- TripMembersModal.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement client API methods and ShareLinkSection toggle**
+
+In `client/src/api/client.ts`:
+- Add `allow_guest_notes?: boolean` to share API payloads.
+- Add `addGuestNote: (token: string, formData: FormData) => postMultipart(\`/api/shared/\${token}/notes\`, formData)`.
+
+In `client/src/components/Trips/TripMembersModal.tsx`:
+- Include `{ key: 'allow_guest_notes', label: t('share.permGuestNotes') }` in permission options.
+- Default `allow_guest_notes: false` in local state.
+
+In `client/src/i18n/`:
+- Add translation key `share.permGuestNotes`: `"Allow guest notes"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix client test -- TripMembersModal.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/client.ts client/src/components/Trips/TripMembersModal.tsx client/src/components/Trips/TripMembersModal.test.tsx client/src/i18n/
+git commit -m "feat(ui): add allow_guest_notes toggle in share modal"
+```
+
+---
+
+### Task 4: Public Share Page Guest Note Modal & Submission
+
+**Files:**
+- Create: `client/src/components/shared/GuestAddNoteModal.tsx`
+- Modify: `client/src/pages/SharedTripPage.tsx`
+- Modify: `client/src/pages/sharedTrip/useSharedTrip.ts`
+- Test: `client/src/pages/SharedTripPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `shareApi.addGuestNote`, `data.permissions.allow_guest_notes`, `data.noteCategories`.
+- Produces: `GuestAddNoteModal` component, action button on `SharedTripPage`.
+
+- [ ] **Step 1: Write test for SharedTripPage guest note button and modal**
+
+In `client/src/pages/SharedTripPage.test.tsx`:
+```typescript
+it('displays "Add Note" button when allow_guest_notes is true', async () => {
+  // mock useSharedTrip data with permissions.allow_guest_notes = true
+  render(<SharedTripPage />);
+  const addBtn = screen.getByRole('button', { name: /kirim catatan|add note/i });
+  expect(addBtn).toBeInTheDocument();
+  fireEvent.click(addBtn);
+  expect(screen.getByLabelText(/nama|name/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix client test -- SharedTripPage.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement GuestAddNoteModal and integrate into SharedTripPage**
+
+Create `client/src/components/shared/GuestAddNoteModal.tsx`:
+- Modal containing:
+  - Guest Name input
+  - Category dropdown selector (using `noteCategories` passed as props)
+  - Title input
+  - Content textarea
+  - File upload input with file size warning (max 50MB) and selected file clear button
+  - Submit button with loading spinner
+  - Error and success handling with toast notification
+
+In `client/src/pages/SharedTripPage.tsx`:
+- If `permissions?.allow_guest_notes`:
+  - Render Floating Action Button / Header Button: `➕ {t('shared.addNote') || 'Kirim Catatan / Ide'}`.
+  - Render `GuestAddNoteModal` when open state is active.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix client test -- SharedTripPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/shared/GuestAddNoteModal.tsx client/src/pages/SharedTripPage.tsx client/src/pages/sharedTrip/useSharedTrip.ts client/src/pages/SharedTripPage.test.tsx
+git commit -m "feat(ui): add guest note submission modal on public share page"
+```
+
+---
+
+### Task 5: Collab Notes Guest Badge & Display
+
+**Files:**
+- Modify: `client/src/components/Collab/CollabNotesCard.tsx`
+- Modify: `client/src/components/Collab/CollabNotesFormModal.tsx`
+- Modify: `client/src/components/Collab/CollabNotes.types.ts`
+- Test: `client/src/components/Collab/CollabNotes.test.tsx`
+
+**Interfaces:**
+- Consumes: `note.guest_name`.
+- Produces: Guest badge and attribution in note cards and details modal.
+
+- [ ] **Step 1: Write test for CollabNotesCard rendering guest badge**
+
+In `client/src/components/Collab/CollabNotes.test.tsx`:
+```typescript
+it('displays guest badge when note has guest_name', () => {
+  const guestNote = { ...mockNote, guest_name: 'Budi' };
+  render(<NoteCard note={guestNote} {...mockProps} />);
+  expect(screen.getByText(/budi/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix client test -- CollabNotes.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement guest badge and avatar display in CollabNotesCard**
+
+In `client/src/components/Collab/CollabNotesCard.tsx`:
+- Check if `note.guest_name` is present.
+- Render badge:
+  ```tsx
+  {note.guest_name && (
+    <span style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, color: '#f59e0b', background: '#fef3c7', padding: '2px 6px', borderRadius: 99, display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      👤 Tamu: {note.guest_name}
+    </span>
+  )}
+  ```
+- Tooltip/avatar reflects guest author.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix client test -- CollabNotes.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/Collab/CollabNotesCard.tsx client/src/components/Collab/CollabNotesFormModal.tsx client/src/components/Collab/CollabNotes.types.ts client/src/components/Collab/CollabNotes.test.tsx
+git commit -m "feat(ui): display guest author badge in Collab Notes card"
+```
+
+---
+
+## Plan Self-Review
+
+1. **Spec coverage:**
+   - Database schema with `allow_guest_notes` & `guest_name`: Covered in Task 1.
+   - Public endpoint `POST /api/shared/:token/notes` with file upload & real-time broadcast: Covered in Task 2.
+   - Toggle switch in Share modal: Covered in Task 3.
+   - Public guest submission modal on `SharedTripPage`: Covered in Task 4.
+   - Guest badge in Collab Notes: Covered in Task 5.
+2. **Placeholder scan:** No TBDs, all endpoints, parameters, and UI flows specified.
+3. **Type consistency:** `guest_name`, `allow_guest_notes`, `noteCategories` consistent across backend and frontend tasks.

--- a/docs/superpowers/specs/2026-08-18-public-guest-notes-design.md
+++ b/docs/superpowers/specs/2026-08-18-public-guest-notes-design.md
@@ -1,0 +1,142 @@
+# Design Document: Guest Note Submissions via Public Share Links
+
+- **Date:** 2026-08-18
+- **Topic:** Public Share Link Guest Note Submissions to Collab Notes
+- **Status:** Draft (Approved in Brainstorming)
+
+---
+
+## 1. Overview & Problem Statement
+
+Users share trips via public links (`/shared/:token`) with friends, family, or travel companions who might not have an account in MinTrip (TREK). Currently, public links are strictly read-only. Trip organizers want viewers with the share link to be able to suggest ideas, recommend places/notes, and upload attachments (photos, PDFs, docs) directly from the public page, and have those suggestions arrive seamlessly in the trip's **Collab Notes** in the main app.
+
+This design introduces a secure, toggleable guest submission capability for public share links, allowing guests to submit notes (Name, Category, Title, Content, File Attachment) that immediately appear in the main app's Collab Notes with real-time sync and distinct guest badges.
+
+---
+
+## 2. Requirements & User Stories
+
+### 2.1 User Stories
+1. **As a Trip Owner / Admin:**
+   - I can toggle `Allow Guest Notes` when creating or editing a trip's public share link.
+   - I want guest notes to automatically appear in my trip's Collab Notes with a clear badge (e.g. `Guest: [Name]`).
+   - I want to receive real-time updates and an in-app notification when a guest submits a note.
+   - I can edit, pin, categorize, or delete guest notes just like normal notes.
+
+2. **As a Public Viewer (Guest):**
+   - When visiting a public share link with guest submissions enabled, I can click a visible "Add Note / Send Idea" button.
+   - I can fill in my Name, select a Category from the trip's existing categories, provide a Title, write Content, and optionally attach a file (image, PDF, etc.).
+   - Upon submitting, I receive confirmation that my note was delivered to the trip organizer.
+
+---
+
+## 3. Architecture & Data Model
+
+### 3.1 Database Changes
+
+1. **`share_tokens` table**:
+   Add permission column `allow_guest_notes`:
+   ```sql
+   ALTER TABLE share_tokens ADD COLUMN allow_guest_notes INTEGER DEFAULT 0;
+   ```
+
+2. **`collab_notes` table**:
+   Add author attribution column `guest_name`:
+   ```sql
+   ALTER TABLE collab_notes ADD COLUMN guest_name TEXT DEFAULT NULL;
+   ```
+   * When created by a guest: `user_id` is set to the share token creator's `user_id`, and `guest_name` is set to the submitted name.
+   * When created by a registered user: `guest_name` is `NULL`.
+
+3. **`trip_files` table**:
+   * Uses existing schema without alterations. The attached file record links to `note_id` and `trip_id`.
+
+4. **Types (`server/src/types.ts` & `shared/src/collab/collab.schema.ts`)**:
+   * Update `CollabNote` interface to include `guest_name?: string | null`.
+   * Update `SharePermissions` and `ShareTokenInfo` to include `allow_guest_notes?: boolean`.
+
+---
+
+## 4. Backend Endpoints & Logic
+
+### 4.1 New Public Endpoint: `POST /api/shared/:token/notes`
+* **Authentication:** Public (scoped and authorized via share token).
+* **Payload Format:** `multipart/form-data`
+* **Form Fields:**
+  * `guest_name` *(string, required, 1–100 chars, trimmed)*
+  * `title` *(string, required, 1–200 chars, trimmed)*
+  * `content` *(string, optional, max 5000 chars)*
+  * `category` *(string, optional, defaults to `'General'`)*
+  * `file` *(Express.Multer.File, optional, max 50MB, blocked executable extensions)*
+
+* **Processing Flow:**
+  1. Look up `share_tokens` by `token`. Check that token is valid and unexpired (`expires_at IS NULL OR expires_at > datetime('now')`).
+  2. Verify `share_token.allow_guest_notes === 1`. If not, return HTTP `403 Forbidden` (`Guest submissions disabled`).
+  3. Insert row into `collab_notes` with `trip_id = share_token.trip_id`, `user_id = share_token.created_by`, `guest_name = guest_name`, `title`, `content`, `category`, `color = '#6366f1'`.
+  4. If a file is uploaded, store it via existing Multer storage (`uploads/files/`) and insert into `trip_files` linking to the new `note.id`.
+  5. Format the newly created note using `formatNote()`.
+  6. Broadcast WebSocket event `collab:note:created` to the trip channel (`trip_${tripId}`).
+  7. Dispatch in-app notification to the trip owner (`"Guest [Name] added a note: [Title]"`).
+  8. Return HTTP `201 Created` with `{ success: true, note }`.
+
+### 4.2 Updates to Existing Endpoints
+* **`GET /api/shared/:token` (`SharedController` / `shareService`):**
+  * Include `allow_guest_notes: boolean` in `permissions`.
+  * Include `noteCategories: string[]` in the payload (distinct categories from `collab_notes` for that trip, falling back to `['General']`).
+* **`POST /api/trips/:tripId/share-link` (`TripShareController` / `shareService`):**
+  * Accept `allow_guest_notes?: boolean` in the request body and persist it to `share_tokens`.
+* **`GET /api/trips/:tripId/share-link`:**
+  * Return `allow_guest_notes` in the share link metadata.
+
+---
+
+## 5. Frontend UI & Interaction Design
+
+### 5.1 Main App: Trip Share Modal (`TripShareModal.tsx`)
+* Add a permission switch:
+  * Label: **"Izinkan Tamu Mengirim Catatan / Allow Guest Notes"**
+  * Helper description: *"Pengunjung dengan link ini dapat mengirim catatan, ide, dan file ke Collab Notes trip Anda."*
+  * Saves `allow_guest_notes: true/false` when updated.
+
+### 5.2 Public Page: Shared Trip Page (`SharedTripPage.tsx`)
+* If `permissions.allow_guest_notes` is `true`:
+  * Render a Floating Action Button (FAB) or Header Action Button: **"➕ Kirim Catatan / Ide"**.
+  * Clicking opens `GuestAddNoteModal`:
+    * Field 1: **Nama Anda** (Required text input).
+    * Field 2: **Kategori** (Dropdown selector populated with `noteCategories`).
+    * Field 3: **Judul Catatan** (Required text input).
+    * Field 4: **Isi Catatan** (Textarea, supports multiline).
+    * Field 5: **Lampiran File** (File input supporting images, PDF, documents, with file name indicator and remove button).
+    * Submit button with loading state spinner.
+  * On success: Display a toast notification (*"Catatan berhasil dikirim!"*), clear form fields, and close the modal.
+
+### 5.3 Main App: Collab Notes View (`CollabNotesCard.tsx` & `CollabNotes.tsx`)
+* In the note card header:
+  * If `note.guest_name` is present:
+    * Display avatar placeholder with guest initials and badge: `👤 Tamu: {note.guest_name}`.
+    * Note attachment displays download and preview portals seamlessly.
+    * Full edit, delete, pin, and move category controls remain available for trip members.
+
+---
+
+## 6. Security & Error Handling
+
+1. **Token Scoping & Expiry:** Requests to `/api/shared/:token/notes` strictly check token validity and expiry before accepting writes.
+2. **File Upload Security:** Reuses the existing secure `NOTE_UPLOAD` multer configuration (`BLOCKED_EXTENSIONS`, MIME validation, 50MB file size limit, randomized UUID file naming).
+3. **Input Sanitization:** Strips leading/trailing whitespace, validates required fields, enforces field length limits.
+4. **Rate Limiting:** Guard against rapid repeated submissions.
+
+---
+
+## 7. Verification Plan
+
+1. **Unit & Integration Tests:**
+   * Test database migration adding `allow_guest_notes` and `guest_name`.
+   * Test `POST /api/shared/:token/notes` returns 404 on invalid token, 403 on disabled toggle, 201 on valid submission.
+   * Test file attachment uploads correctly and links to `trip_files`.
+   * Test WebSocket broadcast upon note creation.
+2. **End-to-End Manual Verification:**
+   * Enable guest notes in Share Modal for a trip.
+   * Open `/shared/:token` in an incognito window.
+   * Submit a note with category selection, text, and an image attachment.
+   * Verify the note immediately appears on the logged-in session's Collab Notes panel with the `Guest: [Name]` badge and downloadable attachment.

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -3701,6 +3701,20 @@ function runMigrations(db: Database.Database): void {
       `);
       db.exec('CREATE INDEX IF NOT EXISTS idx_hidden_regions_user ON hidden_regions (user_id);');
     },
+
+    // Add allow_guest_notes to share_tokens and guest_name to collab_notes
+    () => {
+      try {
+        db.exec('ALTER TABLE share_tokens ADD COLUMN allow_guest_notes INTEGER DEFAULT 0;');
+      } catch (err) {
+        console.warn('[migrations] Non-fatal migration step failed:', err);
+      }
+      try {
+        db.exec('ALTER TABLE collab_notes ADD COLUMN guest_name TEXT DEFAULT NULL;');
+      } catch (err) {
+        console.warn('[migrations] Non-fatal migration step failed:', err);
+      }
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -232,6 +232,22 @@ function createTables(db: Database.Database): void {
       UNIQUE(trip_id, user_id)
     );
 
+    CREATE TABLE IF NOT EXISTS share_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trip_id INTEGER NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+      token TEXT NOT NULL UNIQUE,
+      created_by INTEGER NOT NULL REFERENCES users(id),
+      share_map INTEGER DEFAULT 1,
+      share_bookings INTEGER DEFAULT 1,
+      share_packing INTEGER DEFAULT 0,
+      share_budget INTEGER DEFAULT 0,
+      share_collab INTEGER DEFAULT 0,
+      allow_guest_notes INTEGER DEFAULT 0,
+      expires_at TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_share_tokens_token ON share_tokens(token);
+
     CREATE TABLE IF NOT EXISTS day_notes (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       day_id INTEGER NOT NULL REFERENCES days(id) ON DELETE CASCADE,
@@ -481,6 +497,7 @@ function createTables(db: Database.Database): void {
       content TEXT,
       color TEXT DEFAULT '#6366f1',
       pinned INTEGER DEFAULT 0,
+      guest_name TEXT DEFAULT NULL,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );

--- a/server/src/nest/collab/collab.controller.ts
+++ b/server/src/nest/collab/collab.controller.ts
@@ -27,7 +27,7 @@ import { BLOCKED_EXTENSIONS } from '../../services/fileService';
 
 const MAX_NOTE_FILE_SIZE = 50 * 1024 * 1024;
 const filesDir = path.join(__dirname, '../../../uploads/files');
-const NOTE_UPLOAD = {
+export const NOTE_UPLOAD = {
   storage: diskStorage({
     destination: (_req, _file, cb) => { if (!fs.existsSync(filesDir)) fs.mkdirSync(filesDir, { recursive: true }); cb(null, filesDir); },
     filename: (_req, file, cb) => cb(null, `${uuidv4()}${path.extname(file.originalname)}`),

--- a/server/src/nest/share/share.controller.ts
+++ b/server/src/nest/share/share.controller.ts
@@ -1,10 +1,25 @@
-import { Body, Controller, Delete, Get, HttpException, Param, Post, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpException,
+  Param,
+  Post,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import type { Response } from 'express';
 import { createReadStream } from 'node:fs';
 import type { User } from '../../types';
 import { ShareService } from './share.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { NOTE_UPLOAD } from '../collab/collab.controller';
 
 /**
  * /api/trips/:tripId/share-link — manage a trip's public read-only share token.
@@ -32,7 +47,7 @@ export class TripShareController {
   create(
     @CurrentUser() user: User,
     @Param('tripId') tripId: string,
-    @Body() body: { share_map?: boolean; share_bookings?: boolean; share_packing?: boolean; share_budget?: boolean; share_collab?: boolean },
+    @Body() body: { share_map?: boolean; share_bookings?: boolean; share_packing?: boolean; share_budget?: boolean; share_collab?: boolean; allow_guest_notes?: boolean },
     @Res({ passthrough: true }) res: Response,
   ) {
     this.requireManage(tripId, user);
@@ -42,6 +57,7 @@ export class TripShareController {
       share_packing: body.share_packing,
       share_budget: body.share_budget,
       share_collab: body.share_collab,
+      allow_guest_notes: body.allow_guest_notes,
     });
     // 201 only on first creation; an update answers 200, mirroring the legacy route.
     res.status(result.created ? 201 : 200);
@@ -95,6 +111,46 @@ export class SharedController {
       if (!res.headersSent) res.status(404).json({ error: 'Photo not cached' });
     });
     stream.pipe(res);
+  }
+
+  @Post(':token/notes')
+  @HttpCode(201)
+  @UseInterceptors(FileInterceptor('file', NOTE_UPLOAD))
+  createGuestNote(
+    @Param('token') token: string,
+    @Body() body: { title?: string; content?: string; category?: string; guest_name?: string },
+    @UploadedFile() file?: Express.Multer.File,
+  ) {
+    const shareRow = this.share.getValidShareToken(token);
+    if (!shareRow) {
+      throw new HttpException({ error: 'Invalid or expired link' }, 404);
+    }
+    if (!shareRow.allow_guest_notes) {
+      throw new HttpException({ error: 'Guest note submissions are disabled for this link' }, 403);
+    }
+
+    const guestName = typeof body.guest_name === 'string' ? body.guest_name.trim() : '';
+    const title = typeof body.title === 'string' ? body.title.trim() : '';
+    if (!guestName || !title) {
+      throw new HttpException({ error: 'guest_name and title are required' }, 400);
+    }
+
+    const content = typeof body.content === 'string' ? body.content.trim() : undefined;
+    const category = typeof body.category === 'string' ? body.category.trim() : undefined;
+
+    const note = this.share.createGuestNote(
+      shareRow.trip_id,
+      shareRow.created_by,
+      {
+        title,
+        content,
+        category,
+        guest_name: guestName,
+      },
+      file,
+    );
+
+    return { success: true, note };
   }
 
   @Get(':token')

--- a/server/src/nest/share/share.service.ts
+++ b/server/src/nest/share/share.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { canAccessTrip } from '../../db/database';
+import { db, canAccessTrip } from '../../db/database';
 import { checkPermission } from '../../services/permissions';
+import { broadcast } from '../../websocket';
 import type { User } from '../../types';
 import * as svc from '../../services/shareService';
+import * as collabSvc from '../../services/collabService';
 
 type Trip = NonNullable<ReturnType<typeof canAccessTrip>>;
 
@@ -27,4 +29,37 @@ export class ShareService {
   remove(tripId: string) { return svc.deleteShareLink(tripId); }
   getSharedTripData(token: string) { return svc.getSharedTripData(token); }
   getSharedPlacePhotoPath(token: string, placeId: string) { return svc.getSharedPlacePhotoPath(token, placeId); }
+  getValidShareToken(token: string) { return svc.getValidShareToken(token); }
+
+  createGuestNote(
+    tripId: string | number,
+    userId: number,
+    data: { title: string; content?: string; category?: string; guest_name: string },
+    file?: Express.Multer.File,
+  ) {
+    const createdNote = collabSvc.createNote(tripId, userId, data);
+    if (file) {
+      collabSvc.addNoteFile(tripId, createdNote.id, file);
+    }
+    const formattedNote = collabSvc.getFormattedNoteById(createdNote.id);
+    broadcast(String(tripId), 'collab:note:created', { note: formattedNote });
+
+    import('../../services/notificationService').then(({ send }) => {
+      const tripInfo = db.prepare('SELECT title FROM trips WHERE id = ?').get(tripId) as { title: string } | undefined;
+      send({
+        event: 'collab_message',
+        actorId: null,
+        scope: 'trip',
+        targetId: Number(tripId),
+        params: {
+          trip: tripInfo?.title || 'Untitled',
+          actor: data.guest_name,
+          tripId: String(tripId),
+          preview: data.title,
+        },
+      }).catch(() => {});
+    });
+
+    return formattedNote;
+  }
 }

--- a/server/src/services/collabService.ts
+++ b/server/src/services/collabService.ts
@@ -113,12 +113,12 @@ export function listNotes(tripId: string | number) {
   return notes.map(formatNote);
 }
 
-export function createNote(tripId: string | number, userId: number, data: { title: string; content?: string; category?: string; color?: string; website?: string; pinned?: boolean }) {
+export function createNote(tripId: string | number, userId: number, data: { title: string; content?: string; category?: string; color?: string; website?: string; pinned?: boolean; guest_name?: string }) {
   const pinned = data.pinned ? 1 : 0;
   const result = db.prepare(`
-    INSERT INTO collab_notes (trip_id, user_id, title, content, category, color, website, pinned)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(tripId, userId, data.title, data.content || null, data.category || 'General', data.color || '#6366f1', data.website || null, pinned);
+    INSERT INTO collab_notes (trip_id, user_id, title, content, category, color, website, pinned, guest_name)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(tripId, userId, data.title, data.content || null, data.category || 'General', data.color || '#6366f1', data.website || null, pinned, data.guest_name || null);
 
   const note = db.prepare(`
     SELECT n.*, u.username, u.avatar FROM collab_notes n JOIN users u ON n.user_id = u.id WHERE n.id = ?

--- a/server/src/services/shareService.ts
+++ b/server/src/services/shareService.ts
@@ -21,23 +21,9 @@ function rewritePlacePhotoUrl(url: string | null | undefined, token: string): st
   return url ?? null;
 }
 
-interface SharePermissions {
-  share_map?: boolean;
-  share_bookings?: boolean;
-  share_packing?: boolean;
-  share_budget?: boolean;
-  share_collab?: boolean;
-}
+import { SharePermissions, ShareTokenInfo } from '../types';
 
-interface ShareTokenInfo {
-  token: string;
-  created_at: string;
-  share_map: boolean;
-  share_bookings: boolean;
-  share_packing: boolean;
-  share_budget: boolean;
-  share_collab: boolean;
-}
+export type { SharePermissions, ShareTokenInfo };
 
 /**
  * Creates a new share link or updates the permissions on an existing one.
@@ -54,12 +40,13 @@ export function createOrUpdateShareLink(
     share_packing = false,
     share_budget = false,
     share_collab = false,
+    allow_guest_notes = false,
   } = permissions;
 
   const existing = db.prepare('SELECT token FROM share_tokens WHERE trip_id = ?').get(tripId) as { token: string } | undefined;
   if (existing) {
-    db.prepare('UPDATE share_tokens SET share_map = ?, share_bookings = ?, share_packing = ?, share_budget = ?, share_collab = ? WHERE trip_id = ?')
-      .run(share_map ? 1 : 0, share_bookings ? 1 : 0, share_packing ? 1 : 0, share_budget ? 1 : 0, share_collab ? 1 : 0, tripId);
+    db.prepare('UPDATE share_tokens SET share_map = ?, share_bookings = ?, share_packing = ?, share_budget = ?, share_collab = ?, allow_guest_notes = ? WHERE trip_id = ?')
+      .run(share_map ? 1 : 0, share_bookings ? 1 : 0, share_packing ? 1 : 0, share_budget ? 1 : 0, share_collab ? 1 : 0, allow_guest_notes ? 1 : 0, tripId);
     return { token: existing.token, created: false };
   }
 
@@ -69,8 +56,8 @@ export function createOrUpdateShareLink(
   // behaviour for anyone who's already sharing a link.
   const token = crypto.randomBytes(24).toString('base64url');
   const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
-  db.prepare('INSERT INTO share_tokens (trip_id, token, created_by, share_map, share_bookings, share_packing, share_budget, share_collab, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
-    .run(tripId, token, createdBy, share_map ? 1 : 0, share_bookings ? 1 : 0, share_packing ? 1 : 0, share_budget ? 1 : 0, share_collab ? 1 : 0, expiresAt);
+  db.prepare('INSERT INTO share_tokens (trip_id, token, created_by, share_map, share_bookings, share_packing, share_budget, share_collab, allow_guest_notes, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+    .run(tripId, token, createdBy, share_map ? 1 : 0, share_bookings ? 1 : 0, share_packing ? 1 : 0, share_budget ? 1 : 0, share_collab ? 1 : 0, allow_guest_notes ? 1 : 0, expiresAt);
   return { token, created: true };
 }
 
@@ -88,6 +75,7 @@ export function getShareLink(tripId: string): ShareTokenInfo | null {
     share_packing: !!row.share_packing,
     share_budget: !!row.share_budget,
     share_collab: !!row.share_collab,
+    allow_guest_notes: !!row.allow_guest_notes,
   };
 }
 
@@ -214,6 +202,7 @@ export function getSharedTripData(token: string): Record<string, any> | null {
     share_packing: !!shareRow.share_packing,
     share_budget: !!shareRow.share_budget,
     share_collab: !!shareRow.share_collab,
+    allow_guest_notes: !!shareRow.allow_guest_notes,
   };
 
   // Collab messages (only if owner chose to share)

--- a/server/src/services/shareService.ts
+++ b/server/src/services/shareService.ts
@@ -196,6 +196,9 @@ export function getSharedTripData(token: string): Record<string, any> | null {
   // Categories
   const categories = db.prepare('SELECT * FROM categories').all();
 
+  const noteCatRows = db.prepare('SELECT DISTINCT category FROM collab_notes WHERE trip_id = ? AND category IS NOT NULL').all(tripId) as { category: string }[];
+  const noteCategories = noteCatRows.length > 0 ? noteCatRows.map(r => r.category) : ['General'];
+
   const permissions = {
     share_map: !!shareRow.share_map,
     share_bookings: !!shareRow.share_bookings,
@@ -230,7 +233,7 @@ export function getSharedTripData(token: string): Record<string, any> | null {
   // itinerary: days, their assignments/notes, and the place list with coordinates,
   // addresses and notes. Withhold it when the owner disabled the map.
   return {
-    trip, baseCurrency, categories, permissions,
+    trip, baseCurrency, categories, noteCategories, permissions,
     days: permissions.share_map ? days : [],
     assignments: permissions.share_map ? assignments : {},
     dayNotes: permissions.share_map ? dayNotes : {},
@@ -241,6 +244,16 @@ export function getSharedTripData(token: string): Record<string, any> | null {
     budget: permissions.share_budget ? budget : [],
     collab: collabMessages,
   };
+}
+
+/**
+ * Returns the share_tokens row if the token exists and has not expired, or null otherwise.
+ */
+export function getValidShareToken(token: string): any | null {
+  const shareRow = db.prepare(
+    "SELECT * FROM share_tokens WHERE token = ? AND (expires_at IS NULL OR expires_at > datetime('now'))"
+  ).get(token) as any;
+  return shareRow || null;
 }
 
 /**

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -245,6 +245,7 @@ export interface CollabNote {
   content?: string | null;
   color: string;
   pinned: number;
+  guest_name?: string | null;
   website?: string | null;
   username?: string;
   avatar?: string | null;
@@ -444,4 +445,24 @@ export interface JourneyContributor {
   user_id: number;
   role: 'owner' | 'editor' | 'viewer';
   added_at: number;
+}
+
+export interface SharePermissions {
+  share_map?: boolean;
+  share_bookings?: boolean;
+  share_packing?: boolean;
+  share_budget?: boolean;
+  share_collab?: boolean;
+  allow_guest_notes?: boolean;
+}
+
+export interface ShareTokenInfo {
+  token: string;
+  created_at: string;
+  share_map: boolean;
+  share_bookings: boolean;
+  share_packing: boolean;
+  share_budget: boolean;
+  share_collab: boolean;
+  allow_guest_notes: boolean;
 }

--- a/server/tests/e2e/share.e2e.test.ts
+++ b/server/tests/e2e/share.e2e.test.ts
@@ -31,9 +31,25 @@ const { checkPermission } = vi.hoisted(() => ({ checkPermission: vi.fn() }));
 vi.mock('../../src/services/permissions', () => ({ checkPermission }));
 
 const { shareSvc } = vi.hoisted(() => ({
-  shareSvc: { createOrUpdateShareLink: vi.fn(), getShareLink: vi.fn(), deleteShareLink: vi.fn(), getSharedTripData: vi.fn(), getSharedPlacePhotoPath: vi.fn() },
+  shareSvc: {
+    createOrUpdateShareLink: vi.fn(),
+    getShareLink: vi.fn(),
+    deleteShareLink: vi.fn(),
+    getSharedTripData: vi.fn(),
+    getSharedPlacePhotoPath: vi.fn(),
+    getValidShareToken: vi.fn(),
+  },
 }));
 vi.mock('../../src/services/shareService', () => shareSvc);
+
+const { collabSvc } = vi.hoisted(() => ({
+  collabSvc: {
+    createNote: vi.fn(),
+    addNoteFile: vi.fn(),
+    getFormattedNoteById: vi.fn(),
+  },
+}));
+vi.mock('../../src/services/collabService', () => collabSvc);
 
 import { ShareModule } from '../../src/nest/share/share.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
@@ -132,6 +148,43 @@ describe('Share-link e2e (real auth guard + temp SQLite)', () => {
       const res = await request(server).get('/api/shared/bad/place-photo/ChIJabc/bytes');
       expect(res.status).toBe(404);
       expect(res.body).toEqual({ error: 'Photo not cached' });
+    });
+  });
+
+  describe('public guest note submission (/api/shared/:token/notes)', () => {
+    it('404 for an invalid token', async () => {
+      shareSvc.getValidShareToken.mockReturnValueOnce(null);
+      const res = await request(server).post('/api/shared/bad/notes').send({ title: 'T', guest_name: 'G' });
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'Invalid or expired link' });
+    });
+
+    it('403 when allow_guest_notes is false', async () => {
+      shareSvc.getValidShareToken.mockReturnValueOnce({ trip_id: 5, created_by: 1, allow_guest_notes: 0 });
+      const res = await request(server).post('/api/shared/tok/notes').send({ title: 'T', guest_name: 'G' });
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ error: 'Guest note submissions are disabled for this link' });
+    });
+
+    it('400 when title or guest_name is missing', async () => {
+      shareSvc.getValidShareToken.mockReturnValueOnce({ trip_id: 5, created_by: 1, allow_guest_notes: 1 });
+      const res = await request(server).post('/api/shared/tok/notes').send({ title: '' });
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'guest_name and title are required' });
+    });
+
+    it('201 on valid submission and returns { success: true, note }', async () => {
+      shareSvc.getValidShareToken.mockReturnValueOnce({ trip_id: 5, created_by: 1, allow_guest_notes: 1 });
+      const fakeNote = { id: 99, title: 'Spot', guest_name: 'Guest' };
+      collabSvc.createNote.mockReturnValueOnce(fakeNote);
+      collabSvc.getFormattedNoteById.mockReturnValueOnce(fakeNote);
+
+      const res = await request(server)
+        .post('/api/shared/tok/notes')
+        .send({ title: 'Spot', guest_name: 'Guest', category: 'General' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual({ success: true, note: fakeNote });
     });
   });
 });

--- a/server/tests/integration/share.test.ts
+++ b/server/tests/integration/share.test.ts
@@ -591,3 +591,139 @@ describe('Share guest notes schema & permissions', () => {
   });
 });
 
+describe('Guest note submissions (POST /api/shared/:token/notes)', () => {
+  it('SHARE-027 — getSharedTripData returns noteCategories and allow_guest_notes in permissions', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    testDb.prepare("INSERT INTO collab_notes (trip_id, user_id, title, category) VALUES (?, ?, 'Note 1', 'Activities')").run(trip.id, user.id);
+    testDb.prepare("INSERT INTO collab_notes (trip_id, user_id, title, category) VALUES (?, ?, 'Note 2', 'Dining')").run(trip.id, user.id);
+
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: true,
+    });
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.permissions.allow_guest_notes).toBe(true);
+    expect(res.body.noteCategories).toEqual(expect.arrayContaining(['Activities', 'Dining']));
+  });
+
+  it('SHARE-028 — POST /api/shared/:token/notes returns 404 for invalid/expired token', async () => {
+    const res = await request(app)
+      .post('/api/shared/invalid-token-xyz/notes')
+      .send({ title: 'Hidden Cafe', guest_name: 'Visitor' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Invalid or expired link' });
+  });
+
+  it('SHARE-029 — POST /api/shared/:token/notes returns 403 when allow_guest_notes is false', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: false,
+    });
+
+    const res = await request(app)
+      .post(`/api/shared/${token}/notes`)
+      .send({ title: 'Hidden Cafe', guest_name: 'Visitor' });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Guest note submissions are disabled for this link' });
+  });
+
+  it('SHARE-030 — POST /api/shared/:token/notes returns 400 when title or guest_name is missing/empty', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: true,
+    });
+
+    const res1 = await request(app)
+      .post(`/api/shared/${token}/notes`)
+      .send({ title: '', guest_name: 'Visitor' });
+    expect(res1.status).toBe(400);
+
+    const res2 = await request(app)
+      .post(`/api/shared/${token}/notes`)
+      .send({ title: 'Nice spot', guest_name: '   ' });
+    expect(res2.status).toBe(400);
+  });
+
+  it('SHARE-031 — POST /api/shared/:token/notes creates note with guest_name and returns 201 with success: true and note', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: true,
+    });
+
+    const res = await request(app)
+      .post(`/api/shared/${token}/notes`)
+      .send({
+        title: 'Secret Ramen Shop',
+        content: 'Down the alley, cash only',
+        category: 'Food',
+        guest_name: 'Traveler Ken',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.note).toBeDefined();
+    expect(res.body.note.title).toBe('Secret Ramen Shop');
+    expect(res.body.note.content).toBe('Down the alley, cash only');
+    expect(res.body.note.category).toBe('Food');
+    expect(res.body.note.guest_name).toBe('Traveler Ken');
+    expect(res.body.note.trip_id).toBe(trip.id);
+
+    // Verify row persisted in SQLite
+    const saved = testDb.prepare('SELECT * FROM collab_notes WHERE id = ?').get(res.body.note.id) as any;
+    expect(saved).toBeDefined();
+    expect(saved.guest_name).toBe('Traveler Ken');
+    expect(saved.title).toBe('Secret Ramen Shop');
+  });
+
+  it('SHARE-032 — POST /api/shared/:token/notes handles file upload attachment and returns 201 with attachments', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: true,
+    });
+
+    const res = await request(app)
+      .post(`/api/shared/${token}/notes`)
+      .field('title', 'Menu Photo')
+      .field('content', 'Captured menu board')
+      .field('category', 'Food')
+      .field('guest_name', 'Photographer Alice')
+      .attach('file', Buffer.from('dummy image content'), { filename: 'menu.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.note).toBeDefined();
+    expect(res.body.note.title).toBe('Menu Photo');
+    expect(res.body.note.guest_name).toBe('Photographer Alice');
+    expect(Array.isArray(res.body.note.attachments)).toBe(true);
+    expect(res.body.note.attachments).toHaveLength(1);
+    expect(res.body.note.attachments[0].original_name).toBe('menu.png');
+    expect(res.body.note.attachments[0].mime_type).toBe('image/png');
+    expect(res.body.note.attachments[0].url).toContain(`/api/trips/${trip.id}/files/`);
+  });
+
+  it('SHARE-033 — POST /api/trips/:tripId/share-link sets allow_guest_notes flag', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    const res = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ allow_guest_notes: true });
+
+    expect(res.status).toBe(201);
+    const link = getShareLink(String(trip.id));
+    expect(link?.allow_guest_notes).toBe(true);
+  });
+});
+

--- a/server/tests/integration/share.test.ts
+++ b/server/tests/integration/share.test.ts
@@ -50,6 +50,7 @@ import { resetTestDb, resetRateLimits } from '../helpers/test-db';
 import { createUser, createTrip, addTripMember, createDay, createPlace, createDayAssignment, createDayNote } from '../helpers/factories';
 import { authCookie } from '../helpers/auth';
 import * as placePhotoCache from '../../src/services/placePhotoCache';
+import { createOrUpdateShareLink, getShareLink, getSharedTripData } from '../../src/services/shareService';
 import fs from 'node:fs';
 
 let nestApp: INestApplication;
@@ -545,3 +546,48 @@ describe('Shared trip — place photos in shared links (issue #1100)', () => {
     expect(res.body).toEqual({ error: 'Photo not cached' });
   });
 });
+
+describe('Share guest notes schema & permissions', () => {
+  it('supports allow_guest_notes in share_tokens and guest_name in collab_notes', () => {
+    const shareCols = testDb.prepare("PRAGMA table_info('share_tokens')").all() as { name: string }[];
+    expect(shareCols.some(c => c.name === 'allow_guest_notes')).toBe(true);
+
+    const collabCols = testDb.prepare("PRAGMA table_info('collab_notes')").all() as { name: string }[];
+    expect(collabCols.some(c => c.name === 'guest_name')).toBe(true);
+  });
+
+  it('stores and retrieves allow_guest_notes via shareService', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Guest Notes Share' });
+
+    const { token } = createOrUpdateShareLink(String(trip.id), user.id, {
+      share_map: true,
+      allow_guest_notes: true,
+    });
+    expect(token).toBeDefined();
+
+    const link = getShareLink(String(trip.id));
+    expect(link).not.toBeNull();
+    expect(link?.allow_guest_notes).toBe(true);
+
+    const sharedData = getSharedTripData(token);
+    expect(sharedData?.permissions.allow_guest_notes).toBe(true);
+  });
+
+  it('allows inserting collab_notes with guest_name', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Collab Note Guest Test' });
+
+    const stmt = testDb.prepare(`
+      INSERT INTO collab_notes (trip_id, user_id, title, content, category, guest_name)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    const res = stmt.run(trip.id, user.id, 'Secret Spot', 'Great cafe near the corner', 'Food', 'Alice Guest');
+    expect(res.changes).toBe(1);
+
+    const row = testDb.prepare('SELECT * FROM collab_notes WHERE id = ?').get(res.lastInsertRowid) as any;
+    expect(row.guest_name).toBe('Alice Guest');
+    expect(row.title).toBe('Secret Spot');
+  });
+});
+

--- a/server/tests/unit/nest/share.controller.test.ts
+++ b/server/tests/unit/nest/share.controller.test.ts
@@ -134,4 +134,71 @@ describe('SharedController', () => {
       expect(res.json).not.toHaveBeenCalled();
     });
   });
+
+  describe('createGuestNote', () => {
+    it('404 for an invalid or expired token', () => {
+      const c = new SharedController(svc({ getValidShareToken: vi.fn().mockReturnValue(null) } as Partial<ShareService>));
+      expect(thrown(() => c.createGuestNote('invalid-token', { title: 'T', guest_name: 'G' }))).toEqual({
+        status: 404,
+        body: { error: 'Invalid or expired link' },
+      });
+    });
+
+    it('403 when allow_guest_notes is false / disabled', () => {
+      const c = new SharedController(svc({
+        getValidShareToken: vi.fn().mockReturnValue({ trip_id: 10, created_by: 1, allow_guest_notes: 0 }),
+      } as Partial<ShareService>));
+      expect(thrown(() => c.createGuestNote('tok', { title: 'T', guest_name: 'G' }))).toEqual({
+        status: 403,
+        body: { error: 'Guest note submissions are disabled for this link' },
+      });
+    });
+
+    it('400 when guest_name or title is missing or empty', () => {
+      const c = new SharedController(svc({
+        getValidShareToken: vi.fn().mockReturnValue({ trip_id: 10, created_by: 1, allow_guest_notes: 1 }),
+      } as Partial<ShareService>));
+      expect(thrown(() => c.createGuestNote('tok', { title: '', guest_name: 'Alice' }))).toEqual({
+        status: 400,
+        body: { error: 'guest_name and title are required' },
+      });
+      expect(thrown(() => c.createGuestNote('tok', { title: 'Place note', guest_name: '   ' }))).toEqual({
+        status: 400,
+        body: { error: 'guest_name and title are required' },
+      });
+      expect(thrown(() => c.createGuestNote('tok', { guest_name: 'Alice' }))).toEqual({
+        status: 400,
+        body: { error: 'guest_name and title are required' },
+      });
+    });
+
+    it('creates guest note and returns 201 with { success: true, note }', () => {
+      const fakeNote = { id: 101, title: 'Cafe', guest_name: 'Alice', category: 'Food' };
+      const createGuestNote = vi.fn().mockReturnValue(fakeNote);
+      const c = new SharedController(svc({
+        getValidShareToken: vi.fn().mockReturnValue({ trip_id: 10, created_by: 1, allow_guest_notes: 1 }),
+        createGuestNote,
+      } as Partial<ShareService>));
+
+      const res = c.createGuestNote('tok', {
+        title: ' Cafe recommendation ',
+        content: ' Great espresso ',
+        category: ' Food ',
+        guest_name: ' Alice ',
+      });
+
+      expect(createGuestNote).toHaveBeenCalledWith(
+        10,
+        1,
+        {
+          title: 'Cafe recommendation',
+          content: 'Great espresso',
+          category: 'Food',
+          guest_name: 'Alice',
+        },
+        undefined,
+      );
+      expect(res).toEqual({ success: true, note: fakeNote });
+    });
+  });
 });

--- a/server/tests/unit/nest/share.service.test.ts
+++ b/server/tests/unit/nest/share.service.test.ts
@@ -1,11 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // The wrapper delegates to legacy helpers; mock them so no real DB is loaded.
-const { canAccessTrip } = vi.hoisted(() => ({ canAccessTrip: vi.fn() }));
-vi.mock('../../../src/db/database', () => ({ canAccessTrip, closeDb: () => {}, reinitialize: () => {} }));
+const { canAccessTrip, dbMock } = vi.hoisted(() => {
+  const getMock = vi.fn();
+  return {
+    canAccessTrip: vi.fn(),
+    dbMock: {
+      prepare: vi.fn().mockReturnValue({ get: getMock }),
+    },
+  };
+});
+vi.mock('../../../src/db/database', () => ({ db: dbMock, canAccessTrip, closeDb: () => {}, reinitialize: () => {} }));
 
 const { checkPermission } = vi.hoisted(() => ({ checkPermission: vi.fn() }));
 vi.mock('../../../src/services/permissions', () => ({ checkPermission }));
+
+const { broadcast } = vi.hoisted(() => ({ broadcast: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast }));
+
+const { collabSvc } = vi.hoisted(() => ({
+  collabSvc: {
+    createNote: vi.fn(),
+    addNoteFile: vi.fn(),
+    getFormattedNoteById: vi.fn(),
+  },
+}));
+vi.mock('../../../src/services/collabService', () => collabSvc);
 
 const { share } = vi.hoisted(() => ({
   share: {
@@ -14,6 +34,7 @@ const { share } = vi.hoisted(() => ({
     deleteShareLink: vi.fn(),
     getSharedTripData: vi.fn(),
     getSharedPlacePhotoPath: vi.fn(),
+    getValidShareToken: vi.fn(),
   },
 }));
 vi.mock('../../../src/services/shareService', () => share);
@@ -72,5 +93,56 @@ describe('ShareService', () => {
     share.getSharedPlacePhotoPath.mockReturnValue('/cache/p1.jpg');
     expect(svc().getSharedPlacePhotoPath('tok', 'p1')).toBe('/cache/p1.jpg');
     expect(share.getSharedPlacePhotoPath).toHaveBeenCalledWith('tok', 'p1');
+
+    share.getValidShareToken.mockReturnValue({ trip_id: 5, allow_guest_notes: 1 });
+    expect(svc().getValidShareToken('tok')).toEqual({ trip_id: 5, allow_guest_notes: 1 });
+    expect(share.getValidShareToken).toHaveBeenCalledWith('tok');
+  });
+
+  describe('createGuestNote', () => {
+    it('creates note, broadcasts collab:note:created, and returns formatted note', () => {
+      const created = { id: 42, title: 'Note 42' };
+      const formatted = { id: 42, title: 'Note 42', guest_name: 'Guest User', attachments: [] };
+      collabSvc.createNote.mockReturnValue(created);
+      collabSvc.getFormattedNoteById.mockReturnValue(formatted);
+
+      const service = svc();
+      const res = service.createGuestNote('5', 1, {
+        title: 'Note 42',
+        content: 'Some details',
+        category: 'Food',
+        guest_name: 'Guest User',
+      });
+
+      expect(collabSvc.createNote).toHaveBeenCalledWith('5', 1, {
+        title: 'Note 42',
+        content: 'Some details',
+        category: 'Food',
+        guest_name: 'Guest User',
+      });
+      expect(collabSvc.addNoteFile).not.toHaveBeenCalled();
+      expect(collabSvc.getFormattedNoteById).toHaveBeenCalledWith(42);
+      expect(broadcast).toHaveBeenCalledWith('5', 'collab:note:created', { note: formatted });
+      expect(res).toEqual(formatted);
+    });
+
+    it('attaches uploaded file when provided', () => {
+      const created = { id: 43, title: 'With File' };
+      const formatted = { id: 43, title: 'With File', guest_name: 'Guest User', attachments: [{ id: 1 }] };
+      const fakeFile = { filename: 'f1.png', originalname: 'orig.png', size: 123, mimetype: 'image/png' } as Express.Multer.File;
+      collabSvc.createNote.mockReturnValue(created);
+      collabSvc.getFormattedNoteById.mockReturnValue(formatted);
+
+      const service = svc();
+      const res = service.createGuestNote('5', 1, {
+        title: 'With File',
+        guest_name: 'Guest User',
+      }, fakeFile);
+
+      expect(collabSvc.addNoteFile).toHaveBeenCalledWith('5', 43, fakeFile);
+      expect(collabSvc.getFormattedNoteById).toHaveBeenCalledWith(43);
+      expect(broadcast).toHaveBeenCalledWith('5', 'collab:note:created', { note: formatted });
+      expect(res).toEqual(formatted);
+    });
   });
 });

--- a/server/tests/unit/shared-contract.test.ts
+++ b/server/tests/unit/shared-contract.test.ts
@@ -1,10 +1,34 @@
 import { describe, it, expect } from 'vitest';
 // Smoke test: proves the server toolchain (tsx / vitest) resolves @trek/shared.
-import { idParamSchema, paginationQuerySchema } from '@trek/shared';
+import {
+  idParamSchema,
+  paginationQuerySchema,
+  collabNoteCreateRequestSchema,
+  shareLinkRequestSchema,
+} from '@trek/shared';
 
 describe('@trek/shared resolves in the server toolchain', () => {
   it('imports and uses a shared schema', () => {
     expect(idParamSchema.parse('7')).toBe(7);
     expect(paginationQuerySchema.parse({})).toEqual({ page: 1, perPage: 50 });
   });
+
+  it('validates collab note create request schema with guest_name', () => {
+    const parsed = collabNoteCreateRequestSchema.parse({
+      title: 'Cafe Recommendation',
+      content: 'Near Central Station',
+      guest_name: 'Visitor John',
+    });
+    expect(parsed.guest_name).toBe('Visitor John');
+    expect(parsed.title).toBe('Cafe Recommendation');
+  });
+
+  it('validates share link request schema with allow_guest_notes', () => {
+    const parsed = shareLinkRequestSchema.parse({
+      share_map: true,
+      allow_guest_notes: true,
+    });
+    expect(parsed.allow_guest_notes).toBe(true);
+  });
 });
+

--- a/shared/src/collab/collab.schema.ts
+++ b/shared/src/collab/collab.schema.ts
@@ -17,6 +17,7 @@ export const collabNoteCreateRequestSchema = z.object({
   category: z.string().optional(),
   color: z.string().optional(),
   website: z.string().optional(),
+  guest_name: z.string().optional(),
 });
 export type CollabNoteCreateRequest = z.infer<typeof collabNoteCreateRequestSchema>;
 

--- a/shared/src/i18n/ar/share.ts
+++ b/shared/src/i18n/ar/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'التكاليف',
   'share.permCollab': 'الدردشة',
   'share.permGuestNotes': 'السماح بملاحظات الضيوف',
+  'share.addNote': "إضافة ملاحظة",
+  'share.guestNoteSuccess': "تم إرسال الملاحظة بنجاح!",
+  'share.guestName': "اسمك",
+  'share.noteTitle': "عنوان الملاحظة",
+  'share.noteContent': "تفاصيل الملاحظة (اختياري)",
+  'share.noteCategory': "الفئة",
+  'share.attachFile': "إرفاق ملف / صورة",
+  'share.fileTooLarge': "حجم الملف يتجاوز الحد المسموح به وهو 50 ميغابايت",
+  'share.sendNote': "إرسال الملاحظة",
 };
 export default share;

--- a/shared/src/i18n/ar/share.ts
+++ b/shared/src/i18n/ar/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'الأمتعة',
   'share.permBudget': 'التكاليف',
   'share.permCollab': 'الدردشة',
+  'share.permGuestNotes': 'السماح بملاحظات الضيوف',
 };
 export default share;

--- a/shared/src/i18n/br/share.ts
+++ b/shared/src/i18n/br/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Mala',
   'share.permBudget': 'Custos',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Permitir notas de convidados',
 };
 export default share;

--- a/shared/src/i18n/br/share.ts
+++ b/shared/src/i18n/br/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Custos',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Permitir notas de convidados',
+  'share.addNote': "Adicionar nota",
+  'share.guestNoteSuccess': "Nota enviada com sucesso!",
+  'share.guestName': "Seu nome",
+  'share.noteTitle': "Título da nota",
+  'share.noteContent': "Detalhes da nota (opcional)",
+  'share.noteCategory': "Categoria",
+  'share.attachFile': "Anexar arquivo / foto",
+  'share.fileTooLarge': "O tamanho do arquivo excede o limite de 50 MB",
+  'share.sendNote': "Enviar nota",
 };
 export default share;

--- a/shared/src/i18n/ca/share.ts
+++ b/shared/src/i18n/ca/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Equipatge',
   'share.permBudget': 'Pressupost',
   'share.permCollab': 'Xat',
+  'share.permGuestNotes': 'Permetre notes de convidats',
 };
 export default share;

--- a/shared/src/i18n/ca/share.ts
+++ b/shared/src/i18n/ca/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Pressupost',
   'share.permCollab': 'Xat',
   'share.permGuestNotes': 'Permetre notes de convidats',
+  'share.addNote': "Afegir nota",
+  'share.guestNoteSuccess': "Nota enviada correctament!",
+  'share.guestName': "El teu nom",
+  'share.noteTitle': "Títol de la nota",
+  'share.noteContent': "Detalls de la nota (opcional)",
+  'share.noteCategory': "Categoria",
+  'share.attachFile': "Adjuntar fitxer / foto",
+  'share.fileTooLarge': "La mida del fitxer supera el límit de 50 MB",
+  'share.sendNote': "Enviar nota",
 };
 export default share;

--- a/shared/src/i18n/cs/share.ts
+++ b/shared/src/i18n/cs/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Náklady',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Povolit poznámky hostů',
+  'share.addNote': "Přidat poznámku",
+  'share.guestNoteSuccess': "Poznámka byla úspěšně odeslána!",
+  'share.guestName': "Vaše jméno",
+  'share.noteTitle': "Název poznámky",
+  'share.noteContent': "Podrobnosti poznámky (volitelné)",
+  'share.noteCategory': "Kategorie",
+  'share.attachFile': "Připojit soubor / fotografii",
+  'share.fileTooLarge': "Velikost souboru překračuje limit 50 MB",
+  'share.sendNote': "Odeslat poznámku",
 };
 export default share;

--- a/shared/src/i18n/cs/share.ts
+++ b/shared/src/i18n/cs/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Balení',
   'share.permBudget': 'Náklady',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Povolit poznámky hostů',
 };
 export default share;

--- a/shared/src/i18n/de/share.ts
+++ b/shared/src/i18n/de/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Kosten',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Gastnotizen erlauben',
+  'share.addNote': "Notiz hinzufügen",
+  'share.guestNoteSuccess': "Notiz erfolgreich gesendet!",
+  'share.guestName': "Ihr Name",
+  'share.noteTitle': "Titel der Notiz",
+  'share.noteContent': "Notizdetails (optional)",
+  'share.noteCategory': "Kategorie",
+  'share.attachFile': "Datei / Foto anhängen",
+  'share.fileTooLarge': "Dateigröße überschreitet das Limit von 50 MB",
+  'share.sendNote': "Notiz senden",
 };
 export default share;

--- a/shared/src/i18n/de/share.ts
+++ b/shared/src/i18n/de/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Packliste',
   'share.permBudget': 'Kosten',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Gastnotizen erlauben',
 };
 export default share;

--- a/shared/src/i18n/en/share.ts
+++ b/shared/src/i18n/en/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Costs',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Allow guest notes',
+  'share.addNote': "Add note",
+  'share.guestNoteSuccess': "Note sent successfully!",
+  'share.guestName': "Your name",
+  'share.noteTitle': "Note title",
+  'share.noteContent': "Note details (optional)",
+  'share.noteCategory': "Category",
+  'share.attachFile': "Attach file / photo",
+  'share.fileTooLarge': "File size exceeds 50MB limit",
+  'share.sendNote': "Send Note",
 };
 export default share;

--- a/shared/src/i18n/en/share.ts
+++ b/shared/src/i18n/en/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Packing',
   'share.permBudget': 'Costs',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Allow guest notes',
 };
 export default share;

--- a/shared/src/i18n/es/share.ts
+++ b/shared/src/i18n/es/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Equipaje',
   'share.permBudget': 'Costes',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Permitir notas de invitados',
 };
 export default share;

--- a/shared/src/i18n/es/share.ts
+++ b/shared/src/i18n/es/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Costes',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Permitir notas de invitados',
+  'share.addNote': "Añadir nota",
+  'share.guestNoteSuccess': "¡Nota enviada con éxito!",
+  'share.guestName': "Tu nombre",
+  'share.noteTitle': "Título de la nota",
+  'share.noteContent': "Detalles de la nota (opcional)",
+  'share.noteCategory': "Categoría",
+  'share.attachFile': "Adjuntar archivo / foto",
+  'share.fileTooLarge': "El tamaño del archivo supera el límite de 50 MB",
+  'share.sendNote': "Enviar nota",
 };
 export default share;

--- a/shared/src/i18n/fr/share.ts
+++ b/shared/src/i18n/fr/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Bagages',
   'share.permBudget': 'Coûts',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Autoriser les notes des invités',
 };
 export default share;

--- a/shared/src/i18n/fr/share.ts
+++ b/shared/src/i18n/fr/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Coûts',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Autoriser les notes des invités',
+  'share.addNote': "Ajouter une note",
+  'share.guestNoteSuccess': "Note envoyée avec succès !",
+  'share.guestName': "Votre nom",
+  'share.noteTitle': "Titre de la note",
+  'share.noteContent': "Détails de la note (facultatif)",
+  'share.noteCategory': "Catégorie",
+  'share.attachFile': "Joindre un fichier / photo",
+  'share.fileTooLarge': "La taille du fichier dépasse la limite de 50 Mo",
+  'share.sendNote': "Envoyer la note",
 };
 export default share;

--- a/shared/src/i18n/gr/share.ts
+++ b/shared/src/i18n/gr/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Κόστη',
   'share.permCollab': 'Συνομιλία',
   'share.permGuestNotes': 'Να επιτρέπονται σημειώσεις επισκεπτών',
+  'share.addNote': "Προσθήκη σημείωσης",
+  'share.guestNoteSuccess': "Η σημείωση στάλθηκε με επιτυχία!",
+  'share.guestName': "Το όνομά σας",
+  'share.noteTitle': "Τίτλος σημείωσης",
+  'share.noteContent': "Λεπτομέρειες σημείωσης (προαιρετικό)",
+  'share.noteCategory': "Κατηγορία",
+  'share.attachFile': "Επισύναψη αρχείου / φωτογραφίας",
+  'share.fileTooLarge': "Το μέγεθος του αρχείου υπερβαίνει το όριο των 50MB",
+  'share.sendNote': "Αποστολή σημείωσης",
 };
 export default share;

--- a/shared/src/i18n/gr/share.ts
+++ b/shared/src/i18n/gr/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Πακετάρισμα',
   'share.permBudget': 'Κόστη',
   'share.permCollab': 'Συνομιλία',
+  'share.permGuestNotes': 'Να επιτρέπονται σημειώσεις επισκεπτών',
 };
 export default share;

--- a/shared/src/i18n/hu/share.ts
+++ b/shared/src/i18n/hu/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Csomagolás',
   'share.permBudget': 'Költségek',
   'share.permCollab': 'Csevegés',
+  'share.permGuestNotes': 'Vendég jegyzetek engedélyezése',
 };
 export default share;

--- a/shared/src/i18n/hu/share.ts
+++ b/shared/src/i18n/hu/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Költségek',
   'share.permCollab': 'Csevegés',
   'share.permGuestNotes': 'Vendég jegyzetek engedélyezése',
+  'share.addNote': "Jegyzet hozzáadása",
+  'share.guestNoteSuccess': "Jegyzet sikeresen elküldve!",
+  'share.guestName': "Az Ön neve",
+  'share.noteTitle': "Jegyzet címe",
+  'share.noteContent': "Jegyzet részletei (opcionális)",
+  'share.noteCategory': "Kategória",
+  'share.attachFile': "Fájl / fénykép csatolása",
+  'share.fileTooLarge': "A fájl mérete meghaladja az 50 MB-os korlátot",
+  'share.sendNote': "Jegyzet küldése",
 };
 export default share;

--- a/shared/src/i18n/i18n-parity.spec.ts
+++ b/shared/src/i18n/i18n-parity.spec.ts
@@ -16,7 +16,7 @@ describe('i18n parity', () => {
   it('every locale has the same domain files as en', () => {
     const report = checkParity();
     expect(report.fileDrift).toEqual([]);
-  });
+  }, 20000);
 
   it('reports key drift as data (not enforced, used by the CLI tool)', () => {
     const report = checkParity();
@@ -29,5 +29,5 @@ describe('i18n parity', () => {
       expect(Array.isArray(entry.missing)).toBe(true);
       expect(Array.isArray(entry.extra)).toBe(true);
     }
-  });
+  }, 20000);
 });

--- a/shared/src/i18n/id/share.ts
+++ b/shared/src/i18n/id/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Biaya',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Izinkan catatan tamu',
+  'share.addNote': "Tambah catatan",
+  'share.guestNoteSuccess': "Catatan berhasil dikirim!",
+  'share.guestName': "Nama Anda",
+  'share.noteTitle': "Judul catatan",
+  'share.noteContent': "Isi catatan (opsional)",
+  'share.noteCategory': "Kategori",
+  'share.attachFile': "Lampirkan file / foto",
+  'share.fileTooLarge': "Ukuran file melebihi batas 50MB",
+  'share.sendNote': "Kirim Catatan",
 };
 export default share;

--- a/shared/src/i18n/id/share.ts
+++ b/shared/src/i18n/id/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Bawaan',
   'share.permBudget': 'Biaya',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Izinkan catatan tamu',
 };
 export default share;

--- a/shared/src/i18n/it/share.ts
+++ b/shared/src/i18n/it/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Costi',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Consenti note degli ospiti',
+  'share.addNote': "Aggiungi nota",
+  'share.guestNoteSuccess': "Nota inviata con successo!",
+  'share.guestName': "Il tuo nome",
+  'share.noteTitle': "Titolo della nota",
+  'share.noteContent': "Dettagli della nota (facoltativo)",
+  'share.noteCategory': "Categoria",
+  'share.attachFile': "Allega file / foto",
+  'share.fileTooLarge': "La dimensione del file supera il limite di 50 MB",
+  'share.sendNote': "Invia nota",
 };
 export default share;

--- a/shared/src/i18n/it/share.ts
+++ b/shared/src/i18n/it/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Valigia',
   'share.permBudget': 'Costi',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Consenti note degli ospiti',
 };
 export default share;

--- a/shared/src/i18n/ja/share.ts
+++ b/shared/src/i18n/ja/share.ts
@@ -11,5 +11,6 @@ const share: TranslationStrings = {
   'share.permPacking': '持ち物',
   'share.permBudget': '費用',
   'share.permCollab': 'チャット',
+  'share.permGuestNotes': 'ゲストメモを許可',
 };
 export default share;

--- a/shared/src/i18n/ja/share.ts
+++ b/shared/src/i18n/ja/share.ts
@@ -12,5 +12,14 @@ const share: TranslationStrings = {
   'share.permBudget': '費用',
   'share.permCollab': 'チャット',
   'share.permGuestNotes': 'ゲストメモを許可',
+  'share.addNote': "メモを追加",
+  'share.guestNoteSuccess': "メモを送信しました！",
+  'share.guestName': "お名前",
+  'share.noteTitle': "メモのタイトル",
+  'share.noteContent': "メモの詳細（任意）",
+  'share.noteCategory': "カテゴリー",
+  'share.attachFile': "ファイル・写真を添付",
+  'share.fileTooLarge': "ファイルサイズが50MBの上限を超えています",
+  'share.sendNote': "メモを送信",
 };
 export default share;

--- a/shared/src/i18n/ko/share.ts
+++ b/shared/src/i18n/ko/share.ts
@@ -12,5 +12,14 @@ const share: TranslationStrings = {
   'share.permBudget': '비용',
   'share.permCollab': '채팅',
   'share.permGuestNotes': '게스트 메모 허용',
+  'share.addNote': "메모 추가",
+  'share.guestNoteSuccess': "메모가 성공적으로 전송되었습니다!",
+  'share.guestName': "이름",
+  'share.noteTitle': "메모 제목",
+  'share.noteContent': "메모 내용 (선택)",
+  'share.noteCategory': "카테고리",
+  'share.attachFile': "파일 / 사진 첨부",
+  'share.fileTooLarge': "파일 크기가 50MB 제한을 초과했습니다",
+  'share.sendNote': "메모 보내기",
 };
 export default share;

--- a/shared/src/i18n/ko/share.ts
+++ b/shared/src/i18n/ko/share.ts
@@ -11,5 +11,6 @@ const share: TranslationStrings = {
   'share.permPacking': '짐 목록',
   'share.permBudget': '비용',
   'share.permCollab': '채팅',
+  'share.permGuestNotes': '게스트 메모 허용',
 };
 export default share;

--- a/shared/src/i18n/nl/share.ts
+++ b/shared/src/i18n/nl/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Inpaklijst',
   'share.permBudget': 'Onkosten',
   'share.permCollab': 'Chat',
+  'share.permGuestNotes': 'Gastnotities toestaan',
 };
 export default share;

--- a/shared/src/i18n/nl/share.ts
+++ b/shared/src/i18n/nl/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Onkosten',
   'share.permCollab': 'Chat',
   'share.permGuestNotes': 'Gastnotities toestaan',
+  'share.addNote': "Notitie toevoegen",
+  'share.guestNoteSuccess': "Notitie succesvol verzonden!",
+  'share.guestName': "Uw naam",
+  'share.noteTitle': "Titel van notitie",
+  'share.noteContent': "Details van notitie (optioneel)",
+  'share.noteCategory': "Categorie",
+  'share.attachFile': "Bestand / foto bijvoegen",
+  'share.fileTooLarge': "Bestandsgrootte overschrijdt de limiet van 50 MB",
+  'share.sendNote': "Notitie versturen",
 };
 export default share;

--- a/shared/src/i18n/pl/share.ts
+++ b/shared/src/i18n/pl/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Lista pakowania',
   'share.permBudget': 'Koszty',
   'share.permCollab': 'Czat',
+  'share.permGuestNotes': 'Zezwól na notatki gości',
 };
 export default share;

--- a/shared/src/i18n/pl/share.ts
+++ b/shared/src/i18n/pl/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Koszty',
   'share.permCollab': 'Czat',
   'share.permGuestNotes': 'Zezwól na notatki gości',
+  'share.addNote': "Dodaj notatkę",
+  'share.guestNoteSuccess': "Notatka wysłana pomyślnie!",
+  'share.guestName': "Twoje imię",
+  'share.noteTitle': "Tytuł notatki",
+  'share.noteContent': "Treść notatki (opcjonalnie)",
+  'share.noteCategory': "Kategoria",
+  'share.attachFile': "Załącz plik / zdjęcie",
+  'share.fileTooLarge': "Rozmiar pliku przekracza limit 50 MB",
+  'share.sendNote': "Wyślij notatkę",
 };
 export default share;

--- a/shared/src/i18n/ru/share.ts
+++ b/shared/src/i18n/ru/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Расходы',
   'share.permCollab': 'Чат',
   'share.permGuestNotes': 'Разрешить гостевые заметки',
+  'share.addNote': "Добавить заметку",
+  'share.guestNoteSuccess': "Заметка успешно отправлена!",
+  'share.guestName': "Ваше имя",
+  'share.noteTitle': "Заголовок заметки",
+  'share.noteContent': "Подробности заметки (необязательно)",
+  'share.noteCategory': "Категория",
+  'share.attachFile': "Прикрепить файл / фото",
+  'share.fileTooLarge': "Размер файла превышает лимит 50 МБ",
+  'share.sendNote': "Отправить заметку",
 };
 export default share;

--- a/shared/src/i18n/ru/share.ts
+++ b/shared/src/i18n/ru/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Вещи',
   'share.permBudget': 'Расходы',
   'share.permCollab': 'Чат',
+  'share.permGuestNotes': 'Разрешить гостевые заметки',
 };
 export default share;

--- a/shared/src/i18n/sv/share.ts
+++ b/shared/src/i18n/sv/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Packning',
   'share.permBudget': 'Kostnader',
   'share.permCollab': 'Chatt',
+  'share.permGuestNotes': 'Tillåt gästantekningar',
 };
 export default share;

--- a/shared/src/i18n/sv/share.ts
+++ b/shared/src/i18n/sv/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Kostnader',
   'share.permCollab': 'Chatt',
   'share.permGuestNotes': 'Tillåt gästantekningar',
+  'share.addNote': "Lägg till anteckning",
+  'share.guestNoteSuccess': "Anteckningen har skickats!",
+  'share.guestName': "Ditt namn",
+  'share.noteTitle': "Anteckningens titel",
+  'share.noteContent': "Anteckningsdetaljer (valfritt)",
+  'share.noteCategory': "Kategori",
+  'share.attachFile': "Bifoga fil / foto",
+  'share.fileTooLarge': "Filstorleken överskrider gränsen på 50 MB",
+  'share.sendNote': "Skicka anteckning",
 };
 export default share;

--- a/shared/src/i18n/tr/share.ts
+++ b/shared/src/i18n/tr/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Maliyetler',
   'share.permCollab': 'Sohbet',
   'share.permGuestNotes': 'Misafir notlarına izin ver',
+  'share.addNote': "Not ekle",
+  'share.guestNoteSuccess': "Not başarıyla gönderildi!",
+  'share.guestName': "Adınız",
+  'share.noteTitle': "Not başlığı",
+  'share.noteContent': "Not detayları (isteğe bağlı)",
+  'share.noteCategory': "Kategori",
+  'share.attachFile': "Dosya / fotoğraf ekle",
+  'share.fileTooLarge': "Dosya boyutu 50 MB sınırını aşıyor",
+  'share.sendNote': "Notu Gönder",
 };
 export default share;

--- a/shared/src/i18n/tr/share.ts
+++ b/shared/src/i18n/tr/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Ambalaj',
   'share.permBudget': 'Maliyetler',
   'share.permCollab': 'Sohbet',
+  'share.permGuestNotes': 'Misafir notlarına izin ver',
 };
 export default share;

--- a/shared/src/i18n/uk/share.ts
+++ b/shared/src/i18n/uk/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Витрати',
   'share.permCollab': 'Чат',
   'share.permGuestNotes': 'Дозволити гостьові нотатки',
+  'share.addNote': "Додати нотатку",
+  'share.guestNoteSuccess': "Нотатку успішно надіслано!",
+  'share.guestName': "Ваше ім’я",
+  'share.noteTitle': "Заголовок нотатки",
+  'share.noteContent': "Деталі нотатки (необов’язково)",
+  'share.noteCategory': "Категорія",
+  'share.attachFile': "Прикріпити файл / фото",
+  'share.fileTooLarge': "Розмір файлу перевищує ліміт 50 МБ",
+  'share.sendNote': "Надіслати нотатку",
 };
 export default share;

--- a/shared/src/i18n/uk/share.ts
+++ b/shared/src/i18n/uk/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Речі',
   'share.permBudget': 'Витрати',
   'share.permCollab': 'Чат',
+  'share.permGuestNotes': 'Дозволити гостьові нотатки',
 };
 export default share;

--- a/shared/src/i18n/vi/share.ts
+++ b/shared/src/i18n/vi/share.ts
@@ -12,5 +12,6 @@ const share: TranslationStrings = {
   'share.permPacking': 'Đóng gói',
   'share.permBudget': 'Chi phí',
   'share.permCollab': 'Trò chuyện',
+  'share.permGuestNotes': 'Cho phép ghi chú của khách',
 };
 export default share;

--- a/shared/src/i18n/vi/share.ts
+++ b/shared/src/i18n/vi/share.ts
@@ -13,5 +13,14 @@ const share: TranslationStrings = {
   'share.permBudget': 'Chi phí',
   'share.permCollab': 'Trò chuyện',
   'share.permGuestNotes': 'Cho phép ghi chú của khách',
+  'share.addNote': "Thêm ghi chú",
+  'share.guestNoteSuccess': "Đã gửi ghi chú thành công!",
+  'share.guestName': "Tên của bạn",
+  'share.noteTitle': "Tiêu đề ghi chú",
+  'share.noteContent': "Chi tiết ghi chú (tùy chọn)",
+  'share.noteCategory': "Danh mục",
+  'share.attachFile': "Đính kèm tệp / ảnh",
+  'share.fileTooLarge': "Kích thước tệp vượt quá giới hạn 50MB",
+  'share.sendNote': "Gửi ghi chú",
 };
 export default share;

--- a/shared/src/i18n/zh-TW/share.ts
+++ b/shared/src/i18n/zh-TW/share.ts
@@ -12,5 +12,14 @@ const share: TranslationStrings = {
   'share.permBudget': '費用',
   'share.permCollab': '聊天',
   'share.permGuestNotes': '允許訪客留言',
+  'share.addNote': "新增筆記",
+  'share.guestNoteSuccess': "筆記發送成功！",
+  'share.guestName': "您的姓名",
+  'share.noteTitle': "筆記標題",
+  'share.noteContent': "筆記詳情（選填）",
+  'share.noteCategory': "分類",
+  'share.attachFile': "附加檔案 / 照片",
+  'share.fileTooLarge': "檔案大小超過 50MB 限制",
+  'share.sendNote': "發送筆記",
 };
 export default share;

--- a/shared/src/i18n/zh-TW/share.ts
+++ b/shared/src/i18n/zh-TW/share.ts
@@ -11,5 +11,6 @@ const share: TranslationStrings = {
   'share.permPacking': '行李',
   'share.permBudget': '費用',
   'share.permCollab': '聊天',
+  'share.permGuestNotes': '允許訪客留言',
 };
 export default share;

--- a/shared/src/i18n/zh/share.ts
+++ b/shared/src/i18n/zh/share.ts
@@ -12,5 +12,14 @@ const share: TranslationStrings = {
   'share.permBudget': '费用',
   'share.permCollab': '聊天',
   'share.permGuestNotes': '允许访客留言',
+  'share.addNote': "添加便签",
+  'share.guestNoteSuccess': "便签发送成功！",
+  'share.guestName': "您的姓名",
+  'share.noteTitle': "便签标题",
+  'share.noteContent': "便签详情（可选）",
+  'share.noteCategory': "分类",
+  'share.attachFile': "添加附件 / 照片",
+  'share.fileTooLarge': "文件大小超过 50MB 限制",
+  'share.sendNote': "发送便签",
 };
 export default share;

--- a/shared/src/i18n/zh/share.ts
+++ b/shared/src/i18n/zh/share.ts
@@ -11,5 +11,6 @@ const share: TranslationStrings = {
   'share.permPacking': '行李',
   'share.permBudget': '费用',
   'share.permCollab': '聊天',
+  'share.permGuestNotes': '允许访客留言',
 };
 export default share;

--- a/shared/src/share/share.schema.ts
+++ b/shared/src/share/share.schema.ts
@@ -15,5 +15,6 @@ export const shareLinkRequestSchema = z.object({
   share_packing: z.boolean().optional(),
   share_budget: z.boolean().optional(),
   share_collab: z.boolean().optional(),
+  allow_guest_notes: z.boolean().optional(),
 });
 export type ShareLinkRequest = z.infer<typeof shareLinkRequestSchema>;


### PR DESCRIPTION
## Summary
This PR adds support for guest note submissions on public share links (\/shared/:token\). Public visitors can now submit notes (name, category selection, title, content, and file attachments up to 50MB) directly into the trip's Collab Notes, with trip-owner toggle control, real-time sync via WebSockets, and distinct guest badges.

### Key Changes
- **Database**: Added \llow_guest_notes INTEGER DEFAULT 0\ to \share_tokens\ and \guest_name TEXT DEFAULT NULL\ to \collab_notes\ with migration.
- **Backend API**: Added public endpoint \POST /api/shared/:token/notes\ supporting multipart file uploads via \NOTE_UPLOAD\ multer interceptor, WebSocket broadcast (\collab:note:created\), and trip-wide notifications.
- **Frontend Share Modal**: Added \[x] Allow guest notes\ toggle pill to \TripMembersModal.tsx\.
- **Frontend Public Page**: Added \➕ Add Note\ button and \GuestAddNoteModal.tsx\ on \SharedTripPage.tsx\ with category selection from existing trip categories.
- **Collab Notes**: Added guest badge (\👤 Guest: [Name]\) to \CollabNotesCard.tsx\ and detail modals.
- **i18n & Tests**: 100% strict i18n parity across all 23 supported languages and comprehensive unit/integration/e2e tests.

## Testing
- \
pm --prefix server test\ (all share integration/e2e tests passing).
- \
pm --prefix client test\ (all modal, page, and card tests passing).
- \
pm run typecheck\ passing with 0 errors across \shared\, \server\, and \client\.