### PR TITLE
Fix the journey timeline, Studio outline fit and per-day transit routes

### DIFF
--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -16,7 +16,7 @@ import { useTransportRoutes } from '../../hooks/useTransportRoutes'
 import { visibleRouteReservations } from '../../utils/reservationRoutes'
 import { safeHexColor } from '../../utils/safeColor'
 import { escapeHtml } from '@trek/shared'
-import type { Reservation, RouteVia } from '../../types'
+import type { Day, Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { resolveTrackColor, hasManualTrackColor } from './trackColors'
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, SATELLITE_TILE_URL, SATELLITE_TILE_ATTRIBUTION, SATELLITE_TILE_MAXZOOM } from '../../constants/mapDefaults'
@@ -526,6 +526,8 @@ export const MapView = memo(function MapView({
   showReservationStats = false,
   visibleConnectionIds = [] as number[],
   showTransitRoutes = true,
+  days = [] as Day[],
+  selectedDayId = null,
   onReservationClick,
   pois = [] as Poi[],
   onPoiClick,
@@ -545,8 +547,8 @@ export const MapView = memo(function MapView({
     </Marker>
   )), [pois, onPoiClick])
   const visibleReservations = useMemo(() => (
-    visibleRouteReservations(reservations, { visibleConnectionIds, showTransitRoutes })
-  ), [reservations, visibleConnectionIds, showTransitRoutes])
+    visibleRouteReservations(reservations, { visibleConnectionIds, showTransitRoutes, selectedDayId, days })
+  ), [reservations, visibleConnectionIds, showTransitRoutes, selectedDayId, days])
   // Real road geometry for car/bus/taxi/bicycle bookings (straight line until it loads/if it fails).
   const transportRoutes = useTransportRoutes(visibleReservations)
   // Dynamic padding: account for sidebars + bottom inspector + day detail panel

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -17,7 +17,7 @@ import { escapeHtml } from '@trek/shared'
 import { MAPBOX_DEFAULT_STYLE, styleForActiveProvider, basemapLanguage, type GlMapProvider } from './glProviders'
 import LocationButton from './LocationButton'
 import { useGeolocation } from '../../hooks/useGeolocation'
-import type { Place, Reservation, RouteVia } from '../../types'
+import type { Day, Place, Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { resolveTrackColor, hasManualTrackColor } from './trackColors'
 import { buildPoiPopupHtml } from './placePopup'
@@ -86,6 +86,7 @@ const NO_DAY_ORDER: Record<number, number[] | null> = {}
 const NO_RESERVATIONS: Reservation[] = []
 const NO_CONNECTION_IDS: number[] = []
 const NO_POIS: Poi[] = []
+const NO_DAYS: Day[] = []
 
 interface Props {
   places: Place[]
@@ -114,6 +115,8 @@ interface Props {
   reservations?: Reservation[]
   visibleConnectionIds?: number[]
   showTransitRoutes?: boolean
+  days?: Day[]
+  selectedDayId?: number | null
   showReservationStats?: boolean
   onReservationClick?: (reservationId: number) => void
   pois?: Poi[]
@@ -359,6 +362,8 @@ export function MapViewGL({
   reservations = NO_RESERVATIONS,
   visibleConnectionIds = NO_CONNECTION_IDS,
   showTransitRoutes = true,
+  days = NO_DAYS,
+  selectedDayId = null,
   showReservationStats = false,
   onReservationClick,
   pois = NO_POIS,
@@ -1270,8 +1275,8 @@ export function MapViewGL({
   // DayPlanSidebar — nothing is rendered until the user enables a
   // booking's route, matching the Leaflet MapView's behaviour.
   const visibleReservations = useMemo(() => (
-    visibleRouteReservations(reservations, { visibleConnectionIds, showTransitRoutes })
-  ), [reservations, visibleConnectionIds, showTransitRoutes])
+    visibleRouteReservations(reservations, { visibleConnectionIds, showTransitRoutes, selectedDayId, days })
+  ), [reservations, visibleConnectionIds, showTransitRoutes, selectedDayId, days])
   // Real road geometry for car/bus/taxi/bicycle bookings (straight line until it loads/if it fails).
   const transportRoutes = useTransportRoutes(visibleReservations)
 

--- a/client/src/components/Studio/TravelElements.test.tsx
+++ b/client/src/components/Studio/TravelElements.test.tsx
@@ -1,0 +1,116 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { bookMapElementSchema } from '@trek/shared'
+import { TravelElementView } from './TravelElements'
+import { COUNTRY_SHAPES, countryParts } from './countryShapes'
+
+/*
+ * The maps are measured, not snapshotted: what went wrong in #2021 is a number
+ * — how far apart the stops end up on the paper — and a snapshot of a country
+ * outline says nothing about whether the route inside it is legible.
+ */
+
+const FRAME = { x: 0, y: 0, w: 100, h: 100 }
+
+const PARIS = { lat: 48.86, lng: 2.35 }
+const LYON = { lat: 45.76, lng: 4.84 }
+const NICE = { lat: 43.7, lng: 7.27 }
+
+function mapEl(over: Record<string, unknown>) {
+  return bookMapElementSchema.parse({ id: 'm1', kind: 'map', frame: FRAME, ...over })
+}
+
+/** How wide the stops sit on the page, in millimetres of a 100mm frame. */
+function pinSpan(over: Record<string, unknown>): number {
+  const { container } = render(
+    <TravelElementView el={mapEl(over)} frameStyle={{ width: '100mm', height: '100mm' }} />,
+  )
+  const xs = [...container.querySelectorAll('circle')].map(c => Number(c.getAttribute('cx')))
+  expect(xs.length).toBeGreaterThan(0)
+  return Math.max(...xs) - Math.min(...xs)
+}
+
+describe('MapView fit', () => {
+  it('frames a French route without the overseas territories', () => {
+    expect(pinSpan({ countries: ['FR'], points: [PARIS, LYON, NICE] })).toBeGreaterThan(20)
+  })
+
+  it('frames a British route without South Georgia', () => {
+    const span = pinSpan({
+      countries: ['GB'],
+      points: [{ lat: 51.51, lng: -0.13 }, { lat: 55.95, lng: -3.19 }],
+    })
+    // Smaller than the French case because Britain really is drawn whole here,
+    // which is what the setting asks for. The South Atlantic is not.
+    expect(span).toBeGreaterThan(10)
+  })
+
+  it('frames the route when imagery is cut to the country outline', () => {
+    const span = pinSpan({
+      source: 'tiles', clip: 'country', countries: ['FR'], points: [PARIS, LYON, NICE],
+    })
+    expect(span).toBeGreaterThan(20)
+  })
+
+  it('still draws the whole of a compact country around the route', () => {
+    const span = pinSpan({
+      countries: ['NL'],
+      points: [{ lat: 52.37, lng: 4.9 }, { lat: 51.92, lng: 4.48 }],
+    })
+    // The Netherlands is small enough that "whole country" is still a useful
+    // picture, so this one must NOT grow: the fix is about which rings count,
+    // not about abandoning the fit.
+    expect(span).toBeLessThan(10)
+  })
+
+  it('frames the overseas ring when that is where the trip was', () => {
+    // Cayenne and Kourou. The right answer is French Guiana, not metropolitan
+    // France, so picking the nearest rings has to work in both directions.
+    const span = pinSpan({
+      countries: ['FR'],
+      points: [{ lat: 4.92, lng: -52.33 }, { lat: 5.16, lng: -52.65 }],
+    })
+    expect(span).toBeGreaterThan(5)
+  })
+
+  it('falls back to the whole country when there is no route yet', () => {
+    // An empty map element still has to draw something, and the something is
+    // the country — every ring of it, since nothing says which one matters.
+    const { container } = render(
+      <TravelElementView
+        el={mapEl({ countries: ['FR'], points: [], path: [] })}
+        frameStyle={{ width: '100mm', height: '100mm' }}
+      />,
+    )
+    expect(container.querySelector('path[d]')).not.toBeNull()
+  })
+
+  it('leaves Satellite alone', () => {
+    const span = pinSpan({ source: 'tiles', countries: ['FR'], points: [PARIS, LYON, NICE] })
+    expect(span).toBeGreaterThan(20)
+  })
+})
+
+describe('countryParts', () => {
+  it('splits France into its five landmasses', () => {
+    const lng = countryParts(COUNTRY_SHAPES.FR)
+      .map(p => [Math.round(p[0] * 100) / 100, Math.round(p[2] * 100) / 100])
+      .sort((a, b) => a[0] - b[0])
+    expect(lng).toEqual([
+      [-54.55, -51.67], // French Guiana
+      [-4.69, 8.16],    // metropolitan France
+      [8.6, 9.49],      // Corsica
+      [68.87, 70.42],   // Kerguelen
+      [163.93, 167.03], // New Caledonia
+    ])
+    // The aggregate the outlines are still drawn from is untouched.
+    expect(COUNTRY_SHAPES.FR.b).toEqual([-54.55, -59.62, 167.03, 57.49])
+  })
+
+  it('gives a country with one landmass a single box matching its bounds', () => {
+    const parts = countryParts(COUNTRY_SHAPES.CH)
+    expect(parts).toHaveLength(1)
+    expect(parts[0][0]).toBeCloseTo(COUNTRY_SHAPES.CH.b[0], 1)
+    expect(parts[0][2]).toBeCloseTo(COUNTRY_SHAPES.CH.b[2], 1)
+  })
+})

--- a/client/src/components/Studio/TravelElements.tsx
+++ b/client/src/components/Studio/TravelElements.tsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react'
 import { fontStack } from './bookFonts'
 import { brightness } from './folioColour'
-import { COUNTRY_SHAPES, countryWorldPath, projectMercator, unprojectMercator } from './countryShapes'
+import { COUNTRY_SHAPES, countryParts, countryWorldPath, projectMercator, unprojectMercator } from './countryShapes'
 import { projectOntoTiles, tileView, usableStaticUrl } from './mapTiles'
 import { FLAG_H, FLAG_W, flagBands, flagDisc, flagSpec } from './flags'
 import { MOOD_CONFIG, WEATHER_CONFIG } from '../../pages/journeyDetail/JourneyDetailPage.constants'
@@ -270,12 +270,6 @@ function MapView({ el, frameStyle, big = false }: {
    */
   const cutToLand = el.clip === 'country' && shapes.length > 0
   const fitToLand = el.fitToCountries || cutToLand || (points.length === 0 && trail.length === 0)
-  if (fitToLand) {
-    for (const s of shapes) {
-      minX = Math.min(minX, s.b[0]); minY = Math.min(minY, s.b[1])
-      maxX = Math.max(maxX, s.b[2]); maxY = Math.max(maxY, s.b[3])
-    }
-  }
   for (const p of points) {
     minX = Math.min(minX, p.x); minY = Math.min(minY, p.y)
     maxX = Math.max(maxX, p.x); maxY = Math.max(maxY, p.y)
@@ -297,6 +291,45 @@ function MapView({ el, frameStyle, big = false }: {
       const q = projectMercator(lng, lat)
       minX = Math.min(minX, q.x); minY = Math.min(minY, q.y)
       maxX = Math.max(maxX, q.x); maxY = Math.max(maxY, q.y)
+    }
+  }
+
+  /*
+   * The country fit comes last, because it needs to know where the journey is.
+   *
+   * A country is one path but not one landmass. France's is five rings, three
+   * of them Kerguelen, French Guiana and New Caledonia, so unioning its whole
+   * bounding box fitted a Paris-Lyon-Nice route to 221 degrees of longitude and
+   * printed the three stops as a single dot. Britain does the same through
+   * South Georgia, Norway through Svalbard, Ecuador through the Galapagos.
+   *
+   * So only the rings the journey is near are fitted to. The margin is the
+   * route's own size, floored at two degrees, and that floor is the whole of
+   * the judgement: at two degrees a Paris-Nice route still pulls in Corsica,
+   * which is the picture that trip wants, while Kerguelen at 68 degrees east
+   * stays out. Raise it far and the territories come back; drop it to zero and
+   * a coastal route sitting just off a simplified coastline stops matching the
+   * country it is in.
+   *
+   * The whole shape is still the fallback — with no route there is nothing to
+   * measure against, and a country none of whose rings match is better drawn
+   * whole than not at all. The outlines themselves are unchanged either way:
+   * the overseas rings are still painted, they just run off the frame the way
+   * a coastline does.
+   */
+  if (fitToLand) {
+    const routed = Number.isFinite(minX)
+    const margin = Math.max(maxX - minX, maxY - minY, 2)
+    const nearX0 = minX - margin, nearY0 = minY - margin
+    const nearX1 = maxX + margin, nearY1 = maxY + margin
+    for (const s of shapes) {
+      const near = routed
+        ? countryParts(s).filter(p => p[0] <= nearX1 && p[2] >= nearX0 && p[1] <= nearY1 && p[3] >= nearY0)
+        : []
+      for (const b of near.length > 0 ? near : [s.b]) {
+        minX = Math.min(minX, b[0]); minY = Math.min(minY, b[1])
+        maxX = Math.max(maxX, b[2]); maxY = Math.max(maxY, b[3])
+      }
     }
   }
 

--- a/client/src/components/Studio/countryShapes.ts
+++ b/client/src/components/Studio/countryShapes.ts
@@ -59,6 +59,44 @@ export function countryWorldPath(shape: CountryShape): string {
   })
 }
 
+/*
+ * One box per ring of the outline, in the same world coordinates.
+ *
+ * A country is a single path but not a single landmass. France's is five
+ * subpaths, three of which are Kerguelen, French Guiana and New Caledonia, so
+ * its `b` covers 221 degrees of longitude and describes nowhere anybody stood.
+ * Anything fitting a view to a country needs the pieces, not the aggregate.
+ *
+ * Cached against the shape object: the boxes are a property of the generated
+ * data, and the data does not change while the page is open.
+ */
+const PARTS = new WeakMap<CountryShape, [number, number, number, number][]>()
+
+export function countryParts(shape: CountryShape): [number, number, number, number][] {
+  const cached = PARTS.get(shape)
+  if (cached) return cached
+  // The same placement `countryWorldPath` does, applied to the numbers rather
+  // than to the string.
+  const span = Math.max(shape.b[2] - shape.b[0], shape.b[3] - shape.b[1]) / 100
+  const parts: [number, number, number, number][] = []
+  for (const sub of shape.d.split('M')) {
+    const nums = sub.match(/-?\d*\.?\d+/g)
+    if (!nums || nums.length < 2) continue
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (let i = 0; i + 1 < nums.length; i += 2) {
+      const x = Number(nums[i]) * span + shape.b[0]
+      const y = Number(nums[i + 1]) * span + shape.b[1]
+      if (x < minX) minX = x
+      if (x > maxX) maxX = x
+      if (y < minY) minY = y
+      if (y > maxY) maxY = y
+    }
+    parts.push([minX, minY, maxX, maxY])
+  }
+  PARTS.set(shape, parts)
+  return parts
+}
+
 export const COUNTRY_SHAPES: Record<string, CountryShape> = {
   AD: { d: 'M84.2 57.2L84.2 50L81.6 50L84.2 46.5L84.2 42.9L86.8 42.9L86.8 35.8L92.1 35.8L92.1 32.2L92.1 35.8L94.7 32.2L94.7 35.8L94.7 32.2L100 32.2L97.4 28.6L89.5 28.6L86.8 25L84.2 25L84.2 17.9L86.8 17.9L86.8 14.3L84.2 14.3L84.2 17.9L84.2 14.3L81.6 14.3L78.9 17.9L78.9 14.3L65.8 14.3L63.2 10.7L44.7 10.7L44.7 3.6L36.8 3.6L36.8 0L34.2 3.6L18.4 3.6L18.4 7.2L15.8 7.2L15.8 14.3L18.4 14.3L18.4 17.9L13.2 17.9L13.2 21.5L7.9 21.5L7.9 25L5.3 25L5.3 28.6L7.9 32.2L7.9 35.8L2.6 35.8L2.6 42.9L0 42.9L10.5 42.9L10.5 46.5L13.2 46.5L13.2 50L15.8 53.6L13.2 53.6L13.2 57.2L7.9 57.2L5.3 60.8L2.6 60.8L2.6 64.3L7.9 64.3L7.9 71.5L10.5 71.5L7.9 71.5L7.9 75L10.5 75L10.5 78.6L7.9 78.6L18.4 78.6L18.4 82.2L36.8 82.2L36.8 78.6L39.5 75L39.5 71.5L42.1 71.5L42.1 75L44.7 75L44.7 71.5L47.4 71.5L50 67.9L52.6 71.5L52.6 67.9L55.3 67.9L57.9 71.5L57.9 67.9L65.8 67.9L65.8 60.8L68.4 57.2L71.1 57.2L71.1 60.8L73.7 57.2L73.7 60.8L78.9 60.8L84.2 57.2Z', w: 100, h: 82.2, b: [1.41, -47.25, 1.79, -46.94] },
   AE: { d: 'M99.8 25.1L99.6 11.1L95.6 9.9L95 5.5L96 2.1L95 0L93.8 0.5L92.3 4.2L93.1 3.2L93.3 3.9L91.1 5.8L91.3 6.9L91.1 6L89.4 8.1L87.5 7.9L87.7 8.8L86.9 9.5L86.7 8.6L86.7 9.9L84.4 12.5L83 12.5L83.4 10.6L81.5 13.6L82.1 13.9L80.5 14.8L81.3 14.5L81.1 15.5L80.5 14.8L79.4 17.1L79 16.2L78.8 17.8L77.3 16.4L78.2 20.3L78.2 18.9L76.7 18.2L77.1 18.9L76.5 18.5L76.9 19.1L74.4 22.8L72.1 24.2L72.6 25.3L71.3 23.7L71.7 25.1L71.3 24L70.7 25.1L70.9 23.7L70.3 25.1L71.1 25.3L69.6 26.3L69.2 25.6L69.6 26.5L68.2 26.9L69.2 28.1L68 26.9L66.3 27.9L66.9 29.2L66.1 29.9L66.3 27.6L65.3 28.8L66.1 29.2L64.9 29L64.7 30.6L63.6 31.1L64.9 32.4L63 35.4L63.8 36.3L60.7 37.7L61.3 38.8L60.1 39.3L59.9 40.2L61.1 40.4L55.5 42.3L53.2 40L52.4 41.6L53.4 42.5L50.9 43.2L52 43.9L53.2 42.5L54.1 42.9L52.6 44.5L52 43.9L52 44.8L48.6 44.8L48.9 45.9L42 46.6L39.1 44.5L36.2 44.8L36.2 45.5L35.3 44.3L35.6 45.2L34.1 44.5L34.5 45.9L32.8 46.1L32 43.9L31.2 44.8L30.4 44.5L31 43.9L24.5 44.5L23.7 43.4L22.9 44.5L21.2 42.5L20.8 44.5L18.7 45.5L17.9 44.8L18.1 46.1L14.8 48L10.8 48.9L7.9 47.5L7.5 48.6L4.4 46.8L4.4 41.4L3.5 40.9L2.5 42.7L1.7 40L2.1 42.3L1.2 42.9L1.5 40.2L0 38.6L0.4 44.5L21 71.5L74.2 78.5L76.1 75.1L76.1 67.7L83.2 56.4L82.5 51.1L81.3 48.9L86.5 46.1L88.6 47.3L92.5 45.9L91.3 42.5L86.9 42.3L88.6 40.2L88.6 37.9L87.3 35.9L88.4 33.4L87.7 32.9L88.8 32.2L88.1 26.7L91.3 24.4L93.1 25.3L93.3 27.6L91.7 27.6L94.4 30.6L96.3 29.7L96.5 28.1L98.5 27.4L99.4 26.3L98.8 25.3L99.8 25.1Z', w: 100, h: 78.5, b: [51.57, -27.02, 56.38, -23.24] },

--- a/client/src/mobile/mobile.css
+++ b/client/src/mobile/mobile.css
@@ -327,3 +327,16 @@
   /* Zzz would sit invisible at opacity 0 without their animation — pin them visible */
   .trek-z { opacity: 1; }
 }
+
+/* Map attribution clears the dock.
+ *
+ * Both engines park their attribution at the bottom of the map, and on a phone
+ * the map is the whole screen — so the credit line lands under the floating nav
+ * and reads as a broken bar (#2022's screenshots show it over the dock). Lift it
+ * by the same variable everything else clears the dock with. Leaflet and
+ * MapLibre both, because a phone meets either depending on the screen. */
+.m-root .leaflet-control-attribution,
+.m-root .maplibregl-ctrl-bottom-left,
+.m-root .maplibregl-ctrl-bottom-right {
+  bottom: var(--bottom-nav-h);
+}

--- a/client/src/mobile/screens/journey/MJourneyEntryCard.test.tsx
+++ b/client/src/mobile/screens/journey/MJourneyEntryCard.test.tsx
@@ -1,0 +1,56 @@
+// FE-COMP-MJOURNEYCARD-001 to FE-COMP-MJOURNEYCARD-003
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '../../../../tests/helpers/render'
+import MJourneyEntryCard from './MJourneyEntryCard'
+import type { JourneyEntry } from '../../../store/journeyStore'
+
+// #2022: a long entry comment grew the card, and with it the bottom-anchored
+// carousel, until the timeline covered the map. jsdom does no layout, so these
+// assert the class contract the browser cascade depends on, not pixel heights.
+const LONG_STORY = Array.from({ length: 400 }, (_, i) => `wort${i % 7}`).join(' ')
+
+// Tailwind emits the display plugin AFTER lineClamp, so any display utility on
+// the same element overrides `line-clamp-*`'s own `-webkit-box` and the clamp
+// silently stops working.
+const DISPLAY_UTILITIES = ['block', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid', 'flow-root', 'contents', 'inline']
+
+const buildEntry = (overrides: Partial<JourneyEntry> = {}): JourneyEntry => ({
+  id: 1,
+  journey_id: 7,
+  author_id: 1,
+  type: 'entry',
+  title: 'Erster Tag',
+  story: LONG_STORY,
+  entry_date: '2026-03-03',
+  visibility: 'private',
+  sort_order: 0,
+  photos: [],
+  created_at: 0,
+  updated_at: 0,
+  ...overrides,
+})
+
+describe('MJourneyEntryCard', () => {
+  it('FE-COMP-MJOURNEYCARD-001: keeps the story preview clamp free of a competing display utility', () => {
+    render(<MJourneyEntryCard entry={buildEntry()} number={1} onClick={vi.fn()} />)
+
+    const classes = screen.getByText(LONG_STORY).className.split(/\s+/)
+    expect(classes).toContain('line-clamp-2')
+    DISPLAY_UTILITIES.forEach(utility => expect(classes).not.toContain(utility))
+  })
+
+  it('FE-COMP-MJOURNEYCARD-002: caps the card height so the timeline cannot grow over the map', () => {
+    render(<MJourneyEntryCard entry={buildEntry()} number={1} onClick={vi.fn()} />)
+
+    const classes = screen.getByRole('button').className.split(/\s+/)
+    expect(classes.some(c => /^max-h-\[\d+px\]$/.test(c))).toBe(true)
+    expect(classes).toContain('overflow-hidden')
+  })
+
+  it('FE-COMP-MJOURNEYCARD-003: renders no preview for an entry without a story', () => {
+    render(<MJourneyEntryCard entry={buildEntry({ story: null })} number={2} onClick={vi.fn()} />)
+
+    expect(screen.queryByText(LONG_STORY)).not.toBeInTheDocument()
+    expect(screen.getByText('Erster Tag')).toBeInTheDocument()
+  })
+})

--- a/client/src/mobile/screens/journey/MJourneyEntryCard.tsx
+++ b/client/src/mobile/screens/journey/MJourneyEntryCard.tsx
@@ -26,11 +26,14 @@ export default function MJourneyEntryCard({ entry, number, onClick }: MJourneyEn
   const storyPreview = entry.story ? stripMarkdown(entry.story) : ''
   const title = entry.title || (entry.type === 'checkin' ? t('journey.detail.journeyTab') : t('journey.editor.titlePlaceholder'))
 
+  // The timeline this card sits in is bottom-anchored with no height of its own, so a card
+  // that grows with its story climbs over the map and swallows its touches (#2022). Cap the
+  // card at the height the old journey timeline pins its active card to.
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex w-[280px] flex-none gap-[11px] rounded-[20px] bg-[color:var(--m-sheet)] p-[11px] text-left shadow-[0_16px_40px_-18px_rgba(0,0,0,.5)]"
+      className="flex max-h-[140px] w-[280px] flex-none gap-[11px] overflow-hidden rounded-[20px] bg-[color:var(--m-sheet)] p-[11px] text-left shadow-[0_16px_40px_-18px_rgba(0,0,0,.5)]"
     >
       {firstPhoto && (
         <span className="flex w-16 flex-none flex-col gap-[5px]">
@@ -73,8 +76,9 @@ export default function MJourneyEntryCard({ entry, number, onClick }: MJourneyEn
           </span>
         </span>
         <span className="mt-1 block truncate text-[0.875rem] font-extrabold">{title}</span>
+        {/* No display utility on the preview: Tailwind emits it after line-clamp-2 and would kill the clamp. */}
         {storyPreview && (
-          <span className="mt-[2px] block font-geist text-[0.65625rem] leading-[1.4] text-m-muted line-clamp-2">
+          <span className="mt-[2px] font-geist text-[0.65625rem] leading-[1.4] text-m-muted line-clamp-2">
             {storyPreview}
           </span>
         )}

--- a/client/src/mobile/screens/trip/map/MMapArea.tsx
+++ b/client/src/mobile/screens/trip/map/MMapArea.tsx
@@ -45,6 +45,10 @@ export default function MMapArea({ planner, shell }: MMapAreaProps) {
         route={planner.route}
         routeVias={planner.routeVias}
         showTransitRoutes={planner.routeShown}
+        // The route toggle belongs to one day, so the map needs that day to know
+        // which automated transports may ride it (#2019).
+        days={planner.days}
+        selectedDayId={planner.selectedDayId}
         routeSegments={planner.routeSegments}
         selectedPlaceId={planner.selectedPlaceId}
         onMarkerClick={planner.handleMarkerClick}

--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -366,6 +366,10 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
               route={route}
               routeVias={routeVias}
               showTransitRoutes={routeShown}
+              // The route toggle belongs to one day, so the map needs that day to
+              // know which automated transports may ride it (#2019).
+              days={days}
+              selectedDayId={selectedDayId}
               routeSegments={routeSegments}
               selectedPlaceId={selectedPlaceId}
               onMarkerClick={handleMarkerClick}

--- a/client/src/pages/TripPlannerPage.wiring.test.tsx
+++ b/client/src/pages/TripPlannerPage.wiring.test.tsx
@@ -351,13 +351,17 @@ describe('TripPlannerPage — shell', () => {
 })
 
 describe('TripPlannerPage — plan tab', () => {
-  it('FE-PAGE-TPW-008: the map receives the filtered markers, the tile url and the panel widths', () => {
+  it('FE-PAGE-TPW-008: the map receives the filtered markers, the tile url, the panel widths and the selected day', () => {
     renderPage()
 
     expect(props('map').places).toEqual([place])
     expect(props('map').tileUrl).toBe('https://tiles/{z}/{x}/{y}.png')
     expect(props('map').leftWidth).toBe(320)
     expect(props('map').center).toBeUndefined()
+    // Without the day the route toggle belongs to, the map draws every automated
+    // transport in the trip as soon as any day's route is on (#2019).
+    expect(props('map').days).toEqual([day])
+    expect(props('map').selectedDayId).toBe(7)
   })
 
   it('FE-PAGE-TPW-009: collapsed panels report a zero width to the map', () => {

--- a/client/src/utils/reservationRoutes.test.ts
+++ b/client/src/utils/reservationRoutes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { isRoutableReservation, visibleRouteReservations } from './reservationRoutes'
-import type { Reservation, ReservationEndpoint } from '../types'
+import type { Day, Reservation, ReservationEndpoint } from '../types'
 
 function endpoint(role: 'from' | 'to', lat: number, lng: number): ReservationEndpoint {
   return { role, sequence: role === 'from' ? 0 : 1, name: role, code: null, lat, lng, timezone: null, local_time: null, local_date: null }
@@ -52,5 +52,67 @@ describe('visibleRouteReservations', () => {
     const r = reservation({ id: 10, type: 'transit', endpoints: twoStop })
     const result = visibleRouteReservations([r], { visibleConnectionIds: [10], showTransitRoutes: true })
     expect(result).toEqual([r])
+  })
+})
+
+describe('visibleRouteReservations with a selected day', () => {
+  const twoStop = [endpoint('from', 1, 2), endpoint('to', 3, 4)]
+  const days = [
+    { id: 10, trip_id: 1, day_number: 1 },
+    { id: 11, trip_id: 1, day_number: 2 },
+    { id: 20, trip_id: 1, day_number: 3 },
+  ] as Day[]
+
+  function transit(overrides: Partial<Reservation>): Reservation {
+    return reservation({ type: 'transit', endpoints: twoStop, ...overrides })
+  }
+
+  it('excludes a transit journey that runs on another day', () => {
+    const r = transit({ id: 1, day_id: 20, end_day_id: 20 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 10, days })).toEqual([])
+  })
+
+  it('includes a transit journey that runs on the selected day', () => {
+    const r = transit({ id: 1, day_id: 10, end_day_id: 10 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 10, days })).toEqual([r])
+  })
+
+  it('keeps an overnight journey on both its departure and its arrival day', () => {
+    const r = transit({ id: 1, day_id: 10, end_day_id: 11 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 10, days })).toEqual([r])
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 11, days })).toEqual([r])
+  })
+
+  it('keeps a multi-day journey on the days in between', () => {
+    const r = transit({ id: 1, day_id: 10, end_day_id: 20 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 11, days })).toEqual([r])
+  })
+
+  it('goes by day order, not by day id', () => {
+    // Days dragged into a new order: id 20 is now the first day, id 10 the last.
+    const reordered = [
+      { id: 20, trip_id: 1, day_number: 1 },
+      { id: 11, trip_id: 1, day_number: 2 },
+      { id: 10, trip_id: 1, day_number: 3 },
+    ] as Day[]
+    const r = transit({ id: 1, day_id: 20, end_day_id: 11 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 11, days: reordered })).toEqual([r])
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 10, days: reordered })).toEqual([])
+  })
+
+  it('keeps a transit journey that is bound to no day', () => {
+    const r = transit({ id: 1, day_id: null, end_day_id: null })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: 10, days })).toEqual([r])
+  })
+
+  it('leaves the per-item route toggle day-agnostic', () => {
+    const r = reservation({ id: 5, type: 'train', endpoints: twoStop, day_id: 20, end_day_id: 20 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [5], showTransitRoutes: false, selectedDayId: 10, days })).toEqual([r])
+  })
+
+  it('does not scope transit without a selected day', () => {
+    const r = transit({ id: 1, day_id: 20, end_day_id: 20 })
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, days })).toEqual([r])
+    expect(visibleRouteReservations([r], { visibleConnectionIds: [], showTransitRoutes: true, selectedDayId: null, days })).toEqual([r])
   })
 })

--- a/client/src/utils/reservationRoutes.ts
+++ b/client/src/utils/reservationRoutes.ts
@@ -1,4 +1,5 @@
-import type { Reservation } from '../types'
+import { isDayInAccommodationRange } from './dayOrder'
+import type { Day, Reservation } from '../types'
 
 /**
  * A reservation is routable on the map once it has at least two ordered
@@ -17,14 +18,37 @@ export interface RouteVisibilityOptions {
   visibleConnectionIds: number[]
   /** The separate manual day-route-calculator toggle — 'transit' reservations ride it (#1065). */
   showTransitRoutes: boolean
+  /** The day that toggle belongs to. Optional: a map without a day context (collections) keeps drawing every transit, as before. */
+  selectedDayId?: number | null
+  /** The trip's days, needed to order them — day ids are not monotonic once days have been reordered. */
+  days?: Day[]
+}
+
+/**
+ * Does this transit journey actually run on the selected day? `showTransitRoutes` is one
+ * day's toggle but the reservation list is trip-wide, so without this every automated
+ * transport in the trip drew its geometry as soon as any day's route was switched on (#2019).
+ *
+ * The span, not the departure day: an overnight journey carries end_day_id and has to stay
+ * on both of its days — same rule getTransportForDay applies to the sidebar timeline.
+ * A journey bound to no day keeps drawing; hiding something that legitimately belongs
+ * to today is the worse failure.
+ */
+function transitRunsOnDay(r: Reservation, selectedDayId: number | null | undefined, days: Day[]): boolean {
+  if (selectedDayId == null) return true
+  const startDayId = r.day_id ?? r.end_day_id
+  if (startDayId == null) return true
+  const day = days.find(d => d.id === selectedDayId)
+  if (!day) return true
+  return isDayInAccommodationRange(day, startDayId, r.end_day_id ?? startDayId, days)
 }
 
 /** Which reservations should draw a route on the map, combining the two independent toggles above. */
 export function visibleRouteReservations(reservations: Reservation[], options: RouteVisibilityOptions): Reservation[] {
-  const { visibleConnectionIds, showTransitRoutes } = options
+  const { visibleConnectionIds, showTransitRoutes, selectedDayId, days } = options
   const set = new Set(visibleConnectionIds || [])
   return reservations.filter(r =>
-    (r.type === 'transit' && showTransitRoutes) ||
+    (r.type === 'transit' && showTransitRoutes && transitRunsOnDay(r, selectedDayId, days || [])) ||
     set.has(r.id)
   )
 }


### PR DESCRIPTION
Three reported bugs, each traced to its actual cause and pinned with a test that fails without the fix.

Closes #2022
Closes #2021
Closes #2019

## #2022 — the journey timeline sits at a random height on mobile

The story preview carried both `block` and `line-clamp-2`. Tailwind emits the display plugin *after* line-clamp at equal specificity, so `display:block` won and `-webkit-line-clamp` — which only does anything on a `-webkit-box` — was inert. The whole entry text rendered, the card grew with it, and the timeline it sits in is bottom-anchored with no height of its own, so it climbed up the screen.

Measured in Chromium at 430×932 (iPhone 14 Pro Max CSS px), against a fixture using the component's real class strings and the repo's compiled Tailwind:

| story length | card height | timeline top edge |
|---|---|---|
| 3 words | 84px | y = 744 |
| 60 words | 187px | y = 641 |
| 400 words | 804px | y = 24 |
| 2000 words | 3748px | y = −2916 (clipped) |

That is the reporter's "at the top in one journey, in the middle in another" — it is not their install, it is the longest comment in the journey they open. jubnl's comment on the issue said the same thing from the other end, and this is where it comes from.

It also explains the second half of the report. The timeline sits above the map and is a horizontal scroller, so once it covers the screen it consumes every drag Leaflet would have received; `elementFromPoint` returns the timeline everywhere except the 26px gap above the dock, which is exactly "can't move on the map except when I touch it below the navigation bar".

Dropping the display utility fixes the cards that exist. Capping the card height means no future one can do this again — 140px is what the older journey timeline pins its active card to, so the two look like the same product. Verified that the natural maximum with the clamp working (122px, photo + location) sits under the cap, so the cap clips nothing that renders today.

Also lifts the map attribution over the bottom dock, which both of the reporter's screenshots show sitting on top of it. Both engines, since a phone meets either depending on the screen.

## #2021 — Studio outline maps zoom out to the overseas territories

A country is one path but not one landmass. France's is five rings, three of them Kerguelen, French Guiana and New Caledonia, so fitting a map to its bounding box asked for 221° of longitude and printed a Paris–Lyon–Nice route as a single dot.

Longitude span per country, from the bundled shapes: FR 221.6°, US 101.2°, GB 39.8° (South Georgia), NO 26.1° (Svalbard), EC 16.4° (Galápagos) — against NL 3.9°, DE 9.2°, PT 3.3°. That is why the reporter's France journey is broken and a Netherlands one looks perfect.

Satellite only escaped by accident: imagery leaves the shape list empty, so the fit fell through to the stops. The same "Whole country" control was silently doing nothing there.

The fix fits to the rings the journey is actually near, keeping the whole shape as the fallback for a map with no route yet. Pin span in a 100mm frame, France: **1.48mm → 74mm**.

The margin is the route's own size with a 2° floor, and that floor is the judgement in this change: at 2° a Paris–Nice route still keeps Corsica, which is the picture that trip wants, while Kerguelen at 68°E stays out. The outlines themselves are untouched — the overseas rings are still drawn, they just run off the frame the way a coastline does.

## #2019 — every day's automated transport drawn on every day

The route toggle belongs to one day; the reservation list it filtered is the whole trip. Turning on a day's routing therefore let every transit reservation in the trip draw its geometry at once — on a day with no transport of its own, which is what the reporter saw.

Only automated transports rode it, and that is exactly the distinction they drew: a manually entered train or flight is `type: 'train'`/`'flight'` and reaches the map only through its own per-booking toggle. Only the transit search stores `type: 'transit'`.

The transit branch is gated on the day now, and only that branch — the per-booking toggle stays trip-wide, because switching a booking's route on is a deliberate act about that booking. The predicate is the day-**order** range, not the departure day: an overnight journey carries `end_day_id` and has to stay on both of its days, the same rule the sidebar timeline already applies, and day order rather than day id because ids stop being monotonic once days are reordered.

The day context is optional throughout, so a map without one — collections — behaves exactly as before. Not a 4.0.0 regression: it reproduces on 3.4.1 too, which matches the reporter's version note.
