### PR TITLE
fix(plugins): close a path traversal and three ways the host could be stalled

### DIFF
--- a/server/src/nest/plugins/host/rpc-host.ts
+++ b/server/src/nest/plugins/host/rpc-host.ts
@@ -82,7 +82,11 @@ export class PluginRpcHost {
   }
 
   async dispatch(req: RpcRequest, actingUserId?: number): Promise<RpcResponse | RpcError> {
-    const raw = (req.params ?? {}) as Record<string, unknown>;
+    // Anything but an object is treated as no params at all. The envelope comes
+    // off an IPC channel a plugin can write to, and `'_inv' in raw` below throws a
+    // TypeError on a primitive — outside handle()'s try/catch, so it escapes as a
+    // rejection rather than an error envelope.
+    const raw = (typeof req.params === 'object' && req.params !== null ? req.params : {}) as Record<string, unknown>;
     // The supervisor resolves the acting user from `_inv` BEFORE dispatch and passes
     // the request on untouched, so `_inv` is visible to every handler today and is in
     // effect a reserved param name. Strip it here: no handler and no audit reads

--- a/server/src/nest/plugins/install/safe-extract.ts
+++ b/server/src/nest/plugins/install/safe-extract.ts
@@ -83,6 +83,15 @@ function readTarGz(buf: Buffer, lim: Required<ExtractLimits>): Member[] {
     const prefix = block.subarray(345, 500).toString('utf8').replace(/\0.*$/, '');
     if (prefix) name = `${prefix}/${name}`;
     const size = parseInt(block.subarray(124, 136).toString('utf8').replace(/\0.*$/, '').trim() || '0', 8);
+    // A negative size walks the cursor backwards: `off += 512` and then
+    // `off += Math.ceil(size / 512) * 512` cancel out at -512 and go negative
+    // below it, so the same header is read forever while every pass appends a
+    // member — a 70-byte archive is enough to hold the main thread and exhaust
+    // memory. The entry budgets in extractArchive never get a say; they run on
+    // the list this function has to finish building first.
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new ExtractError(`invalid entry size in tar header: ${block.subarray(124, 136).toString('utf8').replace(/\0.*$/, '').trim()}`);
+    }
     const typeflag = String.fromCharCode(block[156]);
     off += 512;
     const data = tar.subarray(off, off + size);

--- a/server/src/nest/plugins/paths.ts
+++ b/server/src/nest/plugins/paths.ts
@@ -23,9 +23,31 @@ export function pluginsDataRoot(): string {
   return readEnv().plugins.dataDir || path.join(DATA_ROOT, 'plugins-data');
 }
 
+/**
+ * Plugin ids reach these helpers straight from a route parameter — `POST
+ * /api/admin/plugins/:id/uninstall` hands its id to pluginCodeDir, and what comes
+ * back goes to a recursive remove. Express decodes `%2F` AFTER routing, so
+ * `..%2F..%2Fuploads` still matches the route and arrives here as
+ * `../../uploads`; a plain path.join then points outside the plugin tree.
+ *
+ * Deliberately narrower than the manifest's ID_RE, which demands 3–40 lowercase
+ * characters and is the right rule at install time. This one only has to keep an
+ * id from leaving its parent, so it stays permissive about length and case and
+ * refuses exactly what steers a path: separators, a leading dot, and the
+ * drive/stream colon.
+ */
+const SAFE_PLUGIN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function safePluginId(id: string): string {
+  if (typeof id !== 'string' || id.length > 64 || !SAFE_PLUGIN_ID.test(id)) {
+    throw new Error(`invalid plugin id: ${JSON.stringify(id)}`);
+  }
+  return id;
+}
+
 /** A plugin's installed code directory (contains trek-plugin.json + server/index.js). */
 export function pluginCodeDir(id: string): string {
-  return path.join(pluginsCodeRoot(), id);
+  return path.join(pluginsCodeRoot(), safePluginId(id));
 }
 
 /**
@@ -60,7 +82,7 @@ export function ensurePluginModuleType(codeDir: string): void {
 
 /** A plugin's writable data directory (its own sqlite file + any blobs). */
 export function pluginDataDir(id: string): string {
-  return path.join(pluginsDataRoot(), id);
+  return path.join(pluginsDataRoot(), safePluginId(id));
 }
 
 /** The plugin's own sqlite file — opened by the HOST, reached by the plugin only via RPC. */

--- a/server/src/nest/plugins/supervisor/plugin-supervisor.ts
+++ b/server/src/nest/plugins/supervisor/plugin-supervisor.ts
@@ -474,7 +474,7 @@ export class PluginSupervisor {
     sup.child = child;
     sup.lastBeat = Date.now();
 
-    child.on('message', (raw: unknown) => this.onMessage(sup, raw as Envelope));
+    child.on('message', (raw: unknown) => this.handleChildMessage(sup, raw));
     child.on('exit', (code, signal) => this.onExit(sup, code, signal));
     child.on('error', (e) => this.hooks.onLog?.(sup.id, 'error', `child error: ${e.message}`));
     child.stdout?.on('data', (b) => this.recordLog(sup, 'info', String(b).trimEnd()));
@@ -500,6 +500,19 @@ export class PluginSupervisor {
       this.hooks.onLog?.(sup.id, 'warn', `[trek] ${dropped} log line(s) dropped (plugin log rate limit exceeded)`);
     }
     this.hooks.onLog?.(sup.id, level, msg, meta);
+  }
+
+  /**
+   * An EventEmitter listener throws away what its callback returns, and onMessage is
+   * async — so a rejection in there surfaces as an unhandledRejection, which Node 22
+   * turns into process exit. The host installs no net for it (the plugin child does,
+   * for itself), so one malformed envelope would take down the very supervisor whose
+   * job is to contain a misbehaving plugin. Log it against the plugin and carry on.
+   */
+  private handleChildMessage(sup: Supervised, raw: unknown): void {
+    this.onMessage(sup, raw as Envelope).catch((e: unknown) => {
+      this.hooks.onLog?.(sup.id, 'error', `message handling failed: ${e instanceof Error ? e.message : String(e)}`);
+    });
   }
 
   private async onMessage(sup: Supervised, msg: Envelope): Promise<void> {

--- a/server/tests/unit/plugins/protocol-paths.test.ts
+++ b/server/tests/unit/plugins/protocol-paths.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { isKnownPermission, METHOD_PERMISSION, KNOWN_METHODS, HOOK_PERMISSION } from '../../../src/nest/plugins/protocol/envelope';
 import path from 'node:path';
-import { pluginsCodeRoot, pluginsDataRoot, pluginCodeDir, pluginDbFile, resolveChildEntry, serverCodeRoot, pluginPermissionArgs, pluginRealCodeDir, ensurePluginModuleType } from '../../../src/nest/plugins/paths';
+import { pluginsCodeRoot, pluginsDataRoot, pluginCodeDir, pluginDataDir, pluginDbFile, resolveChildEntry, serverCodeRoot, pluginPermissionArgs, pluginRealCodeDir, ensurePluginModuleType } from '../../../src/nest/plugins/paths';
 
 afterEach(() => {
   delete process.env.TREK_PLUGINS_DIR;
@@ -98,6 +98,47 @@ describe('paths', () => {
       expect(JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))).toEqual({ type: 'module' });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * The id these helpers get comes off a route parameter — POST
+ * /api/admin/plugins/:id/uninstall walks it into pluginCodeDir and hands the result
+ * to a recursive remove. Express decodes %2F only AFTER routing, so a traversal
+ * still matches the route and arrives here decoded.
+ */
+describe('plugin id containment', () => {
+  const traversals = [
+    '../../uploads',
+    '../..',
+    '..',
+    '.',
+    'a/b',
+    'a\b',
+    'C:\Windows',
+    '.hidden',
+    '',
+  ];
+
+  it('refuses any id that could point outside its parent', () => {
+    for (const id of traversals) {
+      expect(() => pluginCodeDir(id), id).toThrow(/invalid plugin id/);
+      expect(() => pluginDataDir(id), id).toThrow(/invalid plugin id/);
+    }
+  });
+
+  it('still accepts the ids plugins actually use', () => {
+    for (const id of ['x', 'a1', '001', 'flight-tracker', 'Bad-Id', 'trip.todos', 'koffi_and_friends']) {
+      expect(path.basename(pluginCodeDir(id))).toBe(id);
+      expect(path.basename(pluginDataDir(id))).toBe(id);
+    }
+  });
+
+  it('keeps every accepted id inside the plugin roots', () => {
+    for (const id of ['x', 'flight-tracker', 'a.b', 'a-b_c']) {
+      expect(pluginCodeDir(id).startsWith(pluginsCodeRoot() + path.sep)).toBe(true);
+      expect(pluginDataDir(id).startsWith(pluginsDataRoot() + path.sep)).toBe(true);
     }
   });
 });

--- a/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
+++ b/server/tests/unit/plugins/rpc-host-inv-strip.test.ts
@@ -110,4 +110,29 @@ describe('dispatch strips the supervisor _inv marker', () => {
     await host.dispatch(req('packing.setBagMembers', { tripId: 1, bagId: 80, userIds: [3], _inv: 'req-7' }), 42);
     expect(setBagMembers).toHaveBeenCalledWith('1', '80', [3]);
   });
+
+  /**
+   * The `_inv` check runs before handle()'s try/catch, so a params value that is not
+   * an object used to throw a TypeError out of dispatch instead of coming back as an
+   * error envelope. The supervisor discards the promise dispatch lives on, which made
+   * that an unhandledRejection — process exit, from one malformed envelope.
+   */
+  it('RPCINV-007 params that are not an object come back as an envelope, not a rejection', async () => {
+    const host = new PluginRpcHost('p', new Set(['db:own']), makeDeps(), dbRegistry());
+
+    for (const params of [5, 'text', true] as unknown as Record<string, unknown>[]) {
+      const res = await host.dispatch({ k: 'req', id: 'x', method: 'db.query', params });
+      expect(res).toMatchObject({ k: 'res', id: 'x', ok: false });
+    }
+  });
+
+  it('RPCINV-008 null and undefined params still behave as an empty object', async () => {
+    const host = new PluginRpcHost('p', new Set(['db:own']), makeDeps(), dbRegistry());
+
+    const nulled = await host.dispatch({ k: 'req', id: 'x', method: 'db.query', params: null as unknown as Record<string, unknown> });
+    // The type says params is required; the IPC channel does not, so a child can
+    // leave it off entirely.
+    const missing = await host.dispatch({ k: 'req', id: 'x', method: 'db.query', params: undefined as unknown as Record<string, unknown> });
+    expect(nulled).toEqual(missing);
+  });
 });

--- a/server/tests/unit/plugins/safe-extract.test.ts
+++ b/server/tests/unit/plugins/safe-extract.test.ts
@@ -11,13 +11,15 @@ import zlib from 'node:zlib';
 import { safeJoin, extractArchive, ExtractError } from '../../../src/nest/plugins/install/safe-extract';
 
 // ── tiny archive builders ────────────────────────────────────────────────────
-function tarHeader(name: string, size: number, typeflag = '0', linkname = ''): Buffer {
+function tarHeader(name: string, size: number, typeflag = '0', linkname = '', rawSize?: string): Buffer {
   const h = Buffer.alloc(512, 0);
   h.write(name, 0);
   h.write('0000644', 100);
   h.write('0000000', 108);
   h.write('0000000', 116);
-  h.write(size.toString(8).padStart(11, '0'), 124);
+  // rawSize writes the 12-byte field verbatim, for headers a real tar would never
+  // produce (negative, non-octal) — the reader has to survive those too.
+  h.write(rawSize !== undefined ? rawSize.padEnd(11, ' ') : size.toString(8).padStart(11, '0'), 124);
   h.write('00000000000', 136);
   h.write('        ', 148); // checksum placeholder = spaces
   h.write(typeflag, 156);
@@ -29,12 +31,12 @@ function tarHeader(name: string, size: number, typeflag = '0', linkname = ''): B
   h.write(sum.toString(8).padStart(6, '0') + '\0 ', 148);
   return h;
 }
-function makeTarGz(entries: Array<{ name: string; data?: string; type?: string; link?: string }>): Buffer {
+function makeTarGz(entries: Array<{ name: string; data?: string; type?: string; link?: string; rawSize?: string }>): Buffer {
   const parts: Buffer[] = [];
   for (const e of entries) {
     const body = Buffer.from(e.data ?? '');
-    parts.push(tarHeader(e.name, e.type === '5' || e.type === '2' ? 0 : body.length, e.type ?? '0', e.link ?? ''));
-    if (e.type !== '5' && e.type !== '2') {
+    parts.push(tarHeader(e.name, e.type === '5' || e.type === '2' ? 0 : body.length, e.type ?? '0', e.link ?? '', e.rawSize));
+    if (e.rawSize === undefined && e.type !== '5' && e.type !== '2') {
       parts.push(body);
       const pad = (512 - (body.length % 512)) % 512;
       if (pad) parts.push(Buffer.alloc(pad, 0));
@@ -129,5 +131,21 @@ describe('extractArchive', () => {
 
   it('rejects an unsupported format', () => {
     expect(() => extractArchive(Buffer.from('not an archive'), dest)).toThrow(/unsupported/);
+  });
+
+  // A size field is 12 ASCII bytes of octal, and parseInt honours a leading minus.
+  // The reader advanced by `512 + Math.ceil(size / 512) * 512`, which is zero at
+  // -512 and negative below it: the cursor never leaves the first header, and every
+  // pass appends another member until the heap is gone. Synchronous, on the main
+  // thread, from a 70-byte upload.
+  it('refuses a negative entry size instead of looping on it', () => {
+    const gz = makeTarGz([{ name: 'evil.txt', rawSize: '-1000' }]);
+    expect(() => extractArchive(gz, dest)).toThrow(ExtractError);
+    expect(() => extractArchive(gz, dest)).toThrow(/invalid entry size/);
+  });
+
+  it('refuses a size field that is not a number at all', () => {
+    const gz = makeTarGz([{ name: 'evil.txt', rawSize: 'not-octal' }]);
+    expect(() => extractArchive(gz, dest)).toThrow(/invalid entry size/);
   });
 });

--- a/server/tests/unit/plugins/supervisor-lifecycle.test.ts
+++ b/server/tests/unit/plugins/supervisor-lifecycle.test.ts
@@ -311,3 +311,39 @@ describe('supervisor throttles plugin log/stderr volume (host-thread DoS guard)'
     expect(sup.droppedLogs).toBe(0);
   });
 });
+
+/**
+ * The 'message' listener is where a rejection would escape: an EventEmitter discards
+ * what its callback returns, onMessage is async, and the host has no
+ * unhandledRejection handler — so Node 22 would end the process. A plugin getting to
+ * kill the supervisor that contains it defeats the point of the supervisor.
+ */
+describe('supervisor message handling never escapes as a rejection', () => {
+  it('logs a failed message against the plugin and keeps running', async () => {
+    const onLog = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const s = new PluginSupervisor((() => ({ dispose: vi.fn() })) as any, { onLog }, {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (s as any).onMessage = () => Promise.reject(new Error('malformed envelope'));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => (s as any).handleChildMessage({ id: 'p' }, { k: 'req', id: 'x' })).not.toThrow();
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onLog).toHaveBeenCalledWith('p', 'error', expect.stringContaining('malformed envelope'));
+  });
+
+  it('says nothing when the message is handled normally', async () => {
+    const onLog = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const s = new PluginSupervisor((() => ({ dispose: vi.fn() })) as any, { onLog }, {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (s as any).onMessage = () => Promise.resolve();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (s as any).handleChildMessage({ id: 'p' }, { k: 'evt', topic: 'log' });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onLog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Four findings in the plugin runtime, all reproduced before touching anything. None came from a bug report — they turned up while tracing SonarQube Blockers (#2032), and none of them is one; they are separate defects in code whose entire purpose is to survive a plugin that misbehaves.

**Path traversal in the plugin id.** `POST /api/admin/plugins/:id/uninstall` walks its route parameter into `pluginCodeDir()` and hands the result to `fs.rmSync(..., { recursive: true, force: true })`. Express decodes `%2F` *after* routing, so `..%2F..%2Fuploads` still matches the route and reaches the helper as `../../uploads` — `path.join` then points at the uploads tree, and `deleteData: true` reaches the data root the same way. Verified against the express version in the lockfile: the route matches and `req.params.id` decodes to the traversal.

`pluginCodeDir` and `pluginDataDir` now refuse an id that could leave its parent. Deliberately narrower than the manifest's `ID_RE`, which wants 3–40 lowercase characters and is the right rule at install time; this one only has to keep an id from steering a path, so it stays permissive about length and case. Every comparable filesystem sink in the backend already has its guard — storage keys, extraction, the wiki, backup filenames. This one did not.

**A 70-byte archive that never finishes.** `readTarGz` trusted the tar size field, and `parseInt` honours a leading minus. The cursor advances by `512 + Math.ceil(size / 512) * 512`, which is zero at -512 and negative below it: the same header is read forever while every pass appends a member. It runs synchronously on the main thread, so it takes HTTP, the WebSocket and the database with it, and the entry budgets in `extractArchive` never get a say — they run on the list `readTarGz` has to finish building first. Reachable through plugin sideload. Reproduced against the real function: OOM in three seconds under a 256 MB cap.

**A rejection that ends the process.** The supervisor handed `onMessage`'s promise to an EventEmitter listener, which discards it. A rejection there is an unhandledRejection, the host installs no handler for it (the plugin child does, for itself), and Node 22 ends the process — the supervisor killed by the plugin it exists to contain.

**The rejection that reaches it.** `dispatch()` evaluates `'_inv' in req.params` before `handle()`'s try/catch, so params that are not an object throw a `TypeError` into exactly that discarded promise. Confirmed: `'_inv' in 5` throws.

A fifth candidate was checked and dismissed: `journey-domain.service.ts` interpolates request-body keys as SQL column names, but both loops allow-list the key against a hardcoded set first, so nothing reaches SQL that isn't one of a few literals. Left alone.

## Related Issue or Discussion

None — found while tracing the analyser findings in #2032.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Behaviour

Nothing valid changes shape. The id guard accepts every id a plugin actually uses — including the single-character and mixed-case ones the existing tests rely on — and refuses only separators, a leading dot and the drive colon. The tar reader refuses a header no real archive produces. The supervisor logs against the plugin where it used to exit. 933 plugin tests pass, and the tar case was checked in both directions: with the fix reverted the new test does not complete.