### PR TITLE
feat(api): versioned read-only public API for integrations

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -315,6 +315,14 @@ export const authApi = {
     create: (name: string) => apiClient.post('/auth/mcp-tokens', { name } satisfies McpTokenCreateRequest).then(r => r.data),
     delete: (id: number) => apiClient.delete(`/auth/mcp-tokens/${id}`).then(r => r.data),
   },
+  // Keys for the public API. Same shape as the MCP tokens above and a separate
+  // credential: one drives the assistant tools, the other reads trips over HTTP,
+  // and a key of the wrong kind is refused like one that does not exist.
+  apiKeys: {
+    list: () => apiClient.get('/auth/api-tokens').then(r => r.data),
+    create: (name: string) => apiClient.post('/auth/api-tokens', { name } satisfies McpTokenCreateRequest).then(r => r.data),
+    delete: (id: number) => apiClient.delete(`/auth/api-tokens/${id}`).then(r => r.data),
+  },
   passkey: {
     registerOptions: (password: string) => apiClient.post('/auth/passkey/register/options', { password }).then(r => r.data),
     registerVerify: (attestationResponse: unknown, name?: string) => apiClient.post('/auth/passkey/register/verify', { attestationResponse, name }).then(r => r.data),

--- a/client/src/components/Settings/ApiKeysSection.test.tsx
+++ b/client/src/components/Settings/ApiKeysSection.test.tsx
@@ -1,0 +1,228 @@
+// FE-COMP-APIKEYS-001 to FE-COMP-APIKEYS-010
+import { render, screen, waitFor } from '../../../tests/helpers/render';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../tests/helpers/msw/server';
+import { useAuthStore } from '../../store/authStore';
+import { useAddonStore } from '../../store/addonStore';
+import { resetAllStores, seedStore } from '../../../tests/helpers/store';
+import { buildUser } from '../../../tests/helpers/factories';
+import { ToastContainer } from '../shared/Toast';
+import ApiKeysSection from './ApiKeysSection';
+
+const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+
+beforeAll(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: clipboardWriteText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  clipboardWriteText.mockClear();
+  resetAllStores();
+  vi.clearAllMocks();
+  seedStore(useAuthStore, { user: buildUser(), isAuthenticated: true });
+  seedStore(useAddonStore, { addons: [], loaded: true, loadAddons: vi.fn() });
+  server.use(http.get('/api/auth/api-tokens', () => HttpResponse.json({ tokens: [] })));
+});
+
+function renderSection() {
+  return render(
+    <>
+      <ApiKeysSection />
+      <ToastContainer />
+    </>,
+  );
+}
+
+describe('ApiKeysSection', () => {
+  it('FE-COMP-APIKEYS-001: renders without the MCP addon, because an API key does not need it', async () => {
+    renderSection();
+    expect(await screen.findByText('API Keys')).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-002: reads its own endpoint, not the MCP token list', async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/auth/api-tokens', ({ request }) => {
+        seen.push(new URL(request.url).pathname);
+        return HttpResponse.json({ tokens: [] });
+      }),
+      http.get('/api/auth/mcp-tokens', ({ request }) => {
+        seen.push(new URL(request.url).pathname);
+        return HttpResponse.json({ tokens: [] });
+      }),
+    );
+    renderSection();
+    await waitFor(() => expect(seen).toContain('/api/auth/api-tokens'));
+    expect(seen).not.toContain('/api/auth/mcp-tokens');
+  });
+
+  it('FE-COMP-APIKEYS-003: lists existing keys by prefix, never the key itself', async () => {
+    server.use(
+      http.get('/api/auth/api-tokens', () =>
+        HttpResponse.json({
+          tokens: [
+            {
+              id: 7,
+              name: 'Dawarich',
+              token_prefix: 'trek_abcdefg',
+              created_at: '2026-08-01T10:00:00Z',
+              last_used_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    renderSection();
+    expect(await screen.findByText('Dawarich')).toBeInTheDocument();
+    expect(screen.getByText(/trek_abcdefg\.\.\./)).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-004: shows the empty state when there is nothing to list', async () => {
+    renderSection();
+    expect(await screen.findByText(/No keys yet/)).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-005: creates a key and shows it once, with the warning', async () => {
+    server.use(
+      http.post('/api/auth/api-tokens', () =>
+        HttpResponse.json({
+          token: {
+            id: 1,
+            name: 'Dawarich',
+            raw_token: 'trek_thefullsecretvalue',
+            token_prefix: 'trek_thefull',
+            created_at: '2026-08-27T10:00:00Z',
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: /Create key/ }));
+    await user.type(screen.getByPlaceholderText('e.g. Dawarich'), 'Dawarich');
+    await user.click(screen.getByRole('button', { name: /^Create$/ }));
+
+    expect(await screen.findByText('trek_thefullsecretvalue')).toBeInTheDocument();
+    expect(screen.getByText(/shown once/)).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-006: drops the raw key from the DOM once the modal is closed', async () => {
+    server.use(
+      http.post('/api/auth/api-tokens', () =>
+        HttpResponse.json({
+          token: {
+            id: 1,
+            name: 'Dawarich',
+            raw_token: 'trek_thefullsecretvalue',
+            token_prefix: 'trek_thefull',
+            created_at: '2026-08-27T10:00:00Z',
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: /Create key/ }));
+    await user.type(screen.getByPlaceholderText('e.g. Dawarich'), 'Dawarich');
+    await user.click(screen.getByRole('button', { name: /^Create$/ }));
+    await screen.findByText('trek_thefullsecretvalue');
+    await user.click(screen.getByRole('button', { name: /Done/ }));
+
+    await waitFor(() => expect(screen.queryByText('trek_thefullsecretvalue')).not.toBeInTheDocument());
+    // The list keeps only the prefix, which is what the server stores alongside the hash.
+    expect(screen.getByText(/trek_thefull\.\.\./)).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-007: refuses to create a key without a name', async () => {
+    const user = userEvent.setup();
+    renderSection();
+    await user.click(await screen.findByRole('button', { name: /Create key/ }));
+    expect(screen.getByRole('button', { name: /^Create$/ })).toBeDisabled();
+  });
+
+  it('FE-COMP-APIKEYS-008: asks before deleting, and only deletes on confirm', async () => {
+    let deleted = 0;
+    server.use(
+      http.get('/api/auth/api-tokens', () =>
+        HttpResponse.json({
+          tokens: [
+            { id: 7, name: 'Dawarich', token_prefix: 'trek_abc', created_at: '2026-08-01T10:00:00Z', last_used_at: null },
+          ],
+        }),
+      ),
+      http.delete('/api/auth/api-tokens/7', () => {
+        deleted += 1;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByTitle('Delete key'));
+    expect(deleted).toBe(0);
+    expect(screen.getByText(/stops working immediately/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Cancel$/ }));
+    expect(deleted).toBe(0);
+
+    await user.click(await screen.findByTitle('Delete key'));
+    const [, confirm] = screen.getAllByRole('button', { name: /Delete key/ });
+    await user.click(confirm);
+    await waitFor(() => expect(deleted).toBe(1));
+    await waitFor(() => expect(screen.queryByText('Dawarich')).not.toBeInTheDocument());
+  });
+
+  it('FE-COMP-APIKEYS-009: reports a failed creation instead of pretending it worked', async () => {
+    server.use(http.post('/api/auth/api-tokens', () => HttpResponse.json({ error: 'nope' }, { status: 500 })));
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: /Create key/ }));
+    await user.type(screen.getByPlaceholderText('e.g. Dawarich'), 'Dawarich');
+    await user.click(screen.getByRole('button', { name: /^Create$/ }));
+
+    expect(await screen.findByText(/Could not create the key/)).toBeInTheDocument();
+  });
+
+  it('FE-COMP-APIKEYS-010: copies the new key to the clipboard on request', async () => {
+    server.use(
+      http.post('/api/auth/api-tokens', () =>
+        HttpResponse.json({
+          token: {
+            id: 1,
+            name: 'Dawarich',
+            raw_token: 'trek_thefullsecretvalue',
+            token_prefix: 'trek_thefull',
+            created_at: '2026-08-27T10:00:00Z',
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    // userEvent.setup() installs its own clipboard stub, so the spy goes back on
+    // afterwards — otherwise this asserts against a stub the component never reaches.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+      writable: true,
+    });
+    renderSection();
+
+    await user.click(await screen.findByRole('button', { name: /Create key/ }));
+    await user.type(screen.getByPlaceholderText('e.g. Dawarich'), 'Dawarich');
+    await user.click(screen.getByRole('button', { name: /^Create$/ }));
+    await screen.findByText('trek_thefullsecretvalue');
+    await user.click(screen.getByTitle('Copy'));
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('trek_thefullsecretvalue');
+    // And the button confirms it to the reader, which is the only feedback there is.
+    expect(await screen.findByTitle('Copy')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Settings/ApiKeysSection.tsx
+++ b/client/src/components/Settings/ApiKeysSection.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useState } from 'react'
+import { KeyRound, Plus, Trash2, Copy, Check } from 'lucide-react'
+import Section from './Section'
+import { useTranslation } from '../../i18n'
+import { useToast } from '../shared/Toast'
+import { authApi } from '../../api/client'
+
+/**
+ * Keys for the public API — the credential a user hands to other software that
+ * should read their trips.
+ *
+ * Its own section rather than a third tab under MCP: an API key is not an MCP
+ * credential, it does not need the MCP addon, and burying it under a heading
+ * about AI assistants is how people end up minting the wrong kind. The two look
+ * alike deliberately (name, prefix, shown once) because they are the same
+ * gesture; what differs is which door they open.
+ *
+ * State lives here rather than in the tab's shared hook so the section works on
+ * an instance with MCP switched off.
+ */
+interface ApiKey {
+  id: number
+  name: string
+  token_prefix: string
+  created_at: string
+  last_used_at: string | null
+}
+
+export default function ApiKeysSection(): React.ReactElement {
+  const { t, locale } = useTranslation()
+  const toast = useToast()
+  const [keys, setKeys] = useState<ApiKey[]>([])
+  const [modalOpen, setModalOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+  /** The raw key, held only until the modal closes — the server keeps a hash. */
+  const [created, setCreated] = useState<string | null>(null)
+  const [deleteId, setDeleteId] = useState<number | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    authApi.apiKeys.list().then(d => setKeys(d.tokens || [])).catch(() => {})
+  }, [])
+
+  const handleCreate = async () => {
+    if (!newName.trim() || creating) return
+    setCreating(true)
+    try {
+      const d = await authApi.apiKeys.create(newName.trim())
+      setCreated(d.token.raw_token)
+      setKeys(prev => [
+        { id: d.token.id, name: d.token.name, token_prefix: d.token.token_prefix, created_at: d.token.created_at, last_used_at: null },
+        ...prev,
+      ])
+      setNewName('')
+    } catch {
+      toast.error(t('settings.apiKeys.createFailed'))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleDelete = async (id: number) => {
+    try {
+      await authApi.apiKeys.delete(id)
+      setKeys(prev => prev.filter(k => k.id !== id))
+      toast.success(t('settings.apiKeys.deleted'))
+    } catch {
+      toast.error(t('settings.apiKeys.deleteFailed'))
+    } finally {
+      setDeleteId(null)
+    }
+  }
+
+  const handleCopy = () => {
+    if (!created) return
+    navigator.clipboard.writeText(created)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+    setCreated(null)
+    setNewName('')
+  }
+
+  return (
+    <>
+      <Section title={t('settings.apiKeys.title')} icon={KeyRound}>
+        <p className="text-sm text-content-secondary">{t('settings.apiKeys.description')}</p>
+
+        <div className="flex justify-end">
+          <button type="button" onClick={() => { setModalOpen(true); setCreated(null); setNewName('') }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors text-white bg-slate-900 hover:bg-slate-700">
+            <Plus className="w-3.5 h-3.5" /> {t('settings.apiKeys.create')}
+          </button>
+        </div>
+
+        {keys.length === 0 ? (
+          <p className="text-sm py-2 text-center" style={{ color: 'var(--text-tertiary)' }}>
+            {t('settings.apiKeys.empty')}
+          </p>
+        ) : (
+          <div className="rounded-lg border overflow-hidden border-edge">
+            {keys.map((key, i) => (
+              <div key={key.id} className={`flex items-center gap-3 px-4 py-3 ${i < keys.length - 1 ? 'border-b border-edge' : ''}`}>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate text-content">{key.name}</p>
+                  <p className="text-xs font-mono mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                    {key.token_prefix}...
+                    <span className="ml-3 font-sans">{t('settings.apiKeys.createdAt')} {new Date(key.created_at).toLocaleDateString(locale)}</span>
+                    {key.last_used_at && (
+                      <span className="ml-2">· {t('settings.apiKeys.usedAt')} {new Date(key.last_used_at).toLocaleDateString(locale)}</span>
+                    )}
+                  </p>
+                </div>
+                <button type="button" onClick={() => setDeleteId(key.id)}
+                  className="p-1.5 rounded-lg transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20"
+                  style={{ color: 'var(--text-tertiary)' }} title={t('settings.apiKeys.deleteTitle')}>
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>{t('settings.apiKeys.docsHint')}</p>
+      </Section>
+
+      {modalOpen && (
+        <div role="presentation" className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(0,0,0,0.5)]"
+          onClick={e => { if (e.target === e.currentTarget && !created) closeModal() }}>
+          <div className="rounded-xl shadow-xl w-full max-w-md p-6 space-y-4 bg-surface-card">
+            {!created ? (
+              <>
+                <h3 className="text-lg font-semibold text-content">{t('settings.apiKeys.modal.createTitle')}</h3>
+                <div>
+                  <label className="block text-sm font-medium mb-1.5 text-content-secondary">{t('settings.apiKeys.modal.name')}</label>
+                  <input type="text" value={newName} onChange={e => setNewName(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && handleCreate()}
+                    placeholder={t('settings.apiKeys.modal.namePlaceholder')}
+                    className="w-full px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-slate-400 border-edge bg-surface-secondary text-content"
+                    autoFocus />
+                  <p className="mt-1.5 text-xs" style={{ color: 'var(--text-tertiary)' }}>{t('settings.apiKeys.modal.nameHint')}</p>
+                </div>
+                <div className="flex gap-2 justify-end pt-1">
+                  <button type="button" onClick={closeModal}
+                    className="px-4 py-2 rounded-lg text-sm border border-edge text-content-secondary">
+                    {t('common.cancel')}
+                  </button>
+                  <button type="button" onClick={handleCreate} disabled={!newName.trim() || creating}
+                    className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-slate-900 hover:bg-slate-700 disabled:opacity-50">
+                    {creating ? t('settings.apiKeys.modal.creating') : t('settings.apiKeys.modal.create')}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-semibold text-content">{t('settings.apiKeys.modal.createdTitle')}</h3>
+                <div className="flex items-start gap-2 p-3 rounded-lg border border-amber-200 bg-[rgba(251,191,36,0.1)]">
+                  <span className="text-amber-500 mt-0.5">⚠</span>
+                  <p className="text-sm text-content-secondary">{t('settings.apiKeys.modal.createdWarning')}</p>
+                </div>
+                <div className="relative">
+                  <pre className="p-3 pr-10 rounded-lg text-xs font-mono break-all border whitespace-pre-wrap bg-surface-secondary border-edge text-content">
+                    {created}
+                  </pre>
+                  <button type="button" onClick={handleCopy}
+                    className="absolute top-2 right-2 p-1.5 rounded transition-colors hover:bg-slate-200 dark:hover:bg-slate-600 text-content-secondary"
+                    title={t('settings.apiKeys.copy')}>
+                    {copied ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
+                  </button>
+                </div>
+                <div className="flex justify-end">
+                  <button type="button" onClick={closeModal}
+                    className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-slate-900 hover:bg-slate-700">
+                    {t('settings.apiKeys.modal.done')}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {deleteId !== null && (
+        <div role="presentation" className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(0,0,0,0.5)]"
+          onClick={e => { if (e.target === e.currentTarget) setDeleteId(null) }}>
+          <div className="rounded-xl shadow-xl w-full max-w-sm p-6 space-y-4 bg-surface-card">
+            <h3 className="text-base font-semibold text-content">{t('settings.apiKeys.deleteTitle')}</h3>
+            <p className="text-sm text-content-secondary">{t('settings.apiKeys.deleteMessage')}</p>
+            <div className="flex gap-2 justify-end">
+              <button type="button" onClick={() => setDeleteId(null)}
+                className="px-4 py-2 rounded-lg text-sm border border-edge text-content-secondary">
+                {t('common.cancel')}
+              </button>
+              <button type="button" onClick={() => handleDelete(deleteId)}
+                className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-red-600 hover:bg-red-700">
+                {t('settings.apiKeys.deleteTitle')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/client/src/components/Settings/IntegrationsTab.tsx
+++ b/client/src/components/Settings/IntegrationsTab.tsx
@@ -8,6 +8,7 @@ import { useAddonStore } from '../../store/addonStore'
 import PhotoProvidersSection from './PhotoProvidersSection'
 import AirTrailConnectionSection from './AirTrailConnectionSection'
 import LlmConnectionSection from './LlmConnectionSection'
+import ApiKeysSection from './ApiKeysSection'
 import { ALL_SCOPES } from '../../api/oauthScopes'
 import ScopeGroupPicker from '../OAuth/ScopeGroupPicker'
 import { useAuthStore } from '../../store/authStore'
@@ -109,6 +110,9 @@ export default function IntegrationsTab(): React.ReactElement {
        a managed install. The per-user fallback exists for people who supply their
        own key, and there nobody does. */}
       {S.llmEnabled && !managed && <LlmConnectionSection />}
+      {/* Above MCP on purpose: an API key needs no addon, and someone looking for
+          one should not have to read past a section about AI assistants. */}
+      <ApiKeysSection />
       {S.mcpEnabled && <IntegrationsMcpSection {...S} />}
       <McpTokenModals {...S} />
       <OAuthClientModals {...S} />

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -4154,6 +4154,28 @@ function runMigrations(db: Database.Database): void {
         db.exec("ALTER TABLE reservations ADD COLUMN ingest_state TEXT NOT NULL DEFAULT 'live'");
       }
     },
+
+    /*
+     * Separate an integration key from an MCP token (#2089).
+     *
+     * Both live in mcp_tokens and until now both opened everything a token can
+     * open. That was fine while /mcp was the only consumer; with a public REST
+     * surface it means a key somebody minted for a chat client also reads their
+     * trips over HTTP, and a key minted for an integration can drive every MCP
+     * tool. One credential, two very different blast radii.
+     *
+     * `kind` splits them, and every existing row becomes 'mcp' — that is what
+     * they were issued for, and silently widening a key that is already in
+     * somebody's config would be the opposite of what this migration is for.
+     *
+     * Appended LAST: the array is index-addressed against schema_version.
+     */
+    () => {
+      const cols = db.prepare("SELECT name FROM pragma_table_info('mcp_tokens')").all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'kind')) {
+        db.exec("ALTER TABLE mcp_tokens ADD COLUMN kind TEXT NOT NULL DEFAULT 'mcp'");
+      }
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/nest/app.module.ts
+++ b/server/src/nest/app.module.ts
@@ -11,6 +11,7 @@ import { GlobalAuthGuard } from './auth/global-auth.guard';
 import { MfaPolicyGuard } from './auth/mfa-policy.guard';
 import { ManagedGuard } from './common/managed.guard';
 import { WeatherModule } from './weather/weather.module';
+import { PublicApiModule } from './public-api/public-api.module';
 import { HelpModule } from './help/help.module';
 import { AirportsModule } from './airports/airports.module';
 import { ConfigModule } from './config/config.module';
@@ -75,7 +76,7 @@ import { RealtimeGatewayModule } from './realtime/realtime-gateway.module';
  * migrated.
  */
 @Module({
-  imports: [AppConfigModule, DatabaseModule, RealtimeModule, RealtimeGatewayModule, SchedulingModule, McpModule.forRoot({ accessPolicy: trekMcpAccessPolicy, validateAccess: trekMcpValidateAccess }), HealthModule, PlatformModule, McpTransportModule, WeatherModule, HelpModule, AirportsModule, ConfigModule, SystemNoticesModule, GeoModule, MapsModule, PlaceEnrichmentModule, CategoriesModule, TagsModule, NotificationsModule, AtlasModule, VacayModule, PackingModule, TodoModule, BudgetModule, ReservationsModule, DaysModule, DayNotesModule, AccommodationsModule, AssignmentsModule, PlacesModule, TripsModule, CollabModule, FilesModule, PhotosModule, MemoriesModule, AirtrailModule, JourneyModule, CollectionsModule, ShareModule, TripInviteModule, TransitModule, FeedsModule, SettingsModule, StorageModule, BackupModule, AuthModule, OidcModule, OauthModule, AdminModule, AddonsModule, AuditModule, PermissionsModule, PluginsModule, BookingImportModule, ReservationImportModule, LlmParseModule, ManagedExtModule],
+  imports: [AppConfigModule, DatabaseModule, RealtimeModule, RealtimeGatewayModule, SchedulingModule, McpModule.forRoot({ accessPolicy: trekMcpAccessPolicy, validateAccess: trekMcpValidateAccess }), HealthModule, PlatformModule, McpTransportModule, WeatherModule, PublicApiModule, HelpModule, AirportsModule, ConfigModule, SystemNoticesModule, GeoModule, MapsModule, PlaceEnrichmentModule, CategoriesModule, TagsModule, NotificationsModule, AtlasModule, VacayModule, PackingModule, TodoModule, BudgetModule, ReservationsModule, DaysModule, DayNotesModule, AccommodationsModule, AssignmentsModule, PlacesModule, TripsModule, CollabModule, FilesModule, PhotosModule, MemoriesModule, AirtrailModule, JourneyModule, CollectionsModule, ShareModule, TripInviteModule, TransitModule, FeedsModule, SettingsModule, StorageModule, BackupModule, AuthModule, OidcModule, OauthModule, AdminModule, AddonsModule, AuditModule, PermissionsModule, PluginsModule, BookingImportModule, ReservationImportModule, LlmParseModule, ManagedExtModule],
   providers: [
     // Default-deny: a route is authenticated unless it carries @Public() or
     // @OptionalAuth(), or declares its own @UseGuards chain. Protection used to

--- a/server/src/nest/atlas/atlas.module.ts
+++ b/server/src/nest/atlas/atlas.module.ts
@@ -7,6 +7,10 @@ import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
 import { AtlasMcp } from './atlas.mcp';
 import { AddonsModule } from '../addons/addons.module';
 import { AuthModule } from '../auth/auth.module';
+import { PublicStatsController } from './public-stats.controller';
+import { ApiTokenGuard } from '../public-api/api-token.guard';
+import { TokensModule } from '../tokens/tokens.module';
+import { RateLimitModule } from '../common/rate-limit.module';
 
 /**
  * Atlas addon domain (L7 leaf module). Registered in AppModule. Exports
@@ -17,11 +21,19 @@ import { AuthModule } from '../auth/auth.module';
  * TravelStatsController serves GET /api/auth/travel-stats. The path stays where
  * the client expects it; the code sits here because getTravelStats reads Atlas
  * data. See the comment in that file.
+ *
+ * PublicStatsController serves GET /api/v1/stats on the same reasoning, one prefix
+ * over: the public API's own module is deliberately a leaf and importing
+ * AtlasModule there would drag AuthModule and the storage registry into it, so the
+ * route comes to the data instead. ApiTokenGuard is listed as a provider rather
+ * than pulled in with PublicApiModule: @UseGuards instantiates a guard in the
+ * declaring controller's module, so exporting it from over there would still leave
+ * its TokenService unresolvable here. TokensModule is a leaf, so the edge is free.
  */
 @Module({
-  imports: [AuthModule, PluginGuardsModule, AddonsModule],
-  controllers: [AtlasController, TravelStatsController],
-  providers: [AtlasService, AtlasMcp, AtlasRpc],
+  imports: [AuthModule, PluginGuardsModule, AddonsModule, TokensModule, RateLimitModule],
+  controllers: [AtlasController, TravelStatsController, PublicStatsController],
+  providers: [AtlasService, AtlasMcp, AtlasRpc, ApiTokenGuard],
   exports: [AtlasService],
 })
 export class AtlasModule {}

--- a/server/src/nest/atlas/atlas.service.ts
+++ b/server/src/nest/atlas/atlas.service.ts
@@ -925,6 +925,55 @@ export class AtlasService {
   // travel-stats.controller.ts in this directory.
   // ---------------------------------------------------------------------------
 
+  /**
+   * The trip the user most recently took, with the countries it touched.
+   *
+   * Started, not created: a trip booked for next spring is not what anybody means
+   * by their last trip, so the same `<= date('now')` cut the visited-country query
+   * below uses applies here. All-future trips give null rather than a trip nobody
+   * has been on yet.
+   *
+   * Ordered by end date with the start date as fallback, and the id as a
+   * tie-break — two trips ending the same day is ordinary (a weekend away either
+   * side of a work trip), and without the second key which one is "last" would be
+   * whatever the storage engine happened to return first.
+   *
+   * Countries come from `place_regions`, Atlas's own cache, most-visited first.
+   * No fallback to `getCountryFromCoords` here on purpose: this answers a
+   * dashboard widget, and a point-in-polygon scan over 4MB of boundaries is too
+   * much to spend on a label. An unresolved trip reports an empty list, which the
+   * caller renders as "no country" rather than as a wrong one.
+   */
+  lastTrip(userId: number): { title: string; start_date: string | null; end_date: string | null; countries: string[] } | null {
+    const trip = this.db.get<{ id: number; title: string; start_date: string | null; end_date: string | null }>(`
+    SELECT t.id, t.title, t.start_date, t.end_date
+    FROM trips t
+    LEFT JOIN trip_members tm ON t.id = tm.trip_id
+    WHERE (t.user_id = ? OR tm.user_id = ?)
+      AND COALESCE(t.start_date, t.end_date) IS NOT NULL
+      AND COALESCE(t.start_date, t.end_date) <= date('now')
+    ORDER BY COALESCE(t.end_date, t.start_date) DESC, t.id DESC
+    LIMIT 1
+  `, userId, userId);
+    if (!trip) return null;
+
+    const rows = this.db.all<{ country_code: string; places: number }>(`
+    SELECT pr.country_code, COUNT(DISTINCT p.id) AS places
+    FROM place_regions pr
+    JOIN places p ON p.id = pr.place_id
+    WHERE p.trip_id = ? AND pr.country_code IS NOT NULL
+    GROUP BY pr.country_code
+    ORDER BY places DESC, pr.country_code ASC
+  `, trip.id);
+
+    return {
+      title: trip.title,
+      start_date: trip.start_date,
+      end_date: trip.end_date,
+      countries: rows.map(r => r.country_code.toUpperCase()),
+    };
+  }
+
   getTravelStats(userId: number) {
     // The resolved region rides along so cityFromAddress can tell the city apart from
     // the region sitting right above it in the same address (#1115).

--- a/server/src/nest/atlas/public-stats.controller.ts
+++ b/server/src/nest/atlas/public-stats.controller.ts
@@ -1,0 +1,72 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import type { PublicApiStats } from '@trek/shared';
+import { AtlasService } from './atlas.service';
+import { ApiTokenGuard } from '../public-api/api-token.guard';
+import { enforcePublicApiRateLimit, requireUserId } from '../public-api/public-api-request';
+import { RateLimitService } from '../common/rate-limit.service';
+
+/**
+ * GET /api/v1/stats — aggregate counts for a dashboard widget (#1367).
+ *
+ * Homepage's `customapi` widget and everything shaped like it want a handful of
+ * numbers from one request. `/api/v1/trips` already hands out the rows, but a
+ * widget cannot aggregate a list; it maps a field to a label.
+ *
+ * ── Why this controller sits in atlas/ and not in public-api/ ────────────────
+ *
+ * The figures come from `AtlasService.getTravelStats`, the same call behind the
+ * dashboard's passport card. That is deliberate and is the whole reason this is
+ * not a fresh count: "visited countries" carries years of accumulated rules —
+ * countries reached only by a flight (#1366), layovers that do not count as
+ * visited (#1486, #1535), countries the user hid by hand (#1490), bookings that
+ * belong to someone else on the trip (#1966). A second implementation would
+ * disagree with the card sitting next to it within a release.
+ *
+ * PublicApiModule is deliberately a leaf — its own docblock explains that pulling
+ * AtlasModule in would drag AuthModule and the storage registry behind it, and a
+ * read-only surface that cannot boot without half the application is one that
+ * breaks for reasons it has nothing to do with. So the route comes to the data
+ * instead. TravelStatsController next door already does exactly this for
+ * `/api/auth/travel-stats`, and for the same reason.
+ *
+ * What crosses the boundary is only the request handling: the guard and the shared
+ * rate-limit bucket, so an integration polling `/trips` and `/stats` spends one
+ * budget rather than two.
+ */
+@Controller('api/v1')
+@UseGuards(ApiTokenGuard)
+export class PublicStatsController {
+  constructor(
+    private readonly atlas: AtlasService,
+    private readonly rl: RateLimitService,
+  ) {}
+
+  @Get('stats')
+  stats(@Req() req: Request): PublicApiStats {
+    enforcePublicApiRateLimit(this.rl, req);
+    const userId = requireUserId(req);
+
+    const travel = this.atlas.getTravelStats(userId);
+    const last = this.atlas.lastTrip(userId);
+
+    // Counts, not the arrays behind them. A consumer that wants the members asks
+    // /api/v1/trips; this endpoint exists for the one that wants a number.
+    return {
+      total_trips: travel.totalTrips,
+      total_countries: travel.countries.length,
+      total_cities: travel.cities.length,
+      total_places: travel.totalPlaces,
+      total_days: travel.totalDays,
+      total_distance_km: travel.totalDistanceKm,
+      last_trip: last && {
+        title: last.title,
+        start_date: last.start_date,
+        end_date: last.end_date,
+        // The list's head, so `country` and `countries[0]` can never disagree.
+        country: last.countries[0] ?? null,
+        countries: last.countries,
+      },
+    };
+  }
+}

--- a/server/src/nest/auth/auth.controller.ts
+++ b/server/src/nest/auth/auth.controller.ts
@@ -321,6 +321,43 @@ export class AuthController {
     return { success: true };
   }
 
+  /**
+   * Integration keys for the public API (`/api/v1`).
+   *
+   * Separate from the MCP tokens above because they open different doors: an MCP
+   * token drives every assistant tool, an API key reads trips over HTTP. Same
+   * table, different `kind`, and each surface verifies only its own — so a key
+   * handed to a third-party integration cannot be replayed against /mcp.
+   *
+   * Unlike MCP tokens these are not forbidden on a managed instance: the surface
+   * they unlock is read-only and scoped to the caller's own trips, which is the
+   * whole reason it exists.
+   */
+  @Get('api-tokens')
+  listApiTokens(@CurrentUser() user: User) {
+    return { tokens: this.tokens.listApiTokens(user.id) };
+  }
+
+  @Post('api-tokens')
+  @HttpCode(201)
+  createApiToken(@CurrentUser() user: User, @Body() body: McpTokenCreateDto, @Req() req: Request) {
+    this.limit('login', req, 5);
+    const result = this.tokens.createApiToken(user.id, body.name);
+    if (result.error) {
+      throw new HttpException({ error: result.error }, result.status!);
+    }
+    return { token: result.token };
+  }
+
+  @Delete('api-tokens/:id')
+  deleteApiToken(@CurrentUser() user: User, @Param('id') id: string) {
+    const result = this.tokens.deleteApiToken(user.id, id);
+    if (result.error) {
+      throw new HttpException({ error: result.error }, result.status!);
+    }
+    return { success: true };
+  }
+
   @Post('ws-token')
   @HttpCode(200)
   wsToken(@CurrentUser() user: User) {

--- a/server/src/nest/common/validate-route-guards.ts
+++ b/server/src/nest/common/validate-route-guards.ts
@@ -5,6 +5,7 @@ import { IS_PUBLIC, OPTIONAL_AUTH } from '../auth/public.decorator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CookieAuthGuard } from '../auth/cookie-auth.guard';
 import { OptionalJwtGuard } from '../auth/optional-jwt.guard';
+import { ApiTokenGuard } from '../public-api/api-token.guard';
 
 export interface RouteGuardEntry {
   /** `ControllerClass.methodName` */
@@ -21,7 +22,7 @@ export interface RouteGuardEntry {
  * no req.user, but they never resolve one, so they only ever appear behind one
  * of these three.
  */
-const AUTHENTICATING_GUARDS: unknown[] = [JwtAuthGuard, CookieAuthGuard, OptionalJwtGuard];
+const AUTHENTICATING_GUARDS: unknown[] = [JwtAuthGuard, CookieAuthGuard, OptionalJwtGuard, ApiTokenGuard];
 
 /**
  * Boot-time gate: every registered route must be authenticated, or say why not.

--- a/server/src/nest/public-api/api-token.guard.ts
+++ b/server/src/nest/public-api/api-token.guard.ts
@@ -1,0 +1,73 @@
+import { CanActivate, ExecutionContext, HttpException, Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import { TokenService } from '../tokens/token.service';
+
+/**
+ * Authenticates a caller of the public API with a long-lived `trek_…` token.
+ *
+ * The tokens are the ones users already manage under Settings → Integrations; this
+ * guard adds no new credential type and no new table. It reuses
+ * `TokenService.verifyMcpToken`, which hashes the presented token with SHA-256 and
+ * looks up the hash — the raw token is never stored and never compared in the
+ * application, so a database read cannot yield a usable credential.
+ *
+ * Deliberately narrower than the MCP transport's `verifyToken`, which also accepts
+ * OAuth bearer tokens and a plain web-session JWT:
+ *
+ * - **No session JWT.** A session cookie leaking into a third-party integration is
+ *   exactly what a machine credential exists to prevent, and a JWT that reaches
+ *   this surface is almost always an accident.
+ * - **No OAuth tokens (yet).** They carry scopes this surface does not interpret
+ *   yet, and accepting a credential whose restrictions you ignore is worse than
+ *   refusing it. When `/api/v1` grows write routes, scopes get honoured first.
+ *
+ * The guard authenticates but does not authorise: it resolves `req.user` and stops
+ * there. Which trips that user may read is decided per row against
+ * `DatabaseService.canAccessTrip`, never from anything the caller sent.
+ */
+@Injectable()
+export class ApiTokenGuard implements CanActivate {
+  constructor(private readonly tokens: TokenService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    const token = extractApiToken(req);
+    if (!token) {
+      throw new HttpException(
+        { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+        401,
+      );
+    }
+    const user = this.tokens.verifyMcpToken(token);
+    if (!user) {
+      throw new HttpException(
+        { error: 'Invalid API token', code: 'API_TOKEN_INVALID' },
+        401,
+      );
+    }
+    req.user = user;
+    return true;
+  }
+}
+
+/**
+ * `Authorization: Bearer trek_…` or `X-API-Key: trek_…`.
+ *
+ * Both spellings exist because integrators expect one or the other and neither is
+ * wrong; the header is the only difference. Anything that is not a `trek_` token is
+ * rejected here rather than passed to the lookup — a session JWT would otherwise
+ * travel one step further into the system than it should, and the hash of an
+ * arbitrary string is a pointless query.
+ */
+function extractApiToken(req: Request): string | null {
+  const header = req.headers['authorization'];
+  if (typeof header === 'string' && header.startsWith('Bearer ')) {
+    const candidate = header.slice(7).trim();
+    if (candidate.startsWith('trek_')) return candidate;
+  }
+  const apiKey = req.headers['x-api-key'];
+  if (typeof apiKey === 'string' && apiKey.trim().startsWith('trek_')) {
+    return apiKey.trim();
+  }
+  return null;
+}

--- a/server/src/nest/public-api/api-token.guard.ts
+++ b/server/src/nest/public-api/api-token.guard.ts
@@ -5,11 +5,15 @@ import { TokenService } from '../tokens/token.service';
 /**
  * Authenticates a caller of the public API with a long-lived `trek_…` token.
  *
- * The tokens are the ones users already manage under Settings → Integrations; this
- * guard adds no new credential type and no new table. It reuses
- * `TokenService.verifyMcpToken`, which hashes the presented token with SHA-256 and
- * looks up the hash — the raw token is never stored and never compared in the
- * application, so a database read cannot yield a usable credential.
+ * Accepts an **API key** — the kind users mint under Settings → Integrations for
+ * third-party software. An MCP token does not resolve here, and an API key does not
+ * open the MCP surface: the two are separate credentials with separate blast radii,
+ * and `verifyApiToken` puts the kind in the WHERE clause so a token of the wrong
+ * kind is indistinguishable from one that does not exist.
+ *
+ * The lookup hashes the presented key with SHA-256 and matches the hash — the raw
+ * key is never stored and never compared in the application, so a database read
+ * cannot yield a usable credential.
  *
  * Deliberately narrower than the MCP transport's `verifyToken`, which also accepts
  * OAuth bearer tokens and a plain web-session JWT:
@@ -38,7 +42,7 @@ export class ApiTokenGuard implements CanActivate {
         401,
       );
     }
-    const user = this.tokens.verifyMcpToken(token);
+    const user = this.tokens.verifyApiToken(token);
     if (!user) {
       throw new HttpException(
         { error: 'Invalid API token', code: 'API_TOKEN_INVALID' },

--- a/server/src/nest/public-api/public-api-request.ts
+++ b/server/src/nest/public-api/public-api-request.ts
@@ -1,0 +1,46 @@
+import { HttpException } from '@nestjs/common';
+import type { Request } from 'express';
+import type { RateLimitService } from '../common/rate-limit.service';
+
+/**
+ * What every `/api/v1` route does with the incoming request, in one place because
+ * the surface is served by two controllers: the routes in this directory, and the
+ * stats route that lives in `atlas/` because that is where its data does.
+ *
+ * Sharing these is the point. One rate-limit bucket means an integration polling
+ * both surfaces spends a single budget rather than two, and one user-narrowing
+ * means a route cannot accidentally answer with a different idea of who is calling.
+ */
+
+/**
+ * Keyed by the caller rather than by IP: a self-hosted integration and its user's
+ * browser routinely share an address, and limiting by IP would let one starve the
+ * other. Generous — this is a sync surface, not a login form — but bounded, so a
+ * runaway poll degrades its own integration instead of the instance.
+ */
+export const PUBLIC_API_RATE_WINDOW_MS = 60_000;
+export const PUBLIC_API_RATE_MAX_PER_MINUTE = 120;
+
+/**
+ * Falls back to a constant key when a request somehow carries no user, so the
+ * limiter can never end up with one shared bucket for every anonymous caller.
+ */
+export function enforcePublicApiRateLimit(rl: RateLimitService, req: Request): void {
+  const key = `user:${req.user?.id ?? 'unknown'}`;
+  if (!rl.check('public-api', key, PUBLIC_API_RATE_MAX_PER_MINUTE, PUBLIC_API_RATE_WINDOW_MS, Date.now())) {
+    throw new HttpException({ error: 'Too many requests. Please slow down.' }, 429);
+  }
+}
+
+/**
+ * The guard has already resolved the user; this is the type narrowing plus a
+ * belt-and-braces check. If it ever throws, a route was mounted without the guard —
+ * a 401 is then the right answer, and a loud one.
+ */
+export function requireUserId(req: Request): number {
+  const id = req.user?.id;
+  if (typeof id !== 'number') {
+    throw new HttpException({ error: 'API token required', code: 'API_TOKEN_REQUIRED' }, 401);
+  }
+  return id;
+}

--- a/server/src/nest/public-api/public-api.controller.ts
+++ b/server/src/nest/public-api/public-api.controller.ts
@@ -10,8 +10,8 @@ import {
 } from '@trek/shared';
 import { ApiTokenGuard } from './api-token.guard';
 import { PublicApiService } from './public-api.service';
+import { enforcePublicApiRateLimit, requireUserId } from './public-api-request';
 import { RateLimitService } from '../common/rate-limit.service';
-import type { User } from '../../types';
 
 /**
  * `/api/v1` — the versioned, read-only surface for third-party integrations.
@@ -28,15 +28,10 @@ import type { User } from '../../types';
  * yet, and a token that reads everything is a very different thing from one that
  * can also delete a trip.
  *
- * Rate limited per token rather than per IP: a self-hosted integration and its
- * user's browser routinely share an address, and limiting by IP would let one
- * starve the other. The budget is generous — this is a sync surface, not a login
- * form — but bounded, so a runaway poll degrades its own integration instead of
- * the instance.
+ * Rate limited per caller rather than per IP — the budget lives in
+ * `public-api-request.ts`, because the stats route enforces the same one from
+ * `atlas/`.
  */
-const RATE_WINDOW_MS = 60_000;
-const RATE_MAX_PER_MINUTE = 120;
-
 @Controller('api/v1')
 @UseGuards(ApiTokenGuard)
 export class PublicApiController {
@@ -45,16 +40,8 @@ export class PublicApiController {
     private readonly rl: RateLimitService,
   ) {}
 
-  /**
-   * Keyed by token id, not by IP. Falls back to the user id when a token somehow
-   * carries none, so the limiter can never end up with a shared bucket.
-   */
   private limit(req: Request): void {
-    const user = req.user as User | undefined;
-    const key = `user:${user?.id ?? 'unknown'}`;
-    if (!this.rl.check('public-api', key, RATE_MAX_PER_MINUTE, RATE_WINDOW_MS, Date.now())) {
-      throw new HttpException({ error: 'Too many requests. Please slow down.' }, 429);
-    }
+    enforcePublicApiRateLimit(this.rl, req);
   }
 
   /** Every trip the token's owner can reach, without itineraries. */
@@ -98,19 +85,6 @@ export class PublicApiController {
     }
     return trip;
   }
-}
-
-/**
- * The guard has already resolved the user; this is the type narrowing plus a
- * belt-and-braces check. If it ever throws, a route was mounted without the guard —
- * a 401 is then the right answer, and a loud one.
- */
-function requireUserId(req: Request): number {
-  const id = req.user?.id;
-  if (typeof id !== 'number') {
-    throw new HttpException({ error: 'API token required', code: 'API_TOKEN_REQUIRED' }, 401);
-  }
-  return id;
 }
 
 /**

--- a/server/src/nest/public-api/public-api.controller.ts
+++ b/server/src/nest/public-api/public-api.controller.ts
@@ -9,6 +9,8 @@ import {
 } from '@trek/shared';
 import { ApiTokenGuard } from './api-token.guard';
 import { PublicApiService } from './public-api.service';
+import { RateLimitService } from '../common/rate-limit.service';
+import type { User } from '../../types';
 
 /**
  * `/api/v1` — the versioned, read-only surface for third-party integrations.
@@ -24,15 +26,40 @@ import { PublicApiService } from './public-api.service';
  * missing feature: it would need scope enforcement this surface does not implement
  * yet, and a token that reads everything is a very different thing from one that
  * can also delete a trip.
+ *
+ * Rate limited per token rather than per IP: a self-hosted integration and its
+ * user's browser routinely share an address, and limiting by IP would let one
+ * starve the other. The budget is generous — this is a sync surface, not a login
+ * form — but bounded, so a runaway poll degrades its own integration instead of
+ * the instance.
  */
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX_PER_MINUTE = 120;
+
 @Controller('api/v1')
 @UseGuards(ApiTokenGuard)
 export class PublicApiController {
-  constructor(private readonly api: PublicApiService) {}
+  constructor(
+    private readonly api: PublicApiService,
+    private readonly rl: RateLimitService,
+  ) {}
+
+  /**
+   * Keyed by token id, not by IP. Falls back to the user id when a token somehow
+   * carries none, so the limiter can never end up with a shared bucket.
+   */
+  private limit(req: Request): void {
+    const user = req.user as User | undefined;
+    const key = `user:${user?.id ?? 'unknown'}`;
+    if (!this.rl.check('public-api', key, RATE_MAX_PER_MINUTE, RATE_WINDOW_MS, Date.now())) {
+      throw new HttpException({ error: 'Too many requests. Please slow down.' }, 429);
+    }
+  }
 
   /** Every trip the token's owner can reach, without itineraries. */
   @Get('trips')
   listTrips(@Req() req: Request): PublicApiTripList {
+    this.limit(req);
     return { trips: this.api.listTrips(requireUserId(req)) };
   }
 
@@ -49,6 +76,7 @@ export class PublicApiController {
     @Param('id') id: string,
     @Query('include') include?: string,
   ): PublicApiTrip {
+    this.limit(req);
     const tripId = parseTripId(id);
     const trip = this.api.getTrip(tripId, requireUserId(req), parseInclude(include));
     if (!trip) {

--- a/server/src/nest/public-api/public-api.controller.ts
+++ b/server/src/nest/public-api/public-api.controller.ts
@@ -3,6 +3,7 @@ import type { Request } from 'express';
 import {
   PUBLIC_API_INCLUDES,
   publicApiIncludeQuerySchema,
+  type PublicApiBucketList,
   type PublicApiInclude,
   type PublicApiTrip,
   type PublicApiTripList,
@@ -64,6 +65,19 @@ export class PublicApiController {
   }
 
   /**
+   * The caller's bucket list: places they want to reach, with no trip attached.
+   *
+   * Its own endpoint rather than an `include`, because it hangs off the user and
+   * not off any trip. For a consumer that knows where someone has actually been,
+   * this is the one list in TREK it can answer questions about.
+   */
+  @Get('bucket-list')
+  listBucketList(@Req() req: Request): PublicApiBucketList {
+    this.limit(req);
+    return { items: this.api.listBucketList(requireUserId(req)) };
+  }
+
+  /**
    * One trip, with the sections named in `?include=`.
    *
    * A trip the caller may not read answers 404, identical to one that does not
@@ -122,6 +136,10 @@ function parseTripId(raw: string): number {
  * An unknown section is a 400 rather than being ignored: silently dropping a typo
  * would hand the caller a payload that is missing exactly what they asked for, and
  * they would debug their own code for it.
+ *
+ * `places`, `notes` and `reservations` are reported on days, so asking for one of
+ * them brings `days` along; the service handles that rather than this parser, so
+ * the echo of what the caller asked for stays honest.
  */
 function parseInclude(raw?: string): PublicApiInclude[] {
   if (raw === undefined || raw.trim() === '') return [...PUBLIC_API_INCLUDES];

--- a/server/src/nest/public-api/public-api.controller.ts
+++ b/server/src/nest/public-api/public-api.controller.ts
@@ -1,0 +1,108 @@
+import { Controller, Get, HttpException, Param, Query, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import {
+  PUBLIC_API_INCLUDES,
+  publicApiIncludeQuerySchema,
+  type PublicApiInclude,
+  type PublicApiTrip,
+  type PublicApiTripList,
+} from '@trek/shared';
+import { ApiTokenGuard } from './api-token.guard';
+import { PublicApiService } from './public-api.service';
+
+/**
+ * `/api/v1` — the versioned, read-only surface for third-party integrations.
+ *
+ * Everything else under `/api` is internal: it answers a session cookie, carries no
+ * version, and is free to change with the client. This prefix is the opposite
+ * promise, and the version in the path is what makes that promise keepable — a
+ * breaking change ships as `/api/v2` rather than as an edit here.
+ *
+ * The surface is deliberately small. Two read endpoints are enough for the
+ * integrations asking for one (a location tracker enriching its own trips), and a
+ * small contract is one that can actually be honoured. Write access is not a
+ * missing feature: it would need scope enforcement this surface does not implement
+ * yet, and a token that reads everything is a very different thing from one that
+ * can also delete a trip.
+ */
+@Controller('api/v1')
+@UseGuards(ApiTokenGuard)
+export class PublicApiController {
+  constructor(private readonly api: PublicApiService) {}
+
+  /** Every trip the token's owner can reach, without itineraries. */
+  @Get('trips')
+  listTrips(@Req() req: Request): PublicApiTripList {
+    return { trips: this.api.listTrips(requireUserId(req)) };
+  }
+
+  /**
+   * One trip, with the sections named in `?include=`.
+   *
+   * A trip the caller may not read answers 404, identical to one that does not
+   * exist. That is the point: a 403 would confirm the id is real, which turns the
+   * endpoint into a way to count someone else's trips.
+   */
+  @Get('trips/:id')
+  getTrip(
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Query('include') include?: string,
+  ): PublicApiTrip {
+    const tripId = parseTripId(id);
+    const trip = this.api.getTrip(tripId, requireUserId(req), parseInclude(include));
+    if (!trip) {
+      throw new HttpException({ error: 'Trip not found' }, 404);
+    }
+    return trip;
+  }
+}
+
+/**
+ * The guard has already resolved the user; this is the type narrowing plus a
+ * belt-and-braces check. If it ever throws, a route was mounted without the guard —
+ * a 401 is then the right answer, and a loud one.
+ */
+function requireUserId(req: Request): number {
+  const id = req.user?.id;
+  if (typeof id !== 'number') {
+    throw new HttpException({ error: 'API token required', code: 'API_TOKEN_REQUIRED' }, 401);
+  }
+  return id;
+}
+
+/**
+ * Trip ids are integers. Anything else is rejected before it reaches a query —
+ * `parseInt` would happily turn "12abc" into 12, and a route that quietly accepts
+ * a mangled id is a route whose logs stop matching reality.
+ */
+function parseTripId(raw: string): number {
+  if (!/^\d+$/.test(raw)) {
+    throw new HttpException({ error: 'Invalid trip id' }, 400);
+  }
+  const id = Number(raw);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new HttpException({ error: 'Invalid trip id' }, 400);
+  }
+  return id;
+}
+
+/**
+ * `?include=days,notes`. Absent means everything, because a full sync is the common
+ * case and a caller that wants less says so.
+ *
+ * An unknown section is a 400 rather than being ignored: silently dropping a typo
+ * would hand the caller a payload that is missing exactly what they asked for, and
+ * they would debug their own code for it.
+ */
+function parseInclude(raw?: string): PublicApiInclude[] {
+  if (raw === undefined || raw.trim() === '') return [...PUBLIC_API_INCLUDES];
+  const parsed = publicApiIncludeQuerySchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new HttpException(
+      { error: `include must be a comma-separated list of: ${PUBLIC_API_INCLUDES.join(', ')}` },
+      400,
+    );
+  }
+  return parsed.data;
+}

--- a/server/src/nest/public-api/public-api.module.ts
+++ b/server/src/nest/public-api/public-api.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { PublicApiController } from './public-api.controller';
+import { PublicApiService } from './public-api.service';
+import { ApiTokenGuard } from './api-token.guard';
+import { TokensModule } from '../tokens/tokens.module';
+import { TripMembershipModule } from '../trip-membership/trip-membership.module';
+
+/**
+ * Public API v1 — the versioned read-only surface for third-party integrations.
+ *
+ * Imports rather than re-implements: token verification comes from TokensModule,
+ * trip access from TripMembershipModule and DatabaseService. This module owns the
+ * payload shaping and nothing else, so there is no second place where "who may read
+ * this trip" is decided.
+ */
+@Module({
+  imports: [TokensModule, TripMembershipModule],
+  controllers: [PublicApiController],
+  providers: [PublicApiService, ApiTokenGuard],
+})
+export class PublicApiModule {}

--- a/server/src/nest/public-api/public-api.module.ts
+++ b/server/src/nest/public-api/public-api.module.ts
@@ -4,6 +4,7 @@ import { PublicApiService } from './public-api.service';
 import { ApiTokenGuard } from './api-token.guard';
 import { TokensModule } from '../tokens/tokens.module';
 import { TripMembershipModule } from '../trip-membership/trip-membership.module';
+import { RateLimitModule } from '../common/rate-limit.module';
 
 /**
  * Public API v1 — the versioned read-only surface for third-party integrations.
@@ -14,7 +15,7 @@ import { TripMembershipModule } from '../trip-membership/trip-membership.module'
  * this trip" is decided.
  */
 @Module({
-  imports: [TokensModule, TripMembershipModule],
+  imports: [TokensModule, TripMembershipModule, RateLimitModule],
   controllers: [PublicApiController],
   providers: [PublicApiService, ApiTokenGuard],
 })

--- a/server/src/nest/public-api/public-api.module.ts
+++ b/server/src/nest/public-api/public-api.module.ts
@@ -13,6 +13,11 @@ import { RateLimitModule } from '../common/rate-limit.module';
  * trip access from TripMembershipModule and DatabaseService. This module owns the
  * payload shaping and nothing else, so there is no second place where "who may read
  * this trip" is decided.
+ *
+ * Deliberately a leaf. Pulling in a domain module for one table drags its whole
+ * graph along: AtlasModule needs AuthModule, which boots the storage registry,
+ * which reads app_settings on init. A read-only surface that cannot start without
+ * half the application is one that breaks for reasons it has nothing to do with.
  */
 @Module({
   imports: [TokensModule, TripMembershipModule, RateLimitModule],

--- a/server/src/nest/public-api/public-api.module.ts
+++ b/server/src/nest/public-api/public-api.module.ts
@@ -18,6 +18,10 @@ import { RateLimitModule } from '../common/rate-limit.module';
  * graph along: AtlasModule needs AuthModule, which boots the storage registry,
  * which reads app_settings on init. A read-only surface that cannot start without
  * half the application is one that breaks for reasons it has nothing to do with.
+ *
+ * That constraint is why `GET /api/v1/stats` is not declared here: its figures are
+ * AtlasService's, so the route lives in `atlas/` instead and provides this guard
+ * class itself. No module edge either way — which is the point.
  */
 @Module({
   imports: [TokensModule, TripMembershipModule, RateLimitModule],

--- a/server/src/nest/public-api/public-api.service.ts
+++ b/server/src/nest/public-api/public-api.service.ts
@@ -43,7 +43,7 @@ export class PublicApiService {
     const ids = this.membership.listAccessibleTripIds(userId);
     if (ids.length === 0) return [];
     const rows = this.db.all<TripRow>(
-      `SELECT id, title, description, start_date, end_date, currency, is_archived
+      `SELECT id, title, description, start_date, end_date, currency, is_archived, updated_at
          FROM trips
         WHERE id IN (${ids.map(() => '?').join(',')})
         ORDER BY start_date DESC, id DESC`,
@@ -62,7 +62,7 @@ export class PublicApiService {
   getTrip(tripId: number, userId: number, include: PublicApiInclude[]): PublicApiTrip | null {
     if (!this.db.canAccessTrip(tripId, userId)) return null;
     const row = this.db.get<TripRow>(
-      `SELECT id, title, description, start_date, end_date, currency, is_archived
+      `SELECT id, title, description, start_date, end_date, currency, is_archived, updated_at
          FROM trips WHERE id = ?`,
       tripId,
     );
@@ -227,6 +227,7 @@ function toTripSummary(row: TripRow): PublicApiTripSummary {
     end_date: row.end_date ?? null,
     currency: row.currency ?? null,
     archived: row.is_archived === 1,
+    updated_at: row.updated_at ?? null,
   };
 }
 
@@ -253,6 +254,7 @@ interface TripRow {
   end_date: string | null;
   currency: string | null;
   is_archived: number | null;
+  updated_at: string | null;
 }
 
 interface DayRow {

--- a/server/src/nest/public-api/public-api.service.ts
+++ b/server/src/nest/public-api/public-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import type {
   PublicApiAccommodation,
+  PublicApiBucketListItem,
   PublicApiDay,
   PublicApiDayNote,
   PublicApiInclude,
@@ -70,8 +71,17 @@ export class PublicApiService {
     if (!row) return null;
 
     const trip: PublicApiTrip = toTripSummary(row);
-    if (include.includes('days')) {
+    // Places, notes and reservations hang off days, so asking for one of them
+    // and not for `days` used to return the trip and nothing else — silently,
+    // which is the worst way to answer. Days are implied instead.
+    if (DAY_SCOPED.some((section) => include.includes(section))) {
       trip.days = this.buildDays(tripId, include);
+    }
+    if (include.includes('places')) {
+      trip.unplanned_places = this.buildUnplannedPlaces(tripId);
+    }
+    if (include.includes('reservations')) {
+      trip.unscheduled_reservations = this.buildUnscheduledReservations(tripId);
     }
     if (include.includes('accommodations')) {
       trip.accommodations = this.buildAccommodations(tripId);
@@ -135,18 +145,7 @@ export class PublicApiService {
         ORDER BY da.day_id ASC, da.order_index ASC`,
       tripId,
     );
-    return groupBy(rows, (r) => r.day_id, (r) => ({
-      name: r.name,
-      address: r.address ?? null,
-      lat: r.lat ?? null,
-      lng: r.lng ?? null,
-      time: r.place_time ?? null,
-      end_time: r.end_time ?? null,
-      duration_minutes: r.duration_minutes ?? null,
-      category: r.category ?? null,
-      notes: r.notes ?? null,
-      transport_mode: r.transport_mode ?? null,
-    }));
+    return groupBy(rows, (r: PlaceRow) => r.day_id, toPlace);
   }
 
   private dayNotesByDay(tripId: number): Map<number, PublicApiDayNote[]> {
@@ -178,15 +177,7 @@ export class PublicApiService {
         ORDER BY day_id ASC, reservation_time ASC`,
       tripId,
     );
-    return groupBy(rows, (r) => r.day_id, (r) => ({
-      type: r.type ?? null,
-      title: r.title ?? null,
-      location: r.location ?? null,
-      time: r.reservation_time ?? null,
-      end_time: r.reservation_end_time ?? null,
-      status: r.status ?? null,
-      notes: r.notes ?? null,
-    }));
+    return groupBy(rows, (r: ReservationRow) => r.day_id, toReservation);
   }
 
   /**
@@ -222,6 +213,84 @@ export class PublicApiService {
   }
 
   /**
+   * Places the traveller collected but has not scheduled: no row in
+   * `day_assignments`, so they belong to the trip rather than to any day.
+   *
+   * These are not leftovers. On a real instance roughly half the places on a
+   * trip sit here, and they are the ones a consumer can most usefully act on:
+   * somewhere the traveller wants to go, with a coordinate, and no claim yet
+   * about when.
+   *
+   * Ordered by creation, which is the only order they have: an unscheduled place
+   * has no position relative to its siblings.
+   *
+   * Hotels are excluded. An accommodation's place has no day assignment either,
+   * but it is not a shortlist entry and it is already reported in full under
+   * `accommodations` — listing it twice would read as two different intentions.
+   */
+  private buildUnplannedPlaces(tripId: number): PublicApiPlace[] {
+    const rows = this.db.all<Omit<PlaceRow, 'day_id'>>(
+      `SELECT p.name, p.address, p.lat, p.lng, p.place_time, p.end_time,
+              p.duration_minutes, p.notes, p.transport_mode,
+              c.name AS category
+         FROM places p
+         LEFT JOIN categories c ON c.id = p.category_id
+        WHERE p.trip_id = ?
+          AND NOT EXISTS (SELECT 1 FROM day_assignments da WHERE da.place_id = p.id)
+          AND NOT EXISTS (SELECT 1 FROM day_accommodations a WHERE a.place_id = p.id)
+        ORDER BY p.created_at ASC, p.id ASC`,
+      tripId,
+    );
+    return rows.map(toPlace);
+  }
+
+  /**
+   * Bookings with no day. `reservations.day_id` is nullable and a deleted day
+   * sets it null rather than cascading, so a flight can outlive the day it was
+   * pinned to. Reporting only day-bound bookings would quietly lose those.
+   */
+  private buildUnscheduledReservations(tripId: number): PublicApiReservation[] {
+    const rows = this.db.all<Omit<ReservationRow, 'day_id'>>(
+      `SELECT type, title, location, reservation_time, reservation_end_time,
+              status, notes
+         FROM reservations
+        WHERE trip_id = ? AND day_id IS NULL
+        ORDER BY reservation_time ASC, id ASC`,
+      tripId,
+    );
+    return rows.map(toReservation);
+  }
+
+  /**
+   * The caller's bucket list: places they want to reach, with no trip attached.
+   *
+   * Read here rather than through AtlasService, for the same reason every other
+   * table in this file is: importing a domain module for one SELECT drags its
+   * whole graph in, and this surface has to be able to boot on its own. The query
+   * is scoped by `user_id` in SQL, which is the part that matters.
+   *
+   * Returns entries even when the Atlas addon is switched off: the addon governs
+   * whether TREK shows the feature, not whether the rows exist, and a key whose
+   * answers change when an unrelated toggle moves is a key nobody can build on.
+   */
+  listBucketList(userId: number): PublicApiBucketListItem[] {
+    const rows = this.db.all<BucketListRow>(
+      `SELECT name, lat, lng, country_code, notes, target_date
+         FROM bucket_list WHERE user_id = ?
+        ORDER BY created_at DESC, id DESC`,
+      userId,
+    );
+    return rows.map((r) => ({
+      name: r.name,
+      lat: r.lat ?? null,
+      lng: r.lng ?? null,
+      country_code: r.country_code ?? null,
+      notes: r.notes ?? null,
+      target_date: r.target_date ?? null,
+    }));
+  }
+
+  /**
    * Who is on the trip: the owner first, then members in join order.
    *
    * Names only. The query selects `username` and nothing else — no ids, no email
@@ -243,6 +312,44 @@ export class PublicApiService {
     );
     return rows.map((r) => ({ name: r.username, owner: r.is_owner === 1 }));
   }
+}
+
+/**
+ * Sections that live on a day. Asking for any of them implies `days`, because
+ * that is where they are reported.
+ */
+const DAY_SCOPED: PublicApiInclude[] = ['days', 'places', 'notes', 'reservations'];
+
+/**
+ * One definition of what a place looks like on the wire, used both for places on
+ * a day and for unscheduled ones. Two copies would drift, and the second copy is
+ * always the one that forgets a field.
+ */
+function toPlace(row: Omit<PlaceRow, 'day_id'>): PublicApiPlace {
+  return {
+    name: row.name,
+    address: row.address ?? null,
+    lat: row.lat ?? null,
+    lng: row.lng ?? null,
+    time: row.place_time ?? null,
+    end_time: row.end_time ?? null,
+    duration_minutes: row.duration_minutes ?? null,
+    category: row.category ?? null,
+    notes: row.notes ?? null,
+    transport_mode: row.transport_mode ?? null,
+  };
+}
+
+function toReservation(row: Omit<ReservationRow, 'day_id'>): PublicApiReservation {
+  return {
+    type: row.type ?? null,
+    title: row.title ?? null,
+    location: row.location ?? null,
+    time: row.reservation_time ?? null,
+    end_time: row.reservation_end_time ?? null,
+    status: row.status ?? null,
+    notes: row.notes ?? null,
+  };
 }
 
 function toTripSummary(row: TripRow): PublicApiTripSummary {
@@ -338,4 +445,13 @@ interface AccommodationRow {
   check_in: string | null;
   check_out: string | null;
   notes: string | null;
+}
+
+interface BucketListRow {
+  name: string;
+  lat: number | null;
+  lng: number | null;
+  country_code: string | null;
+  notes: string | null;
+  target_date: string | null;
 }

--- a/server/src/nest/public-api/public-api.service.ts
+++ b/server/src/nest/public-api/public-api.service.ts
@@ -6,6 +6,7 @@ import type {
   PublicApiInclude,
   PublicApiPlace,
   PublicApiReservation,
+  PublicApiTraveller,
   PublicApiTrip,
   PublicApiTripSummary,
 } from '@trek/shared';
@@ -74,6 +75,9 @@ export class PublicApiService {
     }
     if (include.includes('accommodations')) {
       trip.accommodations = this.buildAccommodations(tripId);
+    }
+    if (include.includes('travellers')) {
+      trip.travellers = this.buildTravellers(tripId);
     }
     return trip;
   }
@@ -216,6 +220,29 @@ export class PublicApiService {
       notes: r.notes ?? null,
     }));
   }
+
+  /**
+   * Who is on the trip: the owner first, then members in join order.
+   *
+   * Names only. The query selects `username` and nothing else — no ids, no email
+   * addresses — because an integration key is a credential for reading its owner's
+   * itinerary, not for enumerating the people around them. What it returns is
+   * exactly what those people already see on the trip in TREK.
+   */
+  private buildTravellers(tripId: number): PublicApiTraveller[] {
+    const rows = this.db.all<TravellerRow>(
+      `SELECT u.username, 1 AS is_owner
+         FROM trips t JOIN users u ON u.id = t.user_id
+        WHERE t.id = ?
+        UNION ALL
+       SELECT u.username, 0 AS is_owner
+         FROM trip_members m JOIN users u ON u.id = m.user_id
+        WHERE m.trip_id = ?
+        ORDER BY is_owner DESC`,
+      tripId, tripId,
+    );
+    return rows.map((r) => ({ name: r.username, owner: r.is_owner === 1 }));
+  }
 }
 
 function toTripSummary(row: TripRow): PublicApiTripSummary {
@@ -294,6 +321,11 @@ interface ReservationRow {
   reservation_end_time: string | null;
   status: string | null;
   notes: string | null;
+}
+
+interface TravellerRow {
+  username: string;
+  is_owner: number;
 }
 
 interface AccommodationRow {

--- a/server/src/nest/public-api/public-api.service.ts
+++ b/server/src/nest/public-api/public-api.service.ts
@@ -1,0 +1,307 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  PublicApiAccommodation,
+  PublicApiDay,
+  PublicApiDayNote,
+  PublicApiInclude,
+  PublicApiPlace,
+  PublicApiReservation,
+  PublicApiTrip,
+  PublicApiTripSummary,
+} from '@trek/shared';
+import { DatabaseService } from '../database/database.service';
+import { TripMembershipService } from '../trip-membership/trip-membership.service';
+
+/**
+ * Assembles the read-only public API payloads.
+ *
+ * Two rules run through everything here:
+ *
+ * 1. **Access is decided per trip, against the database, every time.** The list
+ *    comes from `listAccessibleTripIds`, a single trip goes through
+ *    `canAccessTrip` — the same predicates the rest of TREK uses (owner or member).
+ *    Nothing is filtered in application code after a broad read, because a filter
+ *    that is forgotten once leaks everything.
+ * 2. **Rows are never handed out as they are stored.** Ids, foreign keys and
+ *    ordering columns stay inside; the caller gets resolved names, dates and times.
+ *    That keeps the contract stable when the tables move, and it keeps internal
+ *    structure — which user owns what, how ids are numbered — out of the response.
+ *
+ * The child queries are scoped by `trip_id` in SQL rather than by filtering a
+ * wider result set, so a bug in the include handling cannot widen what a caller
+ * sees; at worst it returns less.
+ */
+@Injectable()
+export class PublicApiService {
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly membership: TripMembershipService,
+  ) {}
+
+  /** Every trip the token's owner may read, newest first, without itineraries. */
+  listTrips(userId: number): PublicApiTripSummary[] {
+    const ids = this.membership.listAccessibleTripIds(userId);
+    if (ids.length === 0) return [];
+    const rows = this.db.all<TripRow>(
+      `SELECT id, title, description, start_date, end_date, currency, is_archived
+         FROM trips
+        WHERE id IN (${ids.map(() => '?').join(',')})
+        ORDER BY start_date DESC, id DESC`,
+      ...ids,
+    );
+    return rows.map(toTripSummary);
+  }
+
+  /**
+   * One trip with the requested sections, or null when the caller may not read it.
+   *
+   * Null covers both "no such trip" and "not yours" on purpose — the controller
+   * turns both into the same 404, so the endpoint cannot be used to probe which
+   * trip ids exist.
+   */
+  getTrip(tripId: number, userId: number, include: PublicApiInclude[]): PublicApiTrip | null {
+    if (!this.db.canAccessTrip(tripId, userId)) return null;
+    const row = this.db.get<TripRow>(
+      `SELECT id, title, description, start_date, end_date, currency, is_archived
+         FROM trips WHERE id = ?`,
+      tripId,
+    );
+    if (!row) return null;
+
+    const trip: PublicApiTrip = toTripSummary(row);
+    if (include.includes('days')) {
+      trip.days = this.buildDays(tripId, include);
+    }
+    if (include.includes('accommodations')) {
+      trip.accommodations = this.buildAccommodations(tripId);
+    }
+    return trip;
+  }
+
+  /**
+   * The itinerary. Days are the spine: everything dated hangs off one, which is
+   * what lets a consumer join on `date` alone.
+   *
+   * The per-day children are fetched once for the whole trip and grouped in memory
+   * rather than queried per day — a two-week trip would otherwise cost 42 round
+   * trips for the same rows.
+   */
+  private buildDays(tripId: number, include: PublicApiInclude[]): PublicApiDay[] {
+    const days = this.db.all<DayRow>(
+      `SELECT id, day_number, date, title, notes
+         FROM days WHERE trip_id = ? ORDER BY day_number ASC`,
+      tripId,
+    );
+    if (days.length === 0) return [];
+
+    const placesByDay = include.includes('places') ? this.placesByDay(tripId) : new Map();
+    const notesByDay = include.includes('notes') ? this.dayNotesByDay(tripId) : new Map();
+    const reservationsByDay = include.includes('reservations')
+      ? this.reservationsByDay(tripId)
+      : new Map();
+
+    return days.map((day) => ({
+      date: day.date,
+      day_number: day.day_number,
+      title: day.title ?? null,
+      notes: day.notes ?? null,
+      places: placesByDay.get(day.id) ?? [],
+      day_notes: notesByDay.get(day.id) ?? [],
+      reservations: reservationsByDay.get(day.id) ?? [],
+    }));
+  }
+
+  /**
+   * Places in the order the traveller planned to visit them.
+   *
+   * `order_index` decides the sequence and is then dropped: it is a storage detail
+   * that only means something relative to its siblings, and an array already
+   * carries order.
+   */
+  private placesByDay(tripId: number): Map<number, PublicApiPlace[]> {
+    const rows = this.db.all<PlaceRow>(
+      `SELECT da.day_id,
+              p.name, p.address, p.lat, p.lng, p.place_time, p.end_time,
+              p.duration_minutes, p.notes, p.transport_mode,
+              c.name AS category
+         FROM day_assignments da
+         JOIN places p ON p.id = da.place_id
+         LEFT JOIN categories c ON c.id = p.category_id
+        WHERE p.trip_id = ?
+        ORDER BY da.day_id ASC, da.order_index ASC`,
+      tripId,
+    );
+    return groupBy(rows, (r) => r.day_id, (r) => ({
+      name: r.name,
+      address: r.address ?? null,
+      lat: r.lat ?? null,
+      lng: r.lng ?? null,
+      time: r.place_time ?? null,
+      end_time: r.end_time ?? null,
+      duration_minutes: r.duration_minutes ?? null,
+      category: r.category ?? null,
+      notes: r.notes ?? null,
+      transport_mode: r.transport_mode ?? null,
+    }));
+  }
+
+  private dayNotesByDay(tripId: number): Map<number, PublicApiDayNote[]> {
+    const rows = this.db.all<DayNoteRow>(
+      `SELECT day_id, text, time
+         FROM day_notes WHERE trip_id = ?
+        ORDER BY day_id ASC, sort_order ASC`,
+      tripId,
+    );
+    return groupBy(rows, (r) => r.day_id, (r) => ({
+      text: r.text,
+      time: r.time ?? null,
+    }));
+  }
+
+  /**
+   * Bookings, reported on their starting day.
+   *
+   * A reservation may span days (`end_day_id`), but it is listed once rather than
+   * repeated on each — a consumer that sees the same flight on three days has no
+   * way to tell that from three flights.
+   */
+  private reservationsByDay(tripId: number): Map<number, PublicApiReservation[]> {
+    const rows = this.db.all<ReservationRow>(
+      `SELECT day_id, type, title, location, reservation_time, reservation_end_time,
+              status, notes
+         FROM reservations
+        WHERE trip_id = ? AND day_id IS NOT NULL
+        ORDER BY day_id ASC, reservation_time ASC`,
+      tripId,
+    );
+    return groupBy(rows, (r) => r.day_id, (r) => ({
+      type: r.type ?? null,
+      title: r.title ?? null,
+      location: r.location ?? null,
+      time: r.reservation_time ?? null,
+      end_time: r.reservation_end_time ?? null,
+      status: r.status ?? null,
+      notes: r.notes ?? null,
+    }));
+  }
+
+  /**
+   * Accommodations with their date range resolved from the start/end day rows.
+   *
+   * Stored as day ids, reported as ISO dates: a consumer has no way to look up a
+   * TREK day id, and the dates are what it actually needs to match its own nights.
+   */
+  private buildAccommodations(tripId: number): PublicApiAccommodation[] {
+    const rows = this.db.all<AccommodationRow>(
+      `SELECT p.name, p.address, p.lat, p.lng,
+              ds.date AS start_date, de.date AS end_date,
+              a.check_in, a.check_out, a.notes
+         FROM day_accommodations a
+         LEFT JOIN places p ON p.id = a.place_id
+         LEFT JOIN days ds ON ds.id = a.start_day_id
+         LEFT JOIN days de ON de.id = a.end_day_id
+        WHERE a.trip_id = ?
+        ORDER BY ds.date ASC`,
+      tripId,
+    );
+    return rows.map((r) => ({
+      name: r.name ?? null,
+      address: r.address ?? null,
+      lat: r.lat ?? null,
+      lng: r.lng ?? null,
+      start_date: r.start_date ?? null,
+      end_date: r.end_date ?? null,
+      check_in: r.check_in ?? null,
+      check_out: r.check_out ?? null,
+      notes: r.notes ?? null,
+    }));
+  }
+}
+
+function toTripSummary(row: TripRow): PublicApiTripSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? null,
+    start_date: row.start_date ?? null,
+    end_date: row.end_date ?? null,
+    currency: row.currency ?? null,
+    archived: row.is_archived === 1,
+  };
+}
+
+function groupBy<Row, Out>(
+  rows: Row[],
+  key: (row: Row) => number,
+  map: (row: Row) => Out,
+): Map<number, Out[]> {
+  const grouped = new Map<number, Out[]>();
+  for (const row of rows) {
+    const id = key(row);
+    const bucket = grouped.get(id);
+    if (bucket) bucket.push(map(row));
+    else grouped.set(id, [map(row)]);
+  }
+  return grouped;
+}
+
+interface TripRow {
+  id: number;
+  title: string;
+  description: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  currency: string | null;
+  is_archived: number | null;
+}
+
+interface DayRow {
+  id: number;
+  day_number: number;
+  date: string;
+  title: string | null;
+  notes: string | null;
+}
+
+interface PlaceRow {
+  day_id: number;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  place_time: string | null;
+  end_time: string | null;
+  duration_minutes: number | null;
+  notes: string | null;
+  transport_mode: string | null;
+  category: string | null;
+}
+
+interface DayNoteRow {
+  day_id: number;
+  text: string;
+  time: string | null;
+}
+
+interface ReservationRow {
+  day_id: number;
+  type: string | null;
+  title: string | null;
+  location: string | null;
+  reservation_time: string | null;
+  reservation_end_time: string | null;
+  status: string | null;
+  notes: string | null;
+}
+
+interface AccommodationRow {
+  name: string | null;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  start_date: string | null;
+  end_date: string | null;
+  check_in: string | null;
+  check_out: string | null;
+  notes: string | null;
+}

--- a/server/src/nest/tokens/token.service.ts
+++ b/server/src/nest/tokens/token.service.ts
@@ -9,6 +9,12 @@ import { revokeUserSessions } from '../../mcp/sessionManager';
 import { User } from '../../types';
 
 /**
+ * What a token is allowed to drive. Stored on the row so each surface can accept
+ * only its own: 'mcp' for the assistant tools, 'api' for the public REST surface.
+ */
+type TokenKind = 'mcp' | 'api';
+
+/**
  * Everything that mints or checks a token that is not the login JWT: the
  * long-lived MCP tokens a user manages in settings, and the short-lived ws /
  * download tokens.
@@ -33,18 +39,44 @@ export class TokenService {
   ) {}
 
   listMcpTokens(userId: number) {
+    return this.listTokens(userId, 'mcp');
+  }
+
+  /**
+   * Integration keys for the public API — a different credential from an MCP
+   * token even though both live in this table.
+   *
+   * They are split because they open different doors: an MCP token drives every
+   * tool the assistant exposes, an API key reads trips over HTTP. Handing a
+   * third-party integration something that can also delete a place is a blast
+   * radius nobody asked for, so `kind` keeps the two apart and each surface
+   * verifies the one it accepts.
+   */
+  listApiTokens(userId: number) {
+    return this.listTokens(userId, 'api');
+  }
+
+  private listTokens(userId: number, kind: TokenKind) {
     return this.db.all(
-      'SELECT id, name, token_prefix, created_at, last_used_at FROM mcp_tokens WHERE user_id = ? ORDER BY created_at DESC',
-      userId
+      'SELECT id, name, token_prefix, created_at, last_used_at FROM mcp_tokens WHERE user_id = ? AND kind = ? ORDER BY created_at DESC',
+      userId, kind
     );
   }
 
-  createMcpToken(userId: number, rawName: unknown): { error?: string; status?: number; token?: Record<string, unknown> } {
+  createMcpToken(userId: number, rawName: unknown) {
+    return this.createToken(userId, rawName, 'mcp');
+  }
+
+  createApiToken(userId: number, rawName: unknown) {
+    return this.createToken(userId, rawName, 'api');
+  }
+
+  private createToken(userId: number, rawName: unknown, kind: TokenKind): { error?: string; status?: number; token?: Record<string, unknown> } {
     const name = rawName as string | undefined;
     if (!name?.trim()) return { error: 'Token name is required', status: 400 };
     if (name.trim().length > 100) return { error: 'Token name must be 100 characters or less', status: 400 };
 
-    const tokenCount = this.db.get<{ count: number }>('SELECT COUNT(*) as count FROM mcp_tokens WHERE user_id = ?', userId)!.count;
+    const tokenCount = this.db.get<{ count: number }>('SELECT COUNT(*) as count FROM mcp_tokens WHERE user_id = ? AND kind = ?', userId, kind)!.count;
     if (tokenCount >= 10) return { error: 'Maximum of 10 tokens per user reached', status: 400 };
 
     const rawToken = 'trek_' + randomBytes(24).toString('hex');
@@ -52,8 +84,8 @@ export class TokenService {
     const tokenPrefix = rawToken.slice(0, 13);
 
     const result = this.db.run(
-      'INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix) VALUES (?, ?, ?, ?)',
-      userId, name.trim(), tokenHash, tokenPrefix
+      'INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix, kind) VALUES (?, ?, ?, ?, ?)',
+      userId, name.trim(), tokenHash, tokenPrefix, kind
     );
 
     const token = this.db.get(
@@ -64,8 +96,21 @@ export class TokenService {
     return { token: { ...(token as object), raw_token: rawToken } };
   }
 
-  deleteMcpToken(userId: number, tokenId: string): { error?: string; status?: number; success?: boolean } {
-    const token = this.db.get('SELECT id FROM mcp_tokens WHERE id = ? AND user_id = ?', tokenId, userId);
+  deleteMcpToken(userId: number, tokenId: string) {
+    return this.deleteToken(userId, tokenId, 'mcp');
+  }
+
+  deleteApiToken(userId: number, tokenId: string) {
+    return this.deleteToken(userId, tokenId, 'api');
+  }
+
+  /**
+   * Scoped by kind as well as by owner: without it the integrations panel would
+   * happily delete a token the MCP panel manages, and the user would find a key
+   * missing from a screen they never opened.
+   */
+  private deleteToken(userId: number, tokenId: string, kind: TokenKind): { error?: string; status?: number; success?: boolean } {
+    const token = this.db.get('SELECT id FROM mcp_tokens WHERE id = ? AND user_id = ? AND kind = ?', tokenId, userId, kind);
     if (!token) return { error: 'Token not found', status: 404 };
     this.db.run('DELETE FROM mcp_tokens WHERE id = ?', tokenId);
     // Best-effort, like the changePassword/resetPassword revocations: a session
@@ -130,13 +175,30 @@ export class TokenService {
   // -------------------------------------------------------------------------
 
   verifyMcpToken(rawToken: string): User | null {
+    return this.verifyToken(rawToken, 'mcp');
+  }
+
+  /** Verifies an integration key. An MCP token presented here does not resolve. */
+  verifyApiToken(rawToken: string): User | null {
+    return this.verifyToken(rawToken, 'api');
+  }
+
+  /**
+   * Hash, look up, and require the kind the calling surface accepts.
+   *
+   * The kind is part of the WHERE clause rather than checked afterwards, so a
+   * token of the wrong kind is indistinguishable from one that does not exist —
+   * neither the caller nor a timing measurement learns that the string was a
+   * real credential for somewhere else.
+   */
+  private verifyToken(rawToken: string, kind: TokenKind): User | null {
     const hash = createHash('sha256').update(rawToken).digest('hex');
     const row = this.db.get<User>(`
     SELECT u.id, u.username, u.email, u.role
     FROM mcp_tokens mt
     JOIN users u ON mt.user_id = u.id
-    WHERE mt.token_hash = ?
-  `, hash);
+    WHERE mt.token_hash = ? AND mt.kind = ?
+  `, hash, kind);
     if (row) {
       this.db.run('UPDATE mcp_tokens SET last_used_at = CURRENT_TIMESTAMP WHERE token_hash = ?', hash);
       return row;

--- a/server/tests/e2e/atlas.e2e.test.ts
+++ b/server/tests/e2e/atlas.e2e.test.ts
@@ -251,4 +251,77 @@ describe('Atlas e2e (real auth guard + real service + temp SQLite)', () => {
       expect((await request(server).get('/api/addons/atlas/locate?lat=41.9&lng=12.5')).status).toBe(401);
     });
   });
+
+  // ── GET /api/v1/stats (#1367) ─────────────────────────────────────────────
+  //
+  // Mounted from this module rather than public-api/ because its figures are
+  // AtlasService's; see the controller's docblock. Exercised here because this
+  // is the suite that already boots the real AtlasModule against a full schema —
+  // the public-api e2e builds a hand-rolled minimal one and could not.
+  describe('public API stats', () => {
+    function mintApiKey(uid: number, kind = 'api'): string {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { createHash, randomBytes } = require('crypto');
+      const raw = 'trek_' + randomBytes(24).toString('hex');
+      db.prepare('INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix, kind) VALUES (?, ?, ?, ?, ?)')
+        .run(uid, `key-${kind}-${uid}`, createHash('sha256').update(raw).digest('hex'), raw.slice(0, 12), kind);
+      return raw;
+    }
+
+    it('401 without a key, and a session cookie is not a substitute', async () => {
+      expect((await request(server).get('/api/v1/stats')).status).toBe(401);
+      // The whole point of a machine credential: the browser session does not open it.
+      const res = await request(server).get('/api/v1/stats').set('Cookie', sessionCookie(userId));
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'API token required', code: 'API_TOKEN_REQUIRED' });
+    });
+
+    it('401 for an MCP token — the wrong kind is indistinguishable from no token', async () => {
+      const mcpKey = mintApiKey(userId, 'mcp');
+      const res = await request(server).get('/api/v1/stats').set('X-API-Key', mcpKey);
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid API token', code: 'API_TOKEN_INVALID' });
+    });
+
+    it('200 with counts and the last started trip, over both header spellings', async () => {
+      const { user } = createUser(db as never, { username: 'stats-e2e', email: 'stats-e2e@test.example' });
+      const key = mintApiKey(user.id);
+      const iso = (offset: number) => new Date(Date.now() + offset * 86400000).toISOString().slice(0, 10);
+
+      createTrip(db as never, user.id, { title: 'Older', start_date: iso(-90), end_date: iso(-80) });
+      const recent = createTrip(db as never, user.id, { title: 'Recent', start_date: iso(-40), end_date: iso(-30) });
+      createTrip(db as never, user.id, { title: 'Booked', start_date: iso(30), end_date: iso(40) });
+      const cat = db.prepare('SELECT id FROM categories LIMIT 1').get() as { id: number } | undefined;
+      const placeId = db
+        .prepare('INSERT INTO places (trip_id, name, address, category_id) VALUES (?, ?, ?, ?)')
+        .run(recent.id, 'Trevi', 'Piazza di Trevi, 00187, Roma, Italy', cat?.id ?? null).lastInsertRowid as number;
+      db.prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+        .run(placeId, 'IT', 'IT-62', 'Lazio');
+
+      const res = await request(server).get('/api/v1/stats').set('Authorization', `Bearer ${key}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        total_trips: 3,
+        total_countries: 1,
+        total_places: 1,
+        last_trip: { title: 'Recent', country: 'IT', countries: ['IT'] },
+      });
+      // Scalars all the way — a widget maps fields, it cannot aggregate a list.
+      for (const k of ['total_trips', 'total_countries', 'total_cities', 'total_places', 'total_days', 'total_distance_km']) {
+        expect(typeof res.body[k]).toBe('number');
+      }
+
+      const viaHeader = await request(server).get('/api/v1/stats').set('X-API-Key', key);
+      expect(viaHeader.body).toEqual(res.body);
+    });
+
+    it('counts only the caller own trips', async () => {
+      const { user: stranger } = createUser(db as never, { username: 'stats-other', email: 'stats-other@test.example' });
+      const key = mintApiKey(stranger.id);
+      const res = await request(server).get('/api/v1/stats').set('X-API-Key', key);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ total_trips: 0, total_countries: 0, last_trip: null });
+    });
+  });
+
 });

--- a/server/tests/e2e/public-api.e2e.test.ts
+++ b/server/tests/e2e/public-api.e2e.test.ts
@@ -23,7 +23,8 @@ const { db } = vi.hoisted(() => {
       email TEXT NOT NULL UNIQUE, role TEXT NOT NULL DEFAULT 'user', password_version INTEGER NOT NULL DEFAULT 0);
     CREATE TABLE mcp_tokens (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
       name TEXT NOT NULL, token_hash TEXT NOT NULL, token_prefix TEXT NOT NULL,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP, last_used_at DATETIME);
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP, last_used_at DATETIME,
+      kind TEXT NOT NULL DEFAULT 'mcp');
     CREATE TABLE trips (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
       title TEXT NOT NULL, description TEXT, start_date TEXT, end_date TEXT, currency TEXT,
       is_archived INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -74,18 +75,21 @@ import { PublicApiModule } from '../../src/nest/public-api/public-api.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
 
 /** Mints a token the way TokenService does, so the guard's hash lookup is real. */
-function seedToken(userId: number, raw: string): string {
-  db.prepare('INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix) VALUES (?, ?, ?, ?)').run(
+function seedToken(userId: number, raw: string, kind: 'api' | 'mcp' = 'api'): string {
+  db.prepare('INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix, kind) VALUES (?, ?, ?, ?, ?)').run(
     userId,
     'test',
     createHash('sha256').update(raw).digest('hex'),
     raw.slice(0, 13),
+    kind,
   );
   return raw;
 }
 
 const ADA_TOKEN = 'trek_' + 'a'.repeat(48);
 const BOB_TOKEN = 'trek_' + 'b'.repeat(48);
+/** A valid credential for /mcp — must not open this surface. */
+const MCP_TOKEN = 'trek_' + 'c'.repeat(48);
 
 describe('Public API v1 e2e (real guard + real SQL)', () => {
   let server: Server;
@@ -104,6 +108,7 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
     db.prepare("INSERT INTO users (id, username, email) VALUES (2, 'bob', 'bob@example.com')").run();
     seedToken(1, ADA_TOKEN);
     seedToken(2, BOB_TOKEN);
+    seedToken(1, MCP_TOKEN, 'mcp');
 
     // Ada owns trip 1; Bob owns trip 2; trip 3 is Bob's but Ada is a member.
     db.prepare(
@@ -154,6 +159,12 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
 
     it('401s on an unknown token', async () => {
       expect((await get('/api/v1/trips', 'trek_' + 'z'.repeat(48))).status).toBe(401);
+    });
+
+    it('refuses a valid MCP token — different kind, different door', async () => {
+      const res = await get('/api/v1/trips', MCP_TOKEN);
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid API token', code: 'API_TOKEN_INVALID' });
     });
 
     it('accepts the token via X-API-Key too', async () => {
@@ -244,6 +255,16 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
           notes: null,
         },
       ]);
+    });
+
+    it('lists travellers by name, owner first, without ids or emails', async () => {
+      const res = await get('/api/v1/trips/3?include=travellers', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.travellers).toEqual([
+        { name: 'bob', owner: true },
+        { name: 'ada', owner: false },
+      ]);
+      expect(JSON.stringify(res.body)).not.toContain('@example.com');
     });
 
     it('never exposes internal ids or foreign keys', async () => {

--- a/server/tests/e2e/public-api.e2e.test.ts
+++ b/server/tests/e2e/public-api.e2e.test.ts
@@ -26,7 +26,8 @@ const { db } = vi.hoisted(() => {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP, last_used_at DATETIME);
     CREATE TABLE trips (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
       title TEXT NOT NULL, description TEXT, start_date TEXT, end_date TEXT, currency TEXT,
-      is_archived INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);
+      is_archived INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP);
     CREATE TABLE trip_members (trip_id INTEGER NOT NULL, user_id INTEGER NOT NULL);
     CREATE TABLE days (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
       day_number INTEGER NOT NULL, date TEXT NOT NULL, notes TEXT, title TEXT);
@@ -68,6 +69,7 @@ vi.mock('../../src/db/database', async (importActual) => {
 });
 
 import { DatabaseModule } from '../../src/nest/database/database.module';
+import { RateLimitModule } from '../../src/nest/common/rate-limit.module';
 import { PublicApiModule } from '../../src/nest/public-api/public-api.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
 
@@ -90,7 +92,7 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
   let app: Awaited<ReturnType<typeof build>>;
 
   async function build() {
-    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, PublicApiModule] }).compile();
+    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, RateLimitModule, PublicApiModule] }).compile();
     const nest = moduleRef.createNestApplication();
     nest.useGlobalFilters(new TrekExceptionFilter());
     await nest.init();

--- a/server/tests/e2e/public-api.e2e.test.ts
+++ b/server/tests/e2e/public-api.e2e.test.ts
@@ -34,7 +34,8 @@ const { db } = vi.hoisted(() => {
       day_number INTEGER NOT NULL, date TEXT NOT NULL, notes TEXT, title TEXT);
     CREATE TABLE places (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
       name TEXT NOT NULL, address TEXT, lat REAL, lng REAL, category_id INTEGER,
-      place_time TEXT, end_time TEXT, duration_minutes INTEGER, notes TEXT, transport_mode TEXT);
+      place_time TEXT, end_time TEXT, duration_minutes INTEGER, notes TEXT, transport_mode TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP);
     CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);
     CREATE TABLE day_assignments (id INTEGER PRIMARY KEY AUTOINCREMENT, day_id INTEGER NOT NULL,
       place_id INTEGER NOT NULL, order_index INTEGER NOT NULL DEFAULT 0);
@@ -47,6 +48,9 @@ const { db } = vi.hoisted(() => {
       day_id INTEGER, end_day_id INTEGER, place_id INTEGER, assignment_id INTEGER, title TEXT,
       accommodation_id TEXT, reservation_time TEXT, reservation_end_time TEXT, location TEXT,
       confirmation_number TEXT, notes TEXT, status TEXT, type TEXT);
+    CREATE TABLE bucket_list (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
+      name TEXT NOT NULL, lat REAL, lng REAL, country_code TEXT, notes TEXT,
+      target_date TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);
   `);
   return { db: tmp };
 });
@@ -128,6 +132,12 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
     db.prepare("INSERT INTO places (id, trip_id, name) VALUES (3, 1, 'Hotel Alba')").run();
     // Deliberately inserted out of order to prove order_index decides the sequence.
     db.prepare('INSERT INTO day_assignments (day_id, place_id, order_index) VALUES (1, 2, 1)').run();
+    // Ein Ort auf der Shortlist: Koordinaten, aber noch kein Tag.
+    db.prepare("INSERT INTO places (id, trip_id, name, lat, lng, notes) VALUES (4, 1, 'Boboli-Garten', 43.762, 11.248, 'vielleicht')").run();
+    // Eine Buchung, die keinen Tag (mehr) hat.
+    db.prepare("INSERT INTO reservations (trip_id, day_id, type, title, location, reservation_time, status) VALUES (1, NULL, 'flight', 'LH 1234', 'FRA', '2026-06-14T08:00', 'confirmed')").run();
+    db.prepare("INSERT INTO bucket_list (user_id, name, lat, lng, country_code, notes, target_date) VALUES (1, 'Hokkaido', 43.06, 141.35, 'JP', 'im Winter', '2027-02-01')").run();
+    db.prepare("INSERT INTO bucket_list (user_id, name, lat, lng) VALUES (2, 'Bobs Traumziel', 1.0, 2.0)").run();
     db.prepare('INSERT INTO day_assignments (day_id, place_id, order_index) VALUES (1, 1, 0)').run();
     db.prepare("INSERT INTO day_notes (day_id, trip_id, text, time, sort_order) VALUES (1, 1, 'Tickets mitnehmen', '09:00', 0)").run();
     db.prepare(
@@ -267,6 +277,39 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
       expect(JSON.stringify(res.body)).not.toContain('@example.com');
     });
 
+    it('returns shortlisted places, which are half of a real trip', async () => {
+      const res = await get('/api/v1/trips/1?include=places', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.unplanned_places).toEqual([
+        expect.objectContaining({ name: 'Boboli-Garten', lat: 43.762, lng: 11.248, notes: 'vielleicht' }),
+      ]);
+      // Hotel Alba has no day either, but it is the accommodation and is
+      // reported there — a shortlist that includes your hotel is not a shortlist.
+      expect(res.body.unplanned_places.map((p: { name: string }) => p.name)).not.toContain('Hotel Alba');
+      // And the scheduled ones still sit on their day, not in both places.
+      expect(res.body.days[0].places.map((p: { name: string }) => p.name)).toEqual(['Uffizien', 'Ponte Vecchio']);
+    });
+
+    it('returns bookings that lost their day instead of dropping them', async () => {
+      const res = await get('/api/v1/trips/1?include=reservations', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.unscheduled_reservations).toEqual([
+        expect.objectContaining({ type: 'flight', title: 'LH 1234', location: 'FRA' }),
+      ]);
+    });
+
+    it('implies days when asked for something that lives on one', async () => {
+      // The section Evgenii named first. Before days were implied this answered
+      // the trip summary and nothing else, without saying so.
+      const res = await get('/api/v1/trips/1?include=notes', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.days).toBeDefined();
+      expect(res.body.days[0].day_notes.length).toBeGreaterThan(0);
+      // Still only what was asked for: no places came along for the ride.
+      expect(res.body.days[0].places).toEqual([]);
+      expect(res.body.unplanned_places).toBeUndefined();
+    });
+
     it('never exposes internal ids or foreign keys', async () => {
       const res = await get('/api/v1/trips/1', ADA_TOKEN);
       const serialised = JSON.stringify(res.body);
@@ -291,6 +334,29 @@ describe('Public API v1 e2e (real guard + real SQL)', () => {
 
     it('400s on a non-numeric trip id', async () => {
       expect((await get('/api/v1/trips/abc', ADA_TOKEN)).status).toBe(400);
+    });
+  });
+
+  describe('bucket list', () => {
+    it("returns the caller's own wishlist, with coordinates", async () => {
+      const res = await get('/api/v1/bucket-list', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.items).toEqual([
+        { name: 'Hokkaido', lat: 43.06, lng: 141.35, country_code: 'JP', notes: 'im Winter', target_date: '2027-02-01' },
+      ]);
+    });
+
+    it("does not leak another user's wishlist", async () => {
+      const res = await get('/api/v1/bucket-list', BOB_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.items).toEqual([
+        { name: 'Bobs Traumziel', lat: 1, lng: 2, country_code: null, notes: null, target_date: null },
+      ]);
+    });
+
+    it('needs a token like everything else here', async () => {
+      const res = await request(server).get('/api/v1/bucket-list');
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/server/tests/e2e/public-api.e2e.test.ts
+++ b/server/tests/e2e/public-api.e2e.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Public API v1 e2e — the real ApiTokenGuard and real SQL against a temp SQLite db.
+ *
+ * The unit tests pin the shaping; this one exists for the question a mock cannot
+ * answer: does a token actually only reach its owner's trips? Two users, two trips,
+ * and every path that could leak one into the other is exercised — the list, the
+ * detail route, and a trip shared by membership (which must be visible, because
+ * that is TREK's access model, not an exception to it).
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import type { Server } from 'http';
+import { Test } from '@nestjs/testing';
+import { createHash } from 'crypto';
+
+const { db } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3');
+  const tmp = new Database(':memory:');
+  tmp.exec('PRAGMA journal_mode = WAL');
+  tmp.exec(`
+    CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE, role TEXT NOT NULL DEFAULT 'user', password_version INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE mcp_tokens (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
+      name TEXT NOT NULL, token_hash TEXT NOT NULL, token_prefix TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP, last_used_at DATETIME);
+    CREATE TABLE trips (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL,
+      title TEXT NOT NULL, description TEXT, start_date TEXT, end_date TEXT, currency TEXT,
+      is_archived INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);
+    CREATE TABLE trip_members (trip_id INTEGER NOT NULL, user_id INTEGER NOT NULL);
+    CREATE TABLE days (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
+      day_number INTEGER NOT NULL, date TEXT NOT NULL, notes TEXT, title TEXT);
+    CREATE TABLE places (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
+      name TEXT NOT NULL, address TEXT, lat REAL, lng REAL, category_id INTEGER,
+      place_time TEXT, end_time TEXT, duration_minutes INTEGER, notes TEXT, transport_mode TEXT);
+    CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);
+    CREATE TABLE day_assignments (id INTEGER PRIMARY KEY AUTOINCREMENT, day_id INTEGER NOT NULL,
+      place_id INTEGER NOT NULL, order_index INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE day_notes (id INTEGER PRIMARY KEY AUTOINCREMENT, day_id INTEGER NOT NULL,
+      trip_id INTEGER NOT NULL, text TEXT NOT NULL, time TEXT, icon TEXT, sort_order REAL DEFAULT 0);
+    CREATE TABLE day_accommodations (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
+      place_id INTEGER, start_day_id INTEGER, end_day_id INTEGER, check_in TEXT, check_in_end TEXT,
+      check_out TEXT, confirmation TEXT, notes TEXT);
+    CREATE TABLE reservations (id INTEGER PRIMARY KEY AUTOINCREMENT, trip_id INTEGER NOT NULL,
+      day_id INTEGER, end_day_id INTEGER, place_id INTEGER, assignment_id INTEGER, title TEXT,
+      accommodation_id TEXT, reservation_time TEXT, reservation_end_time TEXT, location TEXT,
+      confirmation_number TEXT, notes TEXT, status TEXT, type TEXT);
+  `);
+  return { db: tmp };
+});
+
+vi.mock('../../src/db/database', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/db/database')>();
+  return {
+    ...actual,
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    canAccessTrip: (tripId: number | string, userId: number) =>
+      db
+        .prepare(
+          `SELECT t.id, t.user_id, t.currency FROM trips t
+             LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ?
+            WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`,
+        )
+        .get(userId, tripId, userId),
+  };
+});
+
+import { DatabaseModule } from '../../src/nest/database/database.module';
+import { PublicApiModule } from '../../src/nest/public-api/public-api.module';
+import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
+
+/** Mints a token the way TokenService does, so the guard's hash lookup is real. */
+function seedToken(userId: number, raw: string): string {
+  db.prepare('INSERT INTO mcp_tokens (user_id, name, token_hash, token_prefix) VALUES (?, ?, ?, ?)').run(
+    userId,
+    'test',
+    createHash('sha256').update(raw).digest('hex'),
+    raw.slice(0, 13),
+  );
+  return raw;
+}
+
+const ADA_TOKEN = 'trek_' + 'a'.repeat(48);
+const BOB_TOKEN = 'trek_' + 'b'.repeat(48);
+
+describe('Public API v1 e2e (real guard + real SQL)', () => {
+  let server: Server;
+  let app: Awaited<ReturnType<typeof build>>;
+
+  async function build() {
+    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, PublicApiModule] }).compile();
+    const nest = moduleRef.createNestApplication();
+    nest.useGlobalFilters(new TrekExceptionFilter());
+    await nest.init();
+    return nest;
+  }
+
+  beforeAll(async () => {
+    db.prepare("INSERT INTO users (id, username, email) VALUES (1, 'ada', 'ada@example.com')").run();
+    db.prepare("INSERT INTO users (id, username, email) VALUES (2, 'bob', 'bob@example.com')").run();
+    seedToken(1, ADA_TOKEN);
+    seedToken(2, BOB_TOKEN);
+
+    // Ada owns trip 1; Bob owns trip 2; trip 3 is Bob's but Ada is a member.
+    db.prepare(
+      "INSERT INTO trips (id, user_id, title, description, start_date, end_date, currency) VALUES (1, 1, 'Toskana', 'Wein', '2026-06-14', '2026-06-16', 'EUR')",
+    ).run();
+    db.prepare("INSERT INTO trips (id, user_id, title, start_date) VALUES (2, 2, 'Bobs Secret', '2026-07-01')").run();
+    db.prepare("INSERT INTO trips (id, user_id, title, start_date) VALUES (3, 2, 'Shared', '2026-08-01')").run();
+    db.prepare('INSERT INTO trip_members (trip_id, user_id) VALUES (3, 1)').run();
+
+    db.prepare("INSERT INTO days (id, trip_id, day_number, date, title) VALUES (1, 1, 1, '2026-06-14', 'Ankunft')").run();
+    db.prepare("INSERT INTO days (id, trip_id, day_number, date) VALUES (2, 1, 2, '2026-06-15')").run();
+    db.prepare("INSERT INTO categories (id, name) VALUES (1, 'Museum')").run();
+    db.prepare(
+      "INSERT INTO places (id, trip_id, name, address, lat, lng, category_id, place_time, duration_minutes, transport_mode) VALUES (1, 1, 'Uffizien', 'Firenze', 43.76, 11.25, 1, '14:00', 180, 'walking')",
+    ).run();
+    db.prepare("INSERT INTO places (id, trip_id, name, lat, lng) VALUES (2, 1, 'Ponte Vecchio', 43.76, 11.24)").run();
+    db.prepare("INSERT INTO places (id, trip_id, name) VALUES (3, 1, 'Hotel Alba')").run();
+    // Deliberately inserted out of order to prove order_index decides the sequence.
+    db.prepare('INSERT INTO day_assignments (day_id, place_id, order_index) VALUES (1, 2, 1)').run();
+    db.prepare('INSERT INTO day_assignments (day_id, place_id, order_index) VALUES (1, 1, 0)').run();
+    db.prepare("INSERT INTO day_notes (day_id, trip_id, text, time, sort_order) VALUES (1, 1, 'Tickets mitnehmen', '09:00', 0)").run();
+    db.prepare(
+      "INSERT INTO reservations (trip_id, day_id, type, title, location, reservation_time, status) VALUES (1, 1, 'flight', 'LH 1234', 'FRA', '2026-06-14T08:00', 'confirmed')",
+    ).run();
+    db.prepare(
+      "INSERT INTO day_accommodations (trip_id, place_id, start_day_id, end_day_id, check_in, check_out) VALUES (1, 3, 1, 2, '15:00', '11:00')",
+    ).run();
+
+    app = await build();
+    server = app.getHttpServer() as Server;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  const get = (path: string, token?: string) => {
+    const req = request(server).get(path);
+    return token ? req.set('Authorization', `Bearer ${token}`) : req;
+  };
+
+  describe('authentication', () => {
+    it('401s without a token', async () => {
+      const res = await get('/api/v1/trips');
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'API token required', code: 'API_TOKEN_REQUIRED' });
+    });
+
+    it('401s on an unknown token', async () => {
+      expect((await get('/api/v1/trips', 'trek_' + 'z'.repeat(48))).status).toBe(401);
+    });
+
+    it('accepts the token via X-API-Key too', async () => {
+      const res = await request(server).get('/api/v1/trips').set('X-API-Key', ADA_TOKEN);
+      expect(res.status).toBe(200);
+    });
+
+    it('records last_used_at so a stale token is visible in settings', async () => {
+      await get('/api/v1/trips', ADA_TOKEN);
+      const row = db.prepare('SELECT last_used_at FROM mcp_tokens WHERE user_id = 1').get() as {
+        last_used_at: string | null;
+      };
+      expect(row.last_used_at).not.toBeNull();
+    });
+  });
+
+  /** The isolation tests. Everything else is convenience; these are the point. */
+  describe('access isolation', () => {
+    it("lists only the caller's own and shared trips", async () => {
+      const res = await get('/api/v1/trips', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.trips.map((t: { id: number }) => t.id).sort()).toEqual([1, 3]);
+    });
+
+    it("does not leak another user's trip into the list", async () => {
+      const res = await get('/api/v1/trips', BOB_TOKEN);
+      expect(res.body.trips.map((t: { id: number }) => t.id).sort()).toEqual([2, 3]);
+      expect(JSON.stringify(res.body)).not.toContain('Toskana');
+    });
+
+    it("404s on another user's trip, identically to one that does not exist", async () => {
+      const foreign = await get('/api/v1/trips/2', ADA_TOKEN);
+      const missing = await get('/api/v1/trips/424242', ADA_TOKEN);
+      expect(foreign.status).toBe(404);
+      expect(foreign.body).toEqual({ error: 'Trip not found' });
+      expect(missing.status).toBe(foreign.status);
+      expect(missing.body).toEqual(foreign.body);
+    });
+
+    it('serves a trip shared by membership, because that is the access model', async () => {
+      const res = await get('/api/v1/trips/3', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('Shared');
+    });
+  });
+
+  describe('payload', () => {
+    it('returns the whole itinerary by default, in planned order', async () => {
+      const res = await get('/api/v1/trips/1', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        id: 1,
+        title: 'Toskana',
+        description: 'Wein',
+        start_date: '2026-06-14',
+        currency: 'EUR',
+        archived: false,
+      });
+      expect(res.body.days).toHaveLength(2);
+
+      const [first] = res.body.days;
+      expect(first.date).toBe('2026-06-14');
+      expect(first.title).toBe('Ankunft');
+      expect(first.places.map((p: { name: string }) => p.name)).toEqual(['Uffizien', 'Ponte Vecchio']);
+      expect(first.places[0]).toMatchObject({
+        lat: 43.76,
+        time: '14:00',
+        duration_minutes: 180,
+        category: 'Museum',
+        transport_mode: 'walking',
+      });
+      expect(first.day_notes).toEqual([{ text: 'Tickets mitnehmen', time: '09:00' }]);
+      expect(first.reservations[0]).toMatchObject({ type: 'flight', title: 'LH 1234', status: 'confirmed' });
+    });
+
+    it('resolves accommodation day ids into ISO dates', async () => {
+      const res = await get('/api/v1/trips/1', ADA_TOKEN);
+      expect(res.body.accommodations).toEqual([
+        {
+          name: 'Hotel Alba',
+          address: null,
+          lat: null,
+          lng: null,
+          start_date: '2026-06-14',
+          end_date: '2026-06-15',
+          check_in: '15:00',
+          check_out: '11:00',
+          notes: null,
+        },
+      ]);
+    });
+
+    it('never exposes internal ids or foreign keys', async () => {
+      const res = await get('/api/v1/trips/1', ADA_TOKEN);
+      const serialised = JSON.stringify(res.body);
+      for (const leak of ['user_id', 'day_id', 'place_id', 'order_index', 'trip_id', 'assignment_id']) {
+        expect(serialised).not.toContain(leak);
+      }
+    });
+
+    it('omits sections the caller did not ask for, rather than sending them empty', async () => {
+      const res = await get('/api/v1/trips/1?include=days,notes', ADA_TOKEN);
+      expect(res.status).toBe(200);
+      expect(res.body.accommodations).toBeUndefined();
+      expect(res.body.days[0].day_notes).toHaveLength(1);
+      expect(res.body.days[0].places).toEqual([]);
+      expect(res.body.days[0].reservations).toEqual([]);
+    });
+
+    it('400s on an unknown include section', async () => {
+      const res = await get('/api/v1/trips/1?include=days,nope', ADA_TOKEN);
+      expect(res.status).toBe(400);
+    });
+
+    it('400s on a non-numeric trip id', async () => {
+      expect((await get('/api/v1/trips/abc', ADA_TOKEN)).status).toBe(400);
+    });
+  });
+});

--- a/server/tests/unit/nest/atlas.service.test.ts
+++ b/server/tests/unit/nest/atlas.service.test.ts
@@ -1695,3 +1695,71 @@ describe('getVisitedRegions — status (#1048)', () => {
     expect(after.regions['FR'][0].status).toBe('visited');
   });
 });
+
+// ── lastTrip (#1367, feeds GET /api/v1/stats) ───────────────────────────────
+
+describe('lastTrip', () => {
+  it('ATLAS-LAST-001: returns null when the user has no trips at all', () => {
+    const { user } = createUser(testDb);
+    expect(atlas.lastTrip(user.id)).toBeNull();
+  });
+
+  it('ATLAS-LAST-002: ignores trips that have not started yet', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'Next spring', start_date: FUTURE_START, end_date: FUTURE_END });
+    // A booked trip is not one you have been on, so there is no "last trip" here.
+    expect(atlas.lastTrip(user.id)).toBeNull();
+  });
+
+  it('ATLAS-LAST-003: picks the most recent started trip and reports its countries', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'Older', start_date: isoOffsetDays(-90), end_date: isoOffsetDays(-80) });
+    const recent = createTrip(testDb, user.id, { title: 'Recent', start_date: PAST_START, end_date: PAST_END });
+    createTrip(testDb, user.id, { title: 'Booked', start_date: FUTURE_START, end_date: FUTURE_END });
+
+    const place = insertPlaceWithCoords(testDb, recent.id, 'Paris Hotel', 48.85, 2.35);
+    testDb
+      .prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+      .run(place.id, 'fr', 'FR-75', 'Ile-de-France');
+
+    const last = atlas.lastTrip(user.id);
+    expect(last).toMatchObject({ title: 'Recent', start_date: PAST_START, end_date: PAST_END });
+    // Upper-cased on the way out — place_regions is not consistent about it.
+    expect(last!.countries).toEqual(['FR']);
+  });
+
+  it('ATLAS-LAST-004: orders a multi-country trip by how many places sit in each', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Interrail', start_date: PAST_START, end_date: PAST_END });
+    const stamp = testDb.prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)');
+    stamp.run(insertPlaceWithCoords(testDb, trip.id, 'Wien', 48.2, 16.37).id, 'AT', 'AT-9', 'Wien');
+    stamp.run(insertPlaceWithCoords(testDb, trip.id, 'Praha', 50.08, 14.44).id, 'CZ', 'CZ-10', 'Praha');
+    stamp.run(insertPlaceWithCoords(testDb, trip.id, 'Brno', 49.19, 16.61).id, 'CZ', 'CZ-64', 'Brno');
+
+    // Two Czech stops beat one Austrian, so CZ leads and becomes `country`.
+    expect(atlas.lastTrip(user.id)!.countries).toEqual(['CZ', 'AT']);
+  });
+
+  it('ATLAS-LAST-005: a trip whose places were never geocoded reports no countries, not a wrong one', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Roadtrip', start_date: PAST_START, end_date: PAST_END });
+    insertPlace(testDb, trip.id, 'That diner off the highway');
+    expect(atlas.lastTrip(user.id)!.countries).toEqual([]);
+  });
+
+  it('ATLAS-LAST-006: a trip shared by membership counts as the caller own last trip', () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id, { title: 'Shared', start_date: PAST_START, end_date: PAST_END });
+    testDb.prepare('INSERT INTO trip_members (trip_id, user_id) VALUES (?, ?)').run(trip.id, member.id);
+    expect(atlas.lastTrip(member.id)?.title).toBe('Shared');
+  });
+
+  it('ATLAS-LAST-007: two trips ending the same day resolve deterministically', () => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'First', start_date: PAST_START, end_date: PAST_END });
+    createTrip(testDb, user.id, { title: 'Second', start_date: PAST_START, end_date: PAST_END });
+    // The id is the tie-break, so the answer cannot depend on storage order.
+    expect(atlas.lastTrip(user.id)?.title).toBe('Second');
+  });
+});

--- a/server/tests/unit/nest/auth.controller.test.ts
+++ b/server/tests/unit/nest/auth.controller.test.ts
@@ -415,6 +415,29 @@ describe('AuthController (authenticated)', () => {
     expect(ac(asvc({}), rl(), { deleteMcpToken: vi.fn().mockReturnValue({}) }).deleteMcpToken(user, 'tid')).toEqual({ success: true });
   });
 
+  // Same four paths as the MCP block above, against the other token kind. They are
+  // separate routes on purpose — an API key and an MCP token open different doors —
+  // so nothing here is implied by the MCP tests passing.
+  it('api-tokens list + create success/error + delete error/success', () => {
+    expect(ac(asvc({}), rl(), { listApiTokens: vi.fn().mockReturnValue([{ id: 'a' }]) }).listApiTokens(user)).toEqual({ tokens: [{ id: 'a' }] });
+    expect(ac(asvc({}), rl(), { createApiToken: vi.fn().mockReturnValue({ token: 'trek_x' }) }).createApiToken(user, { name: 'Homepage' }, req)).toEqual({ token: 'trek_x' });
+    expect(thrown(() => ac(asvc({}), rl(), { createApiToken: vi.fn().mockReturnValue({ error: 'Name taken', status: 409 }) }).createApiToken(user, { name: 'x' }, req))).toEqual({ status: 409, body: { error: 'Name taken' } });
+    expect(thrown(() => ac(asvc({}), rl(), { deleteApiToken: vi.fn().mockReturnValue({ error: 'Not found', status: 404 }) }).deleteApiToken(user, 'tid'))).toEqual({ status: 404, body: { error: 'Not found' } });
+    expect(ac(asvc({}), rl(), { deleteApiToken: vi.fn().mockReturnValue({}) }).deleteApiToken(user, 'tid')).toEqual({ success: true });
+  });
+
+  // The create route shares the 'login' limiter bucket with the MCP one, at 5/window.
+  // Unlike MCP tokens it is NOT refused on a managed instance, so the limiter is the
+  // only thing standing between a scripted caller and an unbounded key list.
+  it('api-tokens create is rate limited after 5 in the window', () => {
+    const limiter = rl();
+    const createApiToken = vi.fn().mockReturnValue({ token: 'trek_x' });
+    const ctl = ac(asvc({}), limiter, { createApiToken });
+    for (let i = 0; i < 5; i++) expect(ctl.createApiToken(user, { name: `k${i}` }, req)).toEqual({ token: 'trek_x' });
+    expect(thrown(() => ctl.createApiToken(user, { name: 'k5' }, req)).status).toBe(429);
+    expect(createApiToken).toHaveBeenCalledTimes(5);
+  });
+
   it('ws-token maps error, else returns the token', () => {
     expect(thrown(() => ac(asvc({}), rl(), { createWsToken: vi.fn().mockReturnValue({ error: 'down', status: 503 }) }).wsToken(user))).toEqual({ status: 503, body: { error: 'down' } });
     expect(ac(asvc({}), rl(), { createWsToken: vi.fn().mockReturnValue({ token: 'ws' }) }).wsToken(user)).toEqual({ token: 'ws' });

--- a/server/tests/unit/nest/public-api.controller.test.ts
+++ b/server/tests/unit/nest/public-api.controller.test.ts
@@ -1,0 +1,128 @@
+/**
+ * PublicApiController — request shaping for /api/v1.
+ *
+ * The controller owns three decisions and the tests below pin all three: how a
+ * trip id is parsed, how `include` is validated, and what a caller is told about a
+ * trip they may not read (nothing that distinguishes it from one that does not
+ * exist).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { HttpException } from '@nestjs/common';
+import type { Request } from 'express';
+import { PUBLIC_API_INCLUDES } from '@trek/shared';
+import { PublicApiController } from '../../../src/nest/public-api/public-api.controller';
+import type { PublicApiService } from '../../../src/nest/public-api/public-api.service';
+
+const TRIP = {
+  id: 12,
+  title: 'Toskana',
+  description: null,
+  start_date: '2026-06-14',
+  end_date: '2026-06-22',
+  currency: 'EUR',
+  archived: false,
+};
+
+function makeController(svc: Partial<PublicApiService>) {
+  return new PublicApiController(svc as PublicApiService);
+}
+
+const req = (userId = 7) => ({ user: { id: userId } }) as Request;
+/** A request the guard never touched — the shape the controller must refuse. */
+const reqWithoutUser = () => ({}) as Request;
+
+function thrown(fn: () => unknown): { status: number; body: unknown } {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpException);
+    const e = err as HttpException;
+    return { status: e.getStatus(), body: e.getResponse() };
+  }
+  throw new Error('expected the handler to throw');
+}
+
+describe('PublicApiController', () => {
+  describe('GET /api/v1/trips', () => {
+    it('returns the accessible trips for the token owner', () => {
+      const listTrips = vi.fn().mockReturnValue([TRIP]);
+      expect(makeController({ listTrips }).listTrips(req(7))).toEqual({ trips: [TRIP] });
+      expect(listTrips).toHaveBeenCalledWith(7);
+    });
+
+    it('returns an empty list rather than 404 when the user has no trips', () => {
+      const listTrips = vi.fn().mockReturnValue([]);
+      expect(makeController({ listTrips }).listTrips(req(7))).toEqual({ trips: [] });
+    });
+
+    it('401s if the guard was somehow bypassed and no user is attached', () => {
+      const listTrips = vi.fn();
+      expect(thrown(() => makeController({ listTrips }).listTrips(reqWithoutUser()))).toEqual({
+        status: 401,
+        body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+      });
+      expect(listTrips).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/v1/trips/:id', () => {
+    it('passes the parsed id and user through, and defaults include to every section', () => {
+      const getTrip = vi.fn().mockReturnValue(TRIP);
+      const res = makeController({ getTrip }).getTrip(req(7), '12', undefined);
+      expect(res).toEqual(TRIP);
+      expect(getTrip).toHaveBeenCalledWith(12, 7, [...PUBLIC_API_INCLUDES]);
+    });
+
+    it('treats an empty include the same as an absent one', () => {
+      const getTrip = vi.fn().mockReturnValue(TRIP);
+      makeController({ getTrip }).getTrip(req(7), '12', '   ');
+      expect(getTrip).toHaveBeenCalledWith(12, 7, [...PUBLIC_API_INCLUDES]);
+    });
+
+    it('narrows to the requested sections and tolerates spacing', () => {
+      const getTrip = vi.fn().mockReturnValue(TRIP);
+      makeController({ getTrip }).getTrip(req(7), '12', 'days, notes');
+      expect(getTrip).toHaveBeenCalledWith(12, 7, ['days', 'notes']);
+    });
+
+    /**
+     * The one that matters: a trip belonging to someone else answers exactly like a
+     * trip that was never created. Anything else turns the endpoint into a way to
+     * count another user's trips.
+     */
+    it('404s for a trip the caller may not read, with no hint that it exists', () => {
+      const getTrip = vi.fn().mockReturnValue(null);
+      expect(thrown(() => makeController({ getTrip }).getTrip(req(7), '999', undefined))).toEqual({
+        status: 404,
+        body: { error: 'Trip not found' },
+      });
+    });
+
+    it.each([
+      ['a non-numeric id', 'abc'],
+      ['a numeric prefix', '12abc'],
+      ['a negative id', '-1'],
+      ['zero', '0'],
+      ['a float', '1.5'],
+      ['an empty id', ''],
+      ['whitespace', ' 12 '],
+      ['a sql fragment', "1 OR 1=1"],
+      ['an id past the safe integer range', '9007199254740993'],
+    ])('400s on %s without touching the service', (_label, raw) => {
+      const getTrip = vi.fn();
+      expect(thrown(() => makeController({ getTrip }).getTrip(req(7), raw, undefined)).status).toBe(400);
+      expect(getTrip).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['an unknown section', 'days,everything'],
+      ['a typo', 'dayz'],
+      ['only commas', ',,,'],
+    ])('400s on %s rather than silently dropping it', (_label, include) => {
+      const getTrip = vi.fn();
+      const res = thrown(() => makeController({ getTrip }).getTrip(req(7), '12', include));
+      expect(res.status).toBe(400);
+      expect(getTrip).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/tests/unit/nest/public-api.controller.test.ts
+++ b/server/tests/unit/nest/public-api.controller.test.ts
@@ -25,6 +25,15 @@ const TRIP = {
   updated_at: '2026-06-01 10:00:00',
 };
 
+const ITEM = {
+  name: 'Hokkaido',
+  lat: 43.06,
+  lng: 141.35,
+  country_code: 'JP',
+  notes: null,
+  target_date: null,
+};
+
 /** The limiter always allows unless a test says otherwise. */
 function makeController(svc: Partial<PublicApiService>, allow = true) {
   const rl = { check: vi.fn().mockReturnValue(allow) } as unknown as RateLimitService;
@@ -47,6 +56,29 @@ function thrown(fn: () => unknown): { status: number; body: unknown } {
 }
 
 describe('PublicApiController', () => {
+  describe('GET /api/v1/bucket-list', () => {
+    it('returns the caller’s wishlist and passes the id from the guard, never the query', () => {
+      const listBucketList = vi.fn().mockReturnValue([ITEM]);
+      expect(makeController({ listBucketList }).listBucketList(req(7))).toEqual({ items: [ITEM] });
+      expect(listBucketList).toHaveBeenCalledWith(7);
+    });
+
+    it('401s when the guard left no user behind', () => {
+      const listBucketList = vi.fn();
+      expect(thrown(() => makeController({ listBucketList }).listBucketList(reqWithoutUser()))).toEqual({
+        status: 401,
+        body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+      });
+      expect(listBucketList).not.toHaveBeenCalled();
+    });
+
+    it('counts against the same rate budget as everything else', () => {
+      const listBucketList = vi.fn();
+      expect(thrown(() => makeController({ listBucketList }, false).listBucketList(req(7))).status).toBe(429);
+      expect(listBucketList).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GET /api/v1/trips', () => {
     it('returns the accessible trips for the token owner', () => {
       const listTrips = vi.fn().mockReturnValue([TRIP]);

--- a/server/tests/unit/nest/public-api.controller.test.ts
+++ b/server/tests/unit/nest/public-api.controller.test.ts
@@ -12,6 +12,7 @@ import type { Request } from 'express';
 import { PUBLIC_API_INCLUDES } from '@trek/shared';
 import { PublicApiController } from '../../../src/nest/public-api/public-api.controller';
 import type { PublicApiService } from '../../../src/nest/public-api/public-api.service';
+import type { RateLimitService } from '../../../src/nest/common/rate-limit.service';
 
 const TRIP = {
   id: 12,
@@ -21,10 +22,13 @@ const TRIP = {
   end_date: '2026-06-22',
   currency: 'EUR',
   archived: false,
+  updated_at: '2026-06-01 10:00:00',
 };
 
-function makeController(svc: Partial<PublicApiService>) {
-  return new PublicApiController(svc as PublicApiService);
+/** The limiter always allows unless a test says otherwise. */
+function makeController(svc: Partial<PublicApiService>, allow = true) {
+  const rl = { check: vi.fn().mockReturnValue(allow) } as unknown as RateLimitService;
+  return new PublicApiController(svc as PublicApiService, rl);
 }
 
 const req = (userId = 7) => ({ user: { id: userId } }) as Request;
@@ -122,6 +126,21 @@ describe('PublicApiController', () => {
       const getTrip = vi.fn();
       const res = thrown(() => makeController({ getTrip }).getTrip(req(7), '12', include));
       expect(res.status).toBe(400);
+      expect(getTrip).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('429s the list once the budget is spent, without reaching the service', () => {
+      const listTrips = vi.fn();
+      const res = thrown(() => makeController({ listTrips }, false).listTrips(req(7)));
+      expect(res).toEqual({ status: 429, body: { error: 'Too many requests. Please slow down.' } });
+      expect(listTrips).not.toHaveBeenCalled();
+    });
+
+    it('429s the detail route the same way', () => {
+      const getTrip = vi.fn();
+      expect(thrown(() => makeController({ getTrip }, false).getTrip(req(7), '12', undefined)).status).toBe(429);
       expect(getTrip).not.toHaveBeenCalled();
     });
   });

--- a/server/tests/unit/nest/public-api.guard.test.ts
+++ b/server/tests/unit/nest/public-api.guard.test.ts
@@ -1,0 +1,109 @@
+/**
+ * ApiTokenGuard — the only door into /api/v1.
+ *
+ * The cases that matter here are the refusals. A guard that lets the right token
+ * through is easy; one that also lets a session JWT, an OAuth bearer or a random
+ * string through is a credential-confusion bug, and those are the tests below.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { HttpException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { ApiTokenGuard } from '../../../src/nest/public-api/api-token.guard';
+import type { TokenService } from '../../../src/nest/tokens/token.service';
+import type { User } from '../../../src/types';
+
+const USER: User = { id: 7, username: 'ada', email: 'ada@example.com', role: 'user' } as User;
+
+function contextWith(headers: Record<string, string | undefined>) {
+  const req: Record<string, unknown> = { headers };
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+    req,
+  } as unknown as ExecutionContext & { req: Record<string, unknown> };
+}
+
+function makeGuard(verify: (raw: string) => User | null) {
+  return new ApiTokenGuard({ verifyMcpToken: verify } as unknown as TokenService);
+}
+
+/** Run the guard, expecting a refusal; return its { status, body }. */
+function refused(fn: () => boolean): { status: number; body: unknown } {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpException);
+    const e = err as HttpException;
+    return { status: e.getStatus(), body: e.getResponse() };
+  }
+  throw new Error('expected the guard to refuse');
+}
+
+describe('ApiTokenGuard', () => {
+  it('accepts a trek_ token via Authorization: Bearer and resolves the user', () => {
+    const verify = vi.fn().mockReturnValue(USER);
+    const ctx = contextWith({ authorization: 'Bearer trek_abc123' });
+    expect(makeGuard(verify).canActivate(ctx)).toBe(true);
+    expect(verify).toHaveBeenCalledWith('trek_abc123');
+    expect(ctx.req.user).toBe(USER);
+  });
+
+  it('accepts the same token via X-API-Key', () => {
+    const verify = vi.fn().mockReturnValue(USER);
+    const ctx = contextWith({ 'x-api-key': 'trek_abc123' });
+    expect(makeGuard(verify).canActivate(ctx)).toBe(true);
+    expect(verify).toHaveBeenCalledWith('trek_abc123');
+  });
+
+  it('trims surrounding whitespace before looking a token up', () => {
+    const verify = vi.fn().mockReturnValue(USER);
+    makeGuard(verify).canActivate(contextWith({ 'x-api-key': '  trek_abc123  ' }));
+    expect(verify).toHaveBeenCalledWith('trek_abc123');
+  });
+
+  it('401s without any credential', () => {
+    const verify = vi.fn();
+    expect(refused(() => makeGuard(verify).canActivate(contextWith({})))).toEqual({
+      status: 401,
+      body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+    });
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it('401s on a token the store does not know, without saying which part was wrong', () => {
+    const verify = vi.fn().mockReturnValue(null);
+    expect(
+      refused(() => makeGuard(verify).canActivate(contextWith({ authorization: 'Bearer trek_nope' }))),
+    ).toEqual({
+      status: 401,
+      body: { error: 'Invalid API token', code: 'API_TOKEN_INVALID' },
+    });
+  });
+
+  /**
+   * The credential-confusion cases. Each of these is a valid credential somewhere
+   * else in TREK, and none of them may open this door — a session cookie that ends
+   * up in a third-party integration is precisely what a machine token prevents.
+   */
+  it.each([
+    ['a session JWT', { authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig' }],
+    ['an OAuth bearer', { authorization: 'Bearer mcp_at_9f3a2b' }],
+    ['a bare random string', { authorization: 'Bearer hunter2' }],
+    ['a non-Bearer scheme', { authorization: 'Basic dHJlazpwdw==' }],
+    ['a trek_ token in the wrong scheme', { authorization: 'Token trek_abc123' }],
+    ['an X-API-Key that is not a trek_ token', { 'x-api-key': 'eyJhbGciOiJIUzI1NiJ9.p.s' }],
+  ])('refuses %s without ever hitting the token store', (_label, headers) => {
+    const verify = vi.fn();
+    expect(refused(() => makeGuard(verify).canActivate(contextWith(headers)))).toEqual({
+      status: 401,
+      body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+    });
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it('ignores an array-valued Authorization header rather than coercing it', () => {
+    const verify = vi.fn();
+    const ctx = contextWith({ authorization: ['Bearer trek_abc'] as unknown as string });
+    expect(refused(() => makeGuard(verify).canActivate(ctx)).status).toBe(401);
+    expect(verify).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/nest/public-api.guard.test.ts
+++ b/server/tests/unit/nest/public-api.guard.test.ts
@@ -23,7 +23,7 @@ function contextWith(headers: Record<string, string | undefined>) {
 }
 
 function makeGuard(verify: (raw: string) => User | null) {
-  return new ApiTokenGuard({ verifyMcpToken: verify } as unknown as TokenService);
+  return new ApiTokenGuard({ verifyApiToken: verify } as unknown as TokenService);
 }
 
 /** Run the guard, expecting a refusal; return its { status, body }. */
@@ -67,6 +67,15 @@ describe('ApiTokenGuard', () => {
       body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
     });
     expect(verify).not.toHaveBeenCalled();
+  });
+
+  it('never reaches for the MCP verifier, so the two credentials cannot swap', () => {
+    const verifyApiToken = vi.fn().mockReturnValue(USER);
+    const verifyMcpToken = vi.fn();
+    const guard = new ApiTokenGuard({ verifyApiToken, verifyMcpToken } as unknown as TokenService);
+    guard.canActivate(contextWith({ authorization: 'Bearer trek_abc123' }));
+    expect(verifyApiToken).toHaveBeenCalledTimes(1);
+    expect(verifyMcpToken).not.toHaveBeenCalled();
   });
 
   it('401s on a token the store does not know, without saying which part was wrong', () => {

--- a/server/tests/unit/nest/public-stats.controller.test.ts
+++ b/server/tests/unit/nest/public-stats.controller.test.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/v1/stats — the aggregate widget endpoint (#1367).
+ *
+ * The interesting part is not the arithmetic, it is that the numbers come from
+ * AtlasService rather than from a second count of their own: a widget showing 23
+ * countries next to a dashboard showing 25 is the bug this endpoint exists to
+ * avoid. So the service is stubbed and the assertions pin the mapping —
+ * `countries.length`, not a re-derivation.
+ *
+ * Rate limiting and the missing-user path are shared with PublicApiController
+ * (public-api-request.ts); they are exercised here too because this controller
+ * lives in another module and could stop calling them without anything failing.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { HttpException } from '@nestjs/common';
+import type { Request } from 'express';
+import { PublicStatsController } from '../../../src/nest/atlas/public-stats.controller';
+import type { AtlasService } from '../../../src/nest/atlas/atlas.service';
+import { RateLimitService } from '../../../src/nest/common/rate-limit.service';
+import { PUBLIC_API_RATE_MAX_PER_MINUTE } from '../../../src/nest/public-api/public-api-request';
+import type { User } from '../../../src/types';
+
+// `null` rather than `undefined` for "no user": passing undefined would trip the
+// default parameter and hand back a request that still has one.
+const req = (userId: number | null = 7) =>
+  ({ headers: {}, user: userId === null ? undefined : ({ id: userId } as User) }) as Request;
+
+const travel = (o: Partial<ReturnType<AtlasService['getTravelStats']>> = {}) => ({
+  countries: ['JP', 'IT'],
+  cities: ['tokyo', 'kyoto', 'rome'],
+  coords: [],
+  totalTrips: 4,
+  totalDays: 31,
+  totalPlaces: 52,
+  totalDistanceKm: 18402,
+  ...o,
+});
+
+function ctl(atlas: Partial<AtlasService> = {}, rl = new RateLimitService()) {
+  return new PublicStatsController(
+    { getTravelStats: vi.fn(() => travel()), lastTrip: vi.fn(() => null), ...atlas } as unknown as AtlasService,
+    rl,
+  );
+}
+
+function thrown(fn: () => unknown): { status: number; body: unknown } {
+  try { fn(); } catch (err) {
+    expect(err).toBeInstanceOf(HttpException);
+    const e = err as HttpException;
+    return { status: e.getStatus(), body: e.getResponse() };
+  }
+  throw new Error('expected throw');
+}
+
+describe('PublicStatsController', () => {
+  it('PUBSTATS-001: reports counts, not the arrays behind them', () => {
+    expect(ctl().stats(req())).toEqual({
+      total_trips: 4,
+      total_countries: 2,
+      total_cities: 3,
+      total_places: 52,
+      total_days: 31,
+      total_distance_km: 18402,
+      last_trip: null,
+    });
+  });
+
+  it('PUBSTATS-002: passes the authenticated user through to the service', () => {
+    const getTravelStats = vi.fn(() => travel());
+    const lastTrip = vi.fn(() => null);
+    ctl({ getTravelStats, lastTrip } as unknown as Partial<AtlasService>).stats(req(42));
+    expect(getTravelStats).toHaveBeenCalledWith(42);
+    expect(lastTrip).toHaveBeenCalledWith(42);
+  });
+
+  it('PUBSTATS-003: last_trip carries the dominant country as the head of the list', () => {
+    const lastTrip = vi.fn(() => ({
+      title: 'Interrail', start_date: '2026-03-01', end_date: '2026-03-12', countries: ['CZ', 'AT'],
+    }));
+    const out = ctl({ lastTrip } as unknown as Partial<AtlasService>).stats(req());
+    expect(out.last_trip).toEqual({
+      title: 'Interrail',
+      start_date: '2026-03-01',
+      end_date: '2026-03-12',
+      country: 'CZ',
+      countries: ['CZ', 'AT'],
+    });
+  });
+
+  it('PUBSTATS-004: an ungeocoded last trip reports country null rather than a wrong one', () => {
+    const lastTrip = vi.fn(() => ({ title: 'Roadtrip', start_date: null, end_date: null, countries: [] }));
+    const out = ctl({ lastTrip } as unknown as Partial<AtlasService>).stats(req());
+    expect(out.last_trip).toMatchObject({ country: null, countries: [] });
+  });
+
+  it('PUBSTATS-005: shares one rate-limit budget with the rest of /api/v1', () => {
+    const rl = new RateLimitService();
+    const c = ctl({}, rl);
+    for (let i = 0; i < PUBLIC_API_RATE_MAX_PER_MINUTE; i++) c.stats(req());
+    expect(thrown(() => c.stats(req()))).toEqual({
+      status: 429,
+      body: { error: 'Too many requests. Please slow down.' },
+    });
+    // A different caller still gets their own budget.
+    expect(() => c.stats(req(8))).not.toThrow();
+  });
+
+  it('PUBSTATS-006: a request with no resolved user is a 401, not a crash', () => {
+    const getTravelStats = vi.fn(() => travel());
+    expect(thrown(() => ctl({ getTravelStats } as unknown as Partial<AtlasService>).stats(req(null)))).toEqual({
+      status: 401,
+      body: { error: 'API token required', code: 'API_TOKEN_REQUIRED' },
+    });
+    // The guard is what should have stopped this; no data was read on the way out.
+    expect(getTravelStats).not.toHaveBeenCalled();
+  });
+
+  it('PUBSTATS-007: the class is listed in its module controllers', async () => {
+    const { AtlasModule } = await import('../../../src/nest/atlas/atlas.module');
+    const controllers = Reflect.getMetadata('controllers', AtlasModule) as unknown[];
+    expect(controllers).toContain(PublicStatsController);
+  });
+});

--- a/server/tests/unit/nest/token.service.test.ts
+++ b/server/tests/unit/nest/token.service.test.ts
@@ -151,6 +151,92 @@ describe('MCP token service', () => {
 });
 
 // ---------------------------------------------------------------------------
+// API keys — the same table, a different door
+//
+// An MCP token drives every assistant tool; an API key reads trips over HTTP.
+// The kind is in the WHERE clause of every lookup, so these tests are the ones
+// that would catch a credential quietly opening the wrong surface.
+// ---------------------------------------------------------------------------
+
+describe('API key service', () => {
+  it('TOKEN-010: an API key does not verify as an MCP token', () => {
+    const { user } = createUser(testDb);
+    const created = svc.createApiToken(user.id, 'dawarich');
+    const raw = (created.token as { raw_token: string }).raw_token;
+
+    expect(svc.verifyApiToken(raw)?.id).toBe(user.id);
+    expect(svc.verifyMcpToken(raw)).toBeNull();
+  });
+
+  it('TOKEN-011: an MCP token does not verify as an API key', () => {
+    const { user } = createUser(testDb);
+    const created = svc.createMcpToken(user.id, 'claude');
+    const raw = (created.token as { raw_token: string }).raw_token;
+
+    expect(svc.verifyMcpToken(raw)?.id).toBe(user.id);
+    expect(svc.verifyApiToken(raw)).toBeNull();
+  });
+
+  it('TOKEN-012: each list shows only its own kind', () => {
+    const { user } = createUser(testDb);
+    svc.createMcpToken(user.id, 'claude');
+    svc.createApiToken(user.id, 'dawarich');
+
+    const mcp = svc.listMcpTokens(user.id) as Record<string, unknown>[];
+    const api = svc.listApiTokens(user.id) as Record<string, unknown>[];
+    expect(mcp.map((t) => t.name)).toEqual(['claude']);
+    expect(api.map((t) => t.name)).toEqual(['dawarich']);
+  });
+
+  it('TOKEN-013: deleting across kinds 404s, identically to an unknown id', () => {
+    const { user } = createUser(testDb);
+    const mcpId = String((svc.createMcpToken(user.id, 'claude').token as { id: number }).id);
+    const apiId = String((svc.createApiToken(user.id, 'dawarich').token as { id: number }).id);
+
+    expect(svc.deleteApiToken(user.id, mcpId)).toEqual({ error: 'Token not found', status: 404 });
+    expect(svc.deleteMcpToken(user.id, apiId)).toEqual({ error: 'Token not found', status: 404 });
+    // Neither row was touched: a wrong-kind delete must not be a way to revoke
+    // someone's assistant access from the API-key screen.
+    expect(testDb.prepare('SELECT id FROM mcp_tokens WHERE id = ?').get(mcpId)).toBeDefined();
+    expect(testDb.prepare('SELECT id FROM mcp_tokens WHERE id = ?').get(apiId)).toBeDefined();
+  });
+
+  it('TOKEN-014: the ten-token ceiling counts each kind on its own', () => {
+    const { user } = createUser(testDb);
+    for (let i = 0; i < 10; i += 1) svc.createMcpToken(user.id, `mcp-${i}`);
+
+    expect(svc.createMcpToken(user.id, 'one-too-many').status).toBe(400);
+    // A full MCP shelf must not lock the user out of minting an API key.
+    expect(svc.createApiToken(user.id, 'dawarich').status).toBeUndefined();
+  });
+
+  it('TOKEN-015: an API key is stored hashed, with only a prefix in the clear', () => {
+    const { user } = createUser(testDb);
+    const created = svc.createApiToken(user.id, 'dawarich');
+    const raw = (created.token as { raw_token: string }).raw_token;
+
+    const row = testDb
+      .prepare('SELECT token_hash, token_prefix, kind FROM mcp_tokens WHERE user_id = ?')
+      .get(user.id) as { token_hash: string; token_prefix: string; kind: string };
+    expect(row.kind).toBe('api');
+    expect(row.token_hash).not.toBe(raw);
+    expect(raw.startsWith(row.token_prefix)).toBe(true);
+  });
+
+  it('TOKEN-016: verifying an API key records last_used_at, so a stale key is visible', () => {
+    const { user } = createUser(testDb);
+    const raw = (svc.createApiToken(user.id, 'dawarich').token as { raw_token: string }).raw_token;
+
+    const before = svc.listApiTokens(user.id) as Record<string, unknown>[];
+    expect(before[0].last_used_at).toBeNull();
+
+    svc.verifyApiToken(raw);
+    const after = svc.listApiTokens(user.id) as Record<string, unknown>[];
+    expect(after[0].last_used_at).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MCP tokens — the admin half
 //
 // Same table, no user scope. These came from AdminService, which only owned

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -516,6 +516,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'إظهار مسارات الحجوزات دائمًا',
   'settings.alwaysShowRoutesHint':
     'يعرض تلقائيًا مسار كل رحلة طيران وقطار وحجز آخر على الخريطة، دون الحاجة إلى تفعيله لكل عنصر على حدة.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'مفاتيح API',
+  'settings.apiKeys.description': 'مفاتيح لواجهة API العامة، حتى تتمكن برامج أخرى من قراءة رحلاتك. للقراءة فقط: لا يمكن للمفتاح تغيير أي شيء أو حذفه.',
+  'settings.apiKeys.create': 'إنشاء مفتاح',
+  'settings.apiKeys.empty': 'لا توجد مفاتيح بعد. أنشئ مفتاحًا لربط برامج أخرى.',
+  'settings.apiKeys.createdAt': 'أُنشئ',
+  'settings.apiKeys.usedAt': 'آخر استخدام',
+  'settings.apiKeys.deleteTitle': 'حذف المفتاح',
+  'settings.apiKeys.deleteMessage': 'كل ما يستخدم هذا المفتاح سيتوقف فورًا. لا يمكن التراجع عن ذلك.',
+  'settings.apiKeys.deleted': 'تم حذف المفتاح',
+  'settings.apiKeys.deleteFailed': 'تعذّر حذف المفتاح',
+  'settings.apiKeys.createFailed': 'تعذّر إنشاء المفتاح',
+  'settings.apiKeys.copy': 'نسخ',
+  'settings.apiKeys.docsHint': 'أرسل المفتاح بصيغة "Authorization: Bearer ..." أو "X-API-Key: ..." إلى /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'إنشاء مفتاح API',
+  'settings.apiKeys.modal.name': 'الاسم',
+  'settings.apiKeys.modal.namePlaceholder': 'مثال: Dawarich',
+  'settings.apiKeys.modal.nameHint': 'لك وحدك، لتتعرّف على المفتاح لاحقًا.',
+  'settings.apiKeys.modal.creating': 'جارٍ الإنشاء...',
+  'settings.apiKeys.modal.create': 'إنشاء',
+  'settings.apiKeys.modal.createdTitle': 'تم إنشاء مفتاح API',
+  'settings.apiKeys.modal.createdWarning': 'انسخ المفتاح الآن. يُعرض مرة واحدة فقط ولا يمكن استرجاعه لاحقًا.',
+  'settings.apiKeys.modal.done': 'تم',
 };
 
 export default settings;

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -532,6 +532,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Sempre mostrar rotas de reserva',
   'settings.alwaysShowRoutesHint':
     'Mostra automaticamente no mapa a rota de cada voo, trem e outra reserva, sem precisar ativar item por item.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Chaves de API',
+  'settings.apiKeys.description': 'Chaves para a API pública, para que outros softwares possam ler suas viagens. Somente leitura: uma chave não pode alterar nem excluir nada.',
+  'settings.apiKeys.create': 'Criar chave',
+  'settings.apiKeys.empty': 'Nenhuma chave ainda. Crie uma para conectar outros softwares.',
+  'settings.apiKeys.createdAt': 'criada',
+  'settings.apiKeys.usedAt': 'último uso',
+  'settings.apiKeys.deleteTitle': 'Excluir chave',
+  'settings.apiKeys.deleteMessage': 'Tudo que usa esta chave para de funcionar imediatamente. Não é possível desfazer.',
+  'settings.apiKeys.deleted': 'Chave excluída',
+  'settings.apiKeys.deleteFailed': 'Não foi possível excluir a chave',
+  'settings.apiKeys.createFailed': 'Não foi possível criar a chave',
+  'settings.apiKeys.copy': 'Copiar',
+  'settings.apiKeys.docsHint': 'Envie a chave como "Authorization: Bearer ..." ou "X-API-Key: ..." para /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Criar chave de API',
+  'settings.apiKeys.modal.name': 'Nome',
+  'settings.apiKeys.modal.namePlaceholder': 'ex.: Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Apenas para você, para reconhecer a chave depois.',
+  'settings.apiKeys.modal.creating': 'Criando...',
+  'settings.apiKeys.modal.create': 'Criar',
+  'settings.apiKeys.modal.createdTitle': 'Chave de API criada',
+  'settings.apiKeys.modal.createdWarning': 'Copie a chave agora. Ela é exibida uma única vez e não pode ser recuperada depois.',
+  'settings.apiKeys.modal.done': 'Concluído',
 };
 
 export default settings;

--- a/shared/src/i18n/ca/settings.ts
+++ b/shared/src/i18n/ca/settings.ts
@@ -535,6 +535,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Mostra sempre les rutes de reserva',
   'settings.alwaysShowRoutesHint':
     'Dibuixa automàticament al mapa la ruta de cada vol, tren i altra reserva — no cal activar-la una per una.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Claus API',
+  'settings.apiKeys.description': 'Claus per a l\'API pública, perquè altres programes puguin llegir els teus viatges. Només lectura: una clau no pot canviar ni esborrar res.',
+  'settings.apiKeys.create': 'Crea una clau',
+  'settings.apiKeys.empty': 'Encara no hi ha claus. Crea\'n una per connectar altres programes.',
+  'settings.apiKeys.createdAt': 'creada',
+  'settings.apiKeys.usedAt': 'últim ús',
+  'settings.apiKeys.deleteTitle': 'Elimina la clau',
+  'settings.apiKeys.deleteMessage': 'Tot el que faci servir aquesta clau deixarà de funcionar immediatament. Això no es pot desfer.',
+  'settings.apiKeys.deleted': 'Clau eliminada',
+  'settings.apiKeys.deleteFailed': 'No s\'ha pogut eliminar la clau',
+  'settings.apiKeys.createFailed': 'No s\'ha pogut crear la clau',
+  'settings.apiKeys.copy': 'Copia',
+  'settings.apiKeys.docsHint': 'Envia la clau com a "Authorization: Bearer ..." o "X-API-Key: ..." a /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Crea una clau API',
+  'settings.apiKeys.modal.name': 'Nom',
+  'settings.apiKeys.modal.namePlaceholder': 'p. ex. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Només per a tu, perquè reconeguis la clau més endavant.',
+  'settings.apiKeys.modal.creating': 'S\'està creant...',
+  'settings.apiKeys.modal.create': 'Crea',
+  'settings.apiKeys.modal.createdTitle': 'Clau API creada',
+  'settings.apiKeys.modal.createdWarning': 'Copia la clau ara. Només es mostra un cop i no es pot recuperar després.',
+  'settings.apiKeys.modal.done': 'Fet',
 };
 
 export default settings;

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -524,6 +524,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Vždy zobrazovat trasy rezervací',
   'settings.alwaysShowRoutesHint':
     'Automaticky zobrazí na mapě trasu každého letu, vlaku a jiné rezervace, aniž byste ji museli zapínat jednotlivě.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Klíče API',
+  'settings.apiKeys.description': 'Klíče pro veřejné API, aby jiný software mohl číst tvoje cesty. Jen pro čtení: klíč nemůže nic měnit ani mazat.',
+  'settings.apiKeys.create': 'Vytvořit klíč',
+  'settings.apiKeys.empty': 'Zatím žádné klíče. Vytvoř jeden a připoj další software.',
+  'settings.apiKeys.createdAt': 'vytvořen',
+  'settings.apiKeys.usedAt': 'naposledy použit',
+  'settings.apiKeys.deleteTitle': 'Smazat klíč',
+  'settings.apiKeys.deleteMessage': 'Vše, co tento klíč používá, okamžitě přestane fungovat. Akci nelze vrátit zpět.',
+  'settings.apiKeys.deleted': 'Klíč smazán',
+  'settings.apiKeys.deleteFailed': 'Klíč se nepodařilo smazat',
+  'settings.apiKeys.createFailed': 'Klíč se nepodařilo vytvořit',
+  'settings.apiKeys.copy': 'Kopírovat',
+  'settings.apiKeys.docsHint': 'Pošli klíč jako "Authorization: Bearer ..." nebo "X-API-Key: ..." na /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Vytvořit klíč API',
+  'settings.apiKeys.modal.name': 'Název',
+  'settings.apiKeys.modal.namePlaceholder': 'např. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Jen pro tebe, abys klíč později poznal.',
+  'settings.apiKeys.modal.creating': 'Vytváří se...',
+  'settings.apiKeys.modal.create': 'Vytvořit',
+  'settings.apiKeys.modal.createdTitle': 'Klíč API vytvořen',
+  'settings.apiKeys.modal.createdWarning': 'Zkopíruj klíč hned teď. Zobrazí se jen jednou a později ho už nelze získat.',
+  'settings.apiKeys.modal.done': 'Hotovo',
 };
 
 export default settings;

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -535,6 +535,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Buchungsrouten immer anzeigen',
   'settings.alwaysShowRoutesHint':
     'Zeigt die Route für jeden Flug, jede Zugfahrt und jede andere Buchung automatisch auf der Karte an – ohne sie einzeln aktivieren zu müssen.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API-Schlüssel',
+  'settings.apiKeys.description': 'Schlüssel für die öffentliche API, damit andere Software deine Reisen lesen kann. Nur lesend: ein Schlüssel kann nichts ändern oder löschen.',
+  'settings.apiKeys.create': 'Schlüssel erstellen',
+  'settings.apiKeys.empty': 'Noch keine Schlüssel. Erstelle einen, um andere Software zu verbinden.',
+  'settings.apiKeys.createdAt': 'erstellt',
+  'settings.apiKeys.usedAt': 'zuletzt genutzt',
+  'settings.apiKeys.deleteTitle': 'Schlüssel löschen',
+  'settings.apiKeys.deleteMessage': 'Alles, was diesen Schlüssel nutzt, hört sofort auf zu funktionieren. Das lässt sich nicht rückgängig machen.',
+  'settings.apiKeys.deleted': 'Schlüssel gelöscht',
+  'settings.apiKeys.deleteFailed': 'Schlüssel konnte nicht gelöscht werden',
+  'settings.apiKeys.createFailed': 'Schlüssel konnte nicht erstellt werden',
+  'settings.apiKeys.copy': 'Kopieren',
+  'settings.apiKeys.docsHint': 'Schicke den Schlüssel als "Authorization: Bearer ..." oder "X-API-Key: ..." an /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'API-Schlüssel erstellen',
+  'settings.apiKeys.modal.name': 'Name',
+  'settings.apiKeys.modal.namePlaceholder': 'z. B. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Nur für dich, damit du den Schlüssel später wiedererkennst.',
+  'settings.apiKeys.modal.creating': 'Wird erstellt...',
+  'settings.apiKeys.modal.create': 'Erstellen',
+  'settings.apiKeys.modal.createdTitle': 'API-Schlüssel erstellt',
+  'settings.apiKeys.modal.createdWarning': 'Kopiere den Schlüssel jetzt. Er wird nur einmal angezeigt und lässt sich später nicht mehr abrufen.',
+  'settings.apiKeys.modal.done': 'Fertig',
 };
 
 export default settings;

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -522,6 +522,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Always show booking routes',
   'settings.alwaysShowRoutesHint':
     'Automatically draw the route for every flight, train and other booking on the map — no need to switch it on per item.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API Keys',
+  'settings.apiKeys.description': 'Keys for the public API, so other software can read your trips. Read-only: a key cannot change or delete anything.',
+  'settings.apiKeys.create': 'Create key',
+  'settings.apiKeys.empty': 'No keys yet. Create one to connect other software.',
+  'settings.apiKeys.createdAt': 'created',
+  'settings.apiKeys.usedAt': 'last used',
+  'settings.apiKeys.deleteTitle': 'Delete key',
+  'settings.apiKeys.deleteMessage': 'Anything using this key stops working immediately. This cannot be undone.',
+  'settings.apiKeys.deleted': 'Key deleted',
+  'settings.apiKeys.deleteFailed': 'Could not delete the key',
+  'settings.apiKeys.createFailed': 'Could not create the key',
+  'settings.apiKeys.copy': 'Copy',
+  'settings.apiKeys.docsHint': 'Send the key as "Authorization: Bearer ..." or "X-API-Key: ..." to /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Create API key',
+  'settings.apiKeys.modal.name': 'Name',
+  'settings.apiKeys.modal.namePlaceholder': 'e.g. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Only for you, so you recognise the key later.',
+  'settings.apiKeys.modal.creating': 'Creating...',
+  'settings.apiKeys.modal.create': 'Create',
+  'settings.apiKeys.modal.createdTitle': 'API key created',
+  'settings.apiKeys.modal.createdWarning': 'Copy the key now. It is shown once and cannot be retrieved later.',
+  'settings.apiKeys.modal.done': 'Done',
 };
 
 export default settings;

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -533,6 +533,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Mostrar siempre las rutas de reserva',
   'settings.alwaysShowRoutesHint':
     'Muestra automáticamente en el mapa la ruta de cada vuelo, tren y otra reserva, sin necesidad de activarla una por una.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Claves API',
+  'settings.apiKeys.description': 'Claves para la API pública, para que otro software pueda leer tus viajes. Solo lectura: una clave no puede cambiar ni borrar nada.',
+  'settings.apiKeys.create': 'Crear clave',
+  'settings.apiKeys.empty': 'Todavía no hay claves. Crea una para conectar otro software.',
+  'settings.apiKeys.createdAt': 'creada',
+  'settings.apiKeys.usedAt': 'último uso',
+  'settings.apiKeys.deleteTitle': 'Eliminar clave',
+  'settings.apiKeys.deleteMessage': 'Todo lo que use esta clave dejará de funcionar de inmediato. Esto no se puede deshacer.',
+  'settings.apiKeys.deleted': 'Clave eliminada',
+  'settings.apiKeys.deleteFailed': 'No se pudo eliminar la clave',
+  'settings.apiKeys.createFailed': 'No se pudo crear la clave',
+  'settings.apiKeys.copy': 'Copiar',
+  'settings.apiKeys.docsHint': 'Envía la clave como "Authorization: Bearer ..." o "X-API-Key: ..." a /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Crear clave API',
+  'settings.apiKeys.modal.name': 'Nombre',
+  'settings.apiKeys.modal.namePlaceholder': 'p. ej. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Solo para ti, para que reconozcas la clave más adelante.',
+  'settings.apiKeys.modal.creating': 'Creando...',
+  'settings.apiKeys.modal.create': 'Crear',
+  'settings.apiKeys.modal.createdTitle': 'Clave API creada',
+  'settings.apiKeys.modal.createdWarning': 'Copia la clave ahora. Se muestra una sola vez y no se puede recuperar después.',
+  'settings.apiKeys.modal.done': 'Listo',
 };
 
 export default settings;

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -541,6 +541,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Toujours afficher les itinéraires de réservation',
   'settings.alwaysShowRoutesHint':
     "Affiche automatiquement sur la carte l'itinéraire de chaque vol, trajet en train et autre réservation, sans avoir à l'activer un par un.",
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Clés API',
+  'settings.apiKeys.description': 'Clés pour l\'API publique, afin que d\'autres logiciels puissent lire vos voyages. Lecture seule : une clé ne peut rien modifier ni supprimer.',
+  'settings.apiKeys.create': 'Créer une clé',
+  'settings.apiKeys.empty': 'Aucune clé pour le moment. Créez-en une pour connecter un autre logiciel.',
+  'settings.apiKeys.createdAt': 'créée',
+  'settings.apiKeys.usedAt': 'dernière utilisation',
+  'settings.apiKeys.deleteTitle': 'Supprimer la clé',
+  'settings.apiKeys.deleteMessage': 'Tout ce qui utilise cette clé cesse de fonctionner immédiatement. Cette action est irréversible.',
+  'settings.apiKeys.deleted': 'Clé supprimée',
+  'settings.apiKeys.deleteFailed': 'Impossible de supprimer la clé',
+  'settings.apiKeys.createFailed': 'Impossible de créer la clé',
+  'settings.apiKeys.copy': 'Copier',
+  'settings.apiKeys.docsHint': 'Envoyez la clé via "Authorization: Bearer ..." ou "X-API-Key: ..." vers /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Créer une clé API',
+  'settings.apiKeys.modal.name': 'Nom',
+  'settings.apiKeys.modal.namePlaceholder': 'p. ex. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Uniquement pour vous, afin de reconnaître la clé plus tard.',
+  'settings.apiKeys.modal.creating': 'Création...',
+  'settings.apiKeys.modal.create': 'Créer',
+  'settings.apiKeys.modal.createdTitle': 'Clé API créée',
+  'settings.apiKeys.modal.createdWarning': 'Copiez la clé maintenant. Elle n\'est affichée qu\'une seule fois et ne peut pas être récupérée ensuite.',
+  'settings.apiKeys.modal.done': 'Terminé',
 };
 
 export default settings;

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -544,6 +544,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Πάντα εμφάνιση διαδρομών κράτησης',
   'settings.alwaysShowRoutesHint':
     'Εμφανίζει αυτόματα στον χάρτη τη διαδρομή κάθε πτήσης, τρένου και άλλης κράτησης, χωρίς να χρειάζεται να την ενεργοποιείτε μία προς μία.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Κλειδιά API',
+  'settings.apiKeys.description': 'Κλειδιά για το δημόσιο API, ώστε άλλο λογισμικό να μπορεί να διαβάζει τα ταξίδια σου. Μόνο για ανάγνωση: ένα κλειδί δεν μπορεί να αλλάξει ή να διαγράψει τίποτα.',
+  'settings.apiKeys.create': 'Δημιουργία κλειδιού',
+  'settings.apiKeys.empty': 'Δεν υπάρχουν κλειδιά ακόμη. Δημιούργησε ένα για να συνδέσεις άλλο λογισμικό.',
+  'settings.apiKeys.createdAt': 'δημιουργήθηκε',
+  'settings.apiKeys.usedAt': 'τελευταία χρήση',
+  'settings.apiKeys.deleteTitle': 'Διαγραφή κλειδιού',
+  'settings.apiKeys.deleteMessage': 'Ό,τι χρησιμοποιεί αυτό το κλειδί σταματά αμέσως να λειτουργεί. Η ενέργεια δεν αναιρείται.',
+  'settings.apiKeys.deleted': 'Το κλειδί διαγράφηκε',
+  'settings.apiKeys.deleteFailed': 'Δεν ήταν δυνατή η διαγραφή του κλειδιού',
+  'settings.apiKeys.createFailed': 'Δεν ήταν δυνατή η δημιουργία του κλειδιού',
+  'settings.apiKeys.copy': 'Αντιγραφή',
+  'settings.apiKeys.docsHint': 'Στείλε το κλειδί ως "Authorization: Bearer ..." ή "X-API-Key: ..." στο /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Δημιουργία κλειδιού API',
+  'settings.apiKeys.modal.name': 'Όνομα',
+  'settings.apiKeys.modal.namePlaceholder': 'π.χ. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Μόνο για σένα, για να αναγνωρίζεις το κλειδί αργότερα.',
+  'settings.apiKeys.modal.creating': 'Δημιουργία...',
+  'settings.apiKeys.modal.create': 'Δημιουργία',
+  'settings.apiKeys.modal.createdTitle': 'Το κλειδί API δημιουργήθηκε',
+  'settings.apiKeys.modal.createdWarning': 'Αντίγραψε το κλειδί τώρα. Εμφανίζεται μία φορά και δεν μπορεί να ανακτηθεί αργότερα.',
+  'settings.apiKeys.modal.done': 'Έτοιμο',
 };
 
 export default settings;

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -534,6 +534,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Mindig jelenjenek meg a foglalási útvonalak',
   'settings.alwaysShowRoutesHint':
     'Automatikusan megjeleníti minden repülőjárat, vonat és egyéb foglalás útvonalát a térképen, nincs szükség egyenkénti bekapcsolásra.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API-kulcsok',
+  'settings.apiKeys.description': 'Kulcsok a nyilvános API-hoz, hogy más szoftverek olvashassák az utazásaidat. Csak olvasható: a kulcs semmit nem módosít és nem töröl.',
+  'settings.apiKeys.create': 'Kulcs létrehozása',
+  'settings.apiKeys.empty': 'Még nincs kulcs. Hozz létre egyet más szoftver csatlakoztatásához.',
+  'settings.apiKeys.createdAt': 'létrehozva',
+  'settings.apiKeys.usedAt': 'utoljára használva',
+  'settings.apiKeys.deleteTitle': 'Kulcs törlése',
+  'settings.apiKeys.deleteMessage': 'Minden, ami ezt a kulcsot használja, azonnal leáll. A művelet nem vonható vissza.',
+  'settings.apiKeys.deleted': 'Kulcs törölve',
+  'settings.apiKeys.deleteFailed': 'A kulcsot nem sikerült törölni',
+  'settings.apiKeys.createFailed': 'A kulcsot nem sikerült létrehozni',
+  'settings.apiKeys.copy': 'Másolás',
+  'settings.apiKeys.docsHint': 'Küldd a kulcsot "Authorization: Bearer ..." vagy "X-API-Key: ..." fejlécként a /api/v1 címre.',
+  'settings.apiKeys.modal.createTitle': 'API-kulcs létrehozása',
+  'settings.apiKeys.modal.name': 'Név',
+  'settings.apiKeys.modal.namePlaceholder': 'pl. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Csak neked, hogy később felismerd a kulcsot.',
+  'settings.apiKeys.modal.creating': 'Létrehozás folyamatban...',
+  'settings.apiKeys.modal.create': 'Létrehozás',
+  'settings.apiKeys.modal.createdTitle': 'API-kulcs létrehozva',
+  'settings.apiKeys.modal.createdWarning': 'Másold ki a kulcsot most. Csak egyszer jelenik meg, később nem kérhető le.',
+  'settings.apiKeys.modal.done': 'Kész',
 };
 
 export default settings;

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -530,6 +530,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Selalu tampilkan rute pemesanan',
   'settings.alwaysShowRoutesHint':
     'Menampilkan rute setiap penerbangan, kereta, dan pemesanan lainnya di peta secara otomatis, tanpa perlu mengaktifkannya satu per satu.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Kunci API',
+  'settings.apiKeys.description': 'Kunci untuk API publik, agar perangkat lunak lain dapat membaca perjalananmu. Hanya baca: kunci tidak dapat mengubah atau menghapus apa pun.',
+  'settings.apiKeys.create': 'Buat kunci',
+  'settings.apiKeys.empty': 'Belum ada kunci. Buat satu untuk menghubungkan perangkat lunak lain.',
+  'settings.apiKeys.createdAt': 'dibuat',
+  'settings.apiKeys.usedAt': 'terakhir dipakai',
+  'settings.apiKeys.deleteTitle': 'Hapus kunci',
+  'settings.apiKeys.deleteMessage': 'Semua yang memakai kunci ini langsung berhenti bekerja. Tindakan ini tidak bisa dibatalkan.',
+  'settings.apiKeys.deleted': 'Kunci dihapus',
+  'settings.apiKeys.deleteFailed': 'Kunci tidak dapat dihapus',
+  'settings.apiKeys.createFailed': 'Kunci tidak dapat dibuat',
+  'settings.apiKeys.copy': 'Salin',
+  'settings.apiKeys.docsHint': 'Kirim kunci sebagai "Authorization: Bearer ..." atau "X-API-Key: ..." ke /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Buat kunci API',
+  'settings.apiKeys.modal.name': 'Nama',
+  'settings.apiKeys.modal.namePlaceholder': 'mis. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Hanya untukmu, agar kamu mengenali kunci ini nanti.',
+  'settings.apiKeys.modal.creating': 'Membuat...',
+  'settings.apiKeys.modal.create': 'Buat',
+  'settings.apiKeys.modal.createdTitle': 'Kunci API dibuat',
+  'settings.apiKeys.modal.createdWarning': 'Salin kunci sekarang. Kunci hanya ditampilkan sekali dan tidak bisa diambil lagi.',
+  'settings.apiKeys.modal.done': 'Selesai',
 };
 
 export default settings;

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -532,6 +532,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Mostra sempre i percorsi delle prenotazioni',
   'settings.alwaysShowRoutesHint':
     'Mostra automaticamente sulla mappa il percorso di ogni volo, treno e altra prenotazione, senza doverlo attivare singolarmente.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Chiavi API',
+  'settings.apiKeys.description': 'Chiavi per l\'API pubblica, così altri software possono leggere i tuoi viaggi. Sola lettura: una chiave non può modificare né eliminare nulla.',
+  'settings.apiKeys.create': 'Crea chiave',
+  'settings.apiKeys.empty': 'Nessuna chiave. Creane una per collegare altri software.',
+  'settings.apiKeys.createdAt': 'creata',
+  'settings.apiKeys.usedAt': 'ultimo uso',
+  'settings.apiKeys.deleteTitle': 'Elimina chiave',
+  'settings.apiKeys.deleteMessage': 'Tutto ciò che usa questa chiave smette di funzionare subito. L\'operazione non è reversibile.',
+  'settings.apiKeys.deleted': 'Chiave eliminata',
+  'settings.apiKeys.deleteFailed': 'Impossibile eliminare la chiave',
+  'settings.apiKeys.createFailed': 'Impossibile creare la chiave',
+  'settings.apiKeys.copy': 'Copia',
+  'settings.apiKeys.docsHint': 'Invia la chiave come "Authorization: Bearer ..." oppure "X-API-Key: ..." a /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Crea chiave API',
+  'settings.apiKeys.modal.name': 'Nome',
+  'settings.apiKeys.modal.namePlaceholder': 'ad es. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Solo per te, per riconoscere la chiave in seguito.',
+  'settings.apiKeys.modal.creating': 'Creazione...',
+  'settings.apiKeys.modal.create': 'Crea',
+  'settings.apiKeys.modal.createdTitle': 'Chiave API creata',
+  'settings.apiKeys.modal.createdWarning': 'Copia la chiave adesso. Viene mostrata una sola volta e non può essere recuperata in seguito.',
+  'settings.apiKeys.modal.done': 'Fatto',
 };
 
 export default settings;

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -502,6 +502,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': '予約ルートを常に表示',
   'settings.alwaysShowRoutesHint':
     'フライトや電車などすべての予約のルートを、個別にオンにしなくても地図上に自動的に表示します。',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API キー',
+  'settings.apiKeys.description': '公開 API 用のキーです。ほかのソフトウェアが旅程を読み取れるようになります。読み取り専用で、変更や削除はできません。',
+  'settings.apiKeys.create': 'キーを作成',
+  'settings.apiKeys.empty': 'キーはまだありません。ほかのソフトウェアと連携するには作成してください。',
+  'settings.apiKeys.createdAt': '作成日',
+  'settings.apiKeys.usedAt': '最終使用',
+  'settings.apiKeys.deleteTitle': 'キーを削除',
+  'settings.apiKeys.deleteMessage': 'このキーを使っているものはすぐに動かなくなります。取り消しはできません。',
+  'settings.apiKeys.deleted': 'キーを削除しました',
+  'settings.apiKeys.deleteFailed': 'キーを削除できませんでした',
+  'settings.apiKeys.createFailed': 'キーを作成できませんでした',
+  'settings.apiKeys.copy': 'コピー',
+  'settings.apiKeys.docsHint': 'キーは "Authorization: Bearer ..." または "X-API-Key: ..." として /api/v1 に送信してください。',
+  'settings.apiKeys.modal.createTitle': 'API キーを作成',
+  'settings.apiKeys.modal.name': '名前',
+  'settings.apiKeys.modal.namePlaceholder': '例: Dawarich',
+  'settings.apiKeys.modal.nameHint': 'あとで見分けるための、あなた用の名前です。',
+  'settings.apiKeys.modal.creating': '作成中...',
+  'settings.apiKeys.modal.create': '作成',
+  'settings.apiKeys.modal.createdTitle': 'API キーを作成しました',
+  'settings.apiKeys.modal.createdWarning': '今すぐキーをコピーしてください。表示は一度きりで、あとから取得はできません。',
+  'settings.apiKeys.modal.done': '完了',
 };
 
 export default settings;

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -519,6 +519,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': '예약 경로 항상 표시',
   'settings.alwaysShowRoutesHint':
     '항공편, 기차 등 모든 예약의 경로를 개별적으로 켤 필요 없이 지도에 자동으로 표시합니다.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API 키',
+  'settings.apiKeys.description': '공개 API용 키입니다. 다른 소프트웨어가 여행을 읽을 수 있습니다. 읽기 전용이라 무엇도 바꾸거나 지울 수 없습니다.',
+  'settings.apiKeys.create': '키 만들기',
+  'settings.apiKeys.empty': '아직 키가 없습니다. 다른 소프트웨어를 연결하려면 하나 만드세요.',
+  'settings.apiKeys.createdAt': '생성일',
+  'settings.apiKeys.usedAt': '마지막 사용',
+  'settings.apiKeys.deleteTitle': '키 삭제',
+  'settings.apiKeys.deleteMessage': '이 키를 쓰는 모든 것이 즉시 작동을 멈춥니다. 되돌릴 수 없습니다.',
+  'settings.apiKeys.deleted': '키를 삭제했습니다',
+  'settings.apiKeys.deleteFailed': '키를 삭제하지 못했습니다',
+  'settings.apiKeys.createFailed': '키를 만들지 못했습니다',
+  'settings.apiKeys.copy': '복사',
+  'settings.apiKeys.docsHint': '키를 "Authorization: Bearer ..." 또는 "X-API-Key: ..." 로 /api/v1 에 보내세요.',
+  'settings.apiKeys.modal.createTitle': 'API 키 만들기',
+  'settings.apiKeys.modal.name': '이름',
+  'settings.apiKeys.modal.namePlaceholder': '예: Dawarich',
+  'settings.apiKeys.modal.nameHint': '나중에 키를 알아보기 위한, 본인용 이름입니다.',
+  'settings.apiKeys.modal.creating': '만드는 중...',
+  'settings.apiKeys.modal.create': '만들기',
+  'settings.apiKeys.modal.createdTitle': 'API 키를 만들었습니다',
+  'settings.apiKeys.modal.createdWarning': '지금 키를 복사하세요. 한 번만 표시되며 나중에 다시 확인할 수 없습니다.',
+  'settings.apiKeys.modal.done': '완료',
 };
 
 export default settings;

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -533,6 +533,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Boekingsroutes altijd tonen',
   'settings.alwaysShowRoutesHint':
     'Toont automatisch de route van elke vlucht, trein en andere boeking op de kaart, zonder dat u dit per boeking hoeft in te schakelen.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API-sleutels',
+  'settings.apiKeys.description': 'Sleutels voor de publieke API, zodat andere software je reizen kan lezen. Alleen-lezen: een sleutel kan niets wijzigen of verwijderen.',
+  'settings.apiKeys.create': 'Sleutel aanmaken',
+  'settings.apiKeys.empty': 'Nog geen sleutels. Maak er een om andere software te koppelen.',
+  'settings.apiKeys.createdAt': 'aangemaakt',
+  'settings.apiKeys.usedAt': 'laatst gebruikt',
+  'settings.apiKeys.deleteTitle': 'Sleutel verwijderen',
+  'settings.apiKeys.deleteMessage': 'Alles wat deze sleutel gebruikt, stopt direct met werken. Dit kan niet ongedaan worden gemaakt.',
+  'settings.apiKeys.deleted': 'Sleutel verwijderd',
+  'settings.apiKeys.deleteFailed': 'Sleutel kon niet worden verwijderd',
+  'settings.apiKeys.createFailed': 'Sleutel kon niet worden aangemaakt',
+  'settings.apiKeys.copy': 'Kopiëren',
+  'settings.apiKeys.docsHint': 'Stuur de sleutel als "Authorization: Bearer ..." of "X-API-Key: ..." naar /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'API-sleutel aanmaken',
+  'settings.apiKeys.modal.name': 'Naam',
+  'settings.apiKeys.modal.namePlaceholder': 'bijv. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Alleen voor jou, zodat je de sleutel later herkent.',
+  'settings.apiKeys.modal.creating': 'Aanmaken...',
+  'settings.apiKeys.modal.create': 'Aanmaken',
+  'settings.apiKeys.modal.createdTitle': 'API-sleutel aangemaakt',
+  'settings.apiKeys.modal.createdWarning': 'Kopieer de sleutel nu. Hij wordt één keer getoond en kan later niet worden opgehaald.',
+  'settings.apiKeys.modal.done': 'Klaar',
 };
 
 export default settings;

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -532,6 +532,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Zawsze pokazuj trasy rezerwacji',
   'settings.alwaysShowRoutesHint':
     'Automatycznie pokazuje na mapie trasę każdego lotu, pociągu i innej rezerwacji, bez konieczności włączania jej pojedynczo.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Klucze API',
+  'settings.apiKeys.description': 'Klucze do publicznego API, aby inne oprogramowanie mogło odczytywać Twoje podróże. Tylko odczyt: klucz niczego nie zmieni ani nie usunie.',
+  'settings.apiKeys.create': 'Utwórz klucz',
+  'settings.apiKeys.empty': 'Brak kluczy. Utwórz jeden, aby połączyć inne oprogramowanie.',
+  'settings.apiKeys.createdAt': 'utworzono',
+  'settings.apiKeys.usedAt': 'ostatnio użyty',
+  'settings.apiKeys.deleteTitle': 'Usuń klucz',
+  'settings.apiKeys.deleteMessage': 'Wszystko, co korzysta z tego klucza, natychmiast przestanie działać. Tej operacji nie można cofnąć.',
+  'settings.apiKeys.deleted': 'Klucz usunięty',
+  'settings.apiKeys.deleteFailed': 'Nie udało się usunąć klucza',
+  'settings.apiKeys.createFailed': 'Nie udało się utworzyć klucza',
+  'settings.apiKeys.copy': 'Kopiuj',
+  'settings.apiKeys.docsHint': 'Wyślij klucz jako "Authorization: Bearer ..." lub "X-API-Key: ..." do /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Utwórz klucz API',
+  'settings.apiKeys.modal.name': 'Nazwa',
+  'settings.apiKeys.modal.namePlaceholder': 'np. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Tylko dla Ciebie, abyś później rozpoznał klucz.',
+  'settings.apiKeys.modal.creating': 'Tworzenie...',
+  'settings.apiKeys.modal.create': 'Utwórz',
+  'settings.apiKeys.modal.createdTitle': 'Klucz API utworzony',
+  'settings.apiKeys.modal.createdWarning': 'Skopiuj klucz teraz. Jest pokazywany tylko raz i później nie można go odzyskać.',
+  'settings.apiKeys.modal.done': 'Gotowe',
 };
 
 export default settings;

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -534,6 +534,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Всегда показывать маршруты бронирований',
   'settings.alwaysShowRoutesHint':
     'Автоматически показывает на карте маршрут для каждого рейса, поезда и другого бронирования — без необходимости включать это отдельно для каждого элемента.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Ключи API',
+  'settings.apiKeys.description': 'Ключи для публичного API, чтобы другие программы могли читать ваши поездки. Только чтение: ключ ничего не изменит и не удалит.',
+  'settings.apiKeys.create': 'Создать ключ',
+  'settings.apiKeys.empty': 'Ключей пока нет. Создайте один, чтобы подключить другую программу.',
+  'settings.apiKeys.createdAt': 'создан',
+  'settings.apiKeys.usedAt': 'последнее использование',
+  'settings.apiKeys.deleteTitle': 'Удалить ключ',
+  'settings.apiKeys.deleteMessage': 'Всё, что использует этот ключ, сразу перестанет работать. Отменить нельзя.',
+  'settings.apiKeys.deleted': 'Ключ удалён',
+  'settings.apiKeys.deleteFailed': 'Не удалось удалить ключ',
+  'settings.apiKeys.createFailed': 'Не удалось создать ключ',
+  'settings.apiKeys.copy': 'Копировать',
+  'settings.apiKeys.docsHint': 'Отправляйте ключ как "Authorization: Bearer ..." или "X-API-Key: ..." на /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Создать ключ API',
+  'settings.apiKeys.modal.name': 'Название',
+  'settings.apiKeys.modal.namePlaceholder': 'например, Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Только для вас, чтобы позже узнать ключ.',
+  'settings.apiKeys.modal.creating': 'Создание...',
+  'settings.apiKeys.modal.create': 'Создать',
+  'settings.apiKeys.modal.createdTitle': 'Ключ API создан',
+  'settings.apiKeys.modal.createdWarning': 'Скопируйте ключ сейчас. Он показывается один раз, позже получить его нельзя.',
+  'settings.apiKeys.modal.done': 'Готово',
 };
 
 export default settings;

--- a/shared/src/i18n/sv/settings.ts
+++ b/shared/src/i18n/sv/settings.ts
@@ -529,6 +529,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Visa alltid bokningsrutter',
   'settings.alwaysShowRoutesHint':
     'Visar automatiskt rutten för varje flyg, tåg och annan bokning på kartan, utan att du behöver aktivera det för varje bokning för sig.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API-nycklar',
+  'settings.apiKeys.description': 'Nycklar för det publika API:et, så att annan programvara kan läsa dina resor. Endast läsning: en nyckel kan inte ändra eller ta bort något.',
+  'settings.apiKeys.create': 'Skapa nyckel',
+  'settings.apiKeys.empty': 'Inga nycklar än. Skapa en för att koppla annan programvara.',
+  'settings.apiKeys.createdAt': 'skapad',
+  'settings.apiKeys.usedAt': 'senast använd',
+  'settings.apiKeys.deleteTitle': 'Ta bort nyckel',
+  'settings.apiKeys.deleteMessage': 'Allt som använder den här nyckeln slutar fungera direkt. Det går inte att ångra.',
+  'settings.apiKeys.deleted': 'Nyckeln togs bort',
+  'settings.apiKeys.deleteFailed': 'Kunde inte ta bort nyckeln',
+  'settings.apiKeys.createFailed': 'Kunde inte skapa nyckeln',
+  'settings.apiKeys.copy': 'Kopiera',
+  'settings.apiKeys.docsHint': 'Skicka nyckeln som "Authorization: Bearer ..." eller "X-API-Key: ..." till /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Skapa API-nyckel',
+  'settings.apiKeys.modal.name': 'Namn',
+  'settings.apiKeys.modal.namePlaceholder': 't.ex. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Bara för dig, så att du känner igen nyckeln senare.',
+  'settings.apiKeys.modal.creating': 'Skapar...',
+  'settings.apiKeys.modal.create': 'Skapa',
+  'settings.apiKeys.modal.createdTitle': 'API-nyckel skapad',
+  'settings.apiKeys.modal.createdWarning': 'Kopiera nyckeln nu. Den visas en gång och kan inte hämtas senare.',
+  'settings.apiKeys.modal.done': 'Klar',
 };
 
 export default settings;

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -530,6 +530,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Rezervasyon rotalarını her zaman göster',
   'settings.alwaysShowRoutesHint':
     'Haritada her uçuş, tren ve diğer rezervasyonun rotasını, tek tek açmaya gerek kalmadan otomatik olarak gösterir.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API Anahtarları',
+  'settings.apiKeys.description': 'Genel API için anahtarlar, böylece başka yazılımlar gezilerini okuyabilir. Yalnızca okuma: bir anahtar hiçbir şeyi değiştiremez veya silemez.',
+  'settings.apiKeys.create': 'Anahtar oluştur',
+  'settings.apiKeys.empty': 'Henüz anahtar yok. Başka bir yazılımı bağlamak için bir tane oluştur.',
+  'settings.apiKeys.createdAt': 'oluşturuldu',
+  'settings.apiKeys.usedAt': 'son kullanım',
+  'settings.apiKeys.deleteTitle': 'Anahtarı sil',
+  'settings.apiKeys.deleteMessage': 'Bu anahtarı kullanan her şey hemen çalışmayı durdurur. Bu işlem geri alınamaz.',
+  'settings.apiKeys.deleted': 'Anahtar silindi',
+  'settings.apiKeys.deleteFailed': 'Anahtar silinemedi',
+  'settings.apiKeys.createFailed': 'Anahtar oluşturulamadı',
+  'settings.apiKeys.copy': 'Kopyala',
+  'settings.apiKeys.docsHint': 'Anahtarı "Authorization: Bearer ..." veya "X-API-Key: ..." olarak /api/v1 adresine gönder.',
+  'settings.apiKeys.modal.createTitle': 'API anahtarı oluştur',
+  'settings.apiKeys.modal.name': 'Ad',
+  'settings.apiKeys.modal.namePlaceholder': 'örn. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Yalnızca senin için, anahtarı sonradan tanıyabilmen için.',
+  'settings.apiKeys.modal.creating': 'Oluşturuluyor...',
+  'settings.apiKeys.modal.create': 'Oluştur',
+  'settings.apiKeys.modal.createdTitle': 'API anahtarı oluşturuldu',
+  'settings.apiKeys.modal.createdWarning': 'Anahtarı şimdi kopyala. Yalnızca bir kez gösterilir ve sonradan alınamaz.',
+  'settings.apiKeys.modal.done': 'Tamam',
 };
 
 export default settings;

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -533,6 +533,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Завжди показувати маршрути бронювань',
   'settings.alwaysShowRoutesHint':
     'Автоматично показує на карті маршрут для кожного рейсу, поїзда та іншого бронювання — без потреби вмикати це окремо для кожного елемента.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Ключі API',
+  'settings.apiKeys.description': 'Ключі для публічного API, щоб інші програми могли читати ваші подорожі. Лише читання: ключ нічого не змінить і не видалить.',
+  'settings.apiKeys.create': 'Створити ключ',
+  'settings.apiKeys.empty': 'Ключів ще немає. Створіть один, щоб підключити іншу програму.',
+  'settings.apiKeys.createdAt': 'створено',
+  'settings.apiKeys.usedAt': 'востаннє використано',
+  'settings.apiKeys.deleteTitle': 'Видалити ключ',
+  'settings.apiKeys.deleteMessage': 'Усе, що використовує цей ключ, одразу перестане працювати. Скасувати не можна.',
+  'settings.apiKeys.deleted': 'Ключ видалено',
+  'settings.apiKeys.deleteFailed': 'Не вдалося видалити ключ',
+  'settings.apiKeys.createFailed': 'Не вдалося створити ключ',
+  'settings.apiKeys.copy': 'Копіювати',
+  'settings.apiKeys.docsHint': 'Надсилайте ключ як "Authorization: Bearer ..." або "X-API-Key: ..." на /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Створити ключ API',
+  'settings.apiKeys.modal.name': 'Назва',
+  'settings.apiKeys.modal.namePlaceholder': 'напр. Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Лише для вас, щоб пізніше впізнати ключ.',
+  'settings.apiKeys.modal.creating': 'Створення...',
+  'settings.apiKeys.modal.create': 'Створити',
+  'settings.apiKeys.modal.createdTitle': 'Ключ API створено',
+  'settings.apiKeys.modal.createdWarning': 'Скопіюйте ключ зараз. Він показується один раз, пізніше його не отримати.',
+  'settings.apiKeys.modal.done': 'Готово',
 };
 
 export default settings;

--- a/shared/src/i18n/vi/settings.ts
+++ b/shared/src/i18n/vi/settings.ts
@@ -534,6 +534,30 @@ const settings: TranslationStrings = {
   'settings.alwaysShowRoutes': 'Luôn hiển thị tuyến đường đặt chỗ',
   'settings.alwaysShowRoutesHint':
     'Tự động hiển thị trên bản đồ tuyến đường của mỗi chuyến bay, tàu hỏa và đặt chỗ khác, không cần bật riêng từng mục.',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'Khóa API',
+  'settings.apiKeys.description': 'Khóa cho API công khai, để phần mềm khác có thể đọc các chuyến đi của bạn. Chỉ đọc: khóa không thể thay đổi hay xóa bất cứ thứ gì.',
+  'settings.apiKeys.create': 'Tạo khóa',
+  'settings.apiKeys.empty': 'Chưa có khóa nào. Tạo một khóa để kết nối phần mềm khác.',
+  'settings.apiKeys.createdAt': 'đã tạo',
+  'settings.apiKeys.usedAt': 'dùng lần cuối',
+  'settings.apiKeys.deleteTitle': 'Xóa khóa',
+  'settings.apiKeys.deleteMessage': 'Mọi thứ đang dùng khóa này sẽ ngừng hoạt động ngay lập tức. Không thể hoàn tác.',
+  'settings.apiKeys.deleted': 'Đã xóa khóa',
+  'settings.apiKeys.deleteFailed': 'Không thể xóa khóa',
+  'settings.apiKeys.createFailed': 'Không thể tạo khóa',
+  'settings.apiKeys.copy': 'Sao chép',
+  'settings.apiKeys.docsHint': 'Gửi khóa dưới dạng "Authorization: Bearer ..." hoặc "X-API-Key: ..." tới /api/v1.',
+  'settings.apiKeys.modal.createTitle': 'Tạo khóa API',
+  'settings.apiKeys.modal.name': 'Tên',
+  'settings.apiKeys.modal.namePlaceholder': 'ví dụ Dawarich',
+  'settings.apiKeys.modal.nameHint': 'Chỉ dành cho bạn, để nhận ra khóa này về sau.',
+  'settings.apiKeys.modal.creating': 'Đang tạo...',
+  'settings.apiKeys.modal.create': 'Tạo',
+  'settings.apiKeys.modal.createdTitle': 'Đã tạo khóa API',
+  'settings.apiKeys.modal.createdWarning': 'Hãy sao chép khóa ngay. Khóa chỉ hiện một lần và không thể lấy lại sau này.',
+  'settings.apiKeys.modal.done': 'Xong',
 };
 
 export default settings;

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -496,6 +496,30 @@ const settings: TranslationStrings = {
   'settings.pluginActivity.columns.status': '結果',
   'settings.alwaysShowRoutes': '一律顯示訂票路線',
   'settings.alwaysShowRoutesHint': '自動在地圖上顯示每個航班、火車及其他預訂的路線,不需要逐一手動開啟。',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API 金鑰',
+  'settings.apiKeys.description': '公開 API 的金鑰，讓其他軟體讀取你的行程。唯讀：金鑰無法修改或刪除任何內容。',
+  'settings.apiKeys.create': '建立金鑰',
+  'settings.apiKeys.empty': '尚無金鑰。建立一組即可連接其他軟體。',
+  'settings.apiKeys.createdAt': '建立於',
+  'settings.apiKeys.usedAt': '最近使用',
+  'settings.apiKeys.deleteTitle': '刪除金鑰',
+  'settings.apiKeys.deleteMessage': '使用這組金鑰的一切都會立即停止運作，且無法復原。',
+  'settings.apiKeys.deleted': '金鑰已刪除',
+  'settings.apiKeys.deleteFailed': '無法刪除金鑰',
+  'settings.apiKeys.createFailed': '無法建立金鑰',
+  'settings.apiKeys.copy': '複製',
+  'settings.apiKeys.docsHint': '將金鑰以 "Authorization: Bearer ..." 或 "X-API-Key: ..." 傳送到 /api/v1。',
+  'settings.apiKeys.modal.createTitle': '建立 API 金鑰',
+  'settings.apiKeys.modal.name': '名稱',
+  'settings.apiKeys.modal.namePlaceholder': '例如 Dawarich',
+  'settings.apiKeys.modal.nameHint': '僅供你自己辨識，方便日後認出這組金鑰。',
+  'settings.apiKeys.modal.creating': '建立中...',
+  'settings.apiKeys.modal.create': '建立',
+  'settings.apiKeys.modal.createdTitle': 'API 金鑰已建立',
+  'settings.apiKeys.modal.createdWarning': '請立即複製金鑰。它只會顯示一次，之後無法再取得。',
+  'settings.apiKeys.modal.done': '完成',
 };
 
 export default settings;

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -492,6 +492,30 @@ const settings: TranslationStrings = {
   'settings.pluginActivity.columns.status': '结果',
   'settings.alwaysShowRoutes': '始终显示预订路线',
   'settings.alwaysShowRoutesHint': '自动在地图上显示每个航班、火车和其他预订的路线,无需逐个手动开启。',
+
+  // Public API keys (Settings -> Integrations)
+  'settings.apiKeys.title': 'API 密钥',
+  'settings.apiKeys.description': '公开 API 的密钥，让其他软件读取你的行程。只读：密钥无法修改或删除任何内容。',
+  'settings.apiKeys.create': '创建密钥',
+  'settings.apiKeys.empty': '还没有密钥。创建一个即可连接其他软件。',
+  'settings.apiKeys.createdAt': '创建于',
+  'settings.apiKeys.usedAt': '最近使用',
+  'settings.apiKeys.deleteTitle': '删除密钥',
+  'settings.apiKeys.deleteMessage': '使用该密钥的一切都会立即停止工作，且无法撤销。',
+  'settings.apiKeys.deleted': '密钥已删除',
+  'settings.apiKeys.deleteFailed': '无法删除密钥',
+  'settings.apiKeys.createFailed': '无法创建密钥',
+  'settings.apiKeys.copy': '复制',
+  'settings.apiKeys.docsHint': '把密钥作为 "Authorization: Bearer ..." 或 "X-API-Key: ..." 发送到 /api/v1。',
+  'settings.apiKeys.modal.createTitle': '创建 API 密钥',
+  'settings.apiKeys.modal.name': '名称',
+  'settings.apiKeys.modal.namePlaceholder': '例如 Dawarich',
+  'settings.apiKeys.modal.nameHint': '仅供你自己识别，方便日后辨认这个密钥。',
+  'settings.apiKeys.modal.creating': '创建中...',
+  'settings.apiKeys.modal.create': '创建',
+  'settings.apiKeys.modal.createdTitle': 'API 密钥已创建',
+  'settings.apiKeys.modal.createdWarning': '请立即复制密钥。它只显示一次，之后无法再次获取。',
+  'settings.apiKeys.modal.done': '完成',
 };
 
 export default settings;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -13,6 +13,7 @@ export * from './common/pagination.schema';
 
 // Domain contracts
 export * from './weather/weather.schema';
+export * from './public-api/public-api.schema';
 export * from './airport/airport.schema';
 export * from './config/config.schema';
 export * from './system-notice/system-notice.schema';

--- a/shared/src/public-api/public-api.schema.ts
+++ b/shared/src/public-api/public-api.schema.ts
@@ -205,3 +205,61 @@ export const publicApiTripListSchema = z.object({
   trips: z.array(publicApiTripSummarySchema),
 });
 export type PublicApiTripList = z.infer<typeof publicApiTripListSchema>;
+
+/**
+ * The trip the traveller most recently took, for a dashboard that wants to name it.
+ *
+ * "Most recently took" means started, not created: a trip booked for next year is
+ * not what anybody means by their last trip. A user whose trips are all in the
+ * future therefore gets `null` here rather than a trip they have not been on.
+ */
+export const publicApiLastTripSchema = z.object({
+  title: z.string(),
+  start_date: z.string().nullable(),
+  end_date: z.string().nullable(),
+  /**
+   * ISO-3166-1 alpha-2 of the country the trip mostly took place in — the one a
+   * widget shows when it has room for exactly one. Null when no place on the trip
+   * ever resolved to a country, which is normal for a trip jotted down without
+   * geocoded stops.
+   */
+  country: z.string().nullable(),
+  /**
+   * Every country the trip touched, most-visited first. `country` is this list's
+   * head; a multi-country trip is not lossy here.
+   */
+  countries: z.array(z.string()),
+});
+export type PublicApiLastTrip = z.infer<typeof publicApiLastTripSchema>;
+
+/**
+ * Aggregate counts for a dashboard widget (#1367) — Homepage's `customapi` and
+ * anything else that renders a handful of numbers and cannot aggregate a list
+ * itself.
+ *
+ * Scalars rather than the arrays behind them. `GET /api/v1/trips` already hands
+ * out the rows for a consumer that wants to count its own way; this endpoint
+ * exists for the one that wants a number and a single HTTP request.
+ *
+ * The figures are the ones TREK's own dashboard shows, computed from the same
+ * source, so a widget cannot disagree with the passport card sitting next to it.
+ * That is the whole reason this is not a fresh count over `/trips`: "visited
+ * countries" carries years of accumulated rules — countries reached only by a
+ * flight, layovers that do not count as visited, countries the user hid by hand —
+ * and a second implementation would drift from the first the week after it shipped.
+ */
+export const publicApiStatsSchema = z.object({
+  /** Trips the caller owns or is a member of, archived ones included. */
+  total_trips: z.number(),
+  /** Distinct countries counted as visited. */
+  total_countries: z.number(),
+  /** Distinct cities, derived from place addresses. */
+  total_cities: z.number(),
+  total_places: z.number(),
+  /** Days across all trips, not days travelled. */
+  total_days: z.number(),
+  /** Flown distance, summed over non-cancelled flight bookings. Kilometres. */
+  total_distance_km: z.number(),
+  last_trip: publicApiLastTripSchema.nullable(),
+});
+export type PublicApiStats = z.infer<typeof publicApiStatsSchema>;

--- a/shared/src/public-api/public-api.schema.ts
+++ b/shared/src/public-api/public-api.schema.ts
@@ -92,6 +92,20 @@ export const publicApiDaySchema = z.object({
 });
 export type PublicApiDay = z.infer<typeof publicApiDaySchema>;
 
+/**
+ * Someone who is on the trip.
+ *
+ * Display name only. Ids would let a consumer correlate the same person across
+ * instances, and email addresses have no business leaving TREK over an
+ * integration key — the name is what a traveller already sees on the trip.
+ */
+export const publicApiTravellerSchema = z.object({
+  name: z.string(),
+  /** True for the trip's owner; everyone else joined as a member. */
+  owner: z.boolean(),
+});
+export type PublicApiTraveller = z.infer<typeof publicApiTravellerSchema>;
+
 /** Trip without its itinerary — what the list endpoint returns. */
 export const publicApiTripSummarySchema = z.object({
   id: z.number(),
@@ -121,6 +135,7 @@ export type PublicApiTripSummary = z.infer<typeof publicApiTripSummarySchema>;
 export const publicApiTripSchema = publicApiTripSummarySchema.extend({
   days: z.array(publicApiDaySchema).optional(),
   accommodations: z.array(publicApiAccommodationSchema).optional(),
+  travellers: z.array(publicApiTravellerSchema).optional(),
 });
 export type PublicApiTrip = z.infer<typeof publicApiTripSchema>;
 
@@ -129,7 +144,7 @@ export type PublicApiTrip = z.infer<typeof publicApiTripSchema>;
  * case is a full sync; a consumer that only wants notes says so and gets a payload
  * a fraction of the size.
  */
-export const PUBLIC_API_INCLUDES = ['days', 'places', 'notes', 'reservations', 'accommodations'] as const;
+export const PUBLIC_API_INCLUDES = ['days', 'places', 'notes', 'reservations', 'accommodations', 'travellers'] as const;
 export type PublicApiInclude = (typeof PUBLIC_API_INCLUDES)[number];
 
 /**

--- a/shared/src/public-api/public-api.schema.ts
+++ b/shared/src/public-api/public-api.schema.ts
@@ -106,6 +106,32 @@ export const publicApiTravellerSchema = z.object({
 });
 export type PublicApiTraveller = z.infer<typeof publicApiTravellerSchema>;
 
+/**
+ * An entry on the traveller's bucket list: somewhere they want to go, with no
+ * trip attached yet.
+ *
+ * Lives on the user rather than on a trip, which is why it has its own endpoint
+ * rather than an `include`. It is the one part of TREK that is explicitly about
+ * places not yet visited, so a consumer that knows where someone actually went
+ * can tell them they got there.
+ */
+export const publicApiBucketListItemSchema = z.object({
+  name: z.string(),
+  lat: z.number().nullable(),
+  lng: z.number().nullable(),
+  /** ISO 3166-1 alpha-2, when the entry is pinned to a country. */
+  country_code: z.string().nullable(),
+  notes: z.string().nullable(),
+  /** An optional date the traveller is aiming for. Not a booking. */
+  target_date: z.string().nullable(),
+});
+export type PublicApiBucketListItem = z.infer<typeof publicApiBucketListItemSchema>;
+
+export const publicApiBucketListSchema = z.object({
+  items: z.array(publicApiBucketListItemSchema),
+});
+export type PublicApiBucketList = z.infer<typeof publicApiBucketListSchema>;
+
 /** Trip without its itinerary — what the list endpoint returns. */
 export const publicApiTripSummarySchema = z.object({
   id: z.number(),
@@ -136,6 +162,24 @@ export const publicApiTripSchema = publicApiTripSummarySchema.extend({
   days: z.array(publicApiDaySchema).optional(),
   accommodations: z.array(publicApiAccommodationSchema).optional(),
   travellers: z.array(publicApiTravellerSchema).optional(),
+  /**
+   * Places on the trip that sit on no day yet — the shortlist a traveller
+   * collects before deciding when to go where.
+   *
+   * Comes with `include=places`, because a section called "places" that silently
+   * omitted half of them would be worse than one that did not exist. On a real
+   * instance these are routinely half of a trip's places, and they carry the
+   * coordinates that make them worth matching against.
+   */
+  unplanned_places: z.array(publicApiPlaceSchema).optional(),
+  /**
+   * Bookings not pinned to a day. A reservation keeps its `day_id` as a nullable
+   * reference, and deleting a day sets it null rather than deleting the booking,
+   * so these exist in the wild and are not an edge case.
+   *
+   * Comes with `include=reservations`, for the same reason as above.
+   */
+  unscheduled_reservations: z.array(publicApiReservationSchema).optional(),
 });
 export type PublicApiTrip = z.infer<typeof publicApiTripSchema>;
 

--- a/shared/src/public-api/public-api.schema.ts
+++ b/shared/src/public-api/public-api.schema.ts
@@ -1,0 +1,139 @@
+import { z } from 'zod';
+
+/**
+ * Public API v1 contract — the read-only surface third-party integrations bind to.
+ *
+ * Everything else in TREK's REST surface is internal: it answers a session cookie,
+ * carries no version, and changes whenever the client changes. This is the opposite
+ * promise. Once an integration ships against `/api/v1`, these shapes are a contract,
+ * so the rules are: fields may be added, never removed or retyped, and a breaking
+ * change gets a new version rather than an edit here.
+ *
+ * The shapes are deliberately NOT the internal row types. A row carries ids, foreign
+ * keys and storage details a consumer has no business depending on (`order_index`,
+ * `assignment_id`, the accommodation's `place_id`); those are resolved here instead,
+ * so the payload survives a refactor of the tables underneath.
+ *
+ * Every dated thing carries `date` in ISO `YYYY-MM-DD`. That is the join key for a
+ * consumer that keeps its own notion of a trip — location trackers bucket points by
+ * day, and matching on a date is the only thing both sides can agree on without
+ * sharing ids.
+ */
+
+/** A place as it sits on a day, with the day's ordering already applied. */
+export const publicApiPlaceSchema = z.object({
+  name: z.string(),
+  address: z.string().nullable(),
+  /** Null for a place the user never geocoded — plenty of them exist. */
+  lat: z.number().nullable(),
+  lng: z.number().nullable(),
+  /** `HH:MM`, null when the stop is not pinned to a time. */
+  time: z.string().nullable(),
+  end_time: z.string().nullable(),
+  duration_minutes: z.number().nullable(),
+  category: z.string().nullable(),
+  notes: z.string().nullable(),
+  /** How the traveller reaches this stop from the previous one. */
+  transport_mode: z.string().nullable(),
+});
+export type PublicApiPlace = z.infer<typeof publicApiPlaceSchema>;
+
+/** A free-text note pinned to a day, optionally to a time within it. */
+export const publicApiDayNoteSchema = z.object({
+  text: z.string(),
+  time: z.string().nullable(),
+});
+export type PublicApiDayNote = z.infer<typeof publicApiDayNoteSchema>;
+
+/**
+ * A booking. `type` is TREK's own vocabulary (flight, train, restaurant, …) and is
+ * passed through unmapped: inventing a canonical enum here would silently drop the
+ * types a consumer might actually care about.
+ */
+export const publicApiReservationSchema = z.object({
+  type: z.string().nullable(),
+  title: z.string().nullable(),
+  location: z.string().nullable(),
+  /** ISO timestamp or `HH:MM`, exactly as the user entered it. */
+  time: z.string().nullable(),
+  end_time: z.string().nullable(),
+  status: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+export type PublicApiReservation = z.infer<typeof publicApiReservationSchema>;
+
+/**
+ * Where the traveller sleeps. Spans days, so it is reported once at trip level with
+ * its own date range rather than duplicated onto every night it covers.
+ */
+export const publicApiAccommodationSchema = z.object({
+  name: z.string().nullable(),
+  address: z.string().nullable(),
+  lat: z.number().nullable(),
+  lng: z.number().nullable(),
+  /** First and last night as ISO dates, resolved from the start/end day rows. */
+  start_date: z.string().nullable(),
+  end_date: z.string().nullable(),
+  check_in: z.string().nullable(),
+  check_out: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+export type PublicApiAccommodation = z.infer<typeof publicApiAccommodationSchema>;
+
+/** One day of the itinerary. `date` is the join key for consumers. */
+export const publicApiDaySchema = z.object({
+  date: z.string(),
+  day_number: z.number(),
+  title: z.string().nullable(),
+  notes: z.string().nullable(),
+  places: z.array(publicApiPlaceSchema),
+  day_notes: z.array(publicApiDayNoteSchema),
+  reservations: z.array(publicApiReservationSchema),
+});
+export type PublicApiDay = z.infer<typeof publicApiDaySchema>;
+
+/** Trip without its itinerary — what the list endpoint returns. */
+export const publicApiTripSummarySchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  description: z.string().nullable(),
+  start_date: z.string().nullable(),
+  end_date: z.string().nullable(),
+  currency: z.string().nullable(),
+  archived: z.boolean(),
+});
+export type PublicApiTripSummary = z.infer<typeof publicApiTripSummarySchema>;
+
+/**
+ * A whole trip. The `days`, `accommodations` and per-day sections are present only
+ * when the caller asked for them via `include`; an omitted section is absent rather
+ * than empty, so a consumer can tell "not requested" from "nothing there".
+ */
+export const publicApiTripSchema = publicApiTripSummarySchema.extend({
+  days: z.array(publicApiDaySchema).optional(),
+  accommodations: z.array(publicApiAccommodationSchema).optional(),
+});
+export type PublicApiTrip = z.infer<typeof publicApiTripSchema>;
+
+/**
+ * The sections a caller may ask for. Defaults to everything, because the common
+ * case is a full sync; a consumer that only wants notes says so and gets a payload
+ * a fraction of the size.
+ */
+export const PUBLIC_API_INCLUDES = ['days', 'places', 'notes', 'reservations', 'accommodations'] as const;
+export type PublicApiInclude = (typeof PUBLIC_API_INCLUDES)[number];
+
+/**
+ * `?include=days,notes` — comma-separated, unknown values rejected rather than
+ * ignored, so a typo surfaces as a 400 instead of a silently missing section.
+ * Absent means all sections.
+ */
+export const publicApiIncludeQuerySchema = z
+  .string()
+  .transform((raw) => raw.split(',').map((part) => part.trim()).filter(Boolean))
+  .pipe(z.array(z.enum(PUBLIC_API_INCLUDES)).min(1));
+
+export const publicApiTripListSchema = z.object({
+  trips: z.array(publicApiTripSummarySchema),
+});
+export type PublicApiTripList = z.infer<typeof publicApiTripListSchema>;

--- a/shared/src/public-api/public-api.schema.ts
+++ b/shared/src/public-api/public-api.schema.ts
@@ -101,6 +101,15 @@ export const publicApiTripSummarySchema = z.object({
   end_date: z.string().nullable(),
   currency: z.string().nullable(),
   archived: z.boolean(),
+  /**
+   * When the trip's own fields last changed — title, dates, currency, cover.
+   *
+   * Explicitly NOT a content timestamp: editing a place, a day or a note does not
+   * touch it, because the child tables carry no `updated_at` of their own. A client
+   * that polls must compare the payload it received, not this value; using it to
+   * skip a fetch would silently miss every itinerary edit.
+   */
+  updated_at: z.string().nullable(),
 });
 export type PublicApiTripSummary = z.infer<typeof publicApiTripSummarySchema>;
 

--- a/wiki/Public-API.md
+++ b/wiki/Public-API.md
@@ -10,6 +10,7 @@ Read trips. That is deliberate and complete:
 
 - list the trips you own or are a member of
 - fetch one trip with its days, places in planned order, day notes, reservations, accommodations and fellow travellers
+- read the bucket list: places the traveller wants to reach, not tied to any trip
 
 It cannot write anything. An integration that reads your itinerary needs no ability to delete a place, and a key that can only read is a very different thing to hand to third-party software.
 
@@ -83,6 +84,15 @@ Pick what you need with `?include=`, comma-separated:
 | `accommodations` | where you sleep, with the date range resolved and check-in/check-out times |
 | `travellers` | who is on the trip, by display name |
 
+Two sections come back at trip level rather than on a day, because that is where they live:
+
+| Field | Comes with | What it is |
+|---|---|---|
+| `unplanned_places` | `places` | places collected but not scheduled yet. On a real instance these are routinely **half** of a trip's places, and they carry coordinates. A hotel is not listed here; it is under `accommodations`. |
+| `unscheduled_reservations` | `reservations` | bookings with no day. Deleting a day detaches its bookings rather than deleting them, so these exist in the wild. |
+
+Asking for `places`, `notes` or `reservations` brings `days` along automatically, since that is where they are reported. `?include=notes` returns the day skeleton with its notes and empty place lists, not an empty trip.
+
 Omitting `include` returns everything. A section you did not ask for is **absent** rather than empty, so your code can tell "not requested" apart from "nothing there". An unknown section name is a `400` rather than being silently ignored — a typo should not hand you a payload quietly missing what you wanted.
 
 ```bash
@@ -131,11 +141,28 @@ curl -H "Authorization: Bearer trek_…" \
 }
 ```
 
+### `GET /api/v1/bucket-list`
+
+Places the caller wants to reach, with no trip attached. Its own endpoint because it hangs off the user, not a trip.
+
+```json
+{
+  "items": [
+    { "name": "Hokkaido", "lat": 43.06, "lng": 141.35,
+      "country_code": "JP", "notes": "in winter", "target_date": "2027-02-01" }
+  ]
+}
+```
+
+`target_date` is an aspiration, not a booking. Entries are returned whether or not the Atlas addon is switched on: the addon governs whether TREK shows the feature, not whether the rows exist, and an endpoint whose answers change when an unrelated toggle moves is one nobody can build on.
+
 ## Notes for integrators
 
 **Join on dates, not ids.** Every day carries an ISO `date`, and accommodations carry a resolved date range rather than internal day ids. If your software keeps its own notion of a trip, the date is the one thing both sides can agree on. TREK's internal ids are not in the payload at all, by design — they would tie you to storage details that are free to change.
 
 **One request, not many.** Rather than separate endpoints per section, `?include=` lets you fetch exactly what you need in a single call. Fetching a trip four times for four sections would burn your rate budget for no benefit.
+
+**There are no timezones.** Times are stored and returned exactly as the traveller typed them: `14:00` means two in the afternoon wherever they were. If you are matching against timestamps of your own, the trip's dates are the reliable join; the times are a hint, not a UTC instant.
 
 **Rate limit: 120 requests per minute**, counted per user rather than per IP address. A self-hosted integration and its owner's browser often share an address, and an IP-based limit would let one starve the other. Exceeding it returns `429`; back off and retry.
 

--- a/wiki/Public-API.md
+++ b/wiki/Public-API.md
@@ -1,0 +1,165 @@
+# Public API
+
+A small, versioned, read-only surface that lets other software read your trips — built for integrations like location trackers, journalling tools and home automation, where something outside TREK wants to know what you planned.
+
+> **Not the same as the internal API.** TREK's own frontend talks to a few hundred endpoints under `/api/…`. Those answer a session cookie, carry no version and change whenever the client changes — they are not a contract, and anything built on them will break. The public API is the opposite promise: a handful of endpoints under `/api/v1/`, authenticated with a key you mint yourself, that will not change shape without a new version number.
+
+## What it can do
+
+Read trips. That is deliberate and complete:
+
+- list the trips you own or are a member of
+- fetch one trip with its days, places in planned order, day notes, reservations, accommodations and fellow travellers
+
+It cannot write anything. An integration that reads your itinerary needs no ability to delete a place, and a key that can only read is a very different thing to hand to third-party software.
+
+## Getting a key
+
+1. Open **Settings → Integrations**
+2. Under **API Keys**, click **Create key** and give it a name you will recognise later (the name is only for you — "Dawarich", "home assistant", "laptop script")
+3. **Copy the key immediately.** It is shown once. TREK stores only a hash of it, so it cannot be shown again — if you lose it, delete the key and make a new one.
+
+Keys look like `trek_` followed by 48 characters. You can hold ten at a time.
+
+> **API keys and MCP tokens are not interchangeable.** They live on the same screen but open different doors: an [MCP token](MCP-Setup) drives every assistant tool, an API key reads trips over HTTP. A key of the wrong kind is rejected exactly like one that does not exist. Mint the kind the other software asks for.
+
+To revoke access, delete the key. It stops working immediately, and anything using it gets a 401 on its next request.
+
+## Using it
+
+Send the key as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer trek_your_key_here" \
+     https://trek.example.com/api/v1/trips
+```
+
+or, if the software you are configuring expects a header named for an API key:
+
+```bash
+curl -H "X-API-Key: trek_your_key_here" \
+     https://trek.example.com/api/v1/trips
+```
+
+Both are equivalent. Use whichever the other side offers.
+
+## Endpoints
+
+### `GET /api/v1/trips`
+
+Every trip you can reach, newest first, without itineraries.
+
+```json
+{
+  "trips": [
+    {
+      "id": 12,
+      "title": "Tuscany",
+      "description": "Wine and hill towns",
+      "start_date": "2026-06-14",
+      "end_date": "2026-06-22",
+      "currency": "EUR",
+      "archived": false,
+      "updated_at": "2026-06-01 10:00:00"
+    }
+  ]
+}
+```
+
+`updated_at` moves when the trip's **own** fields change — title, dates, currency, cover. It does **not** move when a place, a day or a note is edited. Do not use it to decide whether to re-fetch; you would miss every itinerary change. Compare the payload instead.
+
+### `GET /api/v1/trips/{id}`
+
+One trip with its contents. Returns **404** if the trip does not exist *or* is not yours — the two are indistinguishable on purpose, so the endpoint cannot be used to find out which trip ids exist.
+
+Pick what you need with `?include=`, comma-separated:
+
+| Section | What it adds |
+|---|---|
+| `days` | the itinerary spine: one entry per day, with `date`, `day_number`, `title`, `notes` |
+| `places` | stops on each day, **in planned order**, with coordinates, times, duration, category and transport mode |
+| `notes` | timed free-text notes on a day |
+| `reservations` | bookings on their starting day: type, title, location, time, status |
+| `accommodations` | where you sleep, with the date range resolved and check-in/check-out times |
+| `travellers` | who is on the trip, by display name |
+
+Omitting `include` returns everything. A section you did not ask for is **absent** rather than empty, so your code can tell "not requested" apart from "nothing there". An unknown section name is a `400` rather than being silently ignored — a typo should not hand you a payload quietly missing what you wanted.
+
+```bash
+# only the notes, for a lightweight sync
+curl -H "Authorization: Bearer trek_…" \
+     "https://trek.example.com/api/v1/trips/12?include=days,notes"
+```
+
+```json
+{
+  "id": 12,
+  "title": "Tuscany",
+  "start_date": "2026-06-14",
+  "days": [
+    {
+      "date": "2026-06-14",
+      "day_number": 1,
+      "title": "Arrival",
+      "notes": null,
+      "places": [
+        {
+          "name": "Uffizi",
+          "address": "Florence",
+          "lat": 43.76, "lng": 11.25,
+          "time": "14:00", "end_time": null,
+          "duration_minutes": 180,
+          "category": "Museum",
+          "notes": null,
+          "transport_mode": "walking"
+        }
+      ],
+      "day_notes": [{ "text": "Bring the tickets", "time": "09:00" }],
+      "reservations": [
+        { "type": "flight", "title": "LH 1234", "location": "FRA",
+          "time": "2026-06-14T08:00", "end_time": null,
+          "status": "confirmed", "notes": null }
+      ]
+    }
+  ],
+  "accommodations": [
+    { "name": "Hotel Alba", "address": null, "lat": null, "lng": null,
+      "start_date": "2026-06-14", "end_date": "2026-06-15",
+      "check_in": "15:00", "check_out": "11:00", "notes": null }
+  ],
+  "travellers": [{ "name": "ada", "owner": true }, { "name": "bob", "owner": false }]
+}
+```
+
+## Notes for integrators
+
+**Join on dates, not ids.** Every day carries an ISO `date`, and accommodations carry a resolved date range rather than internal day ids. If your software keeps its own notion of a trip, the date is the one thing both sides can agree on. TREK's internal ids are not in the payload at all, by design — they would tie you to storage details that are free to change.
+
+**One request, not many.** Rather than separate endpoints per section, `?include=` lets you fetch exactly what you need in a single call. Fetching a trip four times for four sections would burn your rate budget for no benefit.
+
+**Rate limit: 120 requests per minute**, counted per user rather than per IP address. A self-hosted integration and its owner's browser often share an address, and an IP-based limit would let one starve the other. Exceeding it returns `429`; back off and retry.
+
+**Errors** are JSON with an `error` field:
+
+| Status | Meaning |
+|---|---|
+| `400` | malformed trip id, or an unknown `include` section |
+| `401` | missing, malformed or unknown key — also what you get for a key of the wrong kind |
+| `404` | no such trip, or not one of yours |
+| `429` | rate limit exceeded |
+
+**Versioning.** `/api/v1` may gain fields; it will not lose them or change their types. A breaking change ships as `/api/v2` and both run side by side for a transition period. Write your client to ignore fields it does not know.
+
+## What is not here yet
+
+- **Writing.** Read-only for now. Write access needs per-scope enforcement that this surface does not implement, and a key that only reads is a much safer thing to hand out.
+- **Incremental sync.** There is no `?since=` filter, because TREK cannot yet answer it truthfully — child records carry no modification timestamp, so a filter on `updated_at` would silently hide trips whose itinerary changed. Fetch the list and compare.
+- **Webhooks.** Nothing pushes; poll at a sensible interval.
+
+If you are building something and one of these blocks you, open a discussion — the surface is meant to grow around real integrations rather than ahead of them.
+
+## See also
+
+- [MCP Overview](MCP-Overview) — the other machine-facing surface, for AI assistants
+- [Calendar Feeds](Calendar-Feeds) — subscribe a calendar app to a trip
+- [Admin: MCP Tokens](Admin-MCP-Tokens) — the instance-wide view of issued tokens

--- a/wiki/Public-API.md
+++ b/wiki/Public-API.md
@@ -11,6 +11,7 @@ Read trips. That is deliberate and complete:
 - list the trips you own or are a member of
 - fetch one trip with its days, places in planned order, day notes, reservations, accommodations and fellow travellers
 - read the bucket list: places the traveller wants to reach, not tied to any trip
+- read a handful of totals for a dashboard widget: trips, countries, cities, places, days, flown distance, and the last trip taken
 
 It cannot write anything. An integration that reads your itinerary needs no ability to delete a place, and a key that can only read is a very different thing to hand to third-party software.
 
@@ -155,6 +156,53 @@ Places the caller wants to reach, with no trip attached. Its own endpoint becaus
 ```
 
 `target_date` is an aspiration, not a booking. Entries are returned whether or not the Atlas addon is switched on: the addon governs whether TREK shows the feature, not whether the rows exist, and an endpoint whose answers change when an unrelated toggle moves is one nobody can build on.
+
+### `GET /api/v1/stats`
+
+Totals for a dashboard. Built for widgets like Homepage's `customapi`, which render a few numbers from one request and cannot aggregate a list themselves.
+
+```json
+{
+  "total_trips": 12,
+  "total_countries": 23,
+  "total_cities": 41,
+  "total_places": 143,
+  "total_days": 87,
+  "total_distance_km": 84213,
+  "last_trip": {
+    "title": "Hokkaido in winter",
+    "start_date": "2026-02-03",
+    "end_date": "2026-02-14",
+    "country": "JP",
+    "countries": ["JP"]
+  }
+}
+```
+
+These are the same figures TREK's own dashboard shows, computed from the same source — a widget cannot disagree with the passport card next to it. In particular `total_countries` follows TREK's notion of *visited*: countries reached only by a flight or train count, layovers do not, and countries hidden by hand in Atlas stay hidden.
+
+`last_trip` is the most recent trip that has **started** — a trip booked for next year is not one you have been on — and is `null` when every trip is still ahead. `country` is the country most of its places sit in, and is the head of `countries`, which lists them all for a trip that crossed a border. Both are empty or `null` for a trip whose places were never geocoded.
+
+A Homepage widget then needs no scripting:
+
+```yaml
+- TREK:
+    icon: mdi-map-marker-path
+    widget:
+      type: customapi
+      url: https://trek.example.com/api/v1/stats
+      headers:
+        X-API-Key: trek_your_key_here
+      mappings:
+        - field: total_trips
+          label: Trips
+        - field: total_countries
+          label: Countries
+        - field: total_cities
+          label: Cities
+        - field: last_trip.country
+          label: Last
+```
 
 ## Notes for integrators
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -78,6 +78,9 @@
 - [[Plugin Permissions|Plugin-Permissions]]
 - [[Publishing a Plugin|Plugin-Publishing]]
 
+## Integrations
+- [[Public API|Public-API]]
+
 ## AI / MCP
 - [[MCP Overview|MCP-Overview]]
 - [[MCP Setup|MCP-Setup]]


### PR DESCRIPTION
Groundwork for the Dawarich integration discussed in #214, and for any other integration that wants to read a trip. Also closes #1367, which asked for a stats endpoint a dashboard widget can bind to.

Closes #1367

## Why

TREK's REST surface is internal. It answers a session cookie, carries no version, and is free to change whenever the client changes. That is the right trade for our own frontend and the wrong one for anybody building against us: the first refactor breaks them silently.

Rather than opening the existing 549 endpoints, this adds a small surface that can actually be promised to stay put.

## What

```
GET /api/v1/trips           trips the caller can reach, no itineraries
GET /api/v1/trips/:id       one trip, ?include=days,places,notes,reservations,
                            accommodations,travellers
GET /api/v1/bucket-list     places the caller wants to reach, no trip attached
GET /api/v1/stats           aggregate counts + the last trip taken (#1367)
```

Read-only. Write access would need per-scope enforcement this surface does not implement, and a key that can only read is a very different thing to hand to third-party software.

### `GET /api/v1/stats`

#1367 asked for something Homepage's `customapi` widget can bind to: a few numbers from one request. `/api/v1/trips` already hands out the rows, but a widget maps fields to labels — it cannot aggregate a list.

```json
{ "total_trips": 12, "total_countries": 23, "total_cities": 41,
  "total_places": 143, "total_days": 87, "total_distance_km": 84213,
  "last_trip": { "title": "…", "start_date": "…", "end_date": "…",
                 "country": "JP", "countries": ["JP"] } }
```

The figures come from `AtlasService.getTravelStats` — the same call behind the dashboard's passport card — rather than from a second count over the same tables. "Visited countries" carries years of accumulated rules: countries reached only by a flight (#1366), layovers that do not count as visited (#1486, #1535), countries hidden by hand in Atlas (#1490), bookings belonging to someone else on the trip (#1966). A second implementation would disagree with the card sitting next to it within a release, and that disagreement is what people report as a bug.

`last_trip` means the most recently **started** trip — a trip booked for next spring is not one anybody has been on — and is `null` while every trip is still ahead. `country` is the head of `countries`, so the two can never contradict each other; both are empty for a trip whose places were never geocoded, rather than guessing.

## Auth

A new credential kind rather than a shared one. An MCP token drives every assistant tool; an API key reads trips over HTTP, and handing the same secret to third-party software would give it the whole MCP surface. `mcp_tokens` gains a `kind` column (migration 175, appended, `pragma_table_info`-guarded) and the kind sits in the WHERE clause of every lookup, so a token of the wrong kind is indistinguishable from one that does not exist.

Sent as `Authorization: Bearer` or `X-API-Key`. The guard hashes the presented key with SHA-256 and matches the hash, so the raw key is never stored and never compared in the application.

It deliberately refuses two credentials that work elsewhere:

- **session JWTs**, because a session cookie ending up inside a third-party integration is exactly what a machine credential exists to prevent
- **OAuth bearers**, because they carry scopes this surface does not interpret, and accepting a credential whose restrictions you ignore is worse than refusing it

Keys get their own section in Settings → Integrations rather than a third tab under MCP: an API key is not an MCP credential, it does not need the MCP addon, and burying it under a heading about AI assistants is how people end up minting the wrong kind. Translated into all 23 languages.

## Access

Decided per trip against `canAccessTrip`, the same owner-or-member predicate as everywhere else. The list comes from `listAccessibleTripIds` rather than a broad read filtered afterwards.

A trip the caller may not read answers **404, byte-identical to one that does not exist**. A 403 would confirm the id is real and turn the endpoint into a way to count another user's trips.

## Payload

Rows are not handed out as stored. Ids, foreign keys and `order_index` stay inside; accommodation day ids resolve to ISO dates; places arrive in planned order. Everything dated carries its `date`, because a consumer that keeps its own notion of a trip can join on days but has no way to look up a TREK id.

Two things sit at trip level rather than on a day, because reporting only day-bound rows was quietly losing them:

- **`unplanned_places`** — places collected but not scheduled. On a live instance these are routinely half of a trip's places, and they are the ones carrying a coordinate and no claim about when. Hotels are excluded; they are reported in full under `accommodations`.
- **`unscheduled_reservations`** — bookings with no day. `reservations.day_id` is nullable and deleting a day detaches its bookings rather than removing them, so these exist in the wild.

`travellers` carries display names and an owner flag. No ids, no email addresses: an integration key reads its owner's itinerary, it is not a way to enumerate the people around them.

Asking for `places`, `notes` or `reservations` implies `days`, since that is where they are reported. Sections the caller did not request are **absent rather than empty**, so "not requested" is distinguishable from "nothing there". An unknown `include` value is a 400 rather than silently ignored.

## Tests

94 new: 59 on the API itself (13 guard, 24 controller, 22 e2e), 7 on the credential split, 10 on the settings section, and 18 on the stats endpoint (7 on `lastTrip` against real SQL, 7 on the controller, 4 e2e).

The stats e2e lives in `atlas.e2e.test.ts` rather than `public-api.e2e.test.ts`: that suite already boots the real `AtlasModule` against a full schema, where the public-api one builds a hand-rolled minimal one and could not. It earned its keep immediately — it caught that exporting `ApiTokenGuard` from `PublicApiModule` does not make it resolvable in `AtlasModule`, because `@UseGuards` instantiates a guard in the declaring controller's module.

The e2e suite runs the real guard and real SQL against a temp database with two users, and covers the paths that would leak: the list, the detail route, a trip shared by membership (which must be visible, that is the access model rather than an exception), and an assertion that no internal id and no email address appears anywhere in a response.

Also pinned: every credential-confusion case is refused *before* the token store is touched, an MCP token does not open `/api/v1` and an API key does not open `/mcp`, a cross-kind delete 404s without touching the row, the ten-key ceiling counts each kind on its own, and `last_used_at` is recorded so a stale key stays visible in settings.

## Not in this PR

Named here so nobody assumes otherwise:

- **Per-key scopes.** A key reads everything its owner can read. `?include=` lets the *integration* choose what to fetch; it is not a restriction the *user* places on the key. Someone who wants to share dates and accommodations but not their notes has no switch for that. This is the one gap worth closing before the surface is advertised widely.
- **Writing.** Read-only by design for now. Write access needs the scope enforcement above first.
- **Incremental sync.** No `?since=`, because TREK cannot answer it truthfully: child records carry no modification timestamp, so a filter on the trip's `updated_at` would silently hide trips whose itinerary changed. Documented in the wiki so nobody builds on it by accident.
- **Webhooks.** Nothing pushes.
- **Pagination.** `GET /api/v1/trips` returns every accessible trip. Fine at realistic trip counts, unbounded in principle.
- **Capability discovery.** An integration hitting an older TREK gets a 404 with no way to tell "this instance has no public API" from "no such route". A version endpoint would let clients degrade deliberately.
- **Timezones.** Times are returned exactly as typed; TREK stores no offset, so `14:00` is not a UTC instant. The wiki says so rather than implying a precision that is not there.

## Notes

`ApiTokenGuard` is added to `AUTHENTICATING_GUARDS` in `validate-route-guards.ts` — it resolves `req.user` like the other three, so the boot gate treats the routes as authenticated rather than anonymous.

`PublicApiModule` is deliberately a leaf. Reaching for `AtlasService` to read the bucket list pulled `AuthModule` and the storage registry in behind it and broke the module's own boot, so that one query lives in the service like every other query in the file.

The stats route is the same constraint answered the other way round: its figures genuinely are `AtlasService`'s and cannot be inlined, so the controller moved to `atlas/` instead — the way `TravelStatsController` already serves `/api/auth/travel-stats` from there. `ApiTokenGuard` is provided locally rather than imported with `PublicApiModule`, so there is no module edge in either direction. The shared request handling (one rate-limit bucket, one user narrowing) moved to `public-api/public-api-request.ts` so both controllers spend the same budget.

`wiki/Public-API.md` documents the surface for integrators, linked from a new Integrations section in the sidebar.

Typecheck, `typecheck:tests`, i18n parity and lint are clean; the new files produce zero lint warnings.

