### PR TITLE
fix(mobile): text fields no longer show a dark box inside their row

### DIFF
--- a/client/src/mobile/mobile.css
+++ b/client/src/mobile/mobile.css
@@ -340,3 +340,26 @@
 .m-root .maplibregl-ctrl-bottom-right {
   bottom: var(--bottom-nav-h);
 }
+
+/* Text fields carry the row's background, not their own.
+ *
+ * iOS paints its own background inside a text control, and under
+ * `color-scheme: dark` that fill is darker than the card the field sits on —
+ * so every field showed as a dark rectangle inside a lighter row (#2028). The
+ * mobile fields are deliberately `bg-transparent` because the row around them
+ * supplies the surface, which is exactly why the native fill has nothing
+ * covering it here and shows through; a desktop field hides it behind its own
+ * background. Dropping the native appearance is what actually removes it.
+ *
+ * Only text entry. `file`, `color`, `range` and the date/time pickers need
+ * their native chrome to stay usable, and `select` keeps its own arrow. */
+.m-root input:not([type]),
+.m-root input[type="text"],
+.m-root input[type="password"],
+.m-root input[type="email"],
+.m-root input[type="url"],
+.m-root input[type="search"],
+.m-root textarea {
+  -webkit-appearance: none;
+  appearance: none;
+}


### PR DESCRIPTION
## Description

On iOS in dark mode, every text field in the mobile sheets rendered as a dark rectangle sitting inside its lighter card — visible in the reporter's screenshot on Title, Description and the cover photo search.

iOS paints its own background inside a text control, and under `color-scheme: dark` (set on `.dark`) that fill is darker than the row the field sits on. The mobile fields are deliberately `bg-transparent` because the row around them supplies the surface — which is exactly why the native fill has nothing covering it here and shows through. A desktop field hides it behind its own background, which is why the same dialog looks right there and in light mode.

Setting a transparent `background-color` does not remove that fill; dropping the native appearance does.

The rule lives in `mobile.css`, which is scoped to `.m-root`, so it cannot reach desktop chrome. It covers text entry only — `file`, `color`, `range` and the date/time pickers keep their native chrome, and `select` keeps its own arrow.

It applies to `input` with no `type` attribute as well: 90 of the mobile tree's inputs are written without one, the trip title among them.

The same sheet backs both creating and editing a trip, so both cases the report mentions are covered.

## Related Issue or Discussion

Closes #2028

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Note on verification

Typecheck and the CSS build are clean. The rendering itself is iOS-specific — it cannot be reproduced in a desktop browser, so the visual confirmation wants an iPhone.