### PR TITLE
fix: the twelve open bug reports

### DIFF
--- a/client/src/components/Journey/JourneyDetailPageEntryEditor.test.tsx
+++ b/client/src/components/Journey/JourneyDetailPageEntryEditor.test.tsx
@@ -539,14 +539,14 @@ describe('EntryEditor', () => {
     expect(onUploadPhotos).not.toHaveBeenCalled()
   })
 
-  it('FE-JRN-EDITOR-026: leaves a skeleton without any content a skeleton', async () => {
+  it('FE-JRN-EDITOR-026: promotes a skeleton the user saved without editing (#2008)', async () => {
     const user = userEvent.setup()
     const { onSave } = mountEditor(buildEntry({ id: 21, type: 'skeleton', title: 'Venice' }))
 
     await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => expect(onSave).toHaveBeenCalled())
-    expect(onSave.mock.calls[0][0]).toMatchObject({ type: undefined })
+    expect(onSave.mock.calls[0][0]).toMatchObject({ type: 'entry' })
   })
 
   it('FE-JRN-EDITOR-027: removes a con row again', async () => {

--- a/client/src/components/Journey/JourneyDetailPageEntryEditor.tsx
+++ b/client/src/components/Journey/JourneyDetailPageEntryEditor.tsx
@@ -144,7 +144,9 @@ export function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, trips,
         mood: mood || null,
         weather: weather || null,
         pros_cons: { pros: pros.filter(p => p.trim()), cons: cons.filter(c => c.trim()) },
-        type: ((entry.type === 'skeleton' && (story.trim() || pendingFiles.length > 0 || pendingLinkIds.length > 0 || pendingProviderGroups.length > 0)) ? 'entry' : undefined),
+        // An explicit Save is the user saying this suggestion is now their entry —
+        // it does not need a story to earn that (#2008).
+        type: entry.type === 'skeleton' ? 'entry' : undefined,
       }, persistedEntryIdRef.current ?? undefined)
       if (entryId > 0) persistedEntryIdRef.current = entryId
       // upload queued files after entry is created

--- a/client/src/components/Packing/PackingListPanel.test.tsx
+++ b/client/src/components/Packing/PackingListPanel.test.tsx
@@ -447,7 +447,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Click the Import button (Upload icon in the header)
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     expect(importBtn).toBeTruthy();
     await user.click(importBtn!);
 
@@ -538,7 +538,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Open import modal
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     await user.click(importBtn!);
     await screen.findByText('Import Packing List');
 
@@ -655,7 +655,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Open import modal
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     await user.click(importBtn!);
     await screen.findByText('Import Packing List');
 
@@ -929,7 +929,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Open import modal
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     await user.click(importBtn!);
     await screen.findByText('Import Packing List');
 
@@ -1215,7 +1215,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Open import modal
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     await user.click(importBtn!);
     await screen.findByText('Import Packing List');
 
@@ -1500,7 +1500,7 @@ describe('PackingListPanel', () => {
     const { container } = render(<PackingListPanel tripId={1} items={[]} />);
 
     // Open import modal
-    const importBtn = container.querySelector('svg.lucide-upload')?.closest('button');
+    const importBtn = container.querySelector('svg.lucide-download')?.closest('button');
     await user.click(importBtn!);
     await screen.findByText('Import Packing List');
 

--- a/client/src/components/Packing/PackingListPanelHeader.tsx
+++ b/client/src/components/Packing/PackingListPanelHeader.tsx
@@ -1,5 +1,5 @@
 import {
-  X, Check, CheckCheck, Luggage, Package, FolderPlus, Upload,
+  X, Check, CheckCheck, Luggage, Package, FolderPlus, Download,
 } from 'lucide-react'
 import type { PackingState } from './usePackingListPanel'
 
@@ -46,7 +46,7 @@ export function PackingHeader(S: PackingState) {
               border: '1px solid var(--border-primary)', fontSize: 'calc(12px * var(--fs-scale-body, 1))', fontWeight: 500, cursor: 'pointer',
               fontFamily: 'inherit', background: 'var(--bg-card)', color: 'var(--text-muted)',
             }}>
-              <Upload size={12} /> <span className="hidden sm:inline">{t('packing.import')}</span>
+              <Download size={12} /> <span className="hidden sm:inline">{t('packing.import')}</span>
             </button>
           )}
           {inlineHeader && canEdit && abgehakt > 0 && (

--- a/client/src/components/Packing/PackingListPanelImportModal.tsx
+++ b/client/src/components/Packing/PackingListPanelImportModal.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { Upload } from 'lucide-react'
+import { FileDown } from 'lucide-react'
 import type { PackingState } from './usePackingListPanel'
 
 export function BulkImportModal(S: PackingState) {
@@ -48,7 +48,7 @@ export function BulkImportModal(S: PackingState) {
               border: '1px dashed var(--border-primary)', borderRadius: 8, background: 'none',
               fontSize: 'calc(11px * var(--fs-scale-caption, 1))', color: 'var(--text-faint)', cursor: 'pointer', fontFamily: 'inherit',
             }}>
-              <Upload size={11} /> {t('packing.importCsv')}
+              <FileDown size={11} /> {t('packing.importCsv')}
             </button>
           </div>
           <div style={{ display: 'flex', gap: 8 }}>

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -9,6 +9,7 @@ import { ChevronDown, ChevronRight, ChevronUp, Compass, Navigation, RotateCcw, E
 import { type PickedPlace } from './TransitSearchPanel'
 import { assignmentsApi, reservationsApi, daysApi } from '../../api/client'
 import { calculateRouteWithLegs, optimizeRoute, generateGoogleMapsUrl, generateCoMapsUrl, type NamedWaypoint } from '../Map/RouteCalculator'
+import GoogleMapsIcon from '../shared/GoogleMapsIcon'
 import PlaceAvatar from '../shared/PlaceAvatar'
 import ConfirmDialog from '../shared/ConfirmDialog'
 import { useContextMenu, ContextMenu } from '../shared/ContextMenu'
@@ -2583,12 +2584,7 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                             cursor: 'pointer', fontFamily: 'inherit', flexShrink: 0,
                           }}
                         >
-                          <svg width="14" height="14" viewBox="0 0 48 48" fill="currentColor" aria-hidden="true">
-                            <path d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
-                            <path d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
-                            <path d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
-                            <path d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
-                          </svg>
+                          <GoogleMapsIcon size={14} />
                         </button>
                         {/* The same day, handed to CoMaps for offline navigation (#1904). The
                             day's own travel mode rides along, so the route it builds walks

--- a/client/src/components/Planner/PlacesSidebarHeader.tsx
+++ b/client/src/components/Planner/PlacesSidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { Search, Plus, X, Upload, ChevronDown, Check, MapPin, Star } from 'lucide-react'
+import { Search, Plus, X, Upload, FileDown, ChevronDown, Check, MapPin, Star } from 'lucide-react'
 import { getCategoryIcon } from '../shared/categoryIcons'
 import Tooltip from '../shared/Tooltip'
 import type { SidebarState } from './usePlacesSidebar'
@@ -54,7 +54,7 @@ export function PlacesHeader(S: SidebarState) {
             cursor: 'pointer', fontFamily: 'inherit',
           }}
         >
-          <Upload size={11} strokeWidth={2} /> {t('places.importFile')}
+          <FileDown size={11} strokeWidth={2} /> {t('places.importFile')}
         </button>
         <button
           onClick={() => setListImportOpen(true)}

--- a/client/src/components/Planner/ReservationsPanel.test.tsx
+++ b/client/src/components/Planner/ReservationsPanel.test.tsx
@@ -66,15 +66,16 @@ describe('ReservationsPanel', () => {
 
   it('FE-COMP-RES-005: shows Manual Booking add button', () => {
     render(<ReservationsPanel {...defaultProps} />);
-    // Button text is reservations.addManual = "Manual Booking"
-    expect(screen.getByText('Manual Booking')).toBeInTheDocument();
+    // Button text is reservations.addManual = "Manual Booking" — in the toolbar
+    // and, on an empty list, in the empty state's call to action too (#2007).
+    expect(screen.getAllByText('Manual Booking').length).toBeGreaterThan(0);
   });
 
   it('FE-COMP-RES-006: clicking Manual Booking button calls onAdd', async () => {
     const user = userEvent.setup();
     const onAdd = vi.fn();
     render(<ReservationsPanel {...defaultProps} onAdd={onAdd} />);
-    await user.click(screen.getByText('Manual Booking'));
+    await user.click(screen.getAllByText('Manual Booking')[0]);
     expect(onAdd).toHaveBeenCalled();
   });
 
@@ -654,7 +655,7 @@ describe('ReservationsPanel', () => {
 
   it('FE-PLANNER-RESP-058: the add button dims on hover and restores on leave', () => {
     render(<ReservationsPanel {...defaultProps} />);
-    const add = screen.getByText('Manual Booking').closest('button') as HTMLButtonElement;
+    const add = screen.getAllByText('Manual Booking')[0].closest('button') as HTMLButtonElement;
     act(() => { add.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })); });
     expect(add.style.opacity).toBe('0.88');
     act(() => { add.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })); });

--- a/client/src/components/Planner/ReservationsPanel.tsx
+++ b/client/src/components/Planner/ReservationsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, type CSSProperties } from 'react'
 import { createPortal } from 'react-dom'
 import { useTripStore } from '../../store/tripStore'
 import { useCanDo } from '../../store/permissionsStore'
@@ -705,6 +705,14 @@ interface ReservationsPanelProps {
   tripMembers?: TripMember[]
 }
 
+/** The empty state's call-to-action buttons — same shape as the toolbar's. */
+const CTA_STYLE: CSSProperties = {
+  appearance: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit',
+  display: 'inline-flex', alignItems: 'center', gap: 6,
+  padding: '9px 14px', borderRadius: 10,
+  fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 500,
+}
+
 export default function ReservationsPanel({ tripId, reservations, days, assignments, files = [], onAdd, onImport, bookingImportAvailable, onAirTrailImport, airTrailAvailable, onEdit, onDelete, onNavigateToFiles, titleKey = 'reservations.title', addManualKey = 'reservations.addManual', contributionView = 'reservations', tripMembers = [] }: ReservationsPanelProps) {
   const { t, locale } = useTranslation()
   const can = useCanDo()
@@ -928,7 +936,32 @@ export default function ReservationsPanel({ tripId, reservations, days, assignme
       {/* Content */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '24px 28px 80px' }} className="max-md:!px-4 max-md:!pt-4">
         {total === 0 && reservations.length === 0 ? (
-          <EmptyState scene={contributionView === 'transports' ? 'transport' : 'bookings'} title={t('reservations.empty')} />
+          <EmptyState
+            scene={contributionView === 'transports' ? 'transport' : 'bookings'}
+            title={t('reservations.empty')}
+            // On a fresh trip the toolbar controls sit far right above an empty
+            // page, so the import in particular went unnoticed (#2007).
+            action={canEdit ? (
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+                <button onClick={onAdd} className="bg-accent text-accent-text" style={CTA_STYLE}>
+                  <Plus size={14} strokeWidth={2} />
+                  {t(addManualKey)}
+                </button>
+                {onImport && bookingImportAvailable && (
+                  <button onClick={onImport} className="bg-surface-card text-content" style={{ ...CTA_STYLE, border: '1px solid var(--border-primary)' }}>
+                    <Download size={14} strokeWidth={2} />
+                    {t('reservations.import.cta')}
+                  </button>
+                )}
+                {onAirTrailImport && airTrailAvailable && (
+                  <button onClick={onAirTrailImport} className="bg-surface-secondary text-content" style={{ ...CTA_STYLE, border: '1px solid var(--border-primary)' }}>
+                    <Plane size={14} strokeWidth={2} />
+                    {t('reservations.airtrail.cta')}
+                  </button>
+                )}
+              </div>
+            ) : undefined}
+          />
         ) : total === 0 ? (
           <div style={{ textAlign: 'center', padding: '60px 20px' }}>
             <p className="text-content-faint" style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))' }}>{t('places.noneFound')}</p>

--- a/client/src/components/Studio/StudioSidebar.tsx
+++ b/client/src/components/Studio/StudioSidebar.tsx
@@ -1,8 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import {
-  ChevronDown, ChevronUp, Compass, Copy, Files, ImageIcon, LayoutTemplate, Plus,
-  Search, Shapes, Trash2, Upload, X,
-} from 'lucide-react'
+import { ChevronDown, ChevronUp, Compass, Copy, FileDown, Files, ImageIcon, LayoutTemplate, Plus, Search, Shapes, Trash2, X } from 'lucide-react'
 import type { BookElement, BookPageSetup, JourneyStats } from '@trek/shared'
 import { useElementSize } from '../../hooks/useElementSize'
 import { useStudioStore } from '../../store/studioStore'
@@ -259,7 +256,7 @@ function PagesPanel({
             onClick={() => fileInput.current?.click()}
             title={t('journey.studio.importSpreadHint')}
           >
-            <Upload size={14} />
+            <FileDown size={14} />
             {t('journey.studio.importSpread')}
           </button>
         </div>

--- a/client/src/components/shared/CustomDateTimePicker.tsx
+++ b/client/src/components/shared/CustomDateTimePicker.tsx
@@ -2,6 +2,7 @@ import { Calendar, ChevronLeft, ChevronRight, Keyboard } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from '../../i18n';
+import { useRemeasureSignal } from '../../hooks/useAnchoredPosition';
 
 function daysInMonth(year: number, month: number): number {
   return new Date(year, month + 1, 0).getDate();
@@ -41,6 +42,8 @@ export function CustomDatePicker({
   const [yearPageStart, setYearPageStart] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
   const dropRef = useRef<HTMLDivElement>(null);
+  // Re-renders the open calendar whenever its anchor may have moved (#1999).
+  const reanchor = useRemeasureSignal(open);
 
   const parsed = value ? new Date(value + 'T00:00:00Z') : null;
   const [viewYear, setViewYear] = useState(parsed?.getUTCFullYear() || new Date().getFullYear());
@@ -368,7 +371,10 @@ export function CustomDatePicker({
             aria-label={t('common.datepicker.dialog')}
             style={{
               position: 'fixed',
-              ...(() => {
+              // reanchor ticks on scroll / resize / keyboard so this recomputes
+              // against a fresh rect instead of the one measured on open (#1999).
+              ...((): { top: number; left: number } => {
+                void reanchor;
                 const r = ref.current?.getBoundingClientRect();
                 if (!r) return { top: 0, left: 0 };
                 const w = 268,

--- a/client/src/components/shared/CustomSelect.tsx
+++ b/client/src/components/shared/CustomSelect.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { ChevronDown, Check } from 'lucide-react'
+import { useAnchoredPosition, scrollAnchorIntoView } from '../../hooks/useAnchoredPosition'
 
 interface SelectOption {
   // Callers use both string keys and numeric ids (e.g. day/place ids) as values;
@@ -41,8 +42,16 @@ export default function CustomSelect({
   const dropRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
 
+  // Follows the trigger while the sheet scrolls and while the on-screen keyboard
+  // resizes the viewport, instead of freezing at the rect measured on open (#1999).
+  const anchored = useAnchoredPosition(ref, open)
+
   useEffect(() => {
-    if (open && searchable && searchRef.current) searchRef.current.focus()
+    if (!open || !searchable || !searchRef.current) return
+    searchRef.current.focus()
+    // Focusing raises the keyboard on a phone; scroll the trigger up so the list
+    // it just opened is not left underneath it (#2000).
+    scrollAnchorIntoView(ref.current)
   }, [open, searchable])
 
   useEffect(() => {
@@ -121,15 +130,11 @@ export default function CustomSelect({
       {open && createPortal(
         <div ref={dropRef} style={{
           position: 'fixed',
-          ...(() => {
-            const r = ref.current?.getBoundingClientRect()
-            if (!r) return { top: 0, left: 0, width: 200 }
-            const spaceBelow = window.innerHeight - r.bottom
-            const openUp = spaceBelow < 220 && r.top > spaceBelow
-            return openUp
-              ? { bottom: window.innerHeight - r.top + 4, left: r.left, width: r.width }
-              : { top: r.bottom + 4, left: r.left, width: r.width }
-          })(),
+          ...(anchored
+            ? anchored.flipped
+              ? { bottom: anchored.bottom, left: anchored.left, width: anchored.width }
+              : { top: anchored.top, left: anchored.left, width: anchored.width }
+            : { top: 0, left: 0, width: 200 }),
           zIndex: 99999,
           background: 'var(--bg-card)',
           backdropFilter: 'blur(24px) saturate(180%)',
@@ -139,7 +144,7 @@ export default function CustomSelect({
           boxShadow: '0 8px 32px rgba(0,0,0,0.12)',
           overflow: 'hidden',
           animation: 'trek-menu-enter 200ms cubic-bezier(0.23, 1, 0.32, 1)',
-          transformOrigin: 'top center',
+          transformOrigin: anchored?.flipped ? 'bottom center' : 'top center',
           willChange: 'transform, opacity',
         }}>
           {/* Search */}
@@ -161,8 +166,13 @@ export default function CustomSelect({
             </div>
           )}
 
-          {/* Options */}
-          <div style={{ maxHeight: 220, overflowY: 'auto', padding: '4px' }}>
+          {/* Options — capped at whatever the viewport still shows, so a list opened
+              beside an on-screen keyboard shrinks instead of hiding under it (#2000). */}
+          <div style={{
+            maxHeight: Math.min(220, Math.max(96, (anchored?.maxHeight ?? 220) - (searchable ? 38 : 0))),
+            overflowY: 'auto',
+            padding: '4px',
+          }}>
             {filtered.length === 0 ? (
               <div style={{ padding: '10px 12px', fontSize: 'calc(12px * var(--fs-scale-body, 1))', color: 'var(--text-faint)', textAlign: 'center' }}>—</div>
             ) : (

--- a/client/src/components/shared/CustomTimePicker.tsx
+++ b/client/src/components/shared/CustomTimePicker.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Clock, ChevronUp, ChevronDown } from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { formatClockTime, parseMeridiemTime } from '../../utils/formatters'
+import { useAnchoredPosition } from '../../hooks/useAnchoredPosition'
 
 interface CustomTimePickerProps {
   value: string
@@ -17,6 +18,8 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
   const [inputFocused, setInputFocused] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const dropRef = useRef<HTMLDivElement>(null)
+  // The spinner is short, and it has to keep up with a scrolling sheet (#1999).
+  const anchored = useAnchoredPosition(ref, open, { estimatedHeight: 120, matchWidth: false })
 
   const [h, m] = (parseMeridiemTime(value) ?? value ?? '').split(':').map(Number)
   const hour = isNaN(h) ? null : h
@@ -151,8 +154,11 @@ export default function CustomTimePicker({ value, onChange, placeholder = '00:00
       {open && createPortal(
         <div ref={dropRef} style={{
           position: 'fixed',
-          top: (() => { const r = ref.current?.getBoundingClientRect(); return r ? r.bottom + 4 : 0 })(),
-          left: (() => { const r = ref.current?.getBoundingClientRect(); return r ? r.left : 0 })(),
+          ...(anchored
+            ? anchored.flipped
+              ? { bottom: anchored.bottom, left: anchored.left }
+              : { top: anchored.top, left: anchored.left }
+            : { top: 0, left: 0 }),
           zIndex: 99999,
           background: 'var(--bg-card)', border: '1px solid var(--border-primary)',
           borderRadius: 12, boxShadow: '0 8px 32px rgba(0,0,0,0.12)',

--- a/client/src/components/shared/EmptyState.tsx
+++ b/client/src/components/shared/EmptyState.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import MDancingTrek, { type TrekScene, type TrekMood } from '../../mobile/components/MDancingTrek'
 
 /**
@@ -18,6 +18,7 @@ export default function EmptyState({
   size = 104,
   surface = 'var(--bg-card)',
   className = '',
+  action,
 }: {
   scene?: TrekScene
   mood?: TrekMood
@@ -25,6 +26,8 @@ export default function EmptyState({
   size?: number
   surface?: string
   className?: string
+  /** Optional call to action under the title, for states that have an obvious next step. */
+  action?: ReactNode
 }) {
   return (
     <div
@@ -33,6 +36,7 @@ export default function EmptyState({
     >
       <MDancingTrek scene={scene} mood={mood} size={size} />
       <p className="text-[15px] font-semibold text-content-secondary">{title}</p>
+      {action}
     </div>
   )
 }

--- a/client/src/components/shared/GoogleMapsIcon.test.tsx
+++ b/client/src/components/shared/GoogleMapsIcon.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import GoogleMapsIcon from './GoogleMapsIcon'
+
+describe('GoogleMapsIcon', () => {
+  it('FE-COMP-GMAPS-001: renders a pin, not the four-segment Google search "G" (#2005)', () => {
+    const { container } = render(<GoogleMapsIcon />)
+    const paths = container.querySelectorAll('path')
+    expect(paths).toHaveLength(1)
+    // The old mark was four paths lifted from the Google Search logo.
+    expect(container.innerHTML).not.toContain('M24 9.5c3.54')
+  })
+
+  it('FE-COMP-GMAPS-002: sizes itself and inherits the button colour', () => {
+    const { container } = render(<GoogleMapsIcon size={19} />)
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.getAttribute('width')).toBe('19')
+    expect(svg.getAttribute('height')).toBe('19')
+    expect(svg.getAttribute('fill')).toBe('currentColor')
+  })
+
+  it('FE-COMP-GMAPS-003: stays out of the accessibility tree — the button carries the label', () => {
+    const { container } = render(<GoogleMapsIcon />)
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.getAttribute('aria-hidden')).toBe('true')
+    expect(svg.getAttribute('focusable')).toBe('false')
+  })
+
+  it('FE-COMP-GMAPS-004: passes className and style through', () => {
+    const { container } = render(<GoogleMapsIcon className="text-m-faint" style={{ opacity: 0.5 }} />)
+    const svg = container.querySelector('svg') as SVGElement
+    expect(svg.getAttribute('class')).toBe('text-m-faint')
+    expect(svg.style.opacity).toBe('0.5')
+  })
+})

--- a/client/src/components/shared/GoogleMapsIcon.tsx
+++ b/client/src/components/shared/GoogleMapsIcon.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * The map marker for the "open this day in Google Maps" buttons (#2005).
+ *
+ * What sat here before was the four-segment Google "G" — the *search* mark —
+ * flattened to a single colour, which read as "run a Google search" rather than
+ * "open a map". This is the pin instead: filled, so it is not mistaken for the
+ * outline `MapPin` that labels ordinary places, and monochrome on currentColor
+ * so it sits next to the lucide `Compass` of the CoMaps button beside it
+ * without one of the two shouting. The button's own label carries the brand.
+ *
+ * Same shape as the other hand-vendored marks in the client (`BrandIcon` in
+ * SystemNoticeModal, `ImmichIcon`/`SynologyIcon` in AddonManager): 24×24 box,
+ * `fill="currentColor"`, `aria-hidden` because the button is already labelled.
+ */
+export default function GoogleMapsIcon({ size = 14, className, style }: {
+  size?: number
+  className?: string
+  style?: CSSProperties
+}) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      className={className}
+      style={style}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {/* Teardrop pin with the hole punched out by evenodd, so the glyph stays
+          readable at the 13-14px the toolbars render it at. */}
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 1.5c-4.142 0-7.5 3.358-7.5 7.5 0 5.25 6.09 12.34 6.87 13.222a.84.84 0 0 0 1.26 0C13.41 21.34 19.5 14.25 19.5 9c0-4.142-3.358-7.5-7.5-7.5Zm0 10.25a2.75 2.75 0 1 1 0-5.5 2.75 2.75 0 0 1 0 5.5Z"
+      />
+    </svg>
+  )
+}

--- a/client/src/hooks/useAnchoredPosition.test.ts
+++ b/client/src/hooks/useAnchoredPosition.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAnchoredPosition, useRemeasureSignal, scrollAnchorIntoView } from './useAnchoredPosition'
+
+/** A trigger whose rect we can move between measurements. */
+function anchorAt(top: number, height = 40, left = 20, width = 200) {
+  const el = document.createElement('div')
+  el.getBoundingClientRect = () => ({
+    top, bottom: top + height, left, right: left + width, width, height,
+    x: left, y: top, toJSON: () => ({}),
+  }) as DOMRect
+  document.body.appendChild(el)
+  return el
+}
+
+const setViewport = (h: number) => Object.defineProperty(window, 'innerHeight', { value: h, configurable: true })
+
+describe('useAnchoredPosition', () => {
+  beforeEach(() => {
+    setViewport(800)
+    Object.defineProperty(window, 'visualViewport', { value: undefined, configurable: true })
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('FE-ANCHOR-001: reports nothing while closed', () => {
+    const ref = { current: anchorAt(100) }
+    const { result } = renderHook(() => useAnchoredPosition(ref, false))
+    expect(result.current).toBeNull()
+  })
+
+  it('FE-ANCHOR-002: hangs the panel under the trigger with the trigger width', () => {
+    const ref = { current: anchorAt(100) }
+    const { result } = renderHook(() => useAnchoredPosition(ref, true))
+    expect(result.current).toMatchObject({ top: 144, left: 20, width: 200, flipped: false })
+  })
+
+  it('FE-ANCHOR-003: re-measures when a scroll moves the trigger (#1999)', () => {
+    const el = anchorAt(100)
+    const ref = { current: el }
+    const { result } = renderHook(() => useAnchoredPosition(ref, true))
+    expect(result.current?.top).toBe(144)
+
+    // The trigger scrolled 200px up; the panel has to follow it.
+    el.getBoundingClientRect = () => ({
+      top: -100, bottom: -60, left: 20, right: 220, width: 200, height: 40,
+      x: 20, y: -100, toJSON: () => ({}),
+    }) as DOMRect
+    act(() => { window.dispatchEvent(new Event('scroll')) })
+
+    expect(result.current?.top).toBe(-56)
+  })
+
+  it('FE-ANCHOR-004: flips above the trigger when there is no room below', () => {
+    const ref = { current: anchorAt(760) }
+    const { result } = renderHook(() => useAnchoredPosition(ref, true))
+    expect(result.current?.flipped).toBe(true)
+    expect(result.current?.bottom).toBe(44) // innerHeight 800 - top 760 + gap 4
+  })
+
+  it('FE-ANCHOR-005: shrinks maxHeight into the band a keyboard leaves over (#2000)', () => {
+    const ref = { current: anchorAt(300) }
+    const { result, rerender } = renderHook(() => useAnchoredPosition(ref, true))
+    const roomy = result.current!.maxHeight
+
+    // Keyboard takes the bottom 460px: visualViewport reports the rest.
+    Object.defineProperty(window, 'visualViewport', {
+      value: { height: 340, offsetTop: 0, addEventListener: vi.fn(), removeEventListener: vi.fn() },
+      configurable: true,
+    })
+    act(() => { rerender() })
+    act(() => { window.dispatchEvent(new Event('resize')) })
+
+    expect(result.current!.maxHeight).toBeLessThan(roomy)
+  })
+
+  it('FE-ANCHOR-006: survives a visualViewport that has no listeners', () => {
+    Object.defineProperty(window, 'visualViewport', { value: { height: 900 }, configurable: true })
+    const ref = { current: anchorAt(100) }
+    expect(() => renderHook(() => useAnchoredPosition(ref, true))).not.toThrow()
+  })
+
+  it('FE-ANCHOR-007: unsubscribes when it closes', () => {
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const ref = { current: anchorAt(100) }
+    const { unmount } = renderHook(() => useAnchoredPosition(ref, true))
+    unmount()
+    expect(remove).toHaveBeenCalledWith('scroll', expect.any(Function), true)
+  })
+})
+
+describe('useRemeasureSignal', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('FE-ANCHOR-010: ticks on scroll while open, and not while closed', () => {
+    const { result, rerender } = renderHook(({ open }) => useRemeasureSignal(open), {
+      initialProps: { open: false },
+    })
+    act(() => { window.dispatchEvent(new Event('scroll')) })
+    expect(result.current).toBe(0)
+
+    rerender({ open: true })
+    act(() => { window.dispatchEvent(new Event('scroll')) })
+    expect(result.current).toBeGreaterThan(0)
+  })
+})
+
+describe('scrollAnchorIntoView', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    Object.defineProperty(window, 'visualViewport', { value: undefined, configurable: true })
+  })
+
+  it('FE-ANCHOR-020: does nothing without a visualViewport', () => {
+    expect(() => scrollAnchorIntoView(anchorAt(100))).not.toThrow()
+  })
+
+  it('FE-ANCHOR-021: leaves the scroll alone when nothing shrank', () => {
+    setViewport(800)
+    const listeners: Record<string, () => void> = {}
+    Object.defineProperty(window, 'visualViewport', {
+      value: {
+        height: 800, offsetTop: 0,
+        addEventListener: (e: string, fn: () => void) => { listeners[e] = fn },
+        removeEventListener: () => {},
+      },
+      configurable: true,
+    })
+    const scrollBy = vi.fn()
+    Object.defineProperty(window, 'scrollBy', { value: scrollBy, configurable: true })
+
+    scrollAnchorIntoView(anchorAt(100))
+    listeners.resize?.()
+
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it('FE-ANCHOR-022: nudges the page up by exactly the overflow when a keyboard appears', () => {
+    setViewport(800)
+    const listeners: Record<string, () => void> = {}
+    Object.defineProperty(window, 'visualViewport', {
+      value: {
+        height: 400, offsetTop: 0,
+        addEventListener: (e: string, fn: () => void) => { listeners[e] = fn },
+        removeEventListener: () => {},
+      },
+      configurable: true,
+    })
+    const scrollBy = vi.fn()
+    Object.defineProperty(window, 'scrollBy', { value: scrollBy, configurable: true })
+
+    // Trigger bottom 340 + gap 4 + 220 panel = 564, visible bottom 400 → 164 over.
+    scrollAnchorIntoView(anchorAt(300))
+    listeners.resize?.()
+
+    expect(scrollBy).toHaveBeenCalledWith({ top: 164, behavior: 'smooth' })
+  })
+})

--- a/client/src/hooks/useAnchoredPosition.ts
+++ b/client/src/hooks/useAnchoredPosition.ts
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+export interface AnchoredBox {
+  /** Distance from the viewport top, when the panel hangs below the trigger. */
+  top?: number
+  /** Distance from the viewport bottom, when the panel flips above the trigger. */
+  bottom?: number
+  left: number
+  width: number
+  /** Room the panel has before it would run off the visible viewport. */
+  maxHeight: number
+  /** True while the panel is flipped above its trigger. */
+  flipped: boolean
+}
+
+interface AnchoredOptions {
+  /** Height the panel wants; decides whether it still fits below the trigger. */
+  estimatedHeight?: number
+  /** Gap between trigger and panel. */
+  offset?: number
+  /** Breathing room kept between the panel and the viewport edge. */
+  padding?: number
+  /** Adopt the trigger's width (selects) instead of measuring only its position. */
+  matchWidth?: boolean
+}
+
+/** How much the viewport must shrink before we treat it as an on-screen keyboard. */
+const KEYBOARD_THRESHOLD = 120
+
+/**
+ * Keeps a `position: fixed` popover glued to its trigger (#1999, #2000).
+ *
+ * The popovers used to compute `top`/`left` inline while rendering, which reads
+ * the trigger's rect exactly once: scroll the sheet and the trigger walks off
+ * while the panel stays nailed to the viewport, and on iOS the keyboard slides
+ * up over a panel that was placed before it existed. Measuring in a layout
+ * effect and re-measuring on scroll, resize and visualViewport changes fixes
+ * both, because every one of those is a reason the anchor moved.
+ *
+ * Scroll is listened for in the capture phase so it also catches the inner
+ * scroll containers the sheets use — those never bubble a scroll event.
+ *
+ * The returned box also carries `maxHeight`, so a panel opened next to the
+ * keyboard shrinks into the space that is actually visible rather than
+ * disappearing underneath it.
+ */
+export function useAnchoredPosition(
+  anchorRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+  { estimatedHeight = 220, offset = 4, padding = 8, matchWidth = true }: AnchoredOptions = {},
+): AnchoredBox | null {
+  const [box, setBox] = useState<AnchoredBox | null>(null)
+  // Read in the measure callback so it stays stable across renders.
+  const optsRef = useRef({ estimatedHeight, offset, padding, matchWidth })
+  optsRef.current = { estimatedHeight, offset, padding, matchWidth }
+
+  const measure = useCallback(() => {
+    const el = anchorRef.current
+    if (!el) return
+    const { estimatedHeight: wanted, offset: gap, padding: pad, matchWidth: match } = optsRef.current
+    const r = el.getBoundingClientRect()
+    // visualViewport is the part still visible next to an open keyboard; its
+    // offsetTop is how far the browser scrolled the layout viewport up to keep
+    // the focused field in sight, which shifts where "the bottom" really is.
+    const vv = typeof window !== 'undefined' ? window.visualViewport : null
+    const viewTop = typeof vv?.offsetTop === 'number' ? vv.offsetTop : 0
+    const viewHeight = typeof vv?.height === 'number' ? vv.height : window.innerHeight
+    const viewBottom = viewTop + viewHeight
+
+    const spaceBelow = viewBottom - r.bottom - gap - pad
+    const spaceAbove = r.top - viewTop - gap - pad
+    // Only flip when below genuinely cannot hold the panel and above is roomier,
+    // which keeps the familiar downward direction in the ordinary case.
+    const flipped = spaceBelow < Math.min(wanted, 160) && spaceAbove > spaceBelow
+    const maxHeight = Math.max(96, Math.floor(flipped ? spaceAbove : spaceBelow))
+
+    const next: AnchoredBox = flipped
+      ? { bottom: Math.round(window.innerHeight - r.top + gap), left: r.left, width: r.width, maxHeight, flipped }
+      : { top: Math.round(r.bottom + gap), left: r.left, width: r.width, maxHeight, flipped }
+    if (!match) next.width = 0
+
+    setBox(prev =>
+      prev
+        && prev.top === next.top && prev.bottom === next.bottom
+        && prev.left === next.left && prev.width === next.width
+        && prev.maxHeight === next.maxHeight && prev.flipped === next.flipped
+        ? prev
+        : next,
+    )
+  }, [anchorRef])
+
+  // Measure before paint so the panel never shows up at a stale spot first.
+  useLayoutEffect(() => {
+    if (!open) { setBox(null); return }
+    measure()
+  }, [open, measure])
+
+  useEffect(() => {
+    if (!open) return
+    const el = anchorRef.current
+    // Capture phase: scrolls inside the sheets' own overflow containers do not
+    // bubble, and those are exactly the ones that move the trigger.
+    window.addEventListener('scroll', measure, true)
+    window.addEventListener('resize', measure)
+    // A visualViewport without listeners is a real shape — old Safari reports
+    // one, and so do test doubles — so never assume the methods are there.
+    const vv = typeof window.visualViewport?.addEventListener === 'function' ? window.visualViewport : null
+    vv?.addEventListener('resize', measure)
+    vv?.addEventListener('scroll', measure)
+    // The trigger can change size on its own (a select whose label grows).
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null
+    if (el && ro) ro.observe(el)
+    return () => {
+      window.removeEventListener('scroll', measure, true)
+      window.removeEventListener('resize', measure)
+      vv?.removeEventListener('resize', measure)
+      vv?.removeEventListener('scroll', measure)
+      ro?.disconnect()
+    }
+  }, [open, measure, anchorRef])
+
+  return box
+}
+
+/**
+ * A counter that ticks whenever an open popover's anchor may have moved (#1999).
+ *
+ * For popovers that already do their own placement maths — the date picker
+ * clamps a fixed 268×360 calendar horizontally, which no generic box can express
+ * — re-rendering is all they need: their own calculation then runs against a
+ * fresh rect. Same event set as useAnchoredPosition, including capture-phase
+ * scroll for the sheets' inner scroll containers.
+ */
+export function useRemeasureSignal(open: boolean): number {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    if (!open) return
+    const bump = () => setTick(t => t + 1)
+    window.addEventListener('scroll', bump, true)
+    window.addEventListener('resize', bump)
+    const vv = typeof window.visualViewport?.addEventListener === 'function' ? window.visualViewport : null
+    vv?.addEventListener('resize', bump)
+    vv?.addEventListener('scroll', bump)
+    return () => {
+      window.removeEventListener('scroll', bump, true)
+      window.removeEventListener('resize', bump)
+      vv?.removeEventListener('resize', bump)
+      vv?.removeEventListener('scroll', bump)
+    }
+  }, [open])
+
+  return tick
+}
+
+/**
+ * Scrolls a trigger far enough up that an on-screen keyboard cannot cover the
+ * panel that just opened below it (#2000).
+ *
+ * Called after the panel's search field takes focus. It waits for the keyboard
+ * to actually appear — visualViewport only reports the smaller height once the
+ * animation starts — and then nudges the nearest scroll container just enough,
+ * never more. When nothing shrinks (desktop, or a hardware keyboard) it does
+ * nothing at all.
+ */
+export function scrollAnchorIntoView(anchor: HTMLElement | null, panelHeight = 220): void {
+  if (!anchor || typeof window === 'undefined') return
+  const vv = typeof window.visualViewport?.addEventListener === 'function' ? window.visualViewport : null
+  if (!vv) return
+  const baseline = window.innerHeight
+
+  const nudge = () => {
+    // No keyboard, no problem — leave the user's scroll position alone.
+    if (baseline - vv.height < KEYBOARD_THRESHOLD) return
+    const r = anchor.getBoundingClientRect()
+    const visibleBottom = vv.offsetTop + vv.height
+    const overflow = r.bottom + 4 + panelHeight - visibleBottom
+    if (overflow <= 0) return
+    const scroller = scrollableAncestor(anchor)
+    if (scroller) scroller.scrollTop += overflow
+    else window.scrollBy({ top: overflow, behavior: 'smooth' })
+  }
+
+  // One shot after the keyboard animation, plus a listener in case it is slower.
+  const onResize = () => { vv.removeEventListener('resize', onResize); nudge() }
+  vv.addEventListener('resize', onResize)
+  window.setTimeout(() => { vv.removeEventListener('resize', onResize); nudge() }, 350)
+}
+
+function scrollableAncestor(el: HTMLElement): HTMLElement | null {
+  for (let node: HTMLElement | null = el.parentElement; node && node !== document.body; node = node.parentElement) {
+    const overflow = getComputedStyle(node).overflowY
+    if ((overflow === 'auto' || overflow === 'scroll') && node.scrollHeight > node.clientHeight) return node
+  }
+  return null
+}

--- a/client/src/mobile/screens/journey/MJourneyEntrySheet.tsx
+++ b/client/src/mobile/screens/journey/MJourneyEntrySheet.tsx
@@ -204,10 +204,9 @@ export default function MJourneyEntrySheet({
         weather: weather || null,
         tags: tags.filter(tag => tag.trim()),
         pros_cons: { pros: pros.filter(p => p.trim()), cons: cons.filter(c => c.trim()) },
-        type: entry.type === 'skeleton'
-          && (story.trim() || pendingFiles.length > 0 || pendingLinkIds.length > 0 || pendingProviderGroups.length > 0)
-          ? 'entry'
-          : undefined,
+        // An explicit Save is the user saying this suggestion is now their entry —
+        // it does not need a story to earn that (#2008).
+        type: entry.type === 'skeleton' ? 'entry' : undefined,
       }, persistedEntryIdRef.current ?? undefined)
       if (entryId > 0) persistedEntryIdRef.current = entryId
       if (pendingFiles.length > 0 && entryId) {

--- a/client/src/mobile/screens/trip/MTripShell.tsx
+++ b/client/src/mobile/screens/trip/MTripShell.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ComponentType, type ReactNode } from 'react'
 import { findTodayDayId } from '../../../components/Planner/today'
 import {
-  ChevronLeft, FileDown, List, Map as MapIcon, MoreHorizontal, PackageCheck,
+  ChevronDown, ChevronLeft, Download, FileDown, List, Map as MapIcon, MoreHorizontal, PackageCheck,
   Plane, Plus, Rows3, Ticket, TrainFront, Trash2, Upload, Wallet,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -241,7 +241,7 @@ export default function MTripShell({
     // Entering the map: draw the current day's route and frame it — the
     // BoundsController re-fits to include the polyline once OSRM resolves.
     if (next === 'map') {
-      planner.setRouteShown(true)
+      planner.autoShowRoute()
       if (planner.selectedDayId != null) planner.handleSelectDay(planner.selectedDayId, false)
       focusMapOnDay(planner.selectedDayId)
     } else {
@@ -284,7 +284,7 @@ export default function MTripShell({
       // In map mode a day tap fits to that day's places, draws its route and drops
       // the other days' pins, so the day it framed is the day it shows.
       if (view === 'map') {
-        planner.setRouteShown(true)
+        planner.autoShowRoute()
         focusMapOnDay(dayId)
       }
     }
@@ -335,11 +335,14 @@ export default function MTripShell({
                   // Inactive chips only — an inline background would otherwise beat
                   // the active chip's bg-m-act class.
                   style={active ? undefined : { background: dayTintBackground(tint, 'badge', '--day-tint-chip') }}
-                  className={`flex-1 whitespace-nowrap rounded-full px-3 py-[5px] text-center text-[0.75rem] font-semibold ${
+                  className={`flex flex-1 items-center justify-center gap-[3px] whitespace-nowrap rounded-full px-3 py-[5px] text-center text-[0.75rem] font-semibold ${
                     active ? 'bg-m-act text-m-actfg shadow-[0_6px_16px_-6px_rgba(0,0,0,.4)]' : 'text-m-ink'
                   }`}
                 >
                   {dayChipLabel(day, language, t('planner.dayN', { n: day.day_number ?? idx + 1 }))}
+                  {/* Marks the second tap as "opens the day", the only day-sheet
+                      route that also exists in map view. */}
+                  {active && <ChevronDown size={11} strokeWidth={2.6} aria-hidden="true" className="flex-none opacity-70" />}
                 </button>
               )
             })}
@@ -387,7 +390,7 @@ export default function MTripShell({
             />
             {planner.bookingImportAvailable && (
               <MIconBtn ariaLabel={t('reservations.import.title')} onClick={() => planner.setShowBookingImport(true)} size={40} className="text-m-muted backdrop-blur-[24px] backdrop-saturate-[1.7]">
-                <Upload size={15} strokeWidth={2} />
+                <Download size={15} strokeWidth={2} />
               </MIconBtn>
             )}
             {planner.airTrailAvailable && (
@@ -407,7 +410,7 @@ export default function MTripShell({
             />
             {planner.bookingImportAvailable && (
               <MIconBtn ariaLabel={t('reservations.import.title')} onClick={() => planner.setShowBookingImport(true)} size={40} className="text-m-muted backdrop-blur-[24px] backdrop-saturate-[1.7]">
-                <Upload size={15} strokeWidth={2} />
+                <Download size={15} strokeWidth={2} />
               </MIconBtn>
             )}
             <CompactToggle active={bookingsCompact} onToggle={() => setBookingsCompact(v => !v)} label={t('mobileTrip.compactView')} />

--- a/client/src/mobile/screens/trip/map/MMapArea.tsx
+++ b/client/src/mobile/screens/trip/map/MMapArea.tsx
@@ -50,7 +50,10 @@ export default function MMapArea({ planner, shell }: MMapAreaProps) {
         onMarkerClick={planner.handleMarkerClick}
         // Tap on empty map = deselect, same contract as desktop.
         onMapClick={planner.handleMapClick}
-        onMapContextMenu={planner.handleMapContextMenu}
+        // The chip rail names a day at all times on mobile, so a place dropped on
+        // the map belongs to it — the desktop map has no such context and passes
+        // nothing, which keeps its pool behaviour (#1998).
+        onMapContextMenu={e => planner.handleMapContextMenu(e, planner.selectedDayId)}
         // No center/zoom: the map frames itself on the trip's places at mount.
         tileUrl={planner.mapTileUrl}
         fitKey={planner.fitKey}
@@ -62,7 +65,7 @@ export default function MMapArea({ planner, shell }: MMapAreaProps) {
         // routes this through mapTransportDetail into the day sidebar instead).
         onReservationClick={(rid: number) => shell.openSheet('transport', { reservationId: rid })}
         pois={poi.pois}
-        onPoiClick={planner.openAddPlaceFromPoi}
+        onPoiClick={marker => planner.openAddPlaceFromPoi(marker, planner.selectedDayId)}
         onViewportChange={poi.onViewportChange}
         onMapReady={setGlMap}
       />

--- a/client/src/mobile/screens/trip/places/MPlacesBrowser.tsx
+++ b/client/src/mobile/screens/trip/places/MPlacesBrowser.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import {
-  Bookmark, Check, CheckCheck, CheckCircle2, ListChecks, Loader2, MapPin, MoreHorizontal, Plus,
+  Bookmark, Check, CheckCheck, CheckCircle2, Download, ListChecks, Loader2, MapPin, Plus,
   SlidersHorizontal, Tag, Trash2, X,
 } from 'lucide-react'
 import MDancingTrek from '../../../components/MDancingTrek'
@@ -172,7 +172,7 @@ export default function MPlacesBrowser({ planner, shell }: MPlacesBrowserProps) 
               aria-label={t('mobileTrip.importPlaces')}
               className="flex h-10 w-10 flex-none items-center justify-center rounded-full border border-[color:var(--m-rowbr)] bg-[color:var(--m-ic)] text-m-muted"
             >
-              <MoreHorizontal size={16} strokeWidth={2} />
+              <Download size={16} strokeWidth={2} />
             </button>
           )}
         </div>

--- a/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
@@ -1,6 +1,6 @@
 import { useState, type MouseEvent } from 'react'
 import {
-  ArrowRight, ArrowUpRight, BedDouble, CalendarRange, ChevronRight, Compass, LogIn, LogOut,
+  ArrowRight, BedDouble, CalendarDays, CalendarRange, ChevronRight, Compass, LogIn, LogOut,
   MapPin, Pencil, PencilLine, Route, Ticket, TrainFront, Undo2,
   Car, Footprints, Zap, RotateCcw,
 } from 'lucide-react'
@@ -10,14 +10,20 @@ import { fmtTransitDuration } from '../../../../components/Planner/transitDispla
 import { formatTime } from '../../../../utils/formatters'
 import { useMPlanTimeline, type MPlanTimelineController } from './useMPlanTimeline'
 import { cityPillsForDay, weatherIconFor } from './planTimelineModel'
+import type { PlanRow } from './planTimelineModel'
+import { useMPlanDragReorder } from './useMPlanDragReorder'
+import { useTouchDragBridge } from '../../../../hooks/useTouchDragBridge'
+import { useIsTouch } from '../../../../hooks/useIsTouch'
 import { ConnRow, HotelConnRow, NoteRow, PlaceRow, PlanScheduleRow, ReorderStack, TransitRow, TransportRow } from './MPlanTimelineRows'
+import type { RowDrag } from './MPlanTimelineRows'
 import { usePluginDaySchedule } from '../../../../components/Plugins/PluginDaySchedule'
 import { Fragment } from 'react'
 import MDancingTrek from '../../../components/MDancingTrek'
 import type { MPlanTimelineProps } from '../MTripShell'
 import type { MergedItem } from '../../../../utils/dayMerge'
 import type { Assignment } from '../../../../types'
-import type { ReactNode } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+import GoogleMapsIcon from '../../../../components/shared/GoogleMapsIcon'
 
 /**
  * Plan-tab timeline of the mobile trip screen: the UP-NEXT card in go mode,
@@ -48,6 +54,10 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
   const daySchedule = usePluginDaySchedule(planner.tripId)
   const day = tl.day
   const dayId = day?.id
+  // Mirrors MDaySheet's own label so the pill and the sheet it opens agree.
+  const dayLabel = day
+    ? day.title || t('planner.dayN', { n: day.day_number || planner.days.indexOf(day) + 1 })
+    : ''
   const dayScheduleFor = (anchor: 'assignment' | 'reservation', id: number) =>
     (dayId != null
       ? (anchor === 'assignment' ? daySchedule.byAssignment[dayId]?.[id] : daySchedule.byReservation[dayId]?.[id])
@@ -58,6 +68,27 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
   // planner's selection, same contract as map marker taps.
   const openPlace = (assignment: Assignment) => {
     planner.handlePlaceClick(assignment.place?.id ?? null, assignment.id)
+  }
+
+  // Long-press drag reordering (#1997). Armed only in edit mode, so go-mode taps,
+  // map pans and plain list scrolling keep the gesture — which is what kept
+  // #1432/#1440 from coming back when the old document-wide polyfill was dropped.
+  // Coarse pointers only: a hybrid laptop narrow enough to land in the phone
+  // shell already loads drag-drop-touch (utils/touchDragPolyfill), and two
+  // bridges would fight over one gesture. The rows' native drag props serve
+  // both, so nothing is lost there.
+  const isTouch = useIsTouch()
+  useTouchDragBridge(editing && isTouch)
+  const dnd = useMPlanDragReorder({
+    merged: tl.merged,
+    dayId,
+    onMove: tl.moveRowTo,
+    enabled: editing,
+  })
+  const dragFor = (row: PlanRow): RowDrag | undefined => {
+    const props = dnd.dragPropsFor(row)
+    if (!props) return undefined
+    return { ...props, dragging: dnd.draggingKey === row.key, dropTarget: dnd.dropBeforeKey === row.key }
   }
 
   const reorderFor = (item: MergedItem): ReactNode => {
@@ -85,11 +116,19 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
           collapses that reserved space up to the day chips when the day has no
           up-next (no places), so an empty day shows no gap. */}
       <div
+        data-touch-drag={editing ? '' : undefined}
         className="absolute left-4 right-4 overflow-y-auto overscroll-contain rounded-[22px] border border-[color:var(--m-cbr)] bg-[color:var(--m-card)] px-3.5 pb-2 pt-1 backdrop-blur-[24px] backdrop-saturate-[1.6] bottom-[calc(env(safe-area-inset-bottom,0px)+90px)]"
         style={{ top: `calc(var(--m-safe-top, 12px) + ${editing ? 140 : tl.upNext ? 216 : 102}px)` }}
       >
-        {(tl.hotelChips.length > 0 || tl.weatherTemp != null) && (
-          <TimelineHeader tl={tl} onOpenDay={() => day && shell.openSheet('day', { dayId: day.id })} />
+        {day && (
+          <TimelineHeader
+            tl={tl}
+            // Edit mode already names the day in its own header a row above, so
+            // the pill drops to icon-only there rather than saying it twice.
+            dayLabel={editing ? '' : dayLabel}
+            openLabel={t('day.overview')}
+            onOpenDay={() => shell.openSheet('day', { dayId: day.id })}
+          />
         )}
 
         {tl.hotelLegs.top && (
@@ -108,6 +147,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
                     linkedRes={row.linkedRes}
                     chrome={chrome}
                     reorder={reorderFor(row.item)}
+                    drag={dragFor(row)}
                     onOpen={() => openPlace(row.assignment)}
                     onEdit={() => tl.editAssignment(row.assignment)}
                     onRemove={() => tl.removeAssignment(row.assignment)}
@@ -123,6 +163,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
                     dayId={day.id}
                     chrome={chrome}
                     reorder={reorderFor(row.item)}
+                    drag={dragFor(row)}
                     onOpen={() => {
                       if (editing) tl.editTransport(row.res)
                       else shell.openSheet('transport', { reservationId: row.res.id })
@@ -141,6 +182,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
                     open={tl.openTransitKeys.has(row.key)}
                     chrome={chrome}
                     reorder={reorderFor(row.item)}
+                    drag={dragFor(row)}
                     onToggle={() => tl.toggleTransit(row.key)}
                     onOpenJourney={() => tl.openTransitJourney(row.res)}
                   />
@@ -154,6 +196,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
                   note={row.note}
                   chrome={chrome}
                   reorder={reorderFor(row.item)}
+                  drag={dragFor(row)}
                   onEdit={() => shell.openSheet('note', { dayId: day.id, note: row.note })}
                 />
               )
@@ -185,7 +228,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
             <PlanAction icon={Ticket} label={t('mobileTrip.addBookingShort')} onClick={tl.addBooking} />
             <PlanAction icon={TrainFront} label={t('mobileTrip.addTransportShort')} onClick={tl.addTransport} />
             <PlanAction icon={Route} label={t('dayplan.optimize')} onClick={() => void tl.optimize()} />
-            <PlanAction icon={ArrowUpRight} label={t('mobileTrip.googleMaps')} onClick={tl.exportGoogleMaps} />
+            <PlanAction icon={GoogleMapsIcon} label={t('mobileTrip.googleMaps')} onClick={tl.exportGoogleMaps} />
             <PlanAction icon={Compass} label={t('mobileTrip.coMaps')} onClick={tl.exportCoMaps} />
           </div>
         )}
@@ -316,12 +359,34 @@ function EditHeader({ tl, planner, shell }: {
   )
 }
 
-/** Card header: accommodation chips (check-out / check-in / stay) + the weather chip. */
-function TimelineHeader({ tl, onOpenDay }: { tl: MPlanTimelineController; onOpenDay: () => void }) {
+/**
+ * Card header: the day pill that opens the day sheet, the accommodation chips
+ * (check-out / check-in / stay) and the weather chip.
+ *
+ * The day pill leads unconditionally. It used to be the accommodation chip that
+ * carried this, which left a day without a stay — and, with no weather either,
+ * the whole header — with no way into the day sheet at all (#2004).
+ */
+function TimelineHeader({ tl, dayLabel, openLabel, onOpenDay }: {
+  tl: MPlanTimelineController
+  dayLabel: string
+  openLabel: string
+  onOpenDay: () => void
+}) {
   const WeatherIcon = weatherIconFor(tl.weather?.main)
   return (
     <div className="flex items-center gap-1.5 border-b border-[color:var(--m-rowbr)] px-0.5 py-[9px]">
       <span className="flex min-w-0 items-center gap-1.5 overflow-x-auto">
+        <button
+          type="button"
+          onClick={onOpenDay}
+          aria-label={openLabel}
+          className="flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full bg-[color:var(--m-ic)] px-2.5 py-1 font-geist text-[0.6875rem] font-semibold"
+        >
+          <CalendarDays size={12} strokeWidth={2.2} className="text-m-muted" />
+          {dayLabel}
+          <ChevronRight size={11} strokeWidth={2.4} aria-hidden="true" className="text-m-faint" />
+        </button>
         {tl.hotelChips.map(chip => (
           <button
             key={chip.key}
@@ -336,10 +401,15 @@ function TimelineHeader({ tl, onOpenDay }: { tl: MPlanTimelineController; onOpen
         ))}
       </span>
       {tl.weatherTemp != null && (
-        <span className="ml-auto flex flex-none items-center gap-1 whitespace-nowrap px-1.5 py-1 text-[0.71875rem] font-semibold">
+        <button
+          type="button"
+          onClick={onOpenDay}
+          aria-label={openLabel}
+          className="ml-auto flex flex-none items-center gap-1 whitespace-nowrap px-1.5 py-1 text-[0.71875rem] font-semibold"
+        >
           <WeatherIcon size={13} strokeWidth={2} />
           {tl.weatherTemp}°
-        </span>
+        </button>
       )}
     </div>
   )
@@ -353,7 +423,12 @@ function HotelChipIcon({ variant }: { variant: 'checkout' | 'checkin' | 'stay' }
 }
 
 /** Edit-mode action tile — Place · Note · Booking · Transport · Optimize · Google Maps, three per row. */
-function PlanAction({ icon: Icon, label, onClick }: { icon: LucideIcon; label: string; onClick: () => void }) {
+function PlanAction({ icon: Icon, label, onClick }: {
+  // Google Maps hands in its own brand mark, which is not a lucide icon (#2005).
+  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>
+  label: string
+  onClick: () => void
+}) {
   return (
     <button
       type="button"

--- a/client/src/mobile/screens/trip/plan/MPlanTimelineRows.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimelineRows.tsx
@@ -12,6 +12,7 @@ import { getDisplayTimeForDay, getSpanPhase } from '../../../../utils/dayMerge'
 import { formatTime, splitReservationDateTime } from '../../../../utils/formatters'
 import { transportSubtitle, type TransitMeta, type TransportEntry } from './planTimelineModel'
 import { splitNoteTime } from '../lib/dayNotes'
+import type { DragRowProps } from './useMPlanDragReorder'
 import type { TransitLegDisplay } from '../../../../components/Planner/transitDisplay'
 import type { Assignment, DayNote, Place, Reservation, RouteSegment, TranslationFn } from '../../../../types'
 import { formatScheduleMinutes } from '../../../../components/Plugins/PluginDaySchedule'
@@ -21,7 +22,11 @@ import type { PluginDayScheduleItem } from '../../../../api/client'
  * The five row types of the mobile day timeline (place / manual transport /
  * auto-transit with collapsible legs / travel-time connector / note), each in
  * its go and edit variant. Edit rows swap the left avatar for right-hand action
- * circles; reordering is button-based — no drag on touch (#1432).
+ * circles.
+ *
+ * Reordering has two paths: the up/down stack, and — since #1997 — a long-press
+ * drag carried by `utils/touchDragBridge`. `drag` below is the second one's props;
+ * it is undefined outside edit mode, which is what keeps a plain scroll a scroll.
  */
 
 interface RowChrome {
@@ -30,6 +35,20 @@ interface RowChrome {
   language: string
   timeFormat: string
 }
+
+/** Native drag props from useMPlanDragReorder, plus the row's own drag state. */
+export interface RowDrag extends DragRowProps {
+  dragging: boolean
+  dropTarget: boolean
+}
+
+/** Dims the travelling row and rules a line where the drop would land. */
+const dragClass = (d?: RowDrag): string =>
+  !d ? '' : `${d.dragging ? 'opacity-40' : ''} ${d.dropTarget && !d.dragging ? 'shadow-[inset_0_2px_0_0_var(--m-act)]' : ''}`
+
+/** Only the props a DOM node takes — `dragging`/`dropTarget` are ours. */
+const dragProps = (d?: RowDrag) =>
+  d ? { draggable: d.draggable, onDragStart: d.onDragStart, onDragOver: d.onDragOver, onDrop: d.onDrop, onDragEnd: d.onDragEnd } : {}
 
 const fmtTime = (time: string | null | undefined, c: RowChrome): string =>
   time ? formatTime(time.slice(0, 5), c.language, c.timeFormat) : ''
@@ -100,12 +119,13 @@ const TIME_CHIP = 'flex-none whitespace-nowrap rounded-[6px] bg-[color:var(--m-i
 
 // ── b3) Place row ────────────────────────────────────────────────────────────
 
-export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, onOpen, onEdit, onRemove }: {
+export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, drag, onOpen, onEdit, onRemove }: {
   assignment: Assignment
   fullPlace: Place | undefined
   linkedRes: Reservation | null
   chrome: RowChrome
   reorder: ReactNode
+  drag?: RowDrag
   onOpen: () => void
   onEdit: () => void
   onRemove: () => void
@@ -122,7 +142,7 @@ export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, on
     : place?.address || place?.description || ''
 
   return (
-    <div onClick={onOpen} className="flex cursor-pointer items-center gap-2.5 py-1.5">
+    <div {...dragProps(drag)} onClick={onOpen} className={`flex cursor-pointer items-center gap-2.5 py-1.5 ${dragClass(drag)}`}>
       {!chrome.editing && (
         <AvatarRing className="shadow-[0_3px_8px_-3px_rgba(0,0,0,.4)]">
           <PlaceAvatar
@@ -175,11 +195,12 @@ export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, on
 
 // ── b1) Manual transport / booking row ───────────────────────────────────────
 
-export function TransportRow({ res, dayId, chrome, reorder, onOpen }: {
+export function TransportRow({ res, dayId, chrome, reorder, drag, onOpen }: {
   res: TransportEntry
   dayId: number
   chrome: RowChrome
   reorder: ReactNode
+  drag?: RowDrag
   onOpen: () => void
 }) {
   const Icon = RES_ICONS[res.type as keyof typeof RES_ICONS] || Ticket
@@ -192,7 +213,7 @@ export function TransportRow({ res, dayId, chrome, reorder, onOpen }: {
   const sub = transportSubtitle(res)
 
   return (
-    <div onClick={onOpen} className="mt-1.5 flex cursor-pointer items-center gap-2.5">
+    <div {...dragProps(drag)} onClick={onOpen} className={`mt-1.5 flex cursor-pointer items-center gap-2.5 ${dragClass(drag)}`}>
       {!chrome.editing && (
         <AvatarRing>
           <Icon size={14} strokeWidth={2} />
@@ -313,13 +334,14 @@ function TransitLegRows({ legs, t }: { legs: TransitLegDisplay[]; t: Translation
   )
 }
 
-export function TransitRow({ res, transit, dayId, open, chrome, reorder, onToggle, onOpenJourney }: {
+export function TransitRow({ res, transit, dayId, open, chrome, reorder, drag, onToggle, onOpenJourney }: {
   res: TransportEntry
   transit: TransitMeta
   dayId: number
   open: boolean
   chrome: RowChrome
   reorder: ReactNode
+  drag?: RowDrag
   onToggle: () => void
   onOpenJourney: () => void
 }) {
@@ -331,7 +353,7 @@ export function TransitRow({ res, transit, dayId, open, chrome, reorder, onToggl
   const Chevron = open ? ChevronUp : ChevronDown
 
   return (
-    <div className="mt-1.5 flex items-start gap-2.5">
+    <div {...dragProps(drag)} className={`mt-1.5 flex items-start gap-2.5 ${dragClass(drag)}`}>
       {!chrome.editing && (
         <AvatarRing className="mt-1">
           <Icon size={14} strokeWidth={2} />
@@ -458,10 +480,11 @@ export function HotelConnRow({ seg, name, placement }: {
 
 // ── b5) Day-note row ─────────────────────────────────────────────────────────
 
-export function NoteRow({ note, chrome, reorder, onEdit }: {
+export function NoteRow({ note, chrome, reorder, drag, onEdit }: {
   note: DayNote
   chrome: RowChrome
   reorder: ReactNode
+  drag?: RowDrag
   onEdit: () => void
 }) {
   const Icon = getNoteIcon(note.icon)
@@ -474,8 +497,9 @@ export function NoteRow({ note, chrome, reorder, onEdit }: {
 
   return (
     <div
+      {...dragProps(drag)}
       onClick={chrome.editing ? onEdit : undefined}
-      className={`my-[2px] flex items-center gap-2.5 ${chrome.editing ? 'cursor-pointer' : ''}`}
+      className={`my-[2px] flex items-center gap-2.5 ${chrome.editing ? 'cursor-pointer' : ''} ${dragClass(drag)}`}
     >
       {!chrome.editing && (
         <AvatarRing style={note.color ? { background: skin.iconBackground, borderColor: skin.border } : undefined}>

--- a/client/src/mobile/screens/trip/plan/useMPlanDragReorder.test.ts
+++ b/client/src/mobile/screens/trip/plan/useMPlanDragReorder.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useMPlanDragReorder } from './useMPlanDragReorder'
+import type { MergedItem } from '../../../../utils/dayMerge'
+import type { PlanRow } from './planTimelineModel'
+
+const items = [
+  { type: 'place', data: { id: 1 } },
+  { type: 'place', data: { id: 2 } },
+  { type: 'note', data: { id: 3 } },
+] as unknown as MergedItem[]
+
+const rowFor = (i: number): PlanRow =>
+  ({ key: `row-${i}`, kind: 'place', item: items[i], assignment: {}, linkedRes: null }) as unknown as PlanRow
+
+const connRow = { key: 'conn-1', kind: 'conn', seg: {} } as unknown as PlanRow
+
+/** A DragEvent stand-in with just the parts the hook touches. */
+const dragEvent = () => {
+  const store = new Map<string, string>()
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: {
+      setData: (k: string, v: string) => store.set(k, v),
+      getData: (k: string) => store.get(k) ?? '',
+      set effectAllowed(_v: string) { /* noop */ },
+    },
+  } as never
+}
+
+const setup = (enabled = true) => {
+  const onMove = vi.fn()
+  const hook = renderHook(() => useMPlanDragReorder({ merged: items, dayId: 7, onMove, enabled }))
+  return { ...hook, onMove }
+}
+
+describe('useMPlanDragReorder', () => {
+  it('FE-MOB-DRAG-001: hands out nothing while disabled', () => {
+    const { result } = setup(false)
+    expect(result.current.dragPropsFor(rowFor(0))).toBeUndefined()
+    expect(result.current.draggingKey).toBeNull()
+  })
+
+  it('FE-MOB-DRAG-002: hands out nothing without a day', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() =>
+      useMPlanDragReorder({ merged: items, dayId: null, onMove, enabled: true }))
+    expect(result.current.dragPropsFor(rowFor(0))).toBeUndefined()
+  })
+
+  it('FE-MOB-DRAG-003: leaves connector rows undraggable — they are computed spacing', () => {
+    const { result } = setup()
+    expect(result.current.dragPropsFor(connRow)).toBeUndefined()
+  })
+
+  it('FE-MOB-DRAG-004: marks the travelling row and the row it would land in front of', () => {
+    const { result } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(0))!.onDragStart(dragEvent()) })
+    expect(result.current.draggingKey).toBe('row-0')
+
+    act(() => { result.current.dragPropsFor(rowFor(2))!.onDragOver(dragEvent()) })
+    expect(result.current.dropBeforeKey).toBe('row-2')
+  })
+
+  it('FE-MOB-DRAG-005: moves the source to the target index on drop', () => {
+    const { result, onMove } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(0))!.onDragStart(dragEvent()) })
+    act(() => { result.current.dragPropsFor(rowFor(2))!.onDrop(dragEvent()) })
+
+    expect(onMove).toHaveBeenCalledWith(items[0], 2)
+    // and the drag state is cleared again
+    expect(result.current.draggingKey).toBeNull()
+    expect(result.current.dropBeforeKey).toBeNull()
+  })
+
+  it('FE-MOB-DRAG-006: a drop on the row itself is not a move', () => {
+    const { result, onMove } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(1))!.onDragStart(dragEvent()) })
+    act(() => { result.current.dragPropsFor(rowFor(1))!.onDrop(dragEvent()) })
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('FE-MOB-DRAG-007: a drop without a drag start is ignored', () => {
+    const { result, onMove } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(1))!.onDrop(dragEvent()) })
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('FE-MOB-DRAG-008: dragOver accepts the drop so the touch bridge can read it', () => {
+    const { result } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(0))!.onDragStart(dragEvent()) })
+    const e = dragEvent() as unknown as { preventDefault: ReturnType<typeof vi.fn> }
+    act(() => { result.current.dragPropsFor(rowFor(1))!.onDragOver(e as never) })
+    expect(e.preventDefault).toHaveBeenCalled()
+  })
+
+  it('FE-MOB-DRAG-009: dragEnd clears the state without moving anything', () => {
+    const { result, onMove } = setup()
+    act(() => { result.current.dragPropsFor(rowFor(0))!.onDragStart(dragEvent()) })
+    act(() => { result.current.dragPropsFor(rowFor(0))!.onDragEnd() })
+    expect(result.current.draggingKey).toBeNull()
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('FE-MOB-DRAG-010: survives a DataTransfer shim that refuses setData', () => {
+    const { result } = setup()
+    const broken = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      dataTransfer: { setData: () => { throw new Error('nope') } },
+    } as never
+    expect(() => act(() => { result.current.dragPropsFor(rowFor(0))!.onDragStart(broken) })).not.toThrow()
+    expect(result.current.draggingKey).toBe('row-0')
+  })
+})

--- a/client/src/mobile/screens/trip/plan/useMPlanDragReorder.ts
+++ b/client/src/mobile/screens/trip/plan/useMPlanDragReorder.ts
@@ -1,0 +1,105 @@
+import { useCallback, useRef, useState, type DragEvent } from 'react'
+import type { MergedItem } from '../../../../utils/dayMerge'
+import type { PlanRow } from './planTimelineModel'
+
+interface DragReorderArgs {
+  /** The day's items in merged order — the space a reorder is expressed in. */
+  merged: MergedItem[]
+  dayId: number | null | undefined
+  /** Same mover the up/down buttons use, so both paths share every guard. */
+  onMove: (item: MergedItem, toIndex: number) => void
+  enabled: boolean
+}
+
+export interface DragRowProps {
+  draggable: boolean
+  onDragStart: (e: DragEvent) => void
+  onDragOver: (e: DragEvent) => void
+  onDrop: (e: DragEvent) => void
+  onDragEnd: () => void
+}
+
+export interface MPlanDragReorder {
+  /** Key of the row under the finger, so it can be dimmed while it travels. */
+  draggingKey: string | null
+  /** Key of the row the drop would land in front of, for the insertion line. */
+  dropBeforeKey: string | null
+  dragPropsFor: (row: PlanRow) => DragRowProps | undefined
+}
+
+const NO_DRAG: MPlanDragReorder = {
+  draggingKey: null,
+  dropBeforeKey: null,
+  dragPropsFor: () => undefined,
+}
+
+/**
+ * Long-press drag reordering for the mobile day timeline (#1997).
+ *
+ * The phone shell shipped with up/down buttons only, on the reasoning that a
+ * finger cannot start an HTML5 drag (#1265) and that the document-wide
+ * `drag-drop-touch` polyfill which used to paper over that broke list scrolling
+ * (#1432) and hijacked map pans (#1440). `utils/touchDragBridge` already solved
+ * that for tablets (#1616): it watches only `[draggable]` rows inside an opted-in
+ * `[data-touch-drag]` container, waits out a 320ms press before it claims the
+ * gesture — so a swipe is still a scroll — and then replays real drag events.
+ * This hook is the receiving half the mobile timeline was missing.
+ *
+ * Rows carry native drag props, which means the same code also works with a
+ * mouse (tablet with a trackpad, desktop dev tools) at no extra cost.
+ *
+ * The up/down buttons stay exactly where they are: they are the accessible path,
+ * and they are what still works when a drag is not practical.
+ */
+export function useMPlanDragReorder({ merged, dayId, onMove, enabled }: DragReorderArgs): MPlanDragReorder {
+  const [draggingKey, setDraggingKey] = useState<string | null>(null)
+  const [dropBeforeKey, setDropBeforeKey] = useState<string | null>(null)
+  // The bridge's DataTransfer is a shim on browsers that refuse `new DataTransfer()`,
+  // so the source also rides along in a ref — same as the desktop sidebar does.
+  const sourceRef = useRef<MergedItem | null>(null)
+
+  const clear = useCallback(() => {
+    sourceRef.current = null
+    setDraggingKey(null)
+    setDropBeforeKey(null)
+  }, [])
+
+  const dragPropsFor = useCallback((row: PlanRow): DragRowProps | undefined => {
+    // Connector rows are computed spacing between two stops, not items.
+    if (!enabled || dayId == null || row.kind === 'conn') return undefined
+    const item = row.item
+
+    return {
+      draggable: true,
+      onDragStart: (e: DragEvent) => {
+        sourceRef.current = item
+        setDraggingKey(row.key)
+        try {
+          e.dataTransfer.setData('planRowKey', row.key)
+          e.dataTransfer.effectAllowed = 'move'
+        } catch { /* the bridge's shim may not implement every DataTransfer member */ }
+      },
+      onDragOver: (e: DragEvent) => {
+        if (!sourceRef.current) return
+        // preventDefault is how a drop target says yes — the bridge reads it too.
+        e.preventDefault()
+        e.stopPropagation()
+        setDropBeforeKey(prev => (prev === row.key ? prev : row.key))
+      },
+      onDrop: (e: DragEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+        const source = sourceRef.current
+        clear()
+        if (!source || source === item) return
+        const to = merged.indexOf(item)
+        if (to < 0) return
+        onMove(source, to)
+      },
+      onDragEnd: clear,
+    }
+  }, [enabled, dayId, merged, onMove, clear])
+
+  if (!enabled) return NO_DRAG
+  return { draggingKey, dropBeforeKey, dragPropsFor }
+}

--- a/client/src/mobile/screens/trip/plan/useMPlanTimeline.ts
+++ b/client/src/mobile/screens/trip/plan/useMPlanTimeline.ts
@@ -211,14 +211,18 @@ export function useMPlanTimeline(planner: TripPlanner) {
     }
   }, [dayAssignments, tripActions, tripId, pushUndo, updateRouteForDay, toast, t])
 
-  const moveRow = useCallback((item: MergedItem, direction: 'up' | 'down') => {
+  /**
+   * Moves an item to an arbitrary slot. The buttons swap with a neighbour, a
+   * drag lands anywhere (#1997) — both come through here so the chronology
+   * guard and the undo entry stay identical either way.
+   */
+  const moveRowTo = useCallback((item: MergedItem, toIndex: number) => {
     if (!day) return
     const idx = merged.indexOf(item)
-    const target = direction === 'up' ? idx - 1 : idx + 1
-    if (idx < 0 || target < 0 || target >= merged.length) return
+    if (idx < 0 || toIndex < 0 || toIndex >= merged.length || toIndex === idx) return
     const newOrder = [...merged]
-    newOrder[idx] = merged[target]
-    newOrder[target] = item
+    newOrder.splice(idx, 1)
+    newOrder.splice(toIndex, 0, item)
     // Same guard as the desktop arrow buttons: a TIMED item may not jump past
     // other timed items (untimed items move freely and keep their neighbours).
     if (itemHasTime(item, day.id) && breaksChronology(newOrder, day.id, getDisplayTimeForDay)) {
@@ -227,6 +231,11 @@ export function useMPlanTimeline(planner: TripPlanner) {
     }
     void applyMergedOrder(day.id, newOrder)
   }, [day, merged, applyMergedOrder, toast, t])
+
+  const moveRow = useCallback((item: MergedItem, direction: 'up' | 'down') => {
+    const idx = merged.indexOf(item)
+    moveRowTo(item, direction === 'up' ? idx - 1 : idx + 1)
+  }, [merged, moveRowTo])
 
   // ── Place actions ──
   const removeAssignment = useCallback((assignment: Assignment) => {
@@ -240,18 +249,22 @@ export function useMPlanTimeline(planner: TripPlanner) {
   }, [planner])
 
   // ── Add bar ──
+  // Both of these sit inside a day's toolbar, so the day is the context — the
+  // place gets assigned to it on save and the booking opens pre-dated (#1998).
   const addPlace = useCallback(() => {
     planner.setEditingPlace(null)
     planner.setEditingAssignmentId(null)
     planner.setPrefillCoords(null)
+    planner.setPlaceFormDayId(day?.id ?? null)
     planner.setShowPlaceForm(true)
-  }, [planner])
+  }, [planner, day])
 
   const addBooking = useCallback(() => {
     planner.setEditingReservation(null)
     planner.setBookingForAssignmentId(null)
+    planner.setReservationModalDayId(day?.id ?? null)
     planner.setShowReservationModal(true)
-  }, [planner])
+  }, [planner, day])
 
   const addTransport = useCallback(() => {
     planner.setEditingTransport(null)
@@ -360,6 +373,7 @@ export function useMPlanTimeline(planner: TripPlanner) {
     language, timeFormat: settings.time_format,
     openTransitKeys, toggleTransit,
     moveRow, removeAssignment, editAssignment, editTransport, openTransitJourney,
+    moveRowTo,
     addPlace, addBooking, addTransport,
     optimize, exportGoogleMaps, exportCoMaps, renameDay, fullPlaceOf,
     routeModeOptions, setLegMode,

--- a/client/src/mobile/screens/trip/sheets/ImpFileStep.tsx
+++ b/client/src/mobile/screens/trip/sheets/ImpFileStep.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Check, Upload } from 'lucide-react'
+import { Check, FileDown } from 'lucide-react'
 import { placesApi } from '../../../../api/client'
 import { Eyebrow, FormSheetFooter } from './PlSheetChrome'
 import type { TripPlanner } from '../MTripShell'
@@ -170,7 +170,7 @@ export default function ImpFileStep({ planner, onBack, onDone }: ImpFileStepProp
           onClick={() => inputRef.current?.click()}
           className="mt-3 flex min-h-[88px] w-full flex-col items-center justify-center gap-[6px] rounded-[14px] border-[1.5px] border-dashed border-[color:var(--m-trackoff)] p-4"
         >
-          <Upload size={17} strokeWidth={1.9} className="text-m-faint" />
+          <FileDown size={17} strokeWidth={1.9} className="text-m-faint" />
           {files.length > 0 ? (
             <span className="break-all text-center text-[0.78125rem] font-semibold text-m-ink">
               {files.map(f => f.name).join(', ')}

--- a/client/src/mobile/screens/trip/sheets/MDaySheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MDaySheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
-  CalendarDays, Car, Compass, Footprints, Hotel, Pencil, Plus, RotateCcw,
+  CalendarDays, Car, Compass, Footprints, Hotel, MapPin, Pencil, Plus, RotateCcw,
   Route as RouteIcon, TramFront, Zap,
 } from 'lucide-react'
 import type { WeatherResult } from '@trek/shared'
@@ -15,6 +15,7 @@ import { RES_ICONS, getNoteIcon } from '../../../../components/Planner/DayPlanSi
 import { getDayBookendHotels, isDayInAccommodationRange } from '../../../../utils/dayOrder'
 import { splitReservationDateTime } from '../../../../utils/formatters'
 import { dayCoMapsUrl, dayGoogleMapsUrl, optimizeDayOrder } from '../lib/dayRoute'
+import GoogleMapsIcon from '../../../../components/shared/GoogleMapsIcon'
 import { splitNoteTime } from '../lib/dayNotes'
 import { weatherIconFor } from '../plan/planTimelineModel'
 import type { Assignment, DayNote, Reservation } from '../../../../types'
@@ -197,6 +198,18 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
     shell.openSheet('accommodation', { dayId: day.id })
   }
 
+  // Tapping the stay opens the stay. It used to open the place the stay is
+  // pinned to, which put check-in/check-out/confirmation out of reach entirely —
+  // MAccommodationSheet has taken an accId all along, nothing ever passed one (#2001).
+  const editAccommodation = (accId: number) => {
+    if (!day) return
+    shell.openSheet('accommodation', { dayId: day.id, accId })
+  }
+  const openAccommodationPlace = (placeId: number) => {
+    shell.closeSheet()
+    planner.handlePlaceClick(placeId)
+  }
+
   const cTemp = (c: number) => Math.round(isFahrenheit ? c * 9 / 5 + 32 : c)
   const formattedDate = day?.date
     ? new Date(`${day.date.slice(0, 10)}T00:00:00Z`).toLocaleDateString(locale, {
@@ -328,12 +341,7 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
                     onClick={openInGoogleMaps}
                     className={`flex items-center gap-[5px] rounded-full px-3 py-[7px] text-[0.75rem] font-semibold text-m-ink ${INNER_CLS}`}
                   >
-                    <svg width="13" height="13" viewBox="0 0 48 48" fill="currentColor" aria-hidden="true">
-                      <path d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
-                      <path d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
-                      <path d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
-                      <path d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
-                    </svg>
+                    <GoogleMapsIcon size={13} />
                     {t('planner.openGoogleMaps')}
                   </button>
                 )}
@@ -460,10 +468,15 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
                   const linked = planner.reservations.find(r => String(r.accommodation_id ?? '') === String(acc.id))
                   return (
                     <div key={acc.id} className={`rounded-[16px] px-3 py-[11px] ${INNER_CLS}`}>
-                      <div
-                        className="flex items-center gap-[10px]"
-                        onClick={() => { if (acc.place_id) { shell.closeSheet(); planner.handlePlaceClick(acc.place_id) } }}
-                      >
+                      <div className="flex items-center gap-[10px]">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (canEditDays) editAccommodation(acc.id)
+                            else if (acc.place_id) openAccommodationPlace(acc.place_id)
+                          }}
+                          className="flex min-w-0 flex-1 items-center gap-[10px] text-left"
+                        >
                         {acc.place_image ? (
                           <div
                             className="h-10 w-10 flex-none rounded-[12px] bg-cover bg-center"
@@ -480,9 +493,20 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
                             <div className="truncate font-geist text-[0.65625rem] text-m-muted">{acc.place_address}</div>
                           )}
                         </div>
+                        </button>
                         <span className={`flex-none rounded-full border px-[7px] py-[2px] text-[0.5625rem] font-bold uppercase tracking-[.05em] ${badge.cls}`}>
                           {badge.label}
                         </span>
+                        {canEditDays && acc.place_id != null && (
+                          <button
+                            type="button"
+                            onClick={() => openAccommodationPlace(acc.place_id as number)}
+                            aria-label={t('mobileTrip.viewDetails')}
+                            className="flex flex-none p-[3px] text-m-faint"
+                          >
+                            <MapPin size={13} strokeWidth={1.8} />
+                          </button>
+                        )}
                       </div>
                       {(acc.check_in || acc.check_out || acc.confirmation) && (
                         <div className="mt-[10px] flex gap-[6px]">
@@ -501,7 +525,13 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
                         </div>
                       )}
                       {linked && (
-                        <div className="mt-2 flex items-center gap-2">
+                        // The day's booking list filters hotels out, so this strip is
+                        // the only place the stay's booking shows up — it may as well open it.
+                        <button
+                          type="button"
+                          onClick={() => openReservation(linked)}
+                          className="mt-2 flex w-full items-center gap-2 text-left"
+                        >
                           <span
                             className="h-2 w-2 flex-none rounded-full"
                             style={{ background: linked.status === 'confirmed' ? 'var(--m-st-confirmed)' : 'var(--m-st-pending)' }}
@@ -510,7 +540,7 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
                             {linked.status === 'confirmed' ? t('reservations.confirmed') : t('reservations.pending')}
                             {linked.confirmation_number ? ` · #${linked.confirmation_number}` : ''}
                           </span>
-                        </div>
+                        </button>
                       )}
                     </div>
                   )

--- a/client/src/mobile/screens/trip/sheets/MImportSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MImportSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { ChevronLeft, ChevronRight, Download, MapPin, Upload } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Download, FileDown, MapPin } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import MSheet from '../../../components/MSheet'
 import MIconBtn from '../../../components/MIconBtn'
@@ -51,7 +51,7 @@ export default function MImportSheet({ planner, open, onClose }: MImportSheetPro
       {step === 'menu' && (
         <div className="px-[14px] pb-[14px] pt-1">
           <ImpMenuRow
-            icon={Upload}
+            icon={FileDown}
             title={t('places.importFile')}
             sub="GPX · KML · KMZ"
             onClick={() => setStep('file')}

--- a/client/src/mobile/screens/trip/sheets/MPlaceEditSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MPlaceEditSheet.tsx
@@ -181,6 +181,7 @@ export default function MPlaceEditSheet({ planner, onOpenExpense }: MPlaceEditSh
     setEditingPlace(null)
     setEditingAssignmentId(null)
     setPrefillCoords(null)
+    planner.setPlaceFormDayId(null)
     if (deleteArmed) setDeletePlaceId(null)
   }
 

--- a/client/src/mobile/screens/trip/sheets/MReservationSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MReservationSheet.tsx
@@ -125,7 +125,22 @@ export default function MReservationSheet({ planner, onOpenExpense }: MReservati
       })
       setPendingFiles(pf._sourceFiles ?? [])
     } else {
-      setForm(EMPTY)
+      // Opened from a day's toolbar: start on that day rather than on a blank
+      // date the user has to look up again (#1998). A hotel spans to the next
+      // day, which is what checking in on this day actually means.
+      const ctxDay = planner.reservationModalDayId != null
+        ? days.find(d => d.id === planner.reservationModalDayId)
+        : undefined
+      const ctxDate = ctxDay?.date ? ctxDay.date.slice(0, 10) : ''
+      const nextDay = ctxDay ? days[days.indexOf(ctxDay) + 1] : undefined
+      setForm(ctxDate
+        ? {
+            ...EMPTY,
+            reservation_time: ctxDate,
+            hotel_start_day: ctxDay!.id,
+            hotel_end_day: nextDay?.id ?? ctxDay!.id,
+          }
+        : EMPTY)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showReservationModal])
@@ -186,6 +201,7 @@ export default function MReservationSheet({ planner, onOpenExpense }: MReservati
 
   const handleClose = () => {
     if (importReviewActive) { advanceImportReview(); return }
+    planner.setReservationModalDayId(null)
     setShowReservationModal(false)
     setEditingReservation(null)
     setBookingForAssignmentId(null)

--- a/client/src/mobile/screens/trip/tabs/MPackingImportSheet.tsx
+++ b/client/src/mobile/screens/trip/tabs/MPackingImportSheet.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Upload } from 'lucide-react'
+import { FileDown } from 'lucide-react'
 import MSheet from '../../../components/MSheet'
 import { Eyebrow, FIELD_AREA_CLS, FormSheetFooter, FormSheetHeader } from '../sheets/PlSheetChrome'
 import { packingApi } from '../../../../api/client'
@@ -74,7 +74,7 @@ export default function MPackingImportSheet({ planner, open, onClose }: MPacking
           onClick={() => fileInputRef.current?.click()}
           className="mt-2 flex items-center gap-[6px] rounded-full border border-[color:var(--m-rowbr)] bg-[color:var(--m-ic)] px-[13px] py-[7px] text-[0.75rem] font-semibold text-m-muted"
         >
-          <Upload size={12} strokeWidth={2.2} />
+          <FileDown size={12} strokeWidth={2.2} />
           {t('packing.importCsv')}
         </button>
 

--- a/client/src/mobile/screens/trip/tabs/MPackingListTab.tsx
+++ b/client/src/mobile/screens/trip/tabs/MPackingListTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import {
   Briefcase, Check, CheckCheck, ChevronDown, ChevronUp, HandHelping,
-  LayoutTemplate, MoreHorizontal, Package, Pencil, Plus, RotateCcw, Save as SaveIcon, Trash2, Upload, UserPlus, UserRound,
+  Download, LayoutTemplate, MoreHorizontal, Package, Pencil, Plus, RotateCcw, Save as SaveIcon, Trash2, UserPlus, UserRound,
 } from 'lucide-react'
 import MDancingTrek from '../../../components/MDancingTrek'
 import { useAuthStore } from '../../../../store/authStore'
@@ -323,7 +323,7 @@ export default function MPackingListTab({ planner }: { planner: TripPlanner }) {
               {isAdmin && items.length > 0 && (
                 <ActionRow icon={SaveIcon} label={t('packing.saveAsTemplate')} onClick={() => setActionView('save')} />
               )}
-              <ActionRow icon={Upload} label={t('packing.import')} onClick={() => { setActionsOpen(false); setShowImportSheet(true) }} />
+              <ActionRow icon={Download} label={t('packing.import')} onClick={() => { setActionsOpen(false); setShowImportSheet(true) }} />
             </>
           )}
           {actionView === 'apply' && (

--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -43,7 +43,7 @@ import { useRouteCalculation } from '../hooks/useRouteCalculation'
 import { usePlaceSelection } from '../hooks/usePlaceSelection'
 import { usePlannerHistory } from '../hooks/usePlannerHistory'
 import type { Accommodation, TripMember, Day, Place, Reservation, PackingItem, TodoItem } from '../types'
-import { ListTodo, Upload, Plus, Trash2, FolderPlus } from 'lucide-react'
+import { ListTodo, Download, Plus, Trash2, FolderPlus } from 'lucide-react'
 import { useTripPlanner } from './tripPlanner/useTripPlanner'
 import { usePoiExplore } from '../components/Map/usePoiExplore'
 import PoiCategoryPill from '../components/Map/PoiCategoryPill'
@@ -189,7 +189,7 @@ function ListsContainer({ tripId, packingItems, todoItems }: { tripId: number; p
                   className={`${sharedBtnClass} bg-accent text-accent-text`}
                   style={sharedBtnStyle}
                 >
-                  <Upload size={14} strokeWidth={2.5} />
+                  <Download size={14} strokeWidth={2.5} />
                   <span className="hidden sm:inline">{t('packing.import')}</span>
                 </button>
               </div>

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -200,11 +200,16 @@ export function useTripPlanner() {
   const [editingPlace, setEditingPlace] = useState<Place | null>(null)
   const [prefillCoords, setPrefillCoords] = useState<{ lat: number; lng: number; name?: string; address?: string; website?: string; phone?: string; osm_id?: string } | null>(null)
   const [editingAssignmentId, setEditingAssignmentId] = useState<number | null>(null)
+  // Day context of the open form. Set only by the day-scoped entry points (the
+  // mobile day toolbar, a long-press on the mobile map); every other opener
+  // clears it, so a place added from the pool still lands in the pool (#1998).
+  const [placeFormDayId, setPlaceFormDayId] = useState<number | null>(null)
+  const [reservationModalDayId, setReservationModalDayId] = useState<number | null>(null)
 
   // The bottom-nav "+" opens the new-place form via ?create=place.
   useEffect(() => {
     if (searchParams.get('create') === 'place') {
-      setEditingPlace(null); setEditingAssignmentId(null); setShowPlaceForm(true)
+      setEditingPlace(null); setEditingAssignmentId(null); setPlaceFormDayId(null); setShowPlaceForm(true)
       setSearchParams(p => { p.delete('create'); return p }, { replace: true })
     }
   }, [searchParams])
@@ -268,7 +273,30 @@ export function useTripPlanner() {
   // Manual route planning: off by default, toggled from the day-plan footer. Mode
   // is per-session and selects which travel time the connectors show — either a
   // built-in OSRM profile or a plugin route profile ('plugin:<id>/<profile>').
-  const [routeShown, setRouteShown] = useState(false)
+  // Per-trip route visibility. `null` = the user has never said anything, which
+  // is what lets the mobile map switch it on by default; an explicit false has to
+  // survive every later map entry, and it used to be clobbered on each one (#2003).
+  const routeStorageKey = tripId ? `trek:day-route:${tripId}` : null
+  const [routeChoice, setRouteChoice] = useState<boolean | null>(() => {
+    if (typeof window === 'undefined' || !routeStorageKey) return null
+    const raw = window.localStorage.getItem(routeStorageKey)
+    return raw === 'true' ? true : raw === 'false' ? false : null
+  })
+  const routeShown = routeChoice === true
+  const setRouteShown = useCallback((v: boolean | ((prev: boolean) => boolean)) => {
+    setRouteChoice(prev => {
+      const next = typeof v === 'function' ? v(prev === true) : v
+      if (routeStorageKey && typeof window !== 'undefined') {
+        window.localStorage.setItem(routeStorageKey, String(next))
+      }
+      return next
+    })
+  }, [routeStorageKey])
+  // The mobile map opens with the day's route drawn — a default, not a choice, so
+  // it never overwrites an explicit off and is never written to storage itself.
+  const autoShowRoute = useCallback(() => {
+    setRouteChoice(prev => (prev === null ? true : prev))
+  }, [])
   const [routeProfile, setRouteProfile] = useState<string>('driving')
   const [fitKey, setFitKey] = useState<number>(0)
   const initialFitTripId = useRef<number | null>(null)
@@ -288,7 +316,10 @@ export function useTripPlanner() {
   }, [trip, places])
 
   useEffect(() => {
-    healthApi.features().then(f => setBookingImportAvailable(f.bookingImport)).catch(() => {})
+    // The server runs the import when EITHER kitinerary or the LLM parser is
+    // there (booking-import.service.ts), so gating the entry point on kitinerary
+    // alone hid a working feature on LLM-only instances (#2007).
+    healthApi.features().then(f => setBookingImportAvailable(f.bookingImport || f.aiParsing)).catch(() => {})
   }, [])
 
   const connectionsStorageKey = tripId ? `trek:visible-connections:${tripId}` : null
@@ -488,13 +519,14 @@ export function useTripPlanner() {
     setSelectedPlaceId(null)
   }, [])
 
-  const handleMapContextMenu = useCallback(async (e) => {
+  const handleMapContextMenu = useCallback(async (e, dayId?: number | null) => {
     if (!can('place_edit', trip)) return
     e.originalEvent?.preventDefault()
     const { lat, lng } = e.latlng
     setPrefillCoords({ lat, lng })
     setEditingPlace(null)
     setEditingAssignmentId(null)
+    setPlaceFormDayId(dayId ?? null)
     setShowPlaceForm(true)
     try {
       const { mapsApi } = await import('../../api/client')
@@ -507,7 +539,7 @@ export function useTripPlanner() {
 
   // Open the Add-Place form pre-filled from an OSM "explore" POI marker — all the
   // data already comes from the POI, so no reverse-geocode is needed.
-  const openAddPlaceFromPoi = useCallback((poi: { lat: number; lng: number; name: string; address: string | null; website: string | null; phone: string | null; osm_id: string }) => {
+  const openAddPlaceFromPoi = useCallback((poi: { lat: number; lng: number; name: string; address: string | null; website: string | null; phone: string | null; osm_id: string }, dayId?: number | null) => {
     if (!can('place_edit', trip)) return
     setPrefillCoords({
       lat: poi.lat,
@@ -520,6 +552,7 @@ export function useTripPlanner() {
     })
     setEditingPlace(null)
     setEditingAssignmentId(null)
+    setPlaceFormDayId(dayId ?? null)
     setShowPlaceForm(true)
   }, [trip])
 
@@ -548,6 +581,18 @@ export function useTripPlanner() {
       return { id: editingPlace.id }
     } else {
       const place = await tripActions.addPlace(tripId, data)
+      // Added from inside a day? Then it belongs to that day. Without this the
+      // place drops into the unplanned pool and, on mobile, into a different
+      // screen entirely — which reads as "it wasn't saved" (#1998).
+      if (place?.id && placeFormDayId != null) {
+        try {
+          await tripActions.assignPlaceToDay(tripId, placeFormDayId, place.id)
+          updateRouteForDay(placeFormDayId)
+        } catch (err: unknown) {
+          // The place itself exists; only the day link failed.
+          toast.error(err instanceof Error ? err.message : t('common.unknownError'))
+        }
+      }
       if (pendingFiles?.length > 0 && place?.id) {
         for (const file of pendingFiles) {
           const fd = new FormData()
@@ -567,7 +612,7 @@ export function useTripPlanner() {
       // exist a moment ago (#1298), the same way the booking modals work.
       return place?.id ? { id: place.id } : undefined
     }
-  }, [editingPlace, editingAssignmentId, tripId, toast, pushUndo])
+  }, [editingPlace, editingAssignmentId, placeFormDayId, tripId, toast, pushUndo, updateRouteForDay])
 
   // Open the place editor from any entry point (Places pool, inspector, map).
   // Times live per day-assignment, so when no day is in context resolve the
@@ -576,6 +621,7 @@ export function useTripPlanner() {
   const openPlaceEditor = useCallback((place: Place, preferredAssignmentId: number | null = null) => {
     setEditingPlace(place)
     setEditingAssignmentId(preferredAssignmentId ?? resolvePoolAssignmentId(assignments, place.id))
+    setPlaceFormDayId(null)
     setShowPlaceForm(true)
   }, [assignments])
 
@@ -985,6 +1031,7 @@ export function useTripPlanner() {
     showDayDetail, setShowDayDetail, dayDetailCollapsed, setDayDetailCollapsed,
     showPlaceForm, setShowPlaceForm, editingPlace, setEditingPlace,
     prefillCoords, setPrefillCoords, editingAssignmentId, setEditingAssignmentId,
+    placeFormDayId, setPlaceFormDayId, reservationModalDayId, setReservationModalDayId,
     showTripForm, setShowTripForm, showMembersModal, setShowMembersModal,
     showReservationModal, setShowReservationModal, editingReservation, setEditingReservation,
     showBookingImport, setShowBookingImport, bookingImportAvailable,
@@ -994,7 +1041,7 @@ export function useTripPlanner() {
     transportModalDayId, setTransportModalDayId,
     transportModalAutomated, setTransportModalAutomated, transitPrefill, setTransitPrefill, transitJourney, setTransitJourney,
     reservationPrefill, transportPrefill, importReviewActive, startImportReview, advanceImportReview,
-    routeShown, setRouteShown, routeProfile, setRouteProfile, routeVias, fitKey, setFitKey,
+    routeShown, setRouteShown, autoShowRoute, routeProfile, setRouteProfile, routeVias, fitKey, setFitKey,
     mobileSidebarOpen, setMobileSidebarOpen, mobilePlanScrollTopRef, mobilePlacesScrollTopRef,
     deletePlaceId, setDeletePlaceId, deletePlaceIds, setDeletePlaceIds,
     visibleConnections, toggleConnection, allConnectionsShown, toggleAllConnections, mapTransportDetail, setMapTransportDetail,

--- a/client/src/utils/dayOrder.test.ts
+++ b/client/src/utils/dayOrder.test.ts
@@ -178,13 +178,21 @@ describe('shouldDrawMorningLeg', () => {
     expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: '15:00' })).toBe(true)
   })
 
-  it('does NOT draw on a check-in day when time info is missing (#1597)', () => {
+  it('does NOT draw on a check-in day when the stop is untimed but check-in is not (#1597)', () => {
     // An un-timed first place on an arrival day ("Home" before driving out) cannot prove
     // you were at the hotel yet, so no hotel → first-stop leg — mirroring the evening rule.
     const bookends = { morning: into({ check_in: '15:00' }), morningIsSleptHere: false }
     expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: null })).toBe(false)
+  })
+
+  it('DOES draw on a check-in day when the stay records no check-in time (#2009)', () => {
+    // Nothing to clear, so nothing to fail: the hotel picker leaves the time blank
+    // by default, and treating that as proof against left the loop open every time.
     const noCheckIn = { morning: into({ check_in: null }), morningIsSleptHere: false }
-    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: '19:00' })).toBe(false)
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: '19:00' })).toBe(true)
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: null })).toBe(true)
+    // A transport arrival is still not a hotel departure (#1321).
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: false, time: '19:00' })).toBe(false)
   })
 
   it('does NOT draw on a check-in day for a transport arrival (not a place, #1321)', () => {
@@ -222,11 +230,17 @@ describe('shouldDrawEveningLeg', () => {
     expect(shouldDrawEveningLeg(bookends, checkOutDay, { isPlace: true, time: '11:00' })).toBe(true)
   })
 
-  it('does NOT draw on a check-out day when the place or hotel has no time', () => {
+  it('does NOT draw on a check-out day when the stop is untimed but check-out is not', () => {
     const bookends = { evening: out({ check_out: '11:00' }), eveningIsOvernight: false }
     expect(shouldDrawEveningLeg(bookends, checkOutDay, { isPlace: true, time: null })).toBe(false)
+  })
+
+  it('DOES draw on a check-out day when the stay records no check-out time (#2009)', () => {
     const noCheckOut = { evening: out({ check_out: null }), eveningIsOvernight: false }
-    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: '09:00' })).toBe(false)
+    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: '09:00' })).toBe(true)
+    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: null })).toBe(true)
+    // An evening transport departure is still not a drive back to the hotel (S7).
+    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: false, time: '09:00' })).toBe(false)
   })
 
   it('does NOT draw on a check-out day for a transport departure (not a place, S7)', () => {

--- a/client/src/utils/dayOrder.ts
+++ b/client/src/utils/dayOrder.ts
@@ -73,8 +73,14 @@ export const shouldDrawMorningLeg = (
   const m = bookends.morning
   if (!m || m.start_day_id !== day.id || !firstStop?.isPlace) return false
   const checkIn = parseTimeToMinutes(m.check_in)
+  // No check-in time on the stay means there is no bar to clear, and "no
+  // information" was being read as "proof against" — which silently opened the
+  // loop at the start of every arrival day, since the hotel picker leaves the
+  // time blank by default (#2009). With a time set, #1465 still holds: an
+  // earlier stop is a place you reached before the hotel and draws no leg.
+  if (checkIn == null) return true
   const stop = parseTimeToMinutes(firstStop.time)
-  return checkIn != null && stop != null && stop >= checkIn
+  return stop != null && stop >= checkIn
 }
 
 // Mirror of shouldDrawMorningLeg for the last-stop → hotel evening leg. It is a real drive when
@@ -91,8 +97,11 @@ export const shouldDrawEveningLeg = (
   const e = bookends.evening
   if (!e || e.end_day_id !== day.id || !lastStop?.isPlace) return false
   const checkOut = parseTimeToMinutes(e.check_out)
+  // Mirror of the morning rule: with no check-out time recorded there is nothing
+  // to have missed, so the return leg is drawn and the loop closes (#2009).
+  if (checkOut == null) return true
   const stop = parseTimeToMinutes(lastStop.time)
-  return checkOut != null && stop != null && stop <= checkOut
+  return stop != null && stop <= checkOut
 }
 
 export const isDayInAccommodationRange = (

--- a/client/tests/helpers/mobileTrip.ts
+++ b/client/tests/helpers/mobileTrip.ts
@@ -117,6 +117,10 @@ export function buildPlanner(overrides: Partial<TripPlanner> = {}): TripPlanner 
     setEditingPlace: vi.fn(),
     prefillCoords: null,
     setPrefillCoords: vi.fn(),
+    placeFormDayId: null,
+    setPlaceFormDayId: vi.fn(),
+    reservationModalDayId: null,
+    setReservationModalDayId: vi.fn(),
     editingAssignmentId: null,
     setEditingAssignmentId: vi.fn(),
     showTripForm: false,
@@ -156,6 +160,7 @@ export function buildPlanner(overrides: Partial<TripPlanner> = {}): TripPlanner 
 
     routeShown: false,
     setRouteShown: vi.fn(),
+    autoShowRoute: vi.fn(),
     routeProfile: 'driving',
     setRouteProfile: vi.fn(),
     routeVias: [],

--- a/client/tests/unit/mobile/journey/MJourneyEntrySheet.test.tsx
+++ b/client/tests/unit/mobile/journey/MJourneyEntrySheet.test.tsx
@@ -453,14 +453,14 @@ describe('MJourneyEntrySheet full editor', () => {
     expect(onSave.mock.calls[0][0]).toMatchObject({ type: 'entry' });
   });
 
-  it('FE-MOB-JENTRY-010: leaves an untouched skeleton a skeleton', async () => {
+  it('FE-MOB-JENTRY-010: promotes a skeleton the user saved without editing (#2008)', async () => {
     const user = userEvent.setup();
     const { onSave } = mountSheet(buildEntry({ id: 9, type: 'skeleton', title: 'Venice' }));
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
-    expect(onSave.mock.calls[0][0]).toMatchObject({ type: undefined });
+    expect(onSave.mock.calls[0][0]).toMatchObject({ type: 'entry' });
   });
 
   it('FE-MOB-JENTRY-011: queues picked files, reports progress and uploads them on save', async () => {

--- a/client/tests/unit/mobile/trip/MDaySheet.test.tsx
+++ b/client/tests/unit/mobile/trip/MDaySheet.test.tsx
@@ -343,7 +343,11 @@ describe('MDaySheet', () => {
     // start_day_id is this day, end_day_id a later one → check-in badge plus the stat label.
     expect(screen.getAllByText('Check-in')).toHaveLength(2)
 
+    // Tapping the stay edits the stay; the place is one tap further right (#2001).
     fireEvent.click(screen.getByText('Hotel Sacher'))
+    expect(shell.openSheet).toHaveBeenCalledWith('accommodation', { dayId: 2, accId: ACCOMMODATIONS[0].id })
+
+    fireEvent.click(screen.getByRole('button', { name: 'View details' }))
     expect(shell.closeSheet).toHaveBeenCalled()
     expect(planner.handlePlaceClick).toHaveBeenCalledWith(55)
 

--- a/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
+++ b/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
@@ -208,10 +208,13 @@ describe('MPlanTimeline', () => {
       expect(shell.openSheet).toHaveBeenCalledWith('day', { dayId: 2 })
     })
 
-    it('FE-MOB-PLTL-007: is left out entirely without chips and without weather', () => {
+    it('FE-MOB-PLTL-007: still renders, with the day pill, without chips or weather (#2004)', () => {
       const { container } = renderTimeline()
 
-      expect(container.querySelector('.border-b')).toBeNull()
+      // The pill is the only way into the day sheet, so it may not depend on the
+      // day happening to have an accommodation or a weather reading.
+      expect(container.querySelector('.border-b')).not.toBeNull()
+      expect(screen.getByRole('button', { name: 'day.overview' })).toBeInTheDocument()
     })
 
     it('FE-MOB-PLTL-008: draws the hotel bookend legs above and below the rows', () => {
@@ -349,16 +352,15 @@ describe('MPlanTimeline', () => {
     })
 
     it('FE-MOB-PLTL-020: read-only members get no tappable connectors', () => {
-      const { container } = renderTimeline({}, { can: vi.fn(() => false) }, { mode: 'edit' })
+      renderTimeline({}, { can: vi.fn(() => false) }, { mode: 'edit' })
 
-      expect(container.querySelector('button')).toBeNull()
+      expect(screen.getByText('7 min').closest('button')).toBeNull()
     })
 
     it('FE-MOB-PLTL-020b: go mode keeps the connectors read-only even with edit rights', () => {
-      const { container } = renderTimeline()
+      renderTimeline()
 
       expect(screen.getByText('7 min').closest('button')).toBeNull()
-      expect(container.querySelector('button')).toBeNull()
     })
   })
 
@@ -439,6 +441,8 @@ describe('MPlanTimeline', () => {
       renderTimeline({ day: { ...DAY, title: null } }, {}, { mode: 'edit' })
 
       expect(screen.getByText('planner.dayN:2')).toBeInTheDocument()
+      // …and the day pill next to it stays icon-only so the name is not doubled.
+      expect(screen.getByRole('button', { name: 'day.overview' })).toHaveTextContent('')
     })
 
     it('FE-MOB-PLTL-028: the pencil renames the day and Enter commits the change', () => {

--- a/client/tests/unit/mobile/trip/MTripShell.test.tsx
+++ b/client/tests/unit/mobile/trip/MTripShell.test.tsx
@@ -182,7 +182,7 @@ describe('MTripShell', () => {
   it('FE-MOB-SHELL-014: the map toggle draws the route and refits the selected day', () => {
     const { planner } = renderShell()
     fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.mapView' }))
-    expect(planner.setRouteShown).toHaveBeenCalledWith(true)
+    expect(planner.autoShowRoute).toHaveBeenCalled()
     expect(planner.handleSelectDay).toHaveBeenCalledWith(11, false)
     expect(shellApi.view).toBe('map')
     // The timeline unmounts, the map layer stays warm underneath.
@@ -196,13 +196,15 @@ describe('MTripShell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.listView' }))
     expect(shellApi.view).toBe('plan')
     expect(screen.getByTestId('plan-timeline')).toBeInTheDocument()
-    expect(spy(planner, 'setRouteShown')).toHaveBeenCalledTimes(1)
+    // Entering the map defaults the route on once; leaving it leaves the choice alone.
+    expect(spy(planner, 'autoShowRoute')).toHaveBeenCalledTimes(1)
+    expect(spy(planner, 'setRouteShown')).not.toHaveBeenCalled()
   })
 
   it('FE-MOB-SHELL-016: the map toggle skips the refit while no day is selected', () => {
     const { planner } = renderShell({ selectedDayId: null } as Partial<TripPlanner>)
     fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.mapView' }))
-    expect(planner.setRouteShown).toHaveBeenCalledWith(true)
+    expect(planner.autoShowRoute).toHaveBeenCalled()
     expect(planner.handleSelectDay).not.toHaveBeenCalled()
   })
 
@@ -238,7 +240,7 @@ describe('MTripShell', () => {
     const { planner } = renderShell()
     fireEvent.click(screen.getByRole('button', { name: 'Sun 3' }))
     expect(planner.handleSelectDay).toHaveBeenCalledWith(12, true)
-    expect(planner.setRouteShown).not.toHaveBeenCalled()
+    expect(planner.autoShowRoute).not.toHaveBeenCalled()
   })
 
   it('FE-MOB-SHELL-021: tapping the active day opens the day sheet', () => {
@@ -254,7 +256,7 @@ describe('MTripShell', () => {
     vi.mocked(planner.setRouteShown).mockClear()
     fireEvent.click(screen.getByRole('button', { name: 'Sun 3' }))
     expect(planner.handleSelectDay).toHaveBeenLastCalledWith(12, false)
-    expect(planner.setRouteShown).toHaveBeenCalledWith(true)
+    expect(planner.autoShowRoute).toHaveBeenCalled()
   })
 
   // #1962 — the phone lost the desktop sidebar's collapse chevron, so the map showed


### PR DESCRIPTION
The twelve open bug reports, worked through against dev. Client-only — no server,
no contract, no migration, no new translation keys.

### Mobile planner

- **#2004** — the timeline card header was the only route into the day sheet, and it
  rendered only when the day happened to have an accommodation or a weather reading,
  with the accommodation chip as its sole tap target. A day with neither had no way in
  at all, which also meant no way to *add* an accommodation. A day pill now leads that
  row unconditionally, the weather reading is a target too, and the active day chip
  carries a chevron so the second tap that opens the sheet is visible in map view.
- **#2001** — tapping the stay in the day sheet opened the place it is pinned to, so
  check-in, check-out and the confirmation code had no way in. `MAccommodationSheet`
  has taken an `accId` since the mobile rewrite; nothing ever passed one. The place is
  kept one tap to the right, and the linked hotel booking below opens now as well.
- **#2003** — the route toggle lived only in component state, and entering the map (or
  tapping a day while in it) forced it back on, so turning it off did nothing visible
  and had reset itself by the next look. The choice is remembered per trip; the map
  still defaults it on, but only while the user has never said otherwise.
- **#1998** — a place or booking added from inside a day was not connected to it. The
  place went to the unplanned pool, which on mobile is a different screen — it reads as
  a lost save — and the booking opened with no date. Both entry points now carry their
  day, including a long-press on the mobile map, where the chip rail always names one.
  The desktop map has no such context and passes nothing, so its pool behaviour stands.
- **#1997** — reordering meant two 15px arrows, while the same list on the web takes a
  drag. It takes one here too, through the long-press bridge tablets already use
  (#1616), armed in edit mode and on coarse pointers only. The arrows stay as the
  accessible path, and both routes go through one mover so the chronology guard and the
  undo entry are identical either way.

### Dropdowns

- **#1999, #2000** — the three fixed-position popovers measured their trigger exactly
  once, while rendering. Scroll a sheet and the trigger walked off while the panel
  stayed nailed to the viewport; on iOS the keyboard covered a panel placed before it
  existed. They now re-measure on scroll (capture phase, so the sheets' own scroll
  containers count), on resize and on visualViewport changes, and a list opened next to
  the keyboard shrinks into the space left rather than hiding under it.

### Icons

- **#2006** — every import control wore an outgoing arrow. The places-import sheet
  managed to contradict itself inside one screen: Download in the header, Upload on the
  row below, Upload again one screen deeper. Imports take Download, or FileDown where
  the button opens a file picker; real uploads and the desktop drop zones keep Upload.
- **#2005** — the "open in Google Maps" buttons drew the four-segment Google *search*
  G flattened to one colour. They get a map pin, in one component so the desktop and
  mobile copies stop drifting.

### Elsewhere

- **#2008** — a journey suggestion was only promoted to an entry when a story or a
  photo had been added; a title, a mood, the weather or tags all left it a suggestion,
  and so did saving it untouched. An explicit Save now says it is an entry.
- **#2007** — the desktop import is not missing: it sits at the far right of the
  bookings toolbar, above an empty page with nothing but the mascot. The empty state now
  offers the ways in that apply. Separately, the button only appeared when kitinerary
  was installed, though the server also accepts an import when the LLM parser is
  configured — that gate was hiding a working feature on LLM-only instances.
- **#2009** — with "optimize route from accommodation" on, the drawn route still began
  at the first activity on an arrival day and stopped at the last one on a departure
  day. Both bookend rules read a *missing* check-in time as proof you had not reached
  the hotel, and the picker leaves that field blank by default — so the loop hung open
  at one end on every boundary day, and at both ends for a stay booked on a single day.
  With no time recorded there is nothing to clear. Where a time is set the existing
  rules are untouched: a stop before check-in still draws nothing (#1465), and a
  transport arrival is still not a hotel departure (#1321).

### Noticed, not fixed here

Touch drag on the **desktop tree between 768 and 1023px** — a tablet in portrait, a large
phone in landscape — is still off: `dragDisabled` keys off the <1024px breakpoint, and
`useTouchDragBridge` is armed on `isTouch && !isMobile`, so #1616 only ever reached
tablets at >=1024px. Same symptom as #1997 in a different tree; out of scope for this PR
and worth its own issue.

The **GPX day-route export** (`places.service.ts`, the "Days" option) builds each day
straight from `day_assignments` with no accommodation join at all, so it is unaffected by
#2009 either way — the exported track really is only the activities. Changing that means
teaching a server export about a per-user client setting, which is a design call rather
than a bug fix.

Closes #1997
Closes #1998
Closes #1999
Closes #2000
Closes #2001
Closes #2003
Closes #2004
Closes #2005
Closes #2006
Closes #2007
Closes #2008
Closes #2009
