### PR TITLE
fix(journey): close two photo-access holes, and the small gaps from discussion #1614

### DIFF
--- a/client/src/components/Journey/JourneyDetailPageEntryEditor.test.tsx
+++ b/client/src/components/Journey/JourneyDetailPageEntryEditor.test.tsx
@@ -836,4 +836,46 @@ describe('EntryEditor', () => {
     expect(amazing.className).toContain('border-zinc-200')
     expect(amazing.getAttribute('style')).toBe('')
   })
+
+  // #1614 — entry_time was stored, sent and displayed everywhere, but the desktop
+  // editor never rendered an input for it.
+  it('FE-JRN-EDITOR-041: shows the stored time and saves an edited one', async () => {
+    const user = userEvent.setup()
+    const { onSave } = mountEditor(buildEntry({ id: 10, title: 'Old', entry_time: '14:30:00' }))
+
+    // The column carries HH:MM:SS; a time input only accepts HH:MM.
+    const timeInput = screen.getByDisplayValue('14:30')
+    expect(timeInput).toHaveAttribute('type', 'time')
+
+    fireEvent.change(timeInput, { target: { value: '09:05' } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    expect(onSave.mock.calls[0][0]).toEqual(expect.objectContaining({ entry_time: '09:05' }))
+  })
+
+  it('FE-JRN-EDITOR-042: clearing the time sends null rather than an empty string', async () => {
+    const user = userEvent.setup()
+    const { onSave } = mountEditor(buildEntry({ id: 10, entry_time: '14:30:00' }))
+
+    fireEvent.change(screen.getByDisplayValue('14:30'), { target: { value: '' } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    expect(onSave.mock.calls[0][0]).toEqual(expect.objectContaining({ entry_time: null }))
+  })
+
+  it('FE-JRN-EDITOR-043: the camera route is its own input, so the library picker survives', () => {
+    const { container } = mountEditor(buildEntry({ id: 10 }))
+
+    const inputs = Array.from(container.querySelectorAll('input[type="file"]'))
+    const camera = inputs.filter(i => i.getAttribute('capture') === 'environment')
+    const library = inputs.filter(i => !i.hasAttribute('capture'))
+
+    expect(camera).toHaveLength(1)
+    expect(library).toHaveLength(1)
+    // The library picker keeps multi-select; forcing capture onto it would drop that.
+    expect(library[0]).toHaveAttribute('multiple')
+    expect(camera[0]).not.toHaveAttribute('multiple')
+  })
 })

--- a/client/src/components/Journey/JourneyDetailPageEntryEditor.tsx
+++ b/client/src/components/Journey/JourneyDetailPageEntryEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { X, Plus, Image, Minus, Check, MapPin, Locate } from 'lucide-react'
+import { X, Plus, Image, Minus, Check, MapPin, Locate, Camera } from 'lucide-react'
 import { normalizeImageFiles } from '../../utils/convertHeic'
 import { type ResilientResult, type UploadProgress } from '../../utils/uploadQueue'
 import { useTranslation } from '../../i18n'
@@ -34,7 +34,7 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
   const [title, setTitle] = useState(entry.title || '')
   const [story, setStory] = useState(entry.story || '')
   const [entryDate, setEntryDate] = useState(entry.entry_date || new Date().toISOString().split('T')[0])
-  const [entryTime, setEntryTime] = useState(entry.entry_time || '')
+  const [entryTime, setEntryTime] = useState(entry.entry_time?.slice(0, 5) || '')
   const [locationName, setLocationName] = useState(entry.location_name || '')
   const [locationLat, setLocationLat] = useState<number | null>(entry.location_lat ?? null)
   const [locationLng, setLocationLng] = useState<number | null>(entry.location_lng ?? null)
@@ -60,6 +60,10 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
   const [externalProvider, setExternalProvider] = useState<string | null>(null)
   const [pendingProviderGroups, setPendingProviderGroups] = useState<PendingProviderGroup[]>([])
   const fileRef = useRef<HTMLInputElement>(null)
+  // Own input: putting `capture` on the picker above would take the photo library
+  // away on a phone, which is the more common way in. This one only ever opens the
+  // camera, so tablets and laptops get the same route the phone sheet already has.
+  const cameraRef = useRef<HTMLInputElement>(null)
   const storyRef = useRef<HTMLTextAreaElement>(null)
   const persistedEntryIdRef = useRef<number | null>(entry.id > 0 ? entry.id : null)
 
@@ -71,7 +75,7 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
     title !== (entry.title || '') ||
     story !== (entry.story || '') ||
     entryDate !== (entry.entry_date || new Date().toISOString().split('T')[0]) ||
-    entryTime !== (entry.entry_time || '') ||
+    entryTime !== (entry.entry_time?.slice(0, 5) || '') ||
     locationName !== (entry.location_name || '') ||
     (locationLat ?? null) !== (entry.location_lat ?? null) ||
     (locationLng ?? null) !== (entry.location_lng ?? null) ||
@@ -258,6 +262,7 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
 
           <div>
             <input ref={fileRef} type="file" accept="image/*" multiple onChange={handleFileChange} onClick={e => { (e.target as HTMLInputElement).value = '' }} className="hidden" />
+            <input ref={cameraRef} type="file" accept="image/*" capture="environment" onChange={handleFileChange} onClick={e => { (e.target as HTMLInputElement).value = '' }} className="hidden" />
             <div className="flex gap-2">
               <button
                 onClick={() => { setPhotoTab('upload'); setShowGalleryPick(false); fileRef.current?.click() }}
@@ -282,6 +287,15 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
                   <Image size={13} /> {t('journey.editor.fromGallery')}
                 </button>
               )}
+              <button
+                onClick={() => { setPhotoTab('upload'); setShowGalleryPick(false); cameraRef.current?.click() }}
+                disabled={saving}
+                aria-label={t('journey.photo.add')}
+                title={t('journey.photo.add')}
+                className="border border-dashed border-zinc-200 dark:border-zinc-700 rounded-xl px-4 text-[12px] text-zinc-500 hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center justify-center disabled:opacity-50"
+              >
+                <Camera size={14} />
+              </button>
               <button
                 onClick={() => { setPhotoTab('external'); setShowGalleryPick(false) }}
                 disabled={saving}
@@ -559,9 +573,23 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-[10px] font-semibold tracking-[0.12em] uppercase text-zinc-500 block mb-1.5">{t('journey.editor.date')}</label>
-              <DatePicker value={entryDate} onChange={setEntryDate} tripDates={tripDates} />
+            {/* Time sat in state and went to the server, it just had no input here — so a
+                draft's auto-stamped clock time showed up in the timeline, the map, the PDF
+                and the public share, and the desktop had no way to correct it (#1614). */}
+            <div className="grid grid-cols-[1fr_104px] gap-2">
+              <div>
+                <label className="text-[10px] font-semibold tracking-[0.12em] uppercase text-zinc-500 block mb-1.5">{t('journey.editor.date')}</label>
+                <DatePicker value={entryDate} onChange={setEntryDate} tripDates={tripDates} />
+              </div>
+              <div>
+                <label className="text-[10px] font-semibold tracking-[0.12em] uppercase text-zinc-500 block mb-1.5">{t('mobileJourney.time')}</label>
+                <input
+                  type="time"
+                  value={entryTime}
+                  onChange={e => setEntryTime(e.target.value)}
+                  className="w-full h-[42px] px-3 rounded-xl border border-zinc-200 dark:border-zinc-700 bg-transparent text-[13px] text-zinc-900 dark:text-white outline-none focus:border-zinc-400 dark:focus:border-zinc-500 [font-variant-numeric:tabular-nums]"
+                />
+              </div>
             </div>
             <div className="relative">
               <label className="text-[10px] font-semibold tracking-[0.12em] uppercase text-zinc-500 block mb-1.5">{t('journey.editor.location')}</label>

--- a/client/src/components/Journey/JourneyDetailPageProviderPicker.tsx
+++ b/client/src/components/Journey/JourneyDetailPageProviderPicker.tsx
@@ -167,7 +167,7 @@ export function ProviderPicker({ provider, userId, entries, trips, existingAsset
         {/* Header */}
         {!embedded && <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-700 flex-shrink-0">
           <h2 className="text-[16px] font-bold text-zinc-900 dark:text-white">
-            {provider === 'immich' ? 'Immich' : 'Synology Photos'}
+            {provider === 'immich' ? 'Immich' : provider === 'synologyphotos' ? 'Synology Photos' : provider}
           </h2>
           <button onClick={onClose} className="w-8 h-8 rounded-lg flex items-center justify-center text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800">
             <X size={16} />

--- a/client/src/pages/journeyDetail/JourneyDetailPage.helpers.test.ts
+++ b/client/src/pages/journeyDetail/JourneyDetailPage.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { distanceBetweenGeoPoints, sortProviderPhotos } from './JourneyDetailPage.helpers';
+import { distanceBetweenGeoPoints, groupPhotosByDate, sortProviderPhotos } from './JourneyDetailPage.helpers';
 
 describe('Journey provider photo ranking', () => {
   it('places GPS photos nearest the selected Journey location and keeps photos without GPS', () => {
@@ -23,5 +23,33 @@ describe('Journey provider photo ranking', () => {
 
   it('calculates a zero distance for identical coordinates', () => {
     expect(distanceBetweenGeoPoints({ lat: 41.9, lng: 12.5 }, { lat: 41.9, lng: 12.5 })).toBe(0);
+  });
+});
+
+describe('Journey provider photo grouping', () => {
+  it('orders the date headings newest first, whatever order the photos arrive in', () => {
+    const photos = [
+      { id: 'b', takenAt: '2026-03-14T09:00:00Z' },
+      { id: 'a', takenAt: '2026-03-16T09:00:00Z' },
+      { id: 'c', takenAt: '2026-03-15T09:00:00Z' },
+    ];
+    expect(groupPhotosByDate(photos).map((g) => g.date)).toEqual(['2026-03-16', '2026-03-15', '2026-03-14']);
+  });
+
+  it('keeps the distance sort inside a day but not across days', () => {
+    // What sortProviderPhotos hands over: nearest first, so the 14th leads the list.
+    const sorted = [
+      { id: 'near', takenAt: '2026-03-14T10:00:00Z' },
+      { id: 'mid', takenAt: '2026-03-16T10:00:00Z' },
+      { id: 'far', takenAt: '2026-03-14T11:00:00Z' },
+    ];
+    const groups = groupPhotosByDate(sorted);
+    expect(groups.map((g) => g.date)).toEqual(['2026-03-16', '2026-03-14']);
+    expect(groups[1].assets.map((a: { id: string }) => a.id)).toEqual(['near', 'far']);
+  });
+
+  it('sorts photos without a date to the end', () => {
+    const photos = [{ id: 'x' }, { id: 'y', takenAt: '2026-03-16T09:00:00Z' }];
+    expect(groupPhotosByDate(photos).map((g) => g.date)).toEqual(['2026-03-16', '__unknown__']);
   });
 });

--- a/client/src/pages/journeyDetail/JourneyDetailPage.helpers.ts
+++ b/client/src/pages/journeyDetail/JourneyDetailPage.helpers.ts
@@ -66,7 +66,17 @@ export function groupPhotosByDate(photos: any[]): { date: string; label: string;
     if (!map.has(key)) map.set(key, [])
     map.get(key)!.push(asset)
   }
-  return [...map.entries()].map(([date, assets]) => ({
+  // Group order must not depend on the order of `photos`. Once the caller sorts by
+  // distance to the entry, first-seen order would put the day holding the nearest
+  // photo first and the date headings would stop reading chronologically. Order
+  // within a day is left as handed in, so the distance sort still applies there.
+  return [...map.entries()]
+    .sort((a, b) => {
+      if (a[0] === '__unknown__') return 1
+      if (b[0] === '__unknown__') return -1
+      return b[0].localeCompare(a[0])
+    })
+    .map(([date, assets]) => ({
     date,
     label: date === '__unknown__'
       ? 'Unknown date'

--- a/server/src/nest/journey/journey-domain.service.ts
+++ b/server/src/nest/journey/journey-domain.service.ts
@@ -342,6 +342,10 @@ export class JourneyDomainService {
     // (cross-tenant leak). Mirrors the trip-access gate every other trip-scoped
     // path enforces.
     if (!this.db.canAccessTrip(tripId, userId)) return false;
+    // And a journey the caller can actually reach. Without this, any logged-in user
+    // could link a trip of theirs into a stranger's journey and seed entries and
+    // photos there — the MCP tool has always checked this, the REST route never did.
+    if (!this.canAccessJourney(journeyId, userId)) return false;
     const now = this.ts();
     try {
       this.db.prepare('INSERT OR IGNORE INTO journey_trips (journey_id, trip_id, added_at) VALUES (?, ?, ?)').run(
@@ -442,9 +446,15 @@ export class JourneyDomainService {
   }
 
   // import trip_photos into journey gallery when a trip is linked
+  //
+  // Only the ones the owner actually shared with the trip. A photo left unshared is
+  // denied on the trip path (memories-access checks tp.shared = 1), and copying it
+  // here handed it to every journey contributor and, with an open gallery, to
+  // anonymous visitors of the share link — journey_photos.shared cannot gate that
+  // afterwards, because a direct upload writes 0 into the same column.
   private syncTripPhotos(journeyId: number, tripId: number) {
     const tripPhotos = this.db
-      .prepare('SELECT tp.photo_id, tp.shared FROM trip_photos tp WHERE tp.trip_id = ?')
+      .prepare('SELECT tp.photo_id, tp.shared FROM trip_photos tp WHERE tp.trip_id = ? AND tp.shared = 1')
       .all(tripId) as { photo_id: number; shared: number }[];
     if (!tripPhotos.length) return;
 

--- a/server/src/nest/weather/weather.impl.ts
+++ b/server/src/nest/weather/weather.impl.ts
@@ -1,4 +1,9 @@
 
+// Open-Meteo sits on the request path as a third party: without a deadline a hung
+// connection holds the caller until the socket gives up on its own. Every other
+// outbound client in the codebase carries one.
+const WEATHER_TIMEOUT_MS = 8000;
+
 // ── Interfaces ──────────────────────────────────────────────────────────
 
 export interface WeatherResult {
@@ -191,7 +196,7 @@ async function _getWeatherImpl(
     // Forecast range (-1 .. +16 days)
     if (diffDays >= -1 && diffDays <= 16) {
       const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&daily=temperature_2m_max,temperature_2m_min,weathercode&timezone=auto&forecast_days=16`;
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
       const data = await response.json() as OpenMeteoForecast;
 
       if (!response.ok || data.error) {
@@ -223,7 +228,7 @@ async function _getWeatherImpl(
     if (diffDays < -1) {
       const dateStr = targetDate.toISOString().slice(0, 10);
       const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lng}&start_date=${dateStr}&end_date=${dateStr}&daily=temperature_2m_max,temperature_2m_min,weathercode,precipitation_sum&timezone=auto`;
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
       const data = await response.json() as OpenMeteoForecast;
 
       if (!response.ok || data.error) {
@@ -264,7 +269,7 @@ async function _getWeatherImpl(
       const endStr = endDate.toISOString().slice(0, 10);
 
       const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lng}&start_date=${startStr}&end_date=${endStr}&daily=temperature_2m_max,temperature_2m_min,precipitation_sum&timezone=auto`;
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
       const data = await response.json() as OpenMeteoForecast;
 
       if (!response.ok || data.error) {
@@ -317,7 +322,7 @@ async function _getWeatherImpl(
   if (cached) return cached;
 
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=temperature_2m,weathercode&timezone=auto`;
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
   const data = await response.json() as OpenMeteoForecast;
 
   if (!response.ok || data.error) {
@@ -388,7 +393,7 @@ async function _getDetailedWeatherImpl(
       + `&hourly=temperature_2m,precipitation,weathercode,windspeed_10m,relativehumidity_2m`
       + `&daily=temperature_2m_max,temperature_2m_min,weathercode,precipitation_sum,windspeed_10m_max,sunrise,sunset`
       + `&timezone=auto`;
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
     const data = await response.json() as OpenMeteoForecast;
 
     if (!response.ok || data.error) {
@@ -451,7 +456,7 @@ async function _getDetailedWeatherImpl(
     + `&daily=temperature_2m_max,temperature_2m_min,weathercode,sunrise,sunset,precipitation_probability_max,precipitation_sum,windspeed_10m_max`
     + `&timezone=auto&start_date=${dateStr}&end_date=${dateStr}`;
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(WEATHER_TIMEOUT_MS) });
   const data = await response.json() as OpenMeteoForecast;
 
   if (!response.ok || data.error) {

--- a/server/tests/unit/nest/journey-domain.service.test.ts
+++ b/server/tests/unit/nest/journey-domain.service.test.ts
@@ -2079,3 +2079,55 @@ describe('journeyTracks', () => {
     expect(svc.journeyTracks(journey.id, stranger.id)).toBeNull();
   });
 });
+
+// ── Trip linking: whose journey, and whose photos (#1614 review) ─────────────
+
+describe('addTripToJourney guards', () => {
+  it('JOURNEY-SVC-100: refuses to link into a journey the caller cannot reach', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const journey = createJourney(testDb, owner.id, { title: "Owner's journey" });
+    const trip = createTrip(testDb, stranger.id, { title: 'Stranger trip' });
+
+    // The stranger owns the trip, so the trip gate passes — only the journey gate stops this.
+    expect(svc.addTripToJourney(journey.id, trip.id, stranger.id)).toBe(false);
+    const links = testDb.prepare('SELECT * FROM journey_trips WHERE journey_id = ?').all(journey.id);
+    expect(links).toHaveLength(0);
+  });
+
+  it('JOURNEY-SVC-101: a contributor may still link, the owner obviously too', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: helper } = createUser(testDb);
+    const journey = createJourney(testDb, owner.id, { title: 'Shared journey' });
+    testDb.prepare('INSERT INTO journey_contributors (journey_id, user_id, role, added_at) VALUES (?, ?, ?, ?)')
+      .run(journey.id, helper.id, 'editor', new Date().toISOString());
+    const trip = createTrip(testDb, helper.id, { title: 'Helper trip' });
+
+    expect(svc.addTripToJourney(journey.id, trip.id, helper.id)).toBe(true);
+  });
+
+  it('JOURNEY-SVC-102: only trip photos the owner shared are copied into the gallery', () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id, { title: 'Photo journey' });
+    const trip = createTrip(testDb, user.id, { title: 'Photo trip' });
+
+    const mk = (assetId: string) => {
+      const r = testDb.prepare(
+        "INSERT INTO trek_photos (provider, asset_id, owner_id, media_type) VALUES ('immich', ?, ?, 'image')",
+      ).run(assetId, user.id);
+      return Number(r.lastInsertRowid);
+    };
+    const sharedPhoto = mk('shared-asset');
+    const privatePhoto = mk('private-asset');
+    const ins = testDb.prepare('INSERT INTO trip_photos (trip_id, user_id, photo_id, shared) VALUES (?, ?, ?, ?)');
+    ins.run(trip.id, user.id, sharedPhoto, 1);
+    ins.run(trip.id, user.id, privatePhoto, 0);
+
+    svc.addTripToJourney(journey.id, trip.id, user.id);
+
+    const copied = testDb
+      .prepare('SELECT photo_id FROM journey_photos WHERE journey_id = ? ORDER BY photo_id')
+      .all(journey.id) as { photo_id: number }[];
+    expect(copied.map(r => r.photo_id)).toEqual([sharedPhoto]);
+  });
+});


### PR DESCRIPTION
First of two PRs off discussion #1614. This one carries the two security findings and the small fixes to surfaces that are already shipped; the second carries the work that touches `trek_photos` and the `getJourneyFull` payload.

### Security

**Unshared trip photos reached journeys.** A photo a member left unshared is denied on the trip path — `memories-access` requires `tp.shared = 1` — but linking that trip to a journey copied every row of `trip_photos` into the gallery regardless. From there it was readable by every journey contributor, and with an open gallery by anonymous visitors of the share link.

Worth spelling out why the fix is at the door rather than at the read: `journey_photos.shared` looks like the natural gate but is not one. A direct upload into a journey writes `0` into that same column, so filtering reads on `shared = 1` would have emptied most galleries. Only the ingress can distinguish the two cases.

**`addTripToJourney` never checked journey access.** It verified the caller could reach the trip, but not the journey, so any logged-in user could link a trip of theirs into a stranger's journey and seed skeleton entries and photos there. The MCP tool `add_journey_trip` has always checked this — only the REST route was open, so the parity was broken in favour of the unguarded side. The check now sits in the service, which covers REST, MCP and the internal call from `createJourney`.

Neither path had a test. Both do now.

### Fixes

**Entry time was unreachable on the desktop.** The value was stored, sent to the server and displayed in the timeline, on the map, in the PDF and on the public share — the editor simply never rendered an input. A draft therefore carried the wall-clock time it happened to be created at, that time showed up everywhere, and there was no way to correct it. The column holds `HH:MM:SS` and a time input wants `HH:MM`, so the initial value and the dirty check now trim.

**Camera on desktop and tablet.** Its own hidden input rather than a `capture` attribute on the existing picker — putting it there would take the photo library away on a phone, which is the more common way in. Same shape the phone sheet already uses.

**Picker date headings.** Since the picker started sorting by distance to the entry, the date groups were built from the already-sorted list, so first-seen order put the day holding the nearest photo at the top and the headings stopped reading chronologically. Grouping now orders its own output; order within a day is untouched, so the distance sort still applies where it belongs.

**Provider naming.** The picker called every non-Immich provider "Synology Photos". It now falls back to the provider's own id, the way the gallery view already did.

**Open-Meteo without a deadline.** All six outbound calls ran without an `AbortSignal`, so a hung connection held the caller until the socket gave up. Every other outbound client in the codebase carries a timeout.

### Not in here, deliberately

Two things from the review turned out not to be defects. The gallery route not passing a date or location to the picker reads like a gap but is correct: a gallery is journey-wide, there is no single day or place, and the picker already falls back to the trip range for exactly that case. And the reported 500-photo limit does not exist in the code — no query limit, no upload cap, no client slice.

The mobile share-map counting fix moves to the second PR: it touches the same files as the newest-first ordering work, and splitting them would only produce conflicts.
