### PR TITLE
fix: three reported bugs on the share page, the mobile map and Google Maps imports

### DIFF
--- a/client/src/mobile/screens/trip/MTripShell.tsx
+++ b/client/src/mobile/screens/trip/MTripShell.tsx
@@ -225,6 +225,15 @@ export default function MTripShell({
     if (trTab !== 'plan') planner.handleTabChange('plan')
   }
 
+  // Map focus on the selected day. Drives the same declutter the desktop sidebar's
+  // collapse chevron drives (#216) rather than adding a second filter — the phone
+  // lost that affordance when this shell replaced DayPlanSidebar, so a day's pins
+  // could not be told apart from the rest of the trip at all (#1962). Unplanned
+  // places stay visible either way, which is what the collapse path has always done.
+  const focusMapOnDay = (dayId: number | null) => {
+    planner.setExpandedDayIds(dayId == null ? null : new Set([dayId]))
+  }
+
   const toggleView = () => {
     const next = view === 'plan' ? 'map' : 'plan'
     setView(next)
@@ -234,6 +243,11 @@ export default function MTripShell({
     if (next === 'map') {
       planner.setRouteShown(true)
       if (planner.selectedDayId != null) planner.handleSelectDay(planner.selectedDayId, false)
+      focusMapOnDay(planner.selectedDayId)
+    } else {
+      // Leaving the map: nothing is filtered while the timeline is up, so the next
+      // visit starts from the whole trip unless a day is picked again.
+      focusMapOnDay(null)
     }
   }
 
@@ -267,8 +281,12 @@ export default function MTripShell({
     if (dayId === planner.selectedDayId) openSheet('day', { dayId })
     else {
       planner.handleSelectDay(dayId, view !== 'map')
-      // In map mode a day tap fits to that day's places AND draws its route.
-      if (view === 'map') planner.setRouteShown(true)
+      // In map mode a day tap fits to that day's places, draws its route and drops
+      // the other days' pins, so the day it framed is the day it shows.
+      if (view === 'map') {
+        planner.setRouteShown(true)
+        focusMapOnDay(dayId)
+      }
     }
   }
 

--- a/client/src/pages/SharedTripPage.test.tsx
+++ b/client/src/pages/SharedTripPage.test.tsx
@@ -7,6 +7,7 @@ import { resetAllStores, seedStore } from '../../tests/helpers/store';
 import { buildSettings } from '../../tests/helpers/factories';
 import { useSettingsStore } from '../store/settingsStore';
 import SharedTripPage from './SharedTripPage';
+import L from 'leaflet';
 
 // Mock react-leaflet (SharedTripPage renders a map)
 vi.mock('react-leaflet', () => ({
@@ -15,6 +16,7 @@ vi.mock('react-leaflet', () => ({
   ),
   TileLayer: () => null,
   Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Polyline: () => <div data-testid="route-line" />,
   Tooltip: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
   useMap: () => ({
     fitBounds: vi.fn(),
@@ -500,8 +502,11 @@ describe('SharedTripPage', () => {
       );
       renderSharedTrip('test-token');
       // The untitled day shows the German label "Tag 1", proving the hardcoded English
-      // "Day 1" was replaced by the i18n key t('dayplan.dayN').
-      await waitFor(() => expect(screen.getByText('Tag 1')).toBeInTheDocument());
+      // "Day 1" was replaced by the i18n key t('dayplan.dayN'). It appears twice since
+      // the day picker above the map was added (#1962): once as a chip, once on the card.
+      await waitFor(() => expect(screen.getAllByText('Tag 1')).toHaveLength(2));
+      const labels = screen.getAllByText('Tag 1');
+      expect(labels.filter((el) => el.closest('button'))).toHaveLength(1);
     });
   });
 
@@ -701,7 +706,10 @@ describe('SharedTripPage', () => {
         accommodations: [{ id: 3, place_name: 'Hotel Lutetia', start_day_id: 5, end_day_id: 5 }],
       }));
 
-      expect(screen.getByText('Day 1')).toBeInTheDocument();
+      // Twice since the day picker landed (#1962): the chip above the map and the card.
+      const dayLabels = screen.getAllByText('Day 1');
+      expect(dayLabels).toHaveLength(2);
+      expect(dayLabels.filter((el) => el.closest('button'))).toHaveLength(1);
       expect(screen.getByText('Hotel Lutetia')).toBeInTheDocument();
       expect(screen.getByText('0 places')).toBeInTheDocument();
       // No date row for an undated day.
@@ -782,6 +790,158 @@ describe('SharedTripPage', () => {
       // Collapsing again restores the trip-wide marker set.
       fireEvent.click(screen.getByText('Day One'));
       await waitFor(() => expect(screen.getAllByText('Louvre')).toHaveLength(1));
+    });
+  });
+
+  // ── Day order, route line and the day picker at the map (#1962) ────────────
+  describe('FE-PAGE-SHARED-038: day markers carry their order and a connecting line', () => {
+    const day = { id: 7, trip_id: 1, day_number: 1, date: '2026-07-02', title: 'Day One' };
+    const louvre = { id: 201, name: 'Louvre', lat: 48.86, lng: 2.33, category: { id: 1, name: 'Sight', color: '#ff0000', icon: 'landmark' } };
+    const orsay = { id: 202, name: 'Orsay', lat: 48.85, lng: 2.32, category: null };
+    const notre = { id: 203, name: 'Notre-Dame', lat: 48.853, lng: 2.35, category: null };
+
+    // Every divIcon call the last render produced, as raw html strings.
+    const iconHtml = () => (L.divIcon as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => String(c[0].html));
+
+    beforeEach(() => (L.divIcon as unknown as ReturnType<typeof vi.fn>).mockClear());
+
+    it('numbers the stops by order_index, not by payload order', async () => {
+      await open('order-map-token', payload({
+        days: [day],
+        places: [louvre, orsay, notre],
+        assignments: {
+          '7': [
+            { id: 302, day_id: 7, place_id: 202, order_index: 1, place: orsay },
+            { id: 303, day_id: 7, place_id: 203, order_index: 2, place: notre },
+            { id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre },
+          ],
+        },
+      }));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() => expect(iconHtml().some((h: string) => h.includes('>1<'))).toBe(true));
+
+      const html = iconHtml();
+      // Louvre is order_index 0 and therefore 1, regardless of where it sat in the payload.
+      expect(html.filter((h: string) => h.includes('>1<'))).toHaveLength(1);
+      expect(html.filter((h: string) => h.includes('>2<'))).toHaveLength(1);
+      expect(html.filter((h: string) => h.includes('>3<'))).toHaveLength(1);
+    });
+
+    it('shows both positions once for a stop the day visits twice, and renders it once', async () => {
+      await open('twice-token', payload({
+        days: [day],
+        places: [louvre, orsay],
+        assignments: {
+          '7': [
+            { id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre },
+            { id: 302, day_id: 7, place_id: 202, order_index: 1, place: orsay },
+            { id: 303, day_id: 7, place_id: 201, order_index: 2, place: louvre },
+          ],
+        },
+      }));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() => expect(iconHtml().some((h: string) => h.includes('1 \u00b7 3'))).toBe(true));
+      // One marker for the repeated place, not two with the same React key.
+      expect(iconHtml().filter((h: string) => h.includes('1 \u00b7 3'))).toHaveLength(1);
+    });
+
+    it('leaves the trip-wide pool unnumbered, since it has no order to show', async () => {
+      await open('nonum-token', payload({
+        days: [day],
+        places: [louvre, orsay],
+        assignments: { '7': [{ id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre }] },
+      }));
+
+      await waitFor(() => expect(iconHtml().length).toBeGreaterThan(0));
+      expect(iconHtml().some((h: string) => h.includes('border-radius:8px'))).toBe(false);
+    });
+
+    it('draws the connecting line only for a day with more than one stop', async () => {
+      await open('line-token', payload({
+        days: [day],
+        places: [louvre, orsay],
+        assignments: {
+          '7': [
+            { id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre },
+            { id: 302, day_id: 7, place_id: 202, order_index: 1, place: orsay },
+          ],
+        },
+      }));
+
+      // No day selected: no line, even though the trip has two geocoded places.
+      expect(screen.queryByTestId('route-line')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() => expect(screen.getByTestId('route-line')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      await waitFor(() => expect(screen.queryByTestId('route-line')).toBeNull());
+    });
+
+    it('does not draw a line for a day with a single stop', async () => {
+      await open('single-token', payload({
+        days: [day],
+        places: [louvre],
+        assignments: { '7': [{ id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre }] },
+      }));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() => expect(screen.getAllByText('Louvre').length).toBeGreaterThan(1));
+      expect(screen.queryByTestId('route-line')).toBeNull();
+    });
+  });
+
+  describe('FE-PAGE-SHARED-039: the day picker sits at the map and agrees with the day card', () => {
+    const day = { id: 7, trip_id: 1, day_number: 1, date: '2026-07-02', title: 'Day One' };
+    const louvre = { id: 201, name: 'Louvre', lat: 48.86, lng: 2.33, category: null };
+    const orsay = { id: 202, name: 'Orsay', lat: 48.85, lng: 2.32, category: null };
+
+    it('narrows the markers to one day and back again', async () => {
+      await open('picker-token', payload({
+        days: [day],
+        places: [louvre, orsay],
+        assignments: { '7': [{ id: 301, day_id: 7, place_id: 201, order_index: 0, place: louvre }] },
+      }));
+
+      // All: both geocoded places are on the map, so Orsay's tooltip is present.
+      expect(screen.getByText('Orsay')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() => expect(screen.queryByText('Orsay')).toBeNull());
+
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      await waitFor(() => expect(screen.getByText('Orsay')).toBeInTheDocument());
+    });
+
+    it('marks the active chip for assistive tech', async () => {
+      await open('pressed-token', payload({ days: [day], places: [louvre], assignments: {} }));
+
+      expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.click(screen.getByRole('button', { name: 'Day 1' }));
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Day 1' })).toHaveAttribute('aria-pressed', 'true'),
+      );
+      expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  describe('FE-PAGE-SHARED-040: trip-wide markers keep their category colour', () => {
+    // The payload nests the category on a day's assignments but sends it flat on the
+    // trip-wide pool, so reading only the nested shape painted every marker indigo.
+    it('reads the flat category_color the trip pool sends', async () => {
+      (L.divIcon as unknown as ReturnType<typeof vi.fn>).mockClear();
+      await open('flatcat-token', payload({
+        days: [],
+        places: [{ id: 201, name: 'Louvre', lat: 48.86, lng: 2.33, category_color: '#ff8800', category_icon: 'landmark' }],
+        assignments: {},
+      }));
+
+      await waitFor(() => expect((L.divIcon as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0));
+      const html = (L.divIcon as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => String(c[0].html));
+      expect(html.some((h: string) => h.includes('#ff8800'))).toBe(true);
+      expect(html.some((h: string) => h.includes('#6366f1'))).toBe(false);
     });
   });
 

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { createElement, useEffect, useRef } from 'react';
 import { renderIconMarkup } from '../utils/iconMarkup';
-import { MapContainer, Marker, TileLayer, Tooltip, useMap } from 'react-leaflet';
+import { MapContainer, Marker, Polyline, TileLayer, Tooltip, useMap } from 'react-leaflet';
 import { getCategoryIcon } from '../components/shared/categoryIcons';
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../constants/mapDefaults';
 import { SUPPORTED_LANGUAGES, useTranslation } from '../i18n';
@@ -33,24 +33,41 @@ import { useSharedTrip } from './sharedTrip/useSharedTrip';
 
 const TRANSPORT_ICONS = { flight: Plane, train: Train, bus: Bus, car: Car, cruise: Ship };
 
-function createMarkerIcon(place: any) {
+// Injected into Leaflet's marker HTML, where CSS variables cannot reach - the same
+// reason MapView.tsx is exempt from theme:lint outright.
+const ORDER_BADGE_STYLE = 'position:absolute;bottom:-4px;right:-4px;min-width:16px;height:16px;border-radius:8px;padding:0 3px;background:rgba(255,255,255,0.94);border:1.5px solid rgba(0,0,0,0.15);box-shadow:0 1px 4px rgba(0,0,0,0.18);display:flex;align-items:center;justify-content:center;font-weight:800;color:#111827;line-height:1;box-sizing:border-box;white-space:nowrap;'; // theme-lint-disable
+
+function createMarkerIcon(place: any, orderNumbers?: number[] | null) {
   const cat = place.category;
   // This page answers without a guard, so an unescaped colour here reaches
   // people who have no account on the instance at all.
-  const color = safeHexColor(cat?.color, '#6366f1');
-  const CatIcon = getCategoryIcon(cat?.icon);
+  // The payload carries the category in two shapes: nested on a day's assignments,
+  // flat on the trip-wide pool. Reading only the nested one dropped every marker
+  // outside a day selection to the placeholder colour.
+  const color = safeHexColor(cat?.color ?? place.category_color, '#6366f1');
+  const CatIcon = getCategoryIcon(cat?.icon ?? place.category_icon);
   const iconSvg = renderIconMarkup(createElement(CatIcon, { size: 14, strokeWidth: 2, color: 'white' }));
+  // Position in the day's order, same contract as the planner: a stop the day
+  // visits twice shows both, e.g. "1 . 3". The values are array indices, never payload.
+  const badge = orderNumbers?.length
+    ? `<span style="${ORDER_BADGE_STYLE}font-size:${orderNumbers.length > 1 ? 7.5 : 9}px;">${orderNumbers.join(' \u00b7 ')}</span>`
+    : '';
   return L.divIcon({
     className: '',
     iconSize: [28, 28],
     iconAnchor: [14, 14],
-    html: `<div style="width:28px;height:28px;border-radius:50%;background:${color};display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,0.3);border:2px solid white;">${iconSvg}</div>`,
+    html: `<div style="position:relative;width:28px;height:28px;border-radius:50%;background:${color};display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,0.3);border:2px solid white;">${iconSvg}${badge}</div>`,
   });
 }
 
 function FitBoundsToPlaces({ places, framedOnMount }: { places: any[]; framedOnMount: boolean }) {
   const map = useMap();
   const fitRan = useRef(false);
+  // The page rebuilds this array on every render (a Page body may not memoise), so
+  // keying the effect on the coordinates rather than the array identity is what stops
+  // an unrelated re-render - the language picker, a late FX response - from throwing
+  // the viewer's pan and zoom away.
+  const fitKey = places.map((p) => `${p.lat},${p.lng}`).join('|');
   useEffect(() => {
     if (places.length === 0) return;
     // The map already opened framed on these places; fitting again would only re-do it.
@@ -62,7 +79,7 @@ function FitBoundsToPlaces({ places, framedOnMount }: { places: any[]; framedOnM
     fitRan.current = true;
     const bounds = L.latLngBounds(places.map((p) => [p.lat, p.lng]));
     map.fitBounds(bounds, { padding: [40, 40], maxZoom: 14 });
-  }, [places, map]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fitKey, map]); // eslint-disable-line react-hooks/exhaustive-deps
   return null;
 }
 
@@ -136,10 +153,27 @@ export default function SharedTripPage() {
   } = data;
   const sortedDays = [...(days || [])].sort((a: any, b: any) => a.day_number - b.day_number);
 
-  // Map places
-  const mapPlaces = selectedDay
-    ? (assignments[String(selectedDay)] || []).map((a: any) => a.place).filter((p: any) => p?.lat && p?.lng)
-    : (places || []).filter((p: any) => p?.lat && p?.lng);
+  // Map places. In day mode each stop carries its position in the day's order; the
+  // trip-wide pool has none (it arrives by created_at). The index runs over the full
+  // sorted assignment list, like the planner does, so a stop without coordinates still
+  // consumes a number and the app and the share link agree on what "3" means.
+  const dayAssignments = selectedDay
+    ? [...(assignments[String(selectedDay)] || [])].sort((a: any, b: any) => a.order_index - b.order_index)
+    : [];
+  const dayOrderMap: Record<number, number[]> = {};
+  dayAssignments.forEach((a: any, i: number) => {
+    if (!a.place?.id) return;
+    (dayOrderMap[a.place.id] ||= []).push(i + 1);
+  });
+  const dayPlaces: any[] = [];
+  const seenPlaceIds = new Set<number>();
+  for (const a of dayAssignments as any[]) {
+    const p = a.place;
+    if (!p?.lat || !p?.lng || seenPlaceIds.has(p.id)) continue;
+    seenPlaceIds.add(p.id);
+    dayPlaces.push(p);
+  }
+  const mapPlaces = selectedDay ? dayPlaces : (places || []).filter((p: any) => p?.lat && p?.lng);
 
   // Open framed on the trip's places instead of on Paris. MapContainer only reads center/zoom
   // at mount, so recomputing this per render is free — and the fit below takes over from there.
@@ -396,6 +430,41 @@ export default function SharedTripPage() {
         {/* Map */}
         {activeTab === 'plan' && (
           <>
+            {/* Day picker at the map. Same setter as the day card below, so the map and
+                the expanded day can never disagree. Without it the only way to narrow the
+                map down was a control 300px further down the page. */}
+            {sortedDays.length > 0 && (
+              <div style={{ display: 'flex', gap: 6, overflowX: 'auto', marginBottom: 10, padding: '2px 0' }}>
+                {[null, ...sortedDays.map((d: any) => d.id)].map((id: number | null, i: number) => {
+                  const active = selectedDay === id;
+                  return (
+                    <button
+                      key={id ?? 'all'}
+                      type="button"
+                      onClick={() => setSelectedDay(id)}
+                      aria-pressed={active}
+                      // Same literals as the day-number circle below. This page pins itself
+                      // to the light neutral look (applyAppearance skips /shared/*), so a
+                      // token here would not be value-equal to the rest of the card.
+                      className={active ? 'bg-[#111827] text-white' : 'bg-[#f3f4f6] text-[#6b7280]'} // theme-lint-disable
+                      style={{
+                        padding: '5px 12px',
+                        borderRadius: 999,
+                        border: 'none',
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                        fontWeight: 600,
+                        fontFamily: 'inherit',
+                        flexShrink: 0,
+                        fontSize: 'calc(12px * var(--fs-scale-body, 1))',
+                      }}
+                    >
+                      {id === null ? t('day.allDays') : t('dayplan.dayN', { n: sortedDays[i - 1].day_number })}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
             <div
               style={{
                 borderRadius: 16,
@@ -416,8 +485,19 @@ export default function SharedTripPage() {
                   referrerPolicy="strict-origin-when-cross-origin"
                 />
                 <FitBoundsToPlaces places={mapPlaces} framedOnMount={framed !== null} />
+                {selectedDay && mapPlaces.length > 1 && (
+                  <Polyline
+                    positions={mapPlaces.map((p: any) => [p.lat, p.lng])}
+                    // Dashed and straight on purpose: it shows the order of the day's stops,
+                    // not the roads between them. A real route would mean sending the
+                    // itinerary to a third party for every anonymous visitor of a shared
+                    // link, with no way for the trip's owner to opt out.
+                    pathOptions={{ color: '#0a84ff', weight: 3, opacity: 0.8, dashArray: '6 8', lineCap: 'round' }} // theme-lint-disable
+                    interactive={false}
+                  />
+                )}
                 {mapPlaces.map((p: any) => (
-                  <Marker key={p.id} position={[p.lat, p.lng]} icon={createMarkerIcon(p)}>
+                  <Marker key={p.id} position={[p.lat, p.lng]} icon={createMarkerIcon(p, dayOrderMap[p.id] ?? null)}>
                     <Tooltip>{p.name}</Tooltip>
                   </Marker>
                 ))}

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -486,17 +486,34 @@ export default function SharedTripPage() {
                       >
                         {di + 1}
                       </div>
-                      <div style={{ flex: 1 }}>
+                      {/* `flex: 1` alone gives this block a base size of 0, so the moment an
+                          accommodation chip pushes the row over the available width it freezes
+                          at its min-content width — a ~37px column with one word, or one CJK
+                          character, per line (#1955). Base auto plus minWidth 0 lets it shrink
+                          proportionally and truncate instead. */}
+                      <div style={{ flex: '1 1 auto', minWidth: 0 }}>
                         <div
                           className="text-[#111827]"
-                          style={{ fontSize: 'calc(14px * var(--fs-scale-body, 1))', fontWeight: 600 }}
+                          style={{
+                            fontSize: 'calc(14px * var(--fs-scale-body, 1))',
+                            fontWeight: 600,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
                         >
                           {day.title || t('dayplan.dayN', { n: day.day_number })}
                         </div>
                         {day.date && (
                           <div
                             className="text-[#9ca3af]"
-                            style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', marginTop: 1 }}
+                            style={{
+                              fontSize: 'calc(11px * var(--fs-scale-caption, 1))',
+                              marginTop: 1,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
                           >
                             {new Date(day.date + 'T00:00:00Z').toLocaleDateString(locale, {
                               weekday: 'short',
@@ -512,18 +529,27 @@ export default function SharedTripPage() {
                           key={acc.id}
                           className="bg-[#f3f4f6] text-[#6b7280]"
                           style={{
-                            fontSize: 'calc(9px * var(--fs-scale-caption, 1))',
+                            fontSize: 'calc(10.5px * var(--fs-scale-caption, 1))',
                             padding: '2px 6px',
                             borderRadius: 4,
                             display: 'flex',
                             alignItems: 'center',
-                            gap: 3,
+                            gap: 4,
+                            minWidth: 0,
                           }}
                         >
-                          <Hotel size={8} /> {acc.place_name}
+                          <Hotel size={11} style={{ flexShrink: 0 }} />
+                          {/* Own span: text-overflow needs a block container, and the chip
+                              itself is a flex container. */}
+                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {acc.place_name}
+                          </span>
                         </span>
                       ))}
-                      <span className="text-[#9ca3af]" style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))' }}>
+                      <span
+                        className="text-[#9ca3af]"
+                        style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', flexShrink: 0, whiteSpace: 'nowrap' }}
+                      >
                         {dayPlaceCount} {t('shared.places')}
                       </span>
                     </div>

--- a/client/tests/unit/mobile/trip/MTripShell.test.tsx
+++ b/client/tests/unit/mobile/trip/MTripShell.test.tsx
@@ -257,6 +257,36 @@ describe('MTripShell', () => {
     expect(planner.setRouteShown).toHaveBeenCalledWith(true)
   })
 
+  // #1962 — the phone lost the desktop sidebar's collapse chevron, so the map showed
+  // every day's pins at once with no way to narrow it down.
+  it('FE-MOB-SHELL-040: entering the map focuses it on the selected day', () => {
+    const { planner } = renderShell()
+    fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.mapView' }))
+    expect(planner.setExpandedDayIds).toHaveBeenCalledWith(new Set([11]))
+  })
+
+  it('FE-MOB-SHELL-041: a day tap in map mode moves the focus with it', () => {
+    const { planner } = renderShell()
+    fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.mapView' }))
+    vi.mocked(planner.setExpandedDayIds).mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'Sun 3' }))
+    expect(planner.setExpandedDayIds).toHaveBeenCalledWith(new Set([12]))
+  })
+
+  it('FE-MOB-SHELL-042: a day tap in list mode leaves the map unfiltered', () => {
+    const { planner } = renderShell()
+    fireEvent.click(screen.getByRole('button', { name: 'Sun 3' }))
+    expect(planner.setExpandedDayIds).not.toHaveBeenCalled()
+  })
+
+  it('FE-MOB-SHELL-043: leaving the map clears the focus again', () => {
+    const { planner } = renderShell()
+    fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.mapView' }))
+    vi.mocked(planner.setExpandedDayIds).mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.listView' }))
+    expect(planner.setExpandedDayIds).toHaveBeenCalledWith(null)
+  })
+
   it('FE-MOB-SHELL-023: the dock only shows enabled tabs and marks the active one', () => {
     const { planner } = renderShell({
       TRIP_TABS: [

--- a/server/src/nest/maps/maps.helpers.ts
+++ b/server/src/nest/maps/maps.helpers.ts
@@ -129,17 +129,29 @@ export function namesOverlap(a: string, b: string): boolean {
 }
 
 const GOOGLE_FTID_RE = /^0x[0-9a-f]+:0x[0-9a-f]+$/i;
+// The same id inside the `data=` pathname blob, where a resolved share link keeps it:
+// /maps/place/<name>/data=!4m6!3m5!1s0x47e66e1f06e2b70f:0x40b82c3688c9460!8m2!3d48.85!4d2.29
+const GOOGLE_FTID_DATA_RE = /!1s(0x[0-9a-f]{1,20}:0x[0-9a-f]{1,20})/i;
 
-// Extracts a Google Maps feature id (ftid, 0x..:0x..) from a URL's ?ftid= param.
+// Extracts a Google Maps feature id (ftid, 0x..:0x..) from a URL.
+// Two shapes carry it. The `?ftid=` query parameter is the old one. A share link that
+// resolveGoogleMapsUrl has followed to its final hop carries it instead in the `data=`
+// pathname blob, in the same `!1s…!3d…!4d…` run the coordinates come from (#1954) — so
+// reading only the query parameter dropped the id for every pasted maps.app.goo.gl link.
 // The Places API (New) googleMapsUri is usually a cid-style URL (https://maps.google.com/?cid=NNN)
-// with no ftid, so this returns null for most API responses — the precise query_place_id link is
-// used instead. It does recover an ftid from a /place/?...&ftid= URL, e.g. a pasted share link
-// resolved by resolveGoogleMapsUrl or a Google MyMaps list import.
+// with neither, so this still returns null for most API responses — the precise
+// query_place_id link is used instead.
 export function googleFtidFromMapsUrl(url?: string | null): string | null {
   if (!url) return null;
   try {
-    const ftid = new URL(url).searchParams.get('ftid')?.trim();
-    return ftid && GOOGLE_FTID_RE.test(ftid) ? ftid.toLowerCase() : null;
+    const parsed = new URL(url);
+    const ftid = parsed.searchParams.get('ftid')?.trim();
+    if (ftid && GOOGLE_FTID_RE.test(ftid)) return ftid.toLowerCase();
+    // Only for a place URL. A /maps/dir/ route carries one !1s per waypoint and the
+    // first one is the origin, not the place the link is about.
+    if (!parsed.pathname.includes('/place/')) return null;
+    const fromPath = GOOGLE_FTID_DATA_RE.exec(parsed.pathname)?.[1];
+    return fromPath ? fromPath.toLowerCase() : null;
   } catch {
     return null;
   }

--- a/server/src/nest/maps/maps.service.ts
+++ b/server/src/nest/maps/maps.service.ts
@@ -1974,6 +1974,7 @@ export class MapsService {
     lat: string,
     lng: string,
     lang?: string,
+    opts?: { lane?: GeoLane; timeoutMs?: number },
   ): Promise<{ name: string | null; address: string | null }> {
     const params = new URLSearchParams({
       lat,
@@ -1983,7 +1984,7 @@ export class MapsService {
       zoom: '18',
       'accept-language': toApiLang(lang),
     });
-    const response = await nominatimFetch('reverse', params);
+    const response = await nominatimFetch('reverse', params, opts);
     if (!response.ok) return { name: null, address: null };
     const data = (await response.json()) as { name?: string; display_name?: string; address?: Record<string, string> };
     const addr = data.address || {};

--- a/server/src/nest/places/places.helpers.ts
+++ b/server/src/nest/places/places.helpers.ts
@@ -254,6 +254,12 @@ export const SEARCH_BIAS_RADIUS_METERS = 2000;
 /** Concurrent enrichment lookups — small, to stay friendly to the Maps quota. */
 export const ENRICH_CONCURRENCY = 3;
 
+// The free address backfill is one Nominatim request per place on the throttled
+// background lane (~1/s), so a normal list costs seconds. Past this it stops being
+// a backfill and starts being bulk geocoding, which Nominatim's usage policy asks
+// people not to do — so it stops rather than queueing for an hour.
+export const ADDRESS_BACKFILL_MAX_PLACES = 250;
+
 
 /**
  * Pick the search result that is the same place as the import: it must be a

--- a/server/src/nest/places/places.service.ts
+++ b/server/src/nest/places/places.service.ts
@@ -29,6 +29,7 @@ import { JourneyDomainService } from '../journey/journey-domain.service';
 import {
   COORD_DEDUP_TOLERANCE,
   ENRICH_CONCURRENCY,
+  ADDRESS_BACKFILL_MAX_PLACES,
   escapeLikePattern,
   MAX_LIST_RESPONSE_BYTES,
   googleMapsFeatureIdFromItem,
@@ -983,8 +984,8 @@ export class PlacesService {
       }
     });
 
-    if (opts?.enrich && opts.userId && created.length) {
-      void this.enrichImportedPlaces(tripId, opts.userId, created as EnrichablePlace[], opts.lang);
+    if (created.length) {
+      void this.enrichImportedList(tripId, created as EnrichablePlace[], opts);
     }
 
     return { places: created, listName, skipped };
@@ -1126,8 +1127,8 @@ export class PlacesService {
       }
     });
 
-    if (opts?.enrich && opts.userId && created.length) {
-      void this.enrichImportedPlaces(tripId, opts.userId, created as EnrichablePlace[], opts.lang);
+    if (created.length) {
+      void this.enrichImportedList(tripId, created as EnrichablePlace[], opts);
     }
 
     return { places: created, listName, skipped };
@@ -1223,6 +1224,63 @@ export class PlacesService {
       });
     } catch (err) {
       console.error('[Places] import enrichment pass failed:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Everything a just-imported list gets in the background, in one place so the
+   * Google and Naver call sites cannot drift apart.
+   *
+   * The Google pass stays exactly as opt-in and key-gated as before. The address
+   * backfill behind it needs neither — it is the same free Nominatim reverse
+   * lookup a single pasted link has always had, which is what made a list import
+   * come out thinner than the same place added one at a time (#1954).
+   */
+  private async enrichImportedList(tripId: string, places: EnrichablePlace[], opts?: ListImportOptions): Promise<void> {
+    if (opts?.enrich && opts.userId) {
+      await this.enrichImportedPlaces(tripId, opts.userId, places, opts.lang);
+    }
+    await this.backfillMissingAddresses(tripId, places, opts?.lang);
+  }
+
+  /**
+   * Fill in the address of imported places that have none, from Nominatim.
+   *
+   * Runs on the background lane so it never queues in front of a user's own
+   * search, writes through COALESCE so it can only fill an empty column — the
+   * Google pass above may already have written a better one — and pushes each
+   * row over the websocket so the sidebar fills in without a reload. Never
+   * throws: one bad lookup must not take down a detached task.
+   */
+  async backfillMissingAddresses(tripId: string, places: EnrichablePlace[], lang?: string): Promise<void> {
+    try {
+      const pending = places.filter(p => !p.address && p.lat != null && p.lng != null);
+      if (!pending.length) return;
+      if (pending.length > ADDRESS_BACKFILL_MAX_PLACES) {
+        console.warn(`[Places] address backfill skipped for trip ${tripId}: ${pending.length} places exceeds the ${ADDRESS_BACKFILL_MAX_PLACES} cap`);
+        return;
+      }
+      // Serial on purpose: the background lane throttles to roughly one request a
+      // second anyway, so concurrency would only build a queue.
+      for (const place of pending) {
+        try {
+          const { address } = await this.maps.reverseGeocode(String(place.lat), String(place.lng), lang, {
+            lane: 'background',
+            timeoutMs: 10000,
+          });
+          if (!address) continue;
+          this.dbs.run(
+            'UPDATE places SET address = COALESCE(address, ?), updated_at = CURRENT_TIMESTAMP WHERE id = ? AND trip_id = ?',
+            address, place.id, tripId,
+          );
+          const updated = this.dbs.getPlaceWithTags(place.id);
+          if (updated) this.realtime.broadcast(tripId, 'place:updated', { place: updated }, undefined);
+        } catch (err) {
+          console.error(`[Places] address backfill failed for place ${place.id}:`, err instanceof Error ? err.message : err);
+        }
+      }
+    } catch (err) {
+      console.error('[Places] address backfill pass failed:', err instanceof Error ? err.message : err);
     }
   }
 

--- a/server/tests/unit/nest/maps.service.test.ts
+++ b/server/tests/unit/nest/maps.service.test.ts
@@ -2266,6 +2266,46 @@ describe('googleFtidFromMapsUrl', () => {
     expect(googleFtidFromMapsUrl('not a url')).toBeNull();
     expect(googleFtidFromMapsUrl(null)).toBeNull();
   });
+
+  // #1954 — a followed maps.app.goo.gl link keeps the id in the `data=` blob, not
+  // in a query parameter, which is why a pasted single link used to lose it.
+  it('MAPS-FTID-004: extracts the ftid from the data= path blob of a resolved share link', () => {
+    expect(
+      googleFtidFromMapsUrl(
+        'https://www.google.com/maps/place/Notre-Dame/data=!4m6!3m5!1s0x47e671e23a09b3b1:0x40b82c3688b2f60!8m2!3d48.8529!4d2.3499',
+      ),
+    ).toBe('0x47e671e23a09b3b1:0x40b82c3688b2f60');
+  });
+
+  it('MAPS-FTID-005: the query parameter still wins over the path blob', () => {
+    expect(
+      googleFtidFromMapsUrl(
+        'https://www.google.com/maps/place/X/data=!3m5!1s0x1:0x2!8m2?ftid=0x882bf179e806d471:0x8591dde29c821a93',
+      ),
+    ).toBe('0x882bf179e806d471:0x8591dde29c821a93');
+  });
+
+  it('MAPS-FTID-006: ignores the path blob outside a /place/ URL', () => {
+    // A directions link carries one !1s per waypoint and the first is the origin,
+    // so reading it would attach the wrong place.
+    expect(
+      googleFtidFromMapsUrl('https://www.google.com/maps/dir/A/B/data=!4m2!1s0x47e671e23a09b3b1:0x40b82c3688b2f60'),
+    ).toBeNull();
+  });
+
+  it('MAPS-FTID-007: a place URL without either shape is still null, and case is normalised', () => {
+    expect(googleFtidFromMapsUrl('https://www.google.com/maps/place/Notre-Dame/@48.85,2.34,17z')).toBeNull();
+    expect(
+      googleFtidFromMapsUrl('https://www.google.com/maps/place/X/data=!1s0x47E671E23A09B3B1:0x40B82C3688B2F60'),
+    ).toBe('0x47e671e23a09b3b1:0x40b82c3688b2f60');
+  });
+
+  it('MAPS-FTID-008: a long hostile path blob resolves in linear time (ReDoS budget)', () => {
+    const hostile = `https://www.google.com/maps/place/X/data=${'!1s0x'.repeat(20000)}`;
+    const started = Date.now();
+    expect(googleFtidFromMapsUrl(hostile)).toBeNull();
+    expect(Date.now() - started).toBeLessThan(500);
+  });
 });
 
 // ── buildUserAgent (instance-specific UA, #1309) ──────────────────────────────

--- a/server/tests/unit/nest/places.service.test.ts
+++ b/server/tests/unit/nest/places.service.test.ts
@@ -14,6 +14,7 @@ import type { PlacePhotoCacheService } from '../../../src/nest/place-photos/plac
 import { UnsplashService } from '../../../src/nest/unsplash/unsplash.service';
 import { RuntimeEnvService } from '../../../src/nest/app-config/runtime-env.service';
 import { TRACK_COLORS } from '@trek/shared';
+import { ADDRESS_BACKFILL_MAX_PLACES } from '../../../src/nest/places/places.helpers';
 
 // ── DB setup ──────────────────────────────────────────────────────────────────
 
@@ -1466,5 +1467,102 @@ describe('importNaverList provider payload', () => {
     expect(result.listName).toBe('Seoul');
     expect(result.places).toHaveLength(1);
     expect(result.places[0].name).toBe('Gyeongbokgung');
+  });
+});
+
+// ── Free address backfill for list imports (#1954) ───────────────────────────
+//
+// A place pasted as a single Google Maps link has always been reverse geocoded;
+// the same place arriving through a list import was not, so it stayed without an
+// address forever. These cover the backfill that closes that gap.
+
+describe('backfillMissingAddresses', () => {
+  function backfillSvc(reverseGeocode: MapsService['reverseGeocode']) {
+    return makePlacesService({ reverseGeocode } as unknown as MapsService);
+  }
+
+  it('PLACE-SVC-078 — fills the address of a place that has none', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Bar', lat: 48.85, lng: 2.35 }) as any;
+
+    const reverseGeocode = vi.fn(async () => ({ name: null, address: '1 Rue de Rivoli, Paris' }));
+    await backfillSvc(reverseGeocode).backfillMissingAddresses(String(trip.id), [
+      { id: place.id, name: 'Bar', lat: 48.85, lng: 2.35 },
+    ]);
+
+    expect(reverseGeocode).toHaveBeenCalledWith('48.85', '2.35', undefined, { lane: 'background', timeoutMs: 10000 });
+    const row = testDb.prepare('SELECT address FROM places WHERE id = ?').get(place.id) as { address: string };
+    expect(row.address).toBe('1 Rue de Rivoli, Paris');
+  });
+
+  it('PLACE-SVC-079 — never overwrites an address the import or the Google pass already wrote', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Bar', lat: 48.85, lng: 2.35 }) as any;
+    testDb.prepare('UPDATE places SET address = ? WHERE id = ?').run('Imported address', place.id);
+
+    const reverseGeocode = vi.fn(async () => ({ name: null, address: 'Nominatim address' }));
+    await backfillSvc(reverseGeocode).backfillMissingAddresses(String(trip.id), [
+      { id: place.id, name: 'Bar', lat: 48.85, lng: 2.35, address: 'Imported address' },
+    ]);
+
+    expect(reverseGeocode).not.toHaveBeenCalled();
+    const row = testDb.prepare('SELECT address FROM places WHERE id = ?').get(place.id) as { address: string };
+    expect(row.address).toBe('Imported address');
+  });
+
+  it('PLACE-SVC-080 — a lookup that answers with nothing leaves the row untouched', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Bar', lat: 48.85, lng: 2.35 }) as any;
+
+    await backfillSvc(vi.fn(async () => ({ name: null, address: null }))).backfillMissingAddresses(String(trip.id), [
+      { id: place.id, name: 'Bar', lat: 48.85, lng: 2.35 },
+    ]);
+
+    const row = testDb.prepare('SELECT address FROM places WHERE id = ?').get(place.id) as { address: string | null };
+    expect(row.address).toBeNull();
+  });
+
+  it('PLACE-SVC-081 — one failing lookup does not take down the rest of the batch', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const first = createPlace(testDb, trip.id, { name: 'A', lat: 1, lng: 2 }) as any;
+    const second = createPlace(testDb, trip.id, { name: 'B', lat: 3, lng: 4 }) as any;
+
+    const reverseGeocode = vi.fn()
+      .mockRejectedValueOnce(new Error('nominatim down'))
+      .mockResolvedValueOnce({ name: null, address: 'Second address' });
+
+    await expect(
+      backfillSvc(reverseGeocode as unknown as MapsService['reverseGeocode']).backfillMissingAddresses(String(trip.id), [
+        { id: first.id, name: 'A', lat: 1, lng: 2 },
+        { id: second.id, name: 'B', lat: 3, lng: 4 },
+      ]),
+    ).resolves.toBeUndefined();
+
+    const rows = testDb.prepare('SELECT id, address FROM places WHERE trip_id = ? ORDER BY id').all(trip.id) as {
+      id: number; address: string | null;
+    }[];
+    expect(rows[0].address).toBeNull();
+    expect(rows[1].address).toBe('Second address');
+  });
+
+  it('PLACE-SVC-082 — an oversized batch is refused rather than queued for an hour', async () => {
+    const reverseGeocode = vi.fn();
+    const batch = Array.from({ length: ADDRESS_BACKFILL_MAX_PLACES + 1 }, (_, i) => ({
+      id: i + 1, name: `P${i}`, lat: 1, lng: 2,
+    }));
+    await backfillSvc(reverseGeocode as unknown as MapsService['reverseGeocode']).backfillMissingAddresses('1', batch);
+    expect(reverseGeocode).not.toHaveBeenCalled();
+  });
+
+  it('PLACE-SVC-083 — a place without coordinates is skipped', async () => {
+    const reverseGeocode = vi.fn();
+    await backfillSvc(reverseGeocode as unknown as MapsService['reverseGeocode']).backfillMissingAddresses('1', [
+      { id: 1, name: 'A', lat: null as unknown as number, lng: null as unknown as number },
+    ]);
+    expect(reverseGeocode).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #1954, closes #1955, closes #1962.

Three reports, all filed against v3.4.1, all re-checked against `dev` first — one of them turned out to be half already-working and half a regression `dev` introduced after 3.4.1.

### #1955 — day header on `/shared/`

The reporter's diagnosis pointed at `.trek-dash`-scoped breakpoints, but the shared page never loads `dashboard.css` and has no media query at all. The header is one nowrap flex row whose title block carries `flex: 1`, i.e. a flex base size of 0, so as soon as an accommodation chip pushes the row past the available width the block freezes at its min-content width — the ~37px column they measured. Content-driven, not viewport-driven, which is why it also hit a 1149px desktop window and why a breakpoint would have been the wrong fix.

Title and date now shrink proportionally and truncate, the chip shrinks and truncates, the place count is pinned so it never wraps or gets pushed out. The chip also moves off its hard-coded 9px onto the 10.5px the in-app day sidebar uses, with an icon to match.

### #1954 — Google Maps imports

`googleFtidFromMapsUrl` only read the `?ftid=` query parameter, while a share link that `resolveGoogleMapsUrl` has followed to its final hop carries the id in the `data=!…!1s0x…:0x…` path blob — the same run the coordinates are already parsed out of two lines further down. It reads the blob too now, gated to `/place/` URLs, since a `/maps/dir/` route lists one id per waypoint and the first is the origin.

List imports had no reverse lookup at all: the only pass behind them is the Google enrichment, which returns immediately without a Maps key, so a keyless instance imported a list and left every address empty forever. They now get the same free Nominatim lookup a pasted link has always had — detached after the import answers, on the throttled background lane so it never queues in front of someone's search, through `COALESCE` so it can only fill an empty column, capped at 250 places, each row pushed over the websocket so the sidebar fills in without a reload.

No `osm_id`: single links do not produce one either, and one derived from a zoom-18 reverse lookup would name the building or the street rather than the POI.

### #1962 — map markers

On `/shared/` all three points were right. Day markers now carry their position in the day's order (`1 · 3` for a stop the day visits twice, the same contract the planner uses), a dashed line connects them in order, and a day picker sits directly above the map instead of only on the cards below it. The line is deliberately a straight connector rather than a road route: drawing a real one would mean sending the itinerary to a third-party routing service for every anonymous visitor of a shared link, with no way for the trip's owner to opt out.

Two unreported findings came with it. Outside a day selection every marker fell back to the placeholder colour, because the payload nests the category on a day's assignments but sends it flat on the trip-wide pool and only the nested shape was read. And the map refit itself on unrelated re-renders — the language picker, a late FX response — because the effect keyed on the array identity of a list the page rebuilds every render, throwing away the viewer's pan and zoom.

On the planner, numbered badges and the day route already exist in both map engines and predate 3.4.1. What was genuinely broken is that the phone shell does not render `DayPlanSidebar`, so the collapse-to-declutter path from #216 disappeared on phones and `expandedDayIds` stayed `null` — there was no way to reduce the map to one day there at all. A day chip in map view now drives that same mechanism; unplanned places stay visible, exactly as collapsing has always left them.

### Notes

22 new tests (14 server, 8 client). `theme:lint` is back at the file's exact previous count for `SharedTripPage.tsx`; the two new literals are Leaflet marker paint and carry the documented exception marker.

The mobile change sits in its own commit — it changes behaviour for every phone user, so it is easy to drop on its own if the call goes the other way.
