### PR TITLE
feat(planner): planned filter follows the selected day; day header click toggles selection

### DIFF
--- a/client/src/components/Planner/DayPlanSidebar.test.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.test.tsx
@@ -370,6 +370,17 @@ describe('DayPlanSidebar', () => {
     expect(onSelectDay).toHaveBeenCalledWith(10)
   })
 
+  it('FE-PLANNER-DAYPLAN-209: clicking the selected day header again deselects it', async () => {
+    const user = userEvent.setup()
+    const day = buildDay({ id: 10, date: '2025-06-01', title: 'My Day' })
+    const onSelectDay = vi.fn()
+    const onDayDetail = vi.fn()
+    render(<DayPlanSidebar {...makeDefaultProps({ days: [day], selectedDayId: 10, onSelectDay, onDayDetail })} />)
+    await user.click(screen.getByText('My Day'))
+    expect(onSelectDay).toHaveBeenCalledWith(null)
+    expect(onDayDetail).toHaveBeenCalledWith(null)
+  })
+
   it('FE-PLANNER-DAYPLAN-010: selectedDayId renders without error', () => {
     const day = buildDay({ id: 10, date: '2025-06-01', title: 'My Day' })
     render(<DayPlanSidebar {...makeDefaultProps({ days: [day], selectedDayId: 10 })} />)

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -65,7 +65,7 @@ interface DayPlanSidebarProps {
   selectedAssignmentId: number | null
   onSelectDay: (dayId: number | null, skipFit?: boolean) => void
   onPlaceClick: (placeId: number | null, assignmentId?: number | null) => void
-  onDayDetail: (day: Day) => void
+  onDayDetail: (day: Day | null) => void
   accommodations?: Accommodation[]
   onReorder: (dayId: number, orderedIds: number[]) => void
   onReorderDays?: (orderedIds: number[]) => void
@@ -1579,7 +1579,8 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
               <div
                 className="dp-day-header"
                 data-selected={isSelected}
-                onClick={() => { onSelectDay(day.id); if (onDayDetail) onDayDetail(day) }}
+                // Clicking the selected day again deselects it — same as the day panel's × (#2024).
+                onClick={() => { if (isSelected) { onSelectDay(null); if (onDayDetail) onDayDetail(null) } else { onSelectDay(day.id); if (onDayDetail) onDayDetail(day) } }}
                 onDragOver={e => { e.preventDefault(); if (dragOverDayId !== day.id) setDragOverDayId(day.id) }}
                 onDragLeave={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOverDayId(null) }}
                 onDrop={e => handleDropOnDay(e, day.id)}

--- a/client/src/pages/tripPlanner/useTripPlanner.test.tsx
+++ b/client/src/pages/tripPlanner/useTripPlanner.test.tsx
@@ -680,6 +680,28 @@ describe('useTripPlanner — map derivations', () => {
     expect(result.current.mapPlaces.map(p => p.id)).toEqual([1])
   })
 
+  it('FE-TP-HOOK-111: the planned filter follows the selected day when one is selected', async () => {
+    const onDay7 = geo(1)
+    const onDay8 = geo(2)
+    seedTrip({
+      places: [onDay7, onDay8, geo(3)],
+      assignments: {
+        '7': [buildAssignment({ id: 10, day_id: 7, place: onDay7 })],
+        '8': [buildAssignment({ id: 11, day_id: 8, place: onDay8 })],
+      },
+      placesFilter: 'planned',
+      selectedDayId: 7,
+    })
+
+    const { result } = await renderPlanner()
+
+    expect(result.current.mapPlaces.map(p => p.id)).toEqual([1])
+
+    // No day selected → back to the whole plan
+    act(() => { useTripStore.setState({ selectedDayId: null }) })
+    expect(result.current.mapPlaces.map(p => p.id)).toEqual([1, 2])
+  })
+
   it('FE-TP-HOOK-030: collapsing a day hides its stops unless another expanded day shows them', async () => {
     const shared = geo(1)
     seedTrip({

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -439,9 +439,15 @@ export function useTripPlanner() {
     }
 
     // Planned place IDs — needed by both the 'unplanned' filter (exclude them) and
-    // the new 'planned' filter (keep only them).
+    // the new 'planned' filter (keep only them). With a day selected, 'planned'
+    // follows it like the other filters do; with no day selected it keeps showing
+    // the whole plan (#2024). 'unplanned' always uses the whole-trip set — a place
+    // assigned to any day is not unplanned.
     const plannedIds = placesFilter === 'unplanned' || placesFilter === 'planned'
-      ? new Set(Object.values(assignments).flatMap(da => da.map(a => a.place?.id).filter(Boolean)))
+      ? new Set((placesFilter === 'planned' && selectedDayId
+        ? (assignments[String(selectedDayId)] || [])
+        : Object.values(assignments).flat()
+      ).map(a => a.place?.id).filter(Boolean))
       : null
 
     return places.filter(p => {
@@ -460,7 +466,7 @@ export function useTripPlanner() {
       if (placesFilter === 'planned' && plannedIds && !plannedIds.has(p.id)) return false
       return true
     })
-  }, [places, placesCategoryFilter, placesFilter, assignments, expandedDayIds])
+  }, [places, placesCategoryFilter, placesFilter, assignments, expandedDayIds, selectedDayId])
 
   const { route, routeSegments, routeVias, routeInfo, setRoute, setRouteInfo, updateRouteForDay } = useRouteCalculation({ assignments } as any, selectedDayId, routeShown, routeProfile, tripAccommodations)
 


### PR DESCRIPTION
Follow-up to discussion #2024 (items 1 and 2), offered as code in case it helps — happy to adjust or split if you'd prefer a different shape. Based on `dev` since that's where 4.0 work lives.

## 1. `planned` filter follows the selected day

With a day selected, the **Assigned/planned** places filter now shows only that day's stops — the same way the other filters follow the selection. With no day selected, behavior is unchanged: the whole plan stays on the map (including collapsed days, per the existing #1541 behavior). `unplanned` deliberately keeps using the whole-trip assigned set — a place assigned to any day is not unplanned.

| Filter | No day selected | Day selected |
|---|---|---|
| planned (before) | whole plan | whole plan |
| planned (after) | whole plan | **selected day only** |
| unplanned | unchanged | unchanged |

## 2. Clicking the selected day's header deselects it

A second click on the already-selected day header now clears the selection and closes the day detail panel — identical to pressing the panel's ×. The `onDayDetail` prop type widens to `(day: Day | null) => void` to carry the close.

## Tests

- `FE-TP-HOOK-111`: planned filter scoped with a day selected, whole plan again at `selectedDayId: null`
- `FE-PLANNER-DAYPLAN-209`: second click on the selected header calls `onSelectDay(null)` + `onDayDetail(null)`

Both touched suites pass (344/344).

Item 3 of #2024 (visually distinguishing unassigned pins) is not included — it seems to want a product decision on option vs. default, so I left it to the discussion.
