### PR TITLE
fix(ci): restore the peer dep the swc install drops, and close a test race

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -45,9 +45,28 @@ jobs:
         # Same reason as test.yml: the lockfile was generated on Windows and omits
         # @swc/core's Linux optional native binary, so npm ci skips it on the
         # runner and the server's SWC transform cannot load.
+        #
+        # @testing-library/dom rides along, and has to. This install re-resolves
+        # the tree, and --legacy-peer-deps means npm does not put peer
+        # dependencies back — @testing-library/dom is a peer of
+        # @testing-library/react and not a direct dependency of the client, so it
+        # was silently dropped and all 616 client test files died on
+        # "Cannot find module". In test.yml this step lives in the server job,
+        # which never runs client tests, so the collision only appears once the
+        # jobs are folded into one. The version is read from the peer range rather
+        # than pinned here, so a bump to @testing-library/react carries over.
         run: |
           SWC_VERSION=$(node -p "require('@swc/core/package.json').version")
-          npm install --no-save --legacy-peer-deps "@swc/core-linux-x64-gnu@$SWC_VERSION"
+          DOM_RANGE=$(node -p "require('@testing-library/react/package.json').peerDependencies['@testing-library/dom']")
+          npm install --no-save --legacy-peer-deps \
+            "@swc/core-linux-x64-gnu@$SWC_VERSION" \
+            "@testing-library/dom@$DOM_RANGE"
+
+      - name: Verify the test toolchain survived that install
+        # Cheap tripwire: if a future dependency bump loses another peer the same
+        # way, this fails here with the name of the module instead of 600
+        # identical test failures twenty minutes later.
+        run: node -e "require.resolve('@testing-library/dom'); require.resolve('@swc/core')"
 
       - name: Build shared
         # Only shared, not the root `build`. server and client run their suites

--- a/client/tests/unit/mobile/admin/MAdminStoragePanel.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminStoragePanel.test.tsx
@@ -329,8 +329,16 @@ describe('MAdminStoragePanel', () => {
     server.use(
       http.put('/api/admin/storage', () => HttpResponse.json(savedState)),
       http.post('/api/admin/storage/migrations', async ({ request }) => {
-        postCount += 1;
+        // Parse BEFORE counting, so postCount and migrationPosts move together.
+        // With the increment first, the await left a window where postCount was
+        // already 1 while migrationPosts was still empty — and the GET handler
+        // below reports `migrations: []` for an empty migrationPosts, i.e. "no
+        // migration running". A poll landing in that window told the queue it was
+        // free to dequeue the second candidate, and the `waitFor(postCount === 1)`
+        // further down could resolve inside it too. Rare locally, reliable under
+        // CI load, where the microtask gap is wider than the 50ms test poll.
         const body = (await request.json()) as { category: StorageCategory; to: string };
+        postCount += 1;
         migrationPosts.push(body);
         // Pins the single-flight fix: the second POST must never arrive
         // before the first migration is server-confirmed terminal — a


### PR DESCRIPTION
## Description

Two separate reasons the v4.0.0 release PR (#1719) is red. Neither is a product defect.

### The SonarQube workflow took out every client test

All 616 client test files died on `Cannot find module '@testing-library/dom'`.

That package is a **peer** dependency of `@testing-library/react` and not a direct dependency of the client. The step that installs `@swc/core`'s Linux binary passes `--legacy-peer-deps`, which tells npm not to reinstate peer dependencies when it re-resolves the tree — so the install quietly removed it.

This is a collision I introduced in #2039. In `test.yml` that swc step lives in the **server** job, which never runs client tests; folding the four jobs into one put the install in front of the client suite for the first time. It now rides along with the swc binary, with its version read from the peer range rather than pinned so a bump to `@testing-library/react` carries over, plus a one-line `require.resolve` check straight after — if a future dependency change loses another peer the same way, it fails there with the module name instead of six hundred identical failures twenty minutes later.

### `FE-MOB-MSTOR-015` was a race in the test, not in the panel

`MAdminStoragePanel`'s POST handler did this:

```js
postCount += 1;
const body = await request.json();   // ← window opens here
migrationPosts.push(body);
```

Between the increment and the push there is an await. The GET handler reports `migrations: []` whenever `migrationPosts` is empty — that is, "no migration running" — so a poll landing inside that window told the queue it was free to dequeue the second candidate, and the `waitFor(postCount === 1)` further down could resolve inside it too. Parsing before counting moves the two updates together and closes it.

The panel itself is fine: `startMigration` already awaits `refreshState()` before releasing the queue's in-flight lock, and says so in a comment. This was the mock briefly contradicting the server it stands in for — rare locally, reliable under CI load where the microtask gap is wider than the 50 ms test poll.

## Related Issue or Discussion

Unblocks #1719 (v4.0.0). The workflow half is a regression from #2039.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Verification

The flake was reproduced and cleared where it actually shows up: the whole mobile suite at `--maxWorkers=8`, which is the load profile that surfaced it in CI. `MAdminStoragePanel` passes there now, and five isolated runs are green.

The workflow half cannot be proven locally — it is a Linux-runner tree-resolution problem — so the `require.resolve` tripwire is deliberately placed before the suite rather than after it. If the peer is still missing, this PR's own run says so in seconds.