### PR TITLE
ci(sonar): fold the four coverage jobs into one, on the root scripts

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,103 +16,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  # The four suites mirror the jobs in test.yml — same setup, same
-  # `test:coverage` scripts — because Sonar needs the lcov each package emits.
-  # Without them every line reports as uncovered and the dashboard shows a
-  # collapse that did not happen. They run in parallel and hand their reports to
-  # the scan job as artifacts.
-  shared-coverage:
-    name: Coverage (shared)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci --workspace shared
-      - run: cd shared && npm run test:coverage
-      - uses: actions/upload-artifact@v6
-        with:
-          name: sonar-shared-coverage
-          path: shared/coverage/
-          retention-days: 1
-
-  plugin-sdk-coverage:
-    name: Coverage (plugin-sdk)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: plugin-sdk
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: plugin-sdk/package-lock.json
-      - run: npm ci
-      - run: npm run test:coverage
-      - uses: actions/upload-artifact@v6
-        with:
-          name: sonar-plugin-sdk-coverage
-          path: plugin-sdk/coverage/
-          retention-days: 1
-
-  server-coverage:
-    name: Coverage (server)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci
-
-      - name: Ensure @swc/core's Linux binary for unplugin-swc
-        # Same reason as test.yml: the lockfile was generated on Windows and
-        # omits the Linux optional native binary, so the server's SWC transform
-        # cannot load without this.
-        run: |
-          SWC_VERSION=$(node -p "require('@swc/core/package.json').version")
-          npm install --no-save --legacy-peer-deps "@swc/core-linux-x64-gnu@$SWC_VERSION"
-
-      - name: Build shared
-        run: npm run build --workspace=shared
-      - run: cd server && npm run test:coverage
-      - uses: actions/upload-artifact@v6
-        with:
-          name: sonar-server-coverage
-          path: server/coverage/
-          retention-days: 1
-
-  client-coverage:
-    name: Coverage (client)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci --workspace shared && npm ci --workspace client
-      - name: Build shared
-        run: npm run build --workspace=shared
-      - run: cd client && npm run test:coverage
-      - uses: actions/upload-artifact@v6
-        with:
-          name: sonar-client-coverage
-          path: client/coverage/
-          retention-days: 1
-
   scan:
-    name: SonarQube Scan
+    name: Coverage & Scan
     runs-on: ubuntu-latest
-    needs: [shared-coverage, plugin-sdk-coverage, server-coverage, client-coverage]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -120,24 +26,43 @@ jobs:
           # new code. A shallow clone leaves it blind to both.
           fetch-depth: 0
 
-      # Restored to the exact paths sonar-project.properties names in
-      # sonar.javascript.lcov.reportPaths.
-      - uses: actions/download-artifact@v6
+      - uses: actions/setup-node@v6
         with:
-          name: sonar-shared-coverage
-          path: shared/coverage/
-      - uses: actions/download-artifact@v6
-        with:
-          name: sonar-plugin-sdk-coverage
-          path: plugin-sdk/coverage/
-      - uses: actions/download-artifact@v6
-        with:
-          name: sonar-server-coverage
-          path: server/coverage/
-      - uses: actions/download-artifact@v6
-        with:
-          name: sonar-client-coverage
-          path: client/coverage/
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install plugin-sdk dependencies
+        # plugin-sdk is not a root workspace (workspaces = client, server, shared)
+        # — it ships as its own npm package with its own lockfile, so the root
+        # npm ci does not reach it. Its coverage is part of test:cov all the same.
+        run: cd plugin-sdk && npm ci
+
+      - name: Ensure @swc/core's Linux binary for unplugin-swc
+        # Same reason as test.yml: the lockfile was generated on Windows and omits
+        # @swc/core's Linux optional native binary, so npm ci skips it on the
+        # runner and the server's SWC transform cannot load.
+        run: |
+          SWC_VERSION=$(node -p "require('@swc/core/package.json').version")
+          npm install --no-save --legacy-peer-deps "@swc/core-linux-x64-gnu@$SWC_VERSION"
+
+      - name: Build shared
+        # Only shared, not the root `build`. server and client run their suites
+        # from source through vitest, so building them would add a tsc pass and a
+        # full vite bundle that nothing here reads.
+        run: npm run build --workspace=shared
+
+      - name: Run tests with coverage
+        # One script for all four packages — it already ends with
+        # `--prefix plugin-sdk`. Each writes lcov to <pkg>/coverage/, which is
+        # where sonar.javascript.lcov.reportPaths looks. Without those files every
+        # line reports as uncovered and the dashboard shows a collapse that did
+        # not happen, so this step failing has to stop the scan rather than let it
+        # publish a false number.
+        run: npm run test:cov
 
       - name: Scan
         uses: SonarSource/sonarqube-scan-action@v8


### PR DESCRIPTION
## Description

Follow-up to #2038, acting on the review point: the root already has a script that does all of this. `npm run test:cov` ends with `--prefix plugin-sdk`, so all four packages are covered in one call, and each writes its lcov to `<pkg>/coverage/` — exactly where `sonar.javascript.lcov.reportPaths` looks. The five jobs and the artifact upload/download between them were doing that by hand. **131 lines become 28.**

One correction to the review: the plugin SDK does not need adding to the scripts. `test:cov` already covers it. What it does need is its own `npm ci`, because it is not a root workspace (`workspaces` is `client`, `server`, `shared`) — that part is exactly right.

Three steps survive the fold, kept separate so the reason stays readable:

- **`cd plugin-sdk && npm ci`** — see above.
- **The `@swc/core` Linux binary.** The lockfile was generated on Windows and omits the optional native binary, so `npm ci` skips it on the runner and the server's SWC transform cannot load. `test.yml` carries the same step for the same reason.
- **Only `shared` is built, not the root `build`.** `server` and `client` run their suites from source through vitest, so building them would add a `tsc` pass and a full vite bundle that nothing in this workflow reads.

## Related Issue or Discussion

Follows #2038.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## The trade-off, with numbers

This is slower, and it is worth saying so rather than selling it as a pure win.

The parallel version's first run on `dev` took **16 minutes** — `client` at 11 and `server` at 9 overlapping, then a 4-minute scan. Sequentially those add up instead, so expect **roughly 25**.

Nobody waits on this job: it publishes to a dashboard, it gates nothing, and it runs after the merge rather than before it. Against that, a hundred lines of YAML that restate what a root script already expresses is the more expensive thing to keep. Happy to keep the parallel version instead if the wall-clock matters more than the file — the current one works and is green.