### PR TITLE
fix(booking-import): geocode imported transport endpoints during preview

### DIFF
--- a/server/src/nest/booking-import/booking-import.service.ts
+++ b/server/src/nest/booking-import/booking-import.service.ts
@@ -111,8 +111,9 @@ export class BookingImportService {
         const { items, warnings } = mapReservations(kiItems, file.originalname);
         // LLM extraction is less certain than kitinerary — always flag for review.
         if (aiUsed) for (const it of items) it.needs_review = true;
-        allItems.push(...items);
         allWarnings.push(...warnings);
+        allWarnings.push(...(await this.geocodeEndpoints(items, file.originalname)));
+        allItems.push(...items);
       }
 
       // Report per-file progress so a background import can drive a live widget.
@@ -120,6 +121,56 @@ export class BookingImportService {
     }
 
     return { items: allItems, warnings: allWarnings, files: fileReports };
+  }
+
+  /**
+   * Geocode transport endpoints (stations/stops/terminals/rental desks) that arrived
+   * without coords, so the route draws and map pins appear. The LLM and kitinerary
+   * rarely supply geo for anything but airports.
+   *
+   * This belongs to preview() because preview is the path the clients actually take:
+   * each parsed item is opened in the normal edit modal and saved through
+   * ReservationsService, never through confirm(). An endpoint still lacking coords at
+   * save time is dropped by saveEndpoints() — reservation_endpoints.lat/lng are NOT
+   * NULL — so it would vanish from the booking with nothing said. Hence the warning
+   * instead of a silent skip.
+   *
+   * Unresolvable endpoints are kept, not filtered: they still appear in the review
+   * form's From→To, where the user can set the location by hand before saving.
+   */
+  private async geocodeEndpoints(items: ParsedBookingItem[], fileName: string): Promise<string[]> {
+    const warnings: string[] = [];
+    for (const item of items) {
+      if (!Array.isArray(item.endpoints)) continue;
+      for (const ep of item.endpoints) {
+        if (ep.lat == null || ep.lng == null) {
+          // Name first, then the address: a rental desk's name is often unresolvable
+          // ("Curbside Counter 7") while the address on the same confirmation is exact.
+          for (const query of [ep.name, ep.address]) {
+            if (!query) continue;
+            try {
+              // 'background': an import geocodes every uncoordinated endpoint in one
+              // loop, and must yield to anyone typing in the interactive place search.
+              const hit = (await this.maps.searchNominatim(query, undefined, 'background'))[0];
+              if (hit?.lat != null && hit?.lng != null) {
+                ep.lat = hit.lat;
+                ep.lng = hit.lng;
+                break;
+              }
+            } catch {
+              // Geocoding failure is non-fatal — the booking still imports.
+            }
+          }
+          if (ep.lat == null || ep.lng == null) {
+            warnings.push(`${fileName}: could not locate "${ep.name}" — set it manually on the booking, or it won't be saved`);
+          }
+        }
+        // Transient: neither reservation_endpoints nor the wire contract
+        // (bookingImportEndpointSchema) carries an address.
+        delete ep.address;
+      }
+    }
+    return warnings;
   }
 
   /**

--- a/server/src/nest/booking-import/kitinerary-mapper.ts
+++ b/server/src/nest/booking-import/kitinerary-mapper.ts
@@ -189,7 +189,7 @@ function mapTrain(r: KiReservation, source: ParsedBookingItem['source']): Parsed
   const endpoints: ParsedEndpoint[] = [];
   const dc = coords(t.departureStation?.geo);
   const ac = coords(t.arrivalStation?.geo);
-  // Push named endpoints even without coords — confirm() geocodes them later.
+  // Push named endpoints even without coords — preview() geocodes them by name.
   if (t.departureStation?.name) endpoints.push({ role: 'from', sequence: 0, name: depName, code: null, lat: dc?.lat ?? null, lng: dc?.lng ?? null, timezone: null, local_time: depTime, local_date: depDate });
   if (t.arrivalStation?.name) endpoints.push({ role: 'to', sequence: 1, name: arrName, code: null, lat: ac?.lat ?? null, lng: ac?.lng ?? null, timezone: null, local_time: arrTime, local_date: arrDate });
 
@@ -293,12 +293,14 @@ function mapRentalCar(r: KiReservation, source: ParsedBookingItem['source']): Pa
   const drc = coords(dropoff?.geo);
   const venue: ParsedVenue | undefined = pickup?.name ? { name: pickup.name, ...(pc ?? {}), address: formatAddress(pickup.address) ?? undefined } : undefined;
 
-  // Pickup → return as from/to endpoints (coords optional; confirm() geocodes).
+  // Pickup → return as from/to endpoints (coords optional; preview() geocodes).
+  // A rental desk's name is often unresolvable ("Curbside Counter 7") while its
+  // address is exact, so carry the address along as the geocode fallback.
   const { date: puDate, time: puTime } = splitIso(r.pickupTime);
   const { date: doDate, time: doTime } = splitIso(r.dropoffTime);
   const endpoints: ParsedEndpoint[] = [];
-  if (pickup?.name) endpoints.push({ role: 'from', sequence: 0, name: pickup.name, code: null, lat: pc?.lat ?? null, lng: pc?.lng ?? null, timezone: null, local_time: puTime, local_date: puDate });
-  if (dropoff?.name) endpoints.push({ role: 'to', sequence: 1, name: dropoff.name, code: null, lat: drc?.lat ?? null, lng: drc?.lng ?? null, timezone: null, local_time: doTime, local_date: doDate });
+  if (pickup?.name) endpoints.push({ role: 'from', sequence: 0, name: pickup.name, code: null, lat: pc?.lat ?? null, lng: pc?.lng ?? null, timezone: null, local_time: puTime, local_date: puDate, address: formatAddress(pickup.address) });
+  if (dropoff?.name) endpoints.push({ role: 'to', sequence: 1, name: dropoff.name, code: null, lat: drc?.lat ?? null, lng: drc?.lng ?? null, timezone: null, local_time: doTime, local_date: doDate, address: formatAddress(dropoff.address) });
 
   return {
     type: 'car',

--- a/server/src/nest/booking-import/kitinerary.types.ts
+++ b/server/src/nest/booking-import/kitinerary.types.ts
@@ -156,6 +156,10 @@ export interface ParsedEndpoint {
   timezone: string | null;
   local_time: string | null;
   local_date: string | null;
+  /** Geocode fallback when the name alone doesn't resolve (e.g. a rental desk's
+   *  truncated "Westfield Intl Apt"). Consumed by preview() and stripped before
+   *  the response — reservation_endpoints has no address column. */
+  address?: string | null;
 }
 
 /** Venue used to auto-create a places row on confirm */

--- a/server/tests/unit/nest/booking-import/booking-import.service.test.ts
+++ b/server/tests/unit/nest/booking-import/booking-import.service.test.ts
@@ -23,9 +23,10 @@ function make(opts: { kit?: boolean; ai?: boolean; extract?: any; parse?: any })
   const extractor = { isAvailable: () => opts.kit ?? false, extract: vi.fn(opts.extract ?? (async () => [])) };
   const llmParse = { isAvailable: () => opts.ai ?? false, parse: vi.fn(opts.parse ?? (async () => ({ kiItems: [], warnings: [] }))) };
   const reservations = { create: vi.fn() };
-  // budget/addons/realtime/maps ride the confirm() path only — the preview()
-  // tests never reach them, so stubs beyond the positional slots aren't needed.
-  const maps = { searchNominatim: vi.fn() };
+  // budget/addons/realtime ride the confirm() path only — the preview() tests never
+  // reach them, so stubs beyond the positional slots aren't needed. maps IS reached:
+  // preview() geocodes uncoordinated endpoints.
+  const maps = { searchNominatim: vi.fn(async (): Promise<{ lat: number | null; lng: number | null }[]> => []) };
   // Places became a constructor dep with the place DI fold (was a path mock of
   // services/placeService); only confirm() reaches it, so a bare create stub does.
   const places = { create: vi.fn() };
@@ -85,5 +86,96 @@ describe('BookingImportService.preview', () => {
     expect(extractor.extract).not.toHaveBeenCalled();
     expect(llmParse.parse).toHaveBeenCalled();
     expect(res.items[0].needs_review).toBe(true);
+  });
+});
+
+// A rental car is the clearest case: kitinerary gives the desk a name and an address
+// but no geo, so every endpoint arrives uncoordinated. Without geocoding here they are
+// dropped at save time by saveEndpoints() (reservation_endpoints.lat/lng are NOT NULL).
+const carKi = (pickup: Record<string, unknown>) => ({
+  '@type': 'RentalCarReservation',
+  reservationNumber: 'CAR1',
+  reservationFor: { name: 'Midsize SUV', rentalCompany: { name: 'Acme' } },
+  pickupTime: '2026-09-10T14:00:00',
+  dropoffTime: '2026-09-12T14:00:00',
+  pickupLocation: pickup,
+});
+
+describe('BookingImportService.preview — endpoint geocoding', () => {
+  it('geocodes an uncoordinated endpoint by name, on the background lane', async () => {
+    const { svc, maps } = make({ kit: true, extract: async () => [carKi({ name: 'Eastport Central Depot' })] });
+    maps.searchNominatim.mockResolvedValue([{ lat: 10, lng: 20 }]);
+
+    const res = await svc.preview([file()], 'no-ai', 1);
+
+    expect(res.items[0].endpoints).toEqual([expect.objectContaining({ name: 'Eastport Central Depot', lat: 10, lng: 20 })]);
+    expect(maps.searchNominatim).toHaveBeenCalledTimes(1);
+    expect(maps.searchNominatim).toHaveBeenCalledWith('Eastport Central Depot', undefined, 'background');
+  });
+
+  it('falls back to the address when the name alone does not resolve', async () => {
+    const { svc, maps } = make({
+      kit: true,
+      extract: async () => [carKi({ name: 'Curbside Counter 7', address: '1 Terminal Way, Eastport' })],
+    });
+    maps.searchNominatim
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ lat: 11, lng: 21 }]);
+
+    const res = await svc.preview([file()], 'no-ai', 1);
+
+    expect(res.items[0].endpoints![0]).toEqual(expect.objectContaining({ lat: 11, lng: 21 }));
+    expect(maps.searchNominatim).toHaveBeenNthCalledWith(2, '1 Terminal Way, Eastport', undefined, 'background');
+  });
+
+  it('keeps an unresolvable endpoint and warns that it will not be saved', async () => {
+    const { svc, maps } = make({
+      kit: true,
+      extract: async () => [carKi({ name: 'Curbside Counter 7', address: 'somewhere unmappable' })],
+    });
+    maps.searchNominatim.mockResolvedValue([]);
+
+    const res = await svc.preview([file('rental.pdf')], 'no-ai', 1);
+
+    // Kept, not filtered: it still shows in the review form's From→To so the user
+    // can set the location by hand.
+    expect(res.items[0].endpoints).toHaveLength(1);
+    expect(res.items[0].endpoints![0]).toEqual(expect.objectContaining({ name: 'Curbside Counter 7', lat: null, lng: null }));
+    expect(res.warnings.some(w => w.includes('could not locate "Curbside Counter 7"'))).toBe(true);
+  });
+
+  it('does not re-query an endpoint that already has coordinates', async () => {
+    const { svc, maps } = make({
+      kit: true,
+      extract: async () => [carKi({ name: 'Eastport Depot', geo: { latitude: 1, longitude: 2 } })],
+    });
+
+    const res = await svc.preview([file()], 'no-ai', 1);
+
+    expect(maps.searchNominatim).not.toHaveBeenCalled();
+    expect(res.items[0].endpoints![0]).toEqual(expect.objectContaining({ lat: 1, lng: 2 }));
+  });
+
+  it('treats a geocoder failure as non-fatal and still returns the booking', async () => {
+    const { svc, maps } = make({ kit: true, extract: async () => [carKi({ name: 'Eastport Central Depot' })] });
+    maps.searchNominatim.mockRejectedValue(new Error('nominatim unreachable'));
+
+    const res = await svc.preview([file()], 'no-ai', 1);
+
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0].endpoints![0]).toEqual(expect.objectContaining({ lat: null, lng: null }));
+    expect(res.warnings.some(w => w.includes('could not locate'))).toBe(true);
+  });
+
+  it('strips the transient address so the response matches the wire contract', async () => {
+    const { svc, maps } = make({
+      kit: true,
+      extract: async () => [carKi({ name: 'Curbside Counter 7', address: '1 Terminal Way, Eastport' })],
+    });
+    maps.searchNominatim.mockResolvedValue([{ lat: 1, lng: 2 }]);
+
+    const res = await svc.preview([file()], 'no-ai', 1);
+
+    expect(res.items[0].endpoints![0]).not.toHaveProperty('address');
   });
 });

--- a/server/tests/unit/services/kitineraryMapper.test.ts
+++ b/server/tests/unit/services/kitineraryMapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mapReservations } from '../../../src/nest/booking-import/kitinerary-mapper';
+import type { KiReservation } from '../../../src/nest/booking-import/kitinerary.types';
 
 const airport = (iata: string, lat: number, lng: number) => ({
   iataCode: iata,
@@ -66,5 +67,29 @@ describe('kitinerary mapper — multi-leg flight grouping', () => {
     expect(items).toHaveLength(1);
     expect(items[0].endpoints).toHaveLength(2);
     expect((items[0].metadata as any).legs).toBeUndefined();
+  });
+});
+
+describe('kitinerary mapper — rental car endpoints', () => {
+  it('carries pickup/dropoff addresses on the endpoints as the geocode fallback', () => {
+    const { items } = mapReservations([
+      {
+        '@type': 'RentalCarReservation',
+        reservationNumber: 'C486561570',
+        reservationFor: { name: 'Fullsize SUV', rentalCompany: { name: 'Budget' } },
+        pickupTime: '2026-11-29T16:00:00',
+        dropoffTime: '2026-11-30T16:00:00',
+        pickupLocation: { name: 'Eastport Intl Airport', address: '400 Harbour Rd, Eastport' },
+        // Mangled venue name next to a geocodable address — the real-world case
+        // the fallback exists for.
+        dropoffLocation: { name: 'Westfield Intl Apt', address: '1 Terminal Way, Westfield' },
+      },
+    ] as KiReservation[], 'test.json');
+
+    expect(items).toHaveLength(1);
+    expect(items[0].endpoints).toEqual([
+      expect.objectContaining({ role: 'from', name: 'Eastport Intl Airport', address: '400 Harbour Rd, Eastport' }),
+      expect.objectContaining({ role: 'to', name: 'Westfield Intl Apt', address: '1 Terminal Way, Westfield' }),
+    ]);
   });
 });

--- a/shared/src/reservation/reservation.schema.ts
+++ b/shared/src/reservation/reservation.schema.ts
@@ -262,7 +262,7 @@ const bookingImportEndpointSchema = z.object({
   sequence: z.number(),
   name: z.string(),
   code: z.string().nullable(),
-  // Nullable: the mapper emits named endpoints without coords; confirm() geocodes
+  // Nullable: the mapper emits named endpoints without coords; preview() geocodes
   // them, and only the coord'd ones are persisted.
   lat: z.number().nullable(),
   lng: z.number().nullable(),


### PR DESCRIPTION
## Description

An imported train, bus or rental-car endpoint arrives from extraction with a name but no
coordinates, and nothing geocodes it: the mapper defers to `confirm()`, but the clients
never call `confirm()` — they open each parsed item in the normal edit modal and save
through `ReservationsService`, whose `saveEndpoints()` drops any endpoint still missing
coordinates because `reservation_endpoints.lat`/`lng` are `NOT NULL`. The endpoint shows
in the review form's From→To and is silently gone from the saved booking.

This moves the geocoding into `preview()`, which is the path the clients actually take.
It tries the endpoint name first, then the address from the same confirmation, on the
throttled `'background'` Nominatim lane — `MapsService.searchNominatim`'s docstring
already names booking-import's endpoint loop as that lane's intended caller, so this is
the load pattern it was built for.

Two deliberate differences from the version in `confirm()`:

- **Unresolvable endpoints are kept, not filtered.** They stay visible in the review
  form's From→To so the location can be set by hand before saving.
- **They raise a warning** naming the endpoint, instead of disappearing without a word.

`confirm()` is left exactly as-is. Whether that orphaned path should be removed or
rewired felt like a separate decision, and its own geocoding is a no-op on
already-coordinated endpoints, so the two can't conflict.

The only change outside the server is a one-line comment correction in the shared schema
(it said `confirm()` geocodes these; it's now `preview()`).

## Related Issue or Discussion

Closes #1969

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed *(two stale code comments corrected; no
      user-facing docs affected)*

### Test plan

- `npx vitest run tests/unit/nest/booking-import/booking-import.service.test.ts tests/unit/services/kitineraryMapper.test.ts` — 15 passed
- `npm run typecheck --workspace=server` — clean
- ESLint on the touched files: 19 warnings, identical to the pre-change baseline for the
  same files — no new warnings, no new `any`
- With the `preview()` change reverted, 5 of the 6 new tests fail; the sixth ("does not
  re-query an endpoint that already has coordinates") passes either way by design, since
  it guards against the fix over-reaching
- Also verified end-to-end on a live instance: before the change, importing a rental-car
  confirmation left `reservation_endpoints` with zero rows for the trip while the
  reservation row itself saved fine
