### PR TITLE
Improve mobile itinerary focus and plan discovery

### DIFF
--- a/client/src/components/Planner/today.test.ts
+++ b/client/src/components/Planner/today.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { findTodayDayId, localToday } from './today'
+import { findRelevantDayId, findTodayDayId, localToday } from './today'
 
 describe('localToday', () => {
   it('FE-TODAY-001: reads the date off the local clock, not UTC', () => {
@@ -42,5 +42,41 @@ describe('findTodayDayId', () => {
 
   it('FE-TODAY-006: tolerates a full timestamp in the date column', () => {
     expect(findTodayDayId([{ id: 7, date: '2026-08-11T00:00:00.000Z' }], at(2026, 8, 11))).toBe(7)
+  })
+})
+
+describe('findRelevantDayId', () => {
+  const days = [
+    { id: 1, date: '2026-08-10' },
+    { id: 2, date: '2026-08-12' },
+    { id: 3, date: '2026-08-14' },
+  ]
+  const at = (y: number, m: number, d: number) => new Date(y, m - 1, d, 10, 0, 0)
+
+  it('FE-TODAY-007: keeps the exact local-calendar day when the trip is running', () => {
+    expect(findRelevantDayId(days, at(2026, 8, 12))).toBe(2)
+  })
+
+  it('FE-TODAY-008: selects the next dated day before or between trip days', () => {
+    expect(findRelevantDayId(days, at(2026, 8, 9))).toBe(1)
+    expect(findRelevantDayId(days, at(2026, 8, 11))).toBe(2)
+  })
+
+  it('FE-TODAY-009: keeps the final day after the trip has finished', () => {
+    expect(findRelevantDayId(days, at(2026, 8, 15))).toBe(3)
+  })
+
+  it('FE-TODAY-010: returns null when no dated day can be focused', () => {
+    expect(findRelevantDayId([{ id: 1, date: null }, { id: 2 }], at(2026, 8, 11))).toBeNull()
+    expect(findRelevantDayId([], at(2026, 8, 11))).toBeNull()
+  })
+
+  it('FE-TODAY-011: tolerates full timestamps and does not mutate caller order', () => {
+    const timestampDays = [
+      { id: 2, date: '2026-08-12T00:00:00.000Z' },
+      { id: 1, date: '2026-08-10T00:00:00.000Z' },
+    ]
+    expect(findRelevantDayId(timestampDays, at(2026, 8, 11))).toBe(2)
+    expect(timestampDays.map(day => day.id)).toEqual([2, 1])
   })
 })

--- a/client/src/components/Planner/today.ts
+++ b/client/src/components/Planner/today.ts
@@ -16,6 +16,25 @@ export function localToday(now: Date = new Date()): string {
 }
 
 /**
+ * The most useful dated day when opening a trip on mobile.
+ *
+ * While the trip is running this is today. Before the trip (and in a gap
+ * between dated days) it is the next day on the calendar; after the trip it is
+ * the final day. Callers can still fall back to their first day for undated
+ * itineraries.
+ */
+export function findRelevantDayId(days: Array<{ id: number; date?: string | null }>, now?: Date): number | null {
+  const today = localToday(now)
+  const datedDays = days
+    .map((day, index) => ({ day, index, date: typeof day.date === 'string' ? day.date.slice(0, 10) : '' }))
+    .filter(item => item.date.length === 10)
+    .sort((a, b) => a.date.localeCompare(b.date) || a.index - b.index)
+
+  if (datedDays.length === 0) return null
+  return datedDays.find(item => item.date >= today)?.day.id ?? datedDays[datedDays.length - 1].day.id
+}
+
+/**
  * The id of the day that is today, or null when the trip is not running.
  *
  * Days without a date (a trip planned as "day 1..7" with no calendar attached)

--- a/client/src/mobile/screens/trip/MTripShell.tsx
+++ b/client/src/mobile/screens/trip/MTripShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ComponentType, type ReactNode } from 'react'
-import { findTodayDayId } from '../../../components/Planner/today'
+import { findRelevantDayId } from '../../../components/Planner/today'
 import {
   ChevronDown, ChevronLeft, Download, FileDown, List, Map as MapIcon, MoreHorizontal, PackageCheck,
   Plane, Plus, Rows3, Ticket, TrainFront, Trash2, Upload, Wallet,
@@ -199,16 +199,19 @@ export default function MTripShell({
   const [openFilesTrashSignal, setOpenFilesTrashSignal] = useState(0)
 
   // The mobile plan is single-day: make sure a day is active once days arrive.
-  // Only seed once so an intentional deselect elsewhere is not fought. When the
-  // trip is currently running, open on today's day instead of day 1 so you don't
-  // have to tap the current day every time; otherwise fall back to the first day.
+  // Only seed once so an intentional deselect elsewhere is not fought. Open on
+  // today, the next dated day, or the final dated day after the trip; undated
+  // itineraries retain the historical first-day fallback.
   const seededDayRef = useRef(false)
   useEffect(() => {
-    if (seededDayRef.current || planner.selectedDayId != null || days.length === 0) return
+    if (seededDayRef.current) return
+    if (planner.selectedDayId != null) {
+      seededDayRef.current = true
+      return
+    }
+    if (days.length === 0) return
     seededDayRef.current = true
-    // Same rule as the desktop day plan (#1567), off the same helper so the two
-    // cannot drift on what "today" means.
-    planner.tripActions.setSelectedDay(findTodayDayId(days) ?? days[0].id)
+    planner.tripActions.setSelectedDay(findRelevantDayId(days) ?? days[0].id)
   }, [planner.selectedDayId, days, planner.tripActions])
 
   const trTab = planner.activeTab

--- a/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
@@ -246,7 +246,7 @@ function UpNextCard({ tl, t, onOpen }: {
   const upNext = tl.upNext
   if (!upNext) return null
   const place = upNext.assignment.place
-  const time = place?.place_time ? formatTime(place.place_time.slice(0, 5), tl.language, tl.timeFormat) : ''
+  const time = upNext.displayTime ? formatTime(upNext.displayTime.slice(0, 5), tl.language, tl.timeFormat) : ''
   const sub = place?.address || place?.description || ''
 
   return (

--- a/client/src/mobile/screens/trip/plan/planTimelineModel.ts
+++ b/client/src/mobile/screens/trip/plan/planTimelineModel.ts
@@ -212,30 +212,46 @@ export interface UpNext {
   assignment: Assignment
   /** Minutes until the start time — only when the day is today and the stop is still ahead. */
   minutesUntil: number | null
+  /** Effective assignment time (assignment override first, then place default). */
+  displayTime: string | null
 }
 
 const localIsoDate = (d: Date): string =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 
 /**
- * The "UP NEXT" pick: on today's day the first timed stop that hasn't started
- * yet (with a real countdown); otherwise the first timed stop of the day, or
- * simply the first stop. Null when the day has no places.
+ * The "UP NEXT" pick: nothing for a past dated day; on today's day the first
+ * timed stop that hasn't started yet (with a real countdown); otherwise the
+ * first timed stop of the day, or simply the first stop. Null when the day has
+ * no places or today's timed plan has already finished.
  */
 export function findUpNext(day: Day | undefined, dayAssignments: Assignment[], now: Date): UpNext | null {
   if (dayAssignments.length === 0) return null
   const sorted = [...dayAssignments].sort((a, b) => a.order_index - b.order_index)
-  const timeOf = (a: Assignment) => parseTimeToMinutes(a.place?.place_time)
-  const isToday = !!day?.date && day.date.slice(0, 10) === localIsoDate(now)
+  const displayTimeOf = (assignment: Assignment) => assignment.assignment_time || assignment.place?.place_time || null
+  const timeOf = (assignment: Assignment) => parseTimeToMinutes(displayTimeOf(assignment))
+  const today = localIsoDate(now)
+  const dayDate = day?.date?.slice(0, 10)
+  if (dayDate && dayDate < today) return null
+  const isToday = dayDate === today
+  const timed = sorted.filter(a => timeOf(a) != null).sort((a, b) => (timeOf(a) ?? 0) - (timeOf(b) ?? 0))
+
   if (isToday) {
     const nowMinutes = now.getHours() * 60 + now.getMinutes()
-    const upcoming = sorted
-      .filter(a => { const m = timeOf(a); return m != null && m >= nowMinutes })
-      .sort((a, b) => (timeOf(a) ?? 0) - (timeOf(b) ?? 0))
-    if (upcoming.length > 0) return { assignment: upcoming[0], minutesUntil: (timeOf(upcoming[0]) ?? 0) - nowMinutes }
+    const upcoming = timed.find(a => (timeOf(a) ?? 0) >= nowMinutes)
+    if (upcoming) {
+      return {
+        assignment: upcoming,
+        minutesUntil: (timeOf(upcoming) ?? 0) - nowMinutes,
+        displayTime: displayTimeOf(upcoming),
+      }
+    }
+    // Do not show the morning's first stop as "up next" after the timed plan is over.
+    if (timed.length > 0) return null
   }
-  const timed = sorted.filter(a => timeOf(a) != null).sort((a, b) => (timeOf(a) ?? 0) - (timeOf(b) ?? 0))
-  return { assignment: timed[0] ?? sorted[0], minutesUntil: null }
+
+  const assignment = timed[0] ?? sorted[0]
+  return { assignment, minutesUntil: null, displayTime: displayTimeOf(assignment) }
 }
 
 /** Whether a merged item carries its own time (places/notes) or display time (transports). */

--- a/client/tests/unit/mobile/trip/MTripShell.test.tsx
+++ b/client/tests/unit/mobile/trip/MTripShell.test.tsx
@@ -64,16 +64,17 @@ function renderShell(overrides: Partial<TripPlanner> = {}) {
     TRIP_TABS,
     ...overrides,
   } as Partial<TripPlanner>)
-  const view = render(
+  const Shell = () => (
     <MTripShell
       PlanTimeline={slot('plan-timeline')}
       MapArea={slot('map-area')}
       PlacesBrowser={slot('places-browser')}
       TabPanel={TabSlot}
       Sheets={slot('sheets')}
-    />,
+    />
   )
-  return { ...view, planner: mocks.planner }
+  const view = render(<Shell />)
+  return { ...view, planner: mocks.planner, rerenderShell: () => view.rerender(<Shell />) }
 }
 
 const spy = (planner: TripPlanner, name: keyof TripPlanner) =>
@@ -115,13 +116,17 @@ describe('MTripShell', () => {
     expect(planner.tripActions.setSelectedDay).toHaveBeenCalledWith(12)
   })
 
-  it('FE-MOB-SHELL-005: falls back to the first day when the trip is not running', () => {
-    const { planner } = renderShell({ selectedDayId: null } as Partial<TripPlanner>)
-    expect(planner.tripActions.setSelectedDay).toHaveBeenCalledWith(11)
+  it('FE-MOB-SHELL-005: selects the final dated day after the trip has ended', () => {
+    const endedDays = DAYS.map((day, index) => ({ ...day, date: `2000-05-0${index + 2}` }))
+    const { planner } = renderShell({ selectedDayId: null, days: endedDays } as Partial<TripPlanner>)
+    expect(planner.tripActions.setSelectedDay).toHaveBeenCalledWith(12)
   })
 
-  it('FE-MOB-SHELL-006: leaves an existing day selection alone', () => {
-    const { planner } = renderShell()
+  it('FE-MOB-SHELL-006: leaves an existing and later-cleared day selection alone', () => {
+    const { planner, rerenderShell } = renderShell()
+    expect(planner.tripActions.setSelectedDay).not.toHaveBeenCalled()
+    planner.selectedDayId = null
+    rerenderShell()
     expect(planner.tripActions.setSelectedDay).not.toHaveBeenCalled()
   })
 

--- a/client/tests/unit/mobile/trip/planTimelineModel.test.ts
+++ b/client/tests/unit/mobile/trip/planTimelineModel.test.ts
@@ -11,7 +11,7 @@ import type {
   Accommodation, Assignment, Day, DayNote, Reservation, RouteSegment, TranslationFn,
 } from '../../../../src/types'
 
-// FE-MOB-PTLM-001 to FE-MOB-PTLM-043
+// FE-MOB-PTLM-001 to FE-MOB-PTLM-045
 
 const DAYS = [
   { id: 1, trip_id: 1, day_number: 1, date: '2026-05-01', title: null },
@@ -343,18 +343,33 @@ describe('planTimelineModel — findUpNext', () => {
     const up = findUpNext(DAY2, [late, early, noon], new Date(2026, 4, 2, 10, 15))
     expect(up?.assignment.id).toBe(12)
     expect(up?.minutesUntil).toBe(45)
+    expect(up?.displayTime).toBe('11:00')
   })
 
-  it('FE-MOB-PTLM-033: falls back to the first timed stop once the day is over', () => {
-    const up = findUpNext(DAY2, [early, noon, late], new Date(2026, 4, 2, 23, 30))
+  it('FE-MOB-PTLM-033: returns no stale up-next stop once today\'s timed plan is over', () => {
+    expect(findUpNext(DAY2, [early, noon, late], new Date(2026, 4, 2, 23, 30))).toBeNull()
+  })
+
+  it('FE-MOB-PTLM-044: prefers the assignment time override to the place default', () => {
+    const overridden = {
+      ...early,
+      assignment_time: '14:30',
+    } as Assignment
+    const up = findUpNext(DAY2, [overridden], new Date(2026, 4, 2, 13, 0))
     expect(up?.assignment.id).toBe(11)
-    expect(up?.minutesUntil).toBeNull()
+    expect(up?.minutesUntil).toBe(90)
+    expect(up?.displayTime).toBe('14:30')
   })
 
   it('FE-MOB-PTLM-034: never counts down on a day that is not today', () => {
     const up = findUpNext(DAY2, [late, noon, early], new Date(2026, 4, 1, 8, 0))
     expect(up?.assignment.id).toBe(11)
     expect(up?.minutesUntil).toBeNull()
+    expect(up?.displayTime).toBe('09:00')
+  })
+
+  it('FE-MOB-PTLM-045: hides stale up-next content for a past day', () => {
+    expect(findUpNext(DAY2, [late, noon, early], new Date(2026, 4, 3, 8, 0))).toBeNull()
   })
 
   it('FE-MOB-PTLM-035: uses the manual order when no stop carries a time', () => {

--- a/client/tests/unit/mobile/trip/useMPlanTimeline.test.ts
+++ b/client/tests/unit/mobile/trip/useMPlanTimeline.test.ts
@@ -239,19 +239,19 @@ describe('useMPlanTimeline', () => {
     expect(result.current.openTransitKeys.has('tr-61')).toBe(false)
   })
 
-  it('FE-MOB-PLTL-014: counts down on today and never on any other day', () => {
+  it('FE-MOB-PLTL-014: counts down on today and hides stale content for a past day', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 4, 2, 10, 15))
     const today = makePlanner({ assignments: { '2': [TIMED_EARLY, TIMED_LATE] } })
     const { result } = renderHook(() => useMPlanTimeline(today))
-    expect(result.current.upNext).toEqual({ assignment: TIMED_LATE, minutesUntil: 45 })
+    expect(result.current.upNext).toEqual({ assignment: TIMED_LATE, minutesUntil: 45, displayTime: '11:00' })
 
     const past = makePlanner({
       assignments: { '2': [TIMED_EARLY, TIMED_LATE] },
       days: DAYS.map(d => (d.id === 2 ? { ...d, date: '2026-04-30' } : d)),
     })
     const other = renderHook(() => useMPlanTimeline(past))
-    expect(other.result.current.upNext).toEqual({ assignment: TIMED_EARLY, minutesUntil: null })
+    expect(other.result.current.upNext).toBeNull()
   })
 
   it('FE-MOB-PLTL-015: re-evaluates the countdown on the half-minute tick', () => {
@@ -259,11 +259,11 @@ describe('useMPlanTimeline', () => {
     vi.setSystemTime(new Date(2026, 4, 2, 10, 0))
     const planner = makePlanner({ assignments: { '2': [TIMED_EARLY, TIMED_LATE] } })
     const { result } = renderHook(() => useMPlanTimeline(planner))
-    expect(result.current.upNext).toEqual({ assignment: TIMED_LATE, minutesUntil: 60 })
+    expect(result.current.upNext).toEqual({ assignment: TIMED_LATE, minutesUntil: 60, displayTime: '11:00' })
 
     vi.setSystemTime(new Date(2026, 4, 2, 11, 30))
     act(() => { vi.advanceTimersByTime(30_000) })
-    expect(result.current.upNext).toEqual({ assignment: TIMED_EARLY, minutesUntil: null })
+    expect(result.current.upNext).toBeNull()
   })
 
   it('FE-MOB-PLTL-016: reorders the day when a stop is moved down', async () => {


### PR DESCRIPTION
## Summary
- select the relevant itinerary day when the mobile trip shell opens: today, the next future day, or the final completed day
- keep automatic selection to a single initial seed so later user choices are not overwritten
- calculate UP NEXT from the effective assignment time (`assignment_time` before `place_time`) and render that same display time
- hide stale UP NEXT content after today's timed plan is exhausted and for all historical dates
- adapt the behavior to the current `MTripShell` / `MPlanTimeline` architecture without restoring the legacy mobile planner implementation or changing map coordinates

## Validation
- affected mobile/date tests: 145 passed
- client TypeScript typecheck: passed
- changed-file ESLint and page-pattern lint: passed
- client production build and PWA generation: passed
- `git diff --check` and added-line security scan: passed
- final independent code/security review: passed with no blocking logic or security findings
- local full Windows client run: 613/617 files passed; 12,651 tests passed, with 34 failures in four unrelated UI/translation test files (not classified as pre-existing without a clean-base comparison)

## Compatibility
- rebuilt as a focused eight-file integration on current `dev` (`d194d2cf`), rather than cherry-picking the TREK 3.4.1 implementation
- preserves the current independent mobile shell, plan timeline, map area, desktop layout, PWA architecture, and existing itinerary data
- does not fabricate missing coordinates or change server/database contracts
