### PR TITLE
fix(llm-parse): parse a stringified reservations field from the Anthropic tool response

### DIFF
--- a/server/src/nest/llm-parse/clients/anthropic.client.ts
+++ b/server/src/nest/llm-parse/clients/anthropic.client.ts
@@ -80,7 +80,21 @@ export class AnthropicClient implements LlmExtractionClient {
     }
 
     const toolUse = data.content?.find(b => b.type === 'tool_use' && b.name === TOOL_NAME);
-    const reservations = toolUse?.input?.reservations;
+    let reservations = toolUse?.input?.reservations;
+    // The model is expected to fill `reservations` as a native array — that's what
+    // forcing tool_choice is for — but it occasionally stringifies the field instead,
+    // sometimes double-wrapped as `{"reservations": [...]}`. Parse defensively rather
+    // than letting the Array.isArray check below silently drop a good extraction to [].
+    if (typeof reservations === 'string') {
+      try {
+        const parsed: unknown = JSON.parse(reservations);
+        reservations = Array.isArray(parsed)
+          ? parsed
+          : (parsed as { reservations?: unknown } | null)?.reservations;
+      } catch {
+        reservations = undefined;
+      }
+    }
     return Array.isArray(reservations) ? (reservations as Record<string, unknown>[]) : [];
   }
 }

--- a/server/tests/unit/nest/llm-parse/clients.test.ts
+++ b/server/tests/unit/nest/llm-parse/clients.test.ts
@@ -226,4 +226,33 @@ describe('AnthropicClient', () => {
     const blocks = body.messages[0].content;
     expect(blocks.some((b: any) => b.type === 'document' && b.source.type === 'base64')).toBe(true);
   });
+
+  it('parses a stringified reservations array instead of dropping it to []', async () => {
+    // Observed in live use: despite the array-typed input_schema and a forced
+    // tool_choice, the model sometimes stringifies the field.
+    mockFetch(() =>
+      jsonResponse({
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', name: 'emit_reservations', input: { reservations: '[{"@type":"LodgingReservation"}]' } }],
+      }),
+    );
+    expect(await new AnthropicClient().extract(baseInput)).toEqual([{ '@type': 'LodgingReservation' }]);
+  });
+
+  it('parses a stringified, double-wrapped {reservations:[...]} object', async () => {
+    mockFetch(() =>
+      jsonResponse({
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', name: 'emit_reservations', input: { reservations: '{"reservations":[{"@type":"LodgingReservation"}]}' } }],
+      }),
+    );
+    expect(await new AnthropicClient().extract(baseInput)).toEqual([{ '@type': 'LodgingReservation' }]);
+  });
+
+  it('returns [] for an unparseable stringified reservations field', async () => {
+    mockFetch(() =>
+      jsonResponse({ stop_reason: 'tool_use', content: [{ type: 'tool_use', name: 'emit_reservations', input: { reservations: 'not json' } }] }),
+    );
+    expect(await new AnthropicClient().extract(baseInput)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Description

The Anthropic client accepts the tool result only when it is already an array, so a
`reservations` field the model returned as a JSON-encoded string is dropped and the
import reports nothing found — with no error and nothing logged.

`extract()` now parses a string value before the array check, and unwraps the
`{reservations:[...]}` object when the model double-wraps it. A value that still cannot
be interpreted returns `[]` exactly as before, so the change can't widen what counts as
a valid result.

Three tests: the two shapes observed in practice fail without the fix, and a third pins
that an unparseable value still yields `[]` — that one passes either way on purpose,
guarding the fix from over-reaching rather than pinning the bug.

## Related Issue or Discussion

Closes #1968

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed *(no user-facing behaviour to document — the
      import simply stops losing results)*

### Test plan

- `npx vitest run tests/unit/nest/llm-parse/clients.test.ts` — 19 passed
- `npm run typecheck --workspace=server` — clean
- Reverting the client change fails the two new stringified cases and leaves the guard
  case passing, as intended
