### PR TITLE
docs: the storage seed example lives in the wiki now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
-#      - ./storage-config.json:/app/data/storage-config.json:ro # optional seed-once storage provisioning (README → Storage)
+#      - ./storage-config.json:/app/data/storage-config.json:ro # optional seed-once storage provisioning (wiki: Admin-Storage)
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]

--- a/wiki/Admin-Storage.md
+++ b/wiki/Admin-Storage.md
@@ -143,8 +143,29 @@ For scripted deployments, place a `storage-config.json` in the data directory
 (in Docker: mount it at `/app/data/storage-config.json`). It is imported
 exactly once — on the first boot that has no stored storage configuration —
 then ignored (a log line says so). An invalid file aborts boot with the exact
-validation error. Example and the compose mount line: see the
-[README Storage section](https://github.com/liketrek/TREK#storage).
+validation error.
+
+```jsonc
+// storage-config.json - secrets may be plaintext (encrypted on import)
+// or already-encrypted enc:v1: values.
+{
+  "backends": [
+    { "name": "off-site", "type": "s3", "options": {
+      "endpoint": "https://s3.example.com", "bucket": "trek",
+      "accessKeyId": "...", "secretAccessKey": "..." } },
+    { "name": "backups-mirror", "type": "mirror", "options": {
+      "primary": "backups-local", "replicas": ["off-site"] } }
+  ],
+  "categories": { "backups": "backups-mirror" }
+}
+```
+
+The panel presents this exact setup as **Mirror targets** on `backups-local`.
+
+```yaml
+# docker-compose: add under the trek service's volumes
+      - ./storage-config.json:/app/data/storage-config.json:ro
+```
 
 To reset storage configuration (or re-import a seed file): stop the server,
 `sqlite3 data/travel.db "DELETE FROM app_settings WHERE key LIKE 'storage.%';"`,


### PR DESCRIPTION
## Description

Two references to the README's Storage section outlived the section itself.

`wiki/Admin-Storage.md` sent readers to `github.com/liketrek/TREK#storage` for "the example and the compose mount line". That anchor no longer resolves — and worse, the example it pointed at was only ever in the README, so once that went, no copy of it existed anywhere. The wiki page described `storage-config.json` in prose without ever showing one. Both the example and the mount line are on the page now, where the rest of the seed-file documentation already lives.

The commented-out volume in `docker-compose.yml` carried the same pointer in its trailing comment.

This matters a little more than a normal broken link: `wiki/**` is baked into the image and serves the in-app Help at `/help`, so a dead link ships to every self-hosted instance.

## Related Issue or Discussion

Follow-up to #2048 and the README storage removal.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed

## Verification

The compose file still parses and resolves to the same service and image. The seed example parses as JSON once its comments are stripped, and yields the two backends and the category mapping it claims to.