### PR TITLE
ci: pin the platform order in the multi-arch manifest

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -132,7 +132,8 @@ jobs:
         with:
           path: /tmp/digests
           pattern: digests-*
-          merge-multiple: true
+          # Deliberately NOT merged: the per-platform folder names are what lets
+          # the manifest below be assembled in a fixed order.
 
       - uses: docker/setup-buildx-action@v3
 
@@ -144,9 +145,24 @@ jobs:
       - name: Create and push multi-arch manifest
         working-directory: /tmp/digests
         run: |
+          set -euo pipefail
           VERSION="${{ needs.version-bump.outputs.version }}"
-          mapfile -t digests < <(printf 'mauriceboe/trek@sha256:%s\n' *)
           MAJOR_TAG="$(echo "$VERSION" | cut -d. -f1)-pre"
+          # amd64 first, always. This used to be a glob over hash-named files, so
+          # the order changed from one release to the next: 3.4.1 listed amd64
+          # first and 4.0.0 listed arm64 first. Clients that read the first entry
+          # of the index rather than matching their own platform then compare the
+          # wrong digest and report "no update" — which is what Unraid users hit
+          # on :latest after 4.0.0 shipped. The image was fine; the order was not.
+          digests=()
+          for platform in linux-amd64 linux-arm64; do
+            dir="digests-$platform"
+            [ -d "$dir" ] || { echo "::error::missing digest artifact for $platform"; exit 1; }
+            for f in "$dir"/*; do
+              [ -e "$f" ] || { echo "::error::no digest file in $dir"; exit 1; }
+              digests+=("mauriceboe/trek@sha256:$(basename "$f")")
+            done
+          done
           docker buildx imagetools create \
             -t "mauriceboe/trek:latest-pre" \
             -t "mauriceboe/trek:$MAJOR_TAG" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -176,7 +176,8 @@ jobs:
         with:
           path: /tmp/digests
           pattern: digests-*
-          merge-multiple: true
+          # Deliberately NOT merged: the per-platform folder names are what lets
+          # the manifest below be assembled in a fixed order.
 
       - uses: docker/setup-buildx-action@v3
 
@@ -188,9 +189,24 @@ jobs:
       - name: Create and push multi-arch manifest
         working-directory: /tmp/digests
         run: |
+          set -euo pipefail
           VERSION="${{ needs.version-bump.outputs.version }}"
-          mapfile -t digests < <(printf 'mauriceboe/trek@sha256:%s\n' *)
           MAJOR_TAG="$(echo "$VERSION" | cut -d. -f1)"
+          # amd64 first, always. This used to be a glob over hash-named files, so
+          # the order changed from one release to the next: 3.4.1 listed amd64
+          # first and 4.0.0 listed arm64 first. Clients that read the first entry
+          # of the index rather than matching their own platform then compare the
+          # wrong digest and report "no update" — which is what Unraid users hit
+          # on :latest after 4.0.0 shipped. The image was fine; the order was not.
+          digests=()
+          for platform in linux-amd64 linux-arm64; do
+            dir="digests-$platform"
+            [ -d "$dir" ] || { echo "::error::missing digest artifact for $platform"; exit 1; }
+            for f in "$dir"/*; do
+              [ -e "$f" ] || { echo "::error::no digest file in $dir"; exit 1; }
+              digests+=("mauriceboe/trek@sha256:$(basename "$f")")
+            done
+          done
           docker buildx imagetools create \
             -t "mauriceboe/trek:latest" \
             -t "mauriceboe/trek:$MAJOR_TAG" \


### PR DESCRIPTION
## Description

The manifest list is assembled from a glob over the downloaded digest files, and those files are named after the digest itself. The order was therefore alphabetical by hash and changed from one release to the next: 3.4.1 lists amd64 first, 4.0.0 lists arm64 first.

That is not supposed to matter — a client should pick the entry matching its own platform. But four people updating from 3.4.1 to 4.0.0 on amd64 reported that `:latest` still resolved to 3.4.1, and only a pinned `:4` or `:4.0.0` pulled the new image; Unraid came up twice. Checked at the registry: `latest`, `4` and `4.0.0` return the same digest (`sha256:ae64a5ce…`), the manifest media type is the same OCI index 3.4.1 used, and both releases carry the same two attestation manifests. The flipped platform order is the only difference between the release that updated cleanly and the one that did not.

The digests are now collected per platform in a fixed order, amd64 first. That requires the artifacts to stay unmerged, because the per-platform folder name is the only thing that records which digest belongs to which architecture.

A second thing falls out of the loop: the old glob would happily publish a single-platform manifest if one of the two builds had failed to upload its digest. It now fails with a named error instead of shipping a `:latest` that half the users cannot pull.

Same change in `docker-dev.yml`, which had the identical line.

## Related Issue or Discussion

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed