### PR TITLE
feat(mcp): close the write-surface gaps between MCP and REST

### DIFF
--- a/client/src/api/oauthScopes.ts
+++ b/client/src/api/oauthScopes.ts
@@ -43,6 +43,11 @@ export const SCOPE_GROUPS: Record<string, ScopeKeys> = {
   'journey:read':        { labelKey: 'oauth.scope.journey:read.label',        descriptionKey: 'oauth.scope.journey:read.description',        groupKey: 'oauth.scope.group.journey' },
   'journey:write':       { labelKey: 'oauth.scope.journey:write.label',       descriptionKey: 'oauth.scope.journey:write.description',       groupKey: 'oauth.scope.group.journey' },
   'journey:share':       { labelKey: 'oauth.scope.journey:share.label',       descriptionKey: 'oauth.scope.journey:share.description',       groupKey: 'oauth.scope.group.journey' },
+  'files:read':          { labelKey: 'oauth.scope.files:read.label',          descriptionKey: 'oauth.scope.files:read.description',          groupKey: 'oauth.scope.group.files' },
+  'files:write':         { labelKey: 'oauth.scope.files:write.label',         descriptionKey: 'oauth.scope.files:write.description',         groupKey: 'oauth.scope.group.files' },
+  'files:content':       { labelKey: 'oauth.scope.files:content.label',       descriptionKey: 'oauth.scope.files:content.description',       groupKey: 'oauth.scope.group.files' },
+  'settings:read':       { labelKey: 'oauth.scope.settings:read.label',       descriptionKey: 'oauth.scope.settings:read.description',       groupKey: 'oauth.scope.group.settings' },
+  'settings:write':      { labelKey: 'oauth.scope.settings:write.label',      descriptionKey: 'oauth.scope.settings:write.description',      groupKey: 'oauth.scope.group.settings' },
 }
 
 export const ALL_SCOPES = Object.keys(SCOPE_GROUPS)

--- a/server/src/mcp/scopes.ts
+++ b/server/src/mcp/scopes.ts
@@ -32,6 +32,16 @@ export const SCOPES = {
   JOURNEY_READ:        'journey:read',
   JOURNEY_WRITE:       'journey:write',
   JOURNEY_SHARE:       'journey:share',
+  FILES_READ:          'files:read',
+  FILES_WRITE:         'files:write',
+  // A third mode rather than a second group: listing what a trip carries and
+  // reading the bytes of a booking PDF are different privileges, and the plugin
+  // host already draws that line (db:read:files vs db:read:files:content). Not
+  // implied by files:write, the way journey:share is not implied by
+  // journey:write. The policy's fallback branch covers both.
+  FILES_CONTENT:       'files:content',
+  SETTINGS_READ:       'settings:read',
+  SETTINGS_WRITE:      'settings:write',
 } as const;
 
 export type Scope = typeof SCOPES[keyof typeof SCOPES];
@@ -77,6 +87,11 @@ export const SCOPE_INFO: Record<Scope, ScopeInfo> = {
   'journey:read':        { label: 'View journeys',              description: 'Read journeys, entries, and contributor list',                          group: 'Journey' },
   'journey:write':       { label: 'Manage journeys',            description: 'Create, update, and delete journeys and their entries',                 group: 'Journey' },
   'journey:share':       { label: 'Manage journey links',       description: 'Create, update, and revoke public share links for journeys',            group: 'Journey' },
+  'files:read':          { label: 'View trip files',            description: 'List the documents on a trip: names, sizes, who uploaded them, what they link to', group: 'Files' },
+  'files:write':         { label: 'Organise trip files',        description: 'Rename and describe files, link them to bookings and places, star and trash them', group: 'Files' },
+  'files:content':       { label: 'Read file contents',         description: 'Read what is inside an uploaded document, such as a booking PDF or a ticket', group: 'Files' },
+  'settings:read':       { label: 'View your preferences',      description: 'Read units, time format, language, default currency, and start page',   group: 'Settings' },
+  'settings:write':      { label: 'Change your preferences',    description: 'Change units, time format, language, default currency, and start page. Never stored API keys', group: 'Settings' },
 };
 
 // ---------------------------------------------------------------------------
@@ -112,6 +127,15 @@ export function canDeleteTrips(scopes: string[] | null): boolean {
 export function canShareTrips(scopes: string[] | null): boolean {
   if (!scopes) return true;
   return scopes.includes('trips:share');
+}
+
+/**
+ * files:content is a separate scope from files:read: a token may list a trip's
+ * documents without being allowed to read what is inside them.
+ */
+export function canReadFileContent(scopes: string[] | null): boolean {
+  if (!scopes) return true;
+  return scopes.includes('files:content');
 }
 
 /** journey:share is a separate scope for managing public share links for journeys */

--- a/server/src/nest/addons/addons.mcp.ts
+++ b/server/src/nest/addons/addons.mcp.ts
@@ -1,0 +1,43 @@
+import { McpController, Tool, TOOL_ANNOTATIONS_READONLY, ok, type McpContext } from '../../nest-mcp';
+import { AddonsService } from './addons.service';
+
+/**
+ * Instance-capability MCP surface, reading through the same AddonsService.list()
+ * that GET /api/addons returns.
+ *
+ * Why it exists: the registry drops an entry when either its addon gate or its
+ * scope gate says no, one filter with one outcome, so a session that finds no
+ * budget tools cannot tell "the admin switched budget off" from "this token was
+ * never granted budget:read". The session instructions tell the model to check
+ * availability before assuming a tool exists, which until now it had nothing to
+ * check with.
+ *
+ * No `access` marker, so it is registered for every session. The REST route is
+ * gated by JwtAuthGuard and nothing else, so there is no scope to mirror; the
+ * payload is instance configuration rather than anybody's data; and a scope gate
+ * would withhold the availability answer from exactly the sessions whose thin
+ * tool list needs explaining. settings:read is not the honest fit either, it
+ * covers a user's own preferences.
+ */
+@McpController()
+export class AddonsMcp {
+  constructor(private readonly addons: AddonsService) {}
+
+  @Tool({
+    name: 'list_addons',
+    description:
+      'Report which optional add-ons are enabled on this TREK instance, which collab sub-features (chat, notes, polls, whatsnext) are switched on, and whether packing bag tracking is on. Only enabled entries are listed, so anything absent is off here. Tools belonging to a disabled add-on are never registered, so call this to tell "the feature is off on this instance" apart from "the tool call failed", and before promising a user that budget, packing, collab, atlas, vacay, journey or collections will work.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+  })
+  listAddons(_args: Record<string, never>, _ctx: McpContext) {
+    const { addons, collabFeatures, bagTracking } = this.addons.list();
+    // icon, config and fields are admin-panel chrome: an icon name and the
+    // photo-provider settings form say nothing about what a tool can do.
+    return ok({
+      addons: addons.map(({ id, name, type, enabled }) => ({ id, name, type, enabled })),
+      collabFeatures,
+      bagTracking,
+    });
+  }
+}

--- a/server/src/nest/addons/addons.module.ts
+++ b/server/src/nest/addons/addons.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AddonsController } from './addons.controller';
 import { AddonsService } from './addons.service';
 import { AddonGuard } from './addon.guard';
+import { AddonsMcp } from './addons.mcp';
 
 /**
  * GET /api/addons — enabled add-ons + photo providers (was an inline handler in
@@ -13,10 +14,14 @@ import { AddonGuard } from './addon.guard';
  * adminService per finding `admin-1`) — for the in-container consumers.
  * Deliberately NOT @Global (permissions precedent): e2e TestingModules resolve
  * it transitively through each consumer's explicit import.
+ *
+ * AddonsMcp puts the same listing on the MCP surface, so a model can read which
+ * add-ons this instance has switched on instead of guessing from the tools it
+ * was handed.
  */
 @Module({
   controllers: [AddonsController],
-  providers: [AddonsService, AddonGuard],
+  providers: [AddonsService, AddonGuard, AddonsMcp],
   exports: [AddonsService, AddonGuard],
 })
 export class AddonsModule {}

--- a/server/src/nest/atlas/atlas.mcp.ts
+++ b/server/src/nest/atlas/atlas.mcp.ts
@@ -44,6 +44,14 @@ function jsonContent(uri: string, data: unknown) {
  * get_country_atlas_places passed codes through un-uppercased) was fixed in
  * the trailing quirk commit — both sides now uppercase. The one input schema
  * that grew since is create_bucket_list_item's target_date (#1898).
+ *
+ * Three later additions answer REST rather than the legacy registrar:
+ * locate_atlas_region mirrors GET /locate, without which nothing on the MCP
+ * surface could produce the region code mark_region_visited demands;
+ * list_visited_regions and the atlas-regions resource report the derived and
+ * merged shape GET /regions has always returned instead of the raw manual
+ * rows; and get_atlas_stats carries the dashboard passport figures from
+ * GET /api/auth/travel-stats next to the atlas payload.
  */
 @McpController()
 export class AtlasMcp {
@@ -143,33 +151,68 @@ export class AtlasMcp {
 
   @Tool({
     name: 'get_atlas_stats',
-    description: 'Get atlas statistics — total visited countries, region counts, continent breakdown.',
-    inputSchema: {},
+    description:
+      'Get the full travel picture in one call: visited/planned countries with per-country place and trip counts, continent breakdown, trip and day totals, plus the passport figures the dashboard shows (the cities visited by name and the total distance flown). Prefer this over get_country_atlas_places, which answers for one country only.',
+    inputSchema: {
+      include_coords: z
+        .boolean()
+        .optional()
+        .describe('Also return the coordinate of every saved place, as the dashboard map plots them. Off by default: it is one entry per place.'),
+    },
     annotations: TOOL_ANNOTATIONS_READONLY,
     when: atlasAddonOn,
     access: { group: 'atlas', mode: 'read' },
   })
-  async getAtlasStats(_args: Record<string, never>, ctx: McpContext) {
+  async getAtlasStats({ include_coords }: { include_coords?: boolean }, ctx: McpContext) {
     const stats = await this.atlas.stats(ctx.userId);
-    return ok({ stats });
+    // stats() counts cities and knows nothing of flown distance, so the two
+    // figures the passport card is actually asked for (GET /api/auth/travel-stats)
+    // were unreachable here. Its coords array is one entry per place, which is
+    // rendering data rather than an answer, hence the opt-in.
+    const { coords, ...travel } = this.atlas.getTravelStats(ctx.userId);
+    return ok({ stats, travel: include_coords ? { ...travel, coords } : travel });
   }
 
   @Tool({
     name: 'list_visited_regions',
-    description: 'List all manually visited sub-country regions for the current user.',
+    description:
+      'List visited sub-country regions grouped by country, the way the Atlas map paints them: regions derived from the places on your trips, each with a place count and a visited/planned/idea status, merged with the ones marked by hand and minus the ones dismissed.',
     inputSchema: {},
     annotations: TOOL_ANNOTATIONS_READONLY,
     when: atlasAddonOn,
     access: { group: 'atlas', mode: 'read' },
   })
   async listVisitedRegions(_args: Record<string, never>, ctx: McpContext) {
-    const regions = this.atlas.listManuallyVisitedRegions(ctx.userId);
-    return ok({ regions });
+    // The manual marks are a subset of what the user sees: GET /regions derives
+    // regions from trip places as well, so reporting the raw visited_regions rows
+    // made the tool contradict the map for anyone who never marked one by hand.
+    const regions = await this.atlas.visitedRegions(ctx.userId);
+    return ok(regions);
+  }
+
+  @Tool({
+    name: 'locate_atlas_region',
+    description:
+      'Resolve a coordinate to the country and admin1 region the Atlas map can highlight. This is where the regionCode/countryCode pair mark_region_visited expects comes from. Prefer reverse_geocode when you want a postal address instead of atlas codes.',
+    inputSchema: {
+      lat: z.number().min(-90).max(90).describe('Latitude in decimal degrees'),
+      lng: z.number().min(-180).max(180).describe('Longitude in decimal degrees'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    when: atlasAddonOn,
+    access: { group: 'atlas', mode: 'read' },
+  })
+  async locateAtlasRegion({ lat, lng }: { lat: number; lng: number }, _ctx: McpContext) {
+    // Null fields are an answer, not a failure: the point may sit outside every
+    // bundled polygon, and plenty of countries have no admin1 coverage at all
+    // (#1115). Same as the REST route.
+    const located = await this.atlas.locate(lat, lng);
+    return ok(located);
   }
 
   @Tool({
     name: 'mark_region_visited',
-    description: 'Mark a sub-country region as visited.',
+    description: 'Mark a sub-country region as visited. When you only know a place or a coordinate, get the codes from locate_atlas_region first.',
     inputSchema: {
       regionCode: z.string().describe('ISO region code e.g. US-CA'),
       regionName: z.string(),
@@ -317,13 +360,16 @@ export class AtlasMcp {
   @Resource({
     name: 'atlas-regions',
     uri: 'trek://atlas/regions',
-    description: 'List of manually visited regions for the current user',
+    description: 'Visited regions grouped by country, as the Atlas map paints them',
     mimeType: 'application/json',
     when: atlasAddonOn,
     access: { group: 'atlas', mode: 'read' },
   })
   async atlasRegionsResource(uri: URL, ctx: McpContext) {
-    const regions = this.atlas.listManuallyVisitedRegions(ctx.userId);
+    // Same source as list_visited_regions. Resources here carry the payload
+    // itself, so the { regions } envelope GET /regions sends is unwrapped, the
+    // way bucket-list drops REST's { items }.
+    const { regions } = await this.atlas.visitedRegions(ctx.userId);
     return jsonContent(uri.href, regions);
   }
 }

--- a/server/src/nest/budget/budget.mcp.ts
+++ b/server/src/nest/budget/budget.mcp.ts
@@ -26,9 +26,28 @@ const payersSchema = z.array(z.object({
   amount: z.number().nonnegative(),
 })).describe('Who actually paid, and how much each paid, in the expense currency. Ask the user; do not guess.');
 
+/** Reusable Zod shape for an unequal split: what each participant owes. */
+const splitMembersSchema = z.array(z.object({
+  user_id: z.number().int().positive(),
+  amount: z.number().nonnegative(),
+})).describe('Unequal split: what each participant owes, in the expense currency. The amounts must add up to the expense total. Ask the user; do not guess.');
+
 function parseId(value: string | string[]): number | null {
   const n = Number(Array.isArray(value) ? value[0] : value);
   return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/** Money is compared in whole cents, never in floats (the budget money rule). */
+function toCents(amount: number): number {
+  return Math.round(amount * 100);
+}
+
+function sumCents(amounts: number[]): number {
+  return amounts.reduce((sum, a) => sum + toCents(a), 0);
+}
+
+function formatCents(cents: number): string {
+  return (cents / 100).toFixed(2);
 }
 
 /**
@@ -83,20 +102,88 @@ export class BudgetMcp {
     return Array.from(new Set([ownerId, ...this.membership.listMemberUserIds(tripId)]));
   }
 
+  /**
+   * The total a custom split has to reconcile against: explicit payers derive it
+   * (the write path overwrites total_price with their sum), so the stated total
+   * is not necessarily the figure that ends up in the row.
+   */
+  private settledTotalCents(
+    tripId: number,
+    payers: { user_id: number; amount: number }[] | undefined,
+    total_price: number | undefined,
+    fallbackCents: number,
+  ): number {
+    // Once payers are sent at all, the write path derives the total from them and
+    // an empty list therefore means zero, not "no opinion". Reading total_price
+    // here instead would certify a split against a figure the row never receives.
+    if (payers !== undefined) {
+      const roster = this.db.rosterUserIds(tripId);
+      return sumCents(payers.filter(p => p.amount > 0 && roster.has(p.user_id)).map(p => p.amount));
+    }
+    if (total_price !== undefined) return toCents(total_price);
+    return fallbackCents;
+  }
+
+  /**
+   * Reasons to refuse a custom split, or null when it is safe to persist.
+   *
+   * A split whose shares do not add up to the total hands the settlement a
+   * difference no payment can ever clear, so it is refused here rather than
+   * stored and discovered on the balances screen. An off-roster or repeated
+   * user_id is refused for the same reason: the write path drops both silently,
+   * which would unbalance a split that had just been checked.
+   */
+  private splitRefusal(
+    tripId: number,
+    members: { user_id: number; amount: number }[],
+    totalCents: number,
+    payers?: { user_id: number; amount: number }[],
+  ): string | null {
+    const roster = this.db.rosterUserIds(tripId);
+    const strangers = members.filter(m => !roster.has(m.user_id)).map(m => m.user_id);
+    if (strangers.length > 0) {
+      return `members contains user IDs that are not on this trip: ${strangers.join(', ')}. Resolve them with list_trip_members.`;
+    }
+    if (new Set(members.map(m => m.user_id)).size !== members.length) {
+      return 'members lists the same user twice. Give each participant one amount.';
+    }
+    // A payer the write path will drop takes the total down with it, so the split
+    // certified here would not be the split stored. Refuse rather than let the
+    // difference surface on the balances screen.
+    if (payers) {
+      const payerStrangers = payers.filter(p => p.amount > 0 && !roster.has(p.user_id)).map(p => p.user_id);
+      if (payerStrangers.length > 0) {
+        return `payers contains user IDs that are not on this trip: ${payerStrangers.join(', ')}. Resolve them with list_trip_members.`;
+      }
+    }
+    const splitCents = sumCents(members.map(m => m.amount));
+    if (splitCents !== totalCents) {
+      return `The split does not add up: the member amounts total ${formatCents(splitCents)} but the expense total is ${formatCents(totalCents)}. Adjust the amounts so they sum to the expense total.`;
+    }
+    return null;
+  }
+
+  /** The sibling tools' foreign-id rule: a linked id must live on the same trip. */
+  private placeOnTrip(tripId: number, placeId: number): boolean {
+    return !!this.db.get('SELECT id FROM places WHERE id = ? AND trip_id = ?', placeId, tripId);
+  }
+
   // --- BUDGET ---
 
   @Tool({
     name: 'create_budget_item',
-    description: 'Add a budget/expense item to a trip. The cost is split equally among member_ids (omit to split across all trip members, or pass [] for a planning-only entry with no split). Use `payers` to record who actually paid and how much. Ask the user which trip members share this expense and who paid — resolve user IDs with list_trip_members — rather than guessing.',
+    description: 'Add a budget/expense item to a trip. The cost is split equally among member_ids (omit to split across all trip members, or pass [] for a planning-only entry with no split); for an uneven split, give `members` the amount each participant owes instead. Use `payers` to record who actually paid and how much. Ask the user which trip members share this expense and who paid (resolve user IDs with list_trip_members) rather than guessing.',
     inputSchema: {
       tripId: z.number().int().positive(),
       name: z.string().min(1).max(200),
       category: z.string().max(100).optional().describe('Budget category (e.g. Accommodation, Food, Transport)'),
       total_price: z.number().nonnegative(),
       currency: z.string().max(10).nullable().optional().describe('ISO currency code (e.g. "EUR"); defaults to the trip currency'),
-      member_ids: z.array(z.number().int().positive()).optional().describe('Trip member user IDs splitting this expense. Omit to split across all trip members (owner + members); pass [] for no split.'),
+      member_ids: z.array(z.number().int().positive()).optional().describe('Trip member user IDs splitting this expense equally. Omit to split across all trip members (owner + members); pass [] for no split.'),
+      members: splitMembersSchema.optional().describe('Uneven split: what each participant owes, in the expense currency. The amounts must add up to the expense total. Use this instead of member_ids, never alongside it.'),
       payers: payersSchema.optional().describe('Who paid how much, in the expense currency. When given, total_price is derived from the sum. Ask the user; do not guess.'),
       expense_date: z.string().max(40).nullable().optional().describe('Date the expense occurred, YYYY-MM-DD'),
+      place_id: z.number().int().positive().optional().describe('Place on this trip the expense belongs to (the museum ticket for that museum), linking it in the planner'),
       note: z.string().max(500).optional(),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
@@ -104,17 +191,26 @@ export class BudgetMcp {
     access: { group: 'budget', mode: 'write' },
   })
   async createBudgetItem(
-    { tripId, name, category, total_price, currency, member_ids, payers, expense_date, note }: {
+    { tripId, name, category, total_price, currency, member_ids, members, payers, expense_date, place_id, note }: {
       tripId: number; name: string; category?: string; total_price: number; currency?: string | null;
-      member_ids?: number[]; payers?: { user_id: number; amount: number }[]; expense_date?: string | null; note?: string;
+      member_ids?: number[]; members?: { user_id: number; amount: number }[];
+      payers?: { user_id: number; amount: number }[]; expense_date?: string | null; place_id?: number; note?: string;
     },
     ctx: McpContext,
   ) {
     if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.budget.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('budget_edit', tripId, ctx.userId)) return permissionDenied();
-    const members = this.resolveMemberIds(tripId, member_ids);
-    const itemData = { category, name, total_price, currency, member_ids: members, payers, expense_date, note };
+    if (members !== undefined && member_ids !== undefined) return errorResult('Pass either members (uneven split) or member_ids (equal split), not both.');
+    if (place_id != null && !this.placeOnTrip(tripId, place_id)) return errorResult('place_id does not belong to this trip.');
+    if (members !== undefined) {
+      const refusal = this.splitRefusal(tripId, members, this.settledTotalCents(tripId, payers, total_price, toCents(total_price)), payers);
+      if (refusal) return errorResult(refusal);
+    }
+    // The split participants are the members of an uneven split; the equal-split
+    // list still carries them so the row's `persons` count comes out the same.
+    const splitIds = members ? members.map(m => m.user_id) : this.resolveMemberIds(tripId, member_ids);
+    const itemData = { category, name, total_price, currency, member_ids: splitIds, members, payers, expense_date, place_id, note };
     // Freeze the live FX rate at entry time so a settled position isn't re-opened
     // when live rates drift (#1445) — same as the REST create path.
     await this.budget.freezeForeignRate(tripId, itemData);
@@ -148,17 +244,20 @@ export class BudgetMcp {
 
   @Tool({
     name: 'update_budget_item',
-    description: 'Update an existing budget/expense item in a trip. You can also re-split it via member_ids and record who actually paid via payers (amounts in the expense currency). When changing who shares an expense or who paid, ask the user rather than guessing; resolve user IDs with list_trip_members.',
+    description: 'Update an existing budget/expense item in a trip. You can also re-split it (equally via member_ids, unevenly via members), change the currency it was entered in, move it to another date, and record who actually paid via payers (amounts in the expense currency). When changing who shares an expense or who paid, ask the user rather than guessing; resolve user IDs with list_trip_members.',
     inputSchema: {
       tripId: z.number().int().positive(),
       itemId: z.number().int().positive(),
       name: z.string().min(1).max(200).optional(),
       category: z.string().max(100).optional(),
       total_price: z.number().nonnegative().optional(),
-      member_ids: z.array(z.number().int().positive()).optional().describe('Trip member user IDs splitting this expense; replaces the current split. Omit to leave unchanged, pass [] for no split.'),
+      currency: z.string().max(10).nullable().optional().describe('ISO currency code the expense is in (e.g. "USD"); null puts it back in the trip currency. Changing it re-freezes the FX rate at today\'s rate.'),
+      member_ids: z.array(z.number().int().positive()).optional().describe('Trip member user IDs splitting this expense equally; replaces the current split. Omit to leave unchanged, pass [] for no split.'),
+      members: splitMembersSchema.optional().describe('Uneven split: what each participant owes, in the expense currency; replaces the current split. The amounts must add up to the expense total. Use this instead of member_ids, never alongside it.'),
       payers: payersSchema.optional().describe('Replaces who paid how much, in the expense currency. Omit to leave unchanged. Ask the user; do not guess.'),
       persons: z.number().int().positive().nullable().optional(),
       days: z.number().int().positive().nullable().optional(),
+      expense_date: z.string().max(40).nullable().optional().describe('Date the expense occurred, YYYY-MM-DD; null clears it. Omit to leave unchanged.'),
       note: z.string().max(500).nullable().optional(),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
@@ -166,18 +265,29 @@ export class BudgetMcp {
     access: { group: 'budget', mode: 'write' },
   })
   async updateBudgetItem(
-    { tripId, itemId, name, category, total_price, member_ids, payers, persons, days, note }: {
-      tripId: number; itemId: number; name?: string; category?: string; total_price?: number;
-      member_ids?: number[]; payers?: { user_id: number; amount: number }[]; persons?: number | null; days?: number | null; note?: string | null;
+    { tripId, itemId, name, category, total_price, currency, member_ids, members, payers, persons, days, expense_date, note }: {
+      tripId: number; itemId: number; name?: string; category?: string; total_price?: number; currency?: string | null;
+      member_ids?: number[]; members?: { user_id: number; amount: number }[];
+      payers?: { user_id: number; amount: number }[]; persons?: number | null; days?: number | null;
+      expense_date?: string | null; note?: string | null;
     },
     ctx: McpContext,
   ) {
     if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.budget.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('budget_edit', tripId, ctx.userId)) return permissionDenied();
-    // Freeze-then-write composite (no-op while the schema has no currency input,
-    // but keeps REST and MCP on one code path for the #1445 freeze).
-    const item = await this.budget.update(itemId, tripId, { name, category, total_price, member_ids, payers, persons, days, note });
+    if (members !== undefined && member_ids !== undefined) return errorResult('Pass either members (uneven split) or member_ids (equal split), not both.');
+    if (members !== undefined) {
+      // An edit that leaves the total alone still has to reconcile against it, so
+      // the stored figure stands in when the call does not restate one.
+      const existing = this.budget.getBudgetItem(itemId, tripId);
+      if (!existing) return errorResult('Budget item not found.');
+      const refusal = this.splitRefusal(tripId, members, this.settledTotalCents(tripId, payers, total_price, toCents(existing.total_price)), payers);
+      if (refusal) return errorResult(refusal);
+    }
+    // Freeze-then-write composite: a currency change re-freezes the rate at entry
+    // time (#1445) on the same code path the REST update uses.
+    const item = await this.budget.update(itemId, tripId, { name, category, total_price, currency, member_ids, members, payers, persons, days, expense_date, note });
     if (!item) return errorResult('Budget item not found.');
     this.guards.safeBroadcast(tripId, 'budget:updated', { item });
     return ok({ item });
@@ -187,7 +297,7 @@ export class BudgetMcp {
 
   @Tool({
     name: 'create_budget_item_with_members',
-    description: 'Create a budget/expense item and set the trip members splitting it in one atomic operation. If userIds is omitted, the cost is split across all trip members; pass an explicit list to split among a subset, or an empty array for a planning-only entry with no split. Ask the user which members share this expense rather than guessing; resolve user IDs with list_trip_members. Only use when the item does not yet exist — if it already exists, use set_budget_item_members directly.',
+    description: 'Create a budget/expense item and set the trip members splitting it equally in one atomic operation. If userIds is omitted, the cost is split across all trip members; pass an explicit list to split among a subset, or an empty array for a planning-only entry with no split. Ask the user which members share this expense rather than guessing; resolve user IDs with list_trip_members. Only use when the item does not yet exist; if it already exists, use set_budget_item_members directly. For an uneven split, a foreign currency or a date, use create_budget_item instead.',
     inputSchema: {
       tripId: z.number().int().positive(),
       name: z.string().min(1).max(200),
@@ -195,25 +305,27 @@ export class BudgetMcp {
       total_price: z.number().nonnegative(),
       note: z.string().max(500).optional(),
       userIds: z.array(z.number().int().positive()).optional().describe('User IDs splitting this item; omit to split across all trip members, or pass an empty array for no split'),
+      place_id: z.number().int().positive().optional().describe('Place on this trip the expense belongs to (the museum ticket for that museum), linking it in the planner'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     when: budgetAddonOn,
     access: { group: 'budget', mode: 'write' },
   })
   async createBudgetItemWithMembers(
-    { tripId, name, category, total_price, note, userIds }: {
-      tripId: number; name: string; category?: string; total_price: number; note?: string; userIds?: number[];
+    { tripId, name, category, total_price, note, userIds, place_id }: {
+      tripId: number; name: string; category?: string; total_price: number; note?: string; userIds?: number[]; place_id?: number;
     },
     ctx: McpContext,
   ) {
     if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.budget.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('budget_edit', tripId, ctx.userId)) return permissionDenied();
+    if (place_id != null && !this.placeOnTrip(tripId, place_id)) return errorResult('place_id does not belong to this trip.');
     // Omitted userIds → default to the whole trip, matching create_budget_item.
     const members = (userIds && userIds.length > 0) ? userIds : this.resolveMemberIds(tripId, undefined);
     try {
       const item = this.db.transaction(() => {
-        const created = this.budget.createBudgetItem(tripId, { category, name, total_price, note, member_ids: members });
+        const created = this.budget.createBudgetItem(tripId, { category, name, total_price, note, member_ids: members, place_id });
         return this.budget.getBudgetItem(created.id, tripId)!;
       });
       this.guards.safeBroadcast(tripId, 'budget:created', { item });
@@ -309,27 +421,28 @@ export class BudgetMcp {
 
   @Tool({
     name: 'create_settlement',
-    description: "Record a settle-up payment: from_user_id paid to_user_id the given amount (in the trip's base currency) to settle shared expenses. Use get_settlement_summary first to find who owes whom and how much.",
+    description: "Record a settle-up payment: from_user_id paid to_user_id the given amount to settle shared expenses. The amount is in the trip's base currency unless `currency` says otherwise. Use get_settlement_summary first to find who owes whom and how much.",
     inputSchema: {
       tripId: z.number().int().positive(),
       from_user_id: z.number().int().positive().describe('User ID of the member who paid'),
       to_user_id: z.number().int().positive().describe('User ID of the member who received the payment'),
-      amount: z.number().positive().describe("Amount paid, in the trip's base currency"),
+      amount: z.number().positive().describe('Amount paid, in `currency`'),
+      currency: z.string().max(10).nullable().optional().describe("ISO currency code the payment was made in (e.g. \"USD\"); defaults to the trip currency. Its FX rate is frozen now, so the transfer keeps cancelling its expense when live rates drift."),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     when: budgetAddonOn,
     access: { group: 'budget', mode: 'write' },
   })
   async createSettlement(
-    { tripId, from_user_id, to_user_id, amount }: { tripId: number; from_user_id: number; to_user_id: number; amount: number },
+    { tripId, from_user_id, to_user_id, amount, currency }: { tripId: number; from_user_id: number; to_user_id: number; amount: number; currency?: string | null },
     ctx: McpContext,
   ) {
     if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.budget.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('budget_edit', tripId, ctx.userId)) return permissionDenied();
-    // Freeze-then-write composite, same as the REST path (no-op while the
-    // schema has no currency input — see the #1445 note in the class doc).
-    const settlement = await this.budget.createSettlement(tripId, { from_user_id, to_user_id, amount }, ctx.userId);
+    // Freeze-then-write composite, same as the REST path: the rate for the display
+    // currency is frozen at entry time (#1445).
+    const settlement = await this.budget.createSettlement(tripId, { from_user_id, to_user_id, amount, currency }, ctx.userId);
     if (!settlement) return errorResult('Settlement not found.');
     this.guards.safeBroadcast(tripId, 'budget:settlement-created', { settlement });
     return ok({ settlement });
@@ -337,27 +450,29 @@ export class BudgetMcp {
 
   @Tool({
     name: 'update_settlement',
-    description: 'Update a recorded settle-up payment (who paid, who received, and the amount).',
+    description: 'Update a recorded settle-up payment (who paid, who received, the amount and the currency it was made in). Every field is a full replace, so restate the ones that stay the same.',
     inputSchema: {
       tripId: z.number().int().positive(),
       settlementId: z.number().int().positive(),
       from_user_id: z.number().int().positive().describe('User ID of the member who paid'),
       to_user_id: z.number().int().positive().describe('User ID of the member who received the payment'),
-      amount: z.number().positive().describe("Amount paid, in the trip's base currency"),
+      amount: z.number().positive().describe('Amount paid, in `currency`'),
+      currency: z.string().max(10).nullable().optional().describe('ISO currency code the payment was made in (e.g. "USD"); null puts it back in the trip currency. Omit to leave it as recorded, which also keeps the rate frozen at settle time.'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     when: budgetAddonOn,
     access: { group: 'budget', mode: 'write' },
   })
   async updateSettlement(
-    { tripId, settlementId, from_user_id, to_user_id, amount }: { tripId: number; settlementId: number; from_user_id: number; to_user_id: number; amount: number },
+    { tripId, settlementId, from_user_id, to_user_id, amount, currency }: { tripId: number; settlementId: number; from_user_id: number; to_user_id: number; amount: number; currency?: string | null },
     ctx: McpContext,
   ) {
     if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.budget.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('budget_edit', tripId, ctx.userId)) return permissionDenied();
-    // Freeze-then-write composite, same as the REST path.
-    const settlement = await this.budget.updateSettlement(settlementId, tripId, { from_user_id, to_user_id, amount });
+    // Freeze-then-write composite, same as the REST path: an edit that leaves the
+    // currency alone keeps the rate frozen at settle time.
+    const settlement = await this.budget.updateSettlement(settlementId, tripId, { from_user_id, to_user_id, amount, currency });
     if (!settlement) return errorResult('Settlement not found.');
     this.guards.safeBroadcast(tripId, 'budget:settlement-updated', { settlement });
     return ok({ settlement });

--- a/server/src/nest/categories/categories.mcp.ts
+++ b/server/src/nest/categories/categories.mcp.ts
@@ -6,7 +6,9 @@ import {
 } from '../../nest-mcp';
 import { z } from 'zod';
 import { createCategoryRequestSchema, updateCategoryRequestSchema } from '@trek/shared';
-import { AuthService } from '../auth/auth.service';
+import { DatabaseService } from '../database/database.service';
+import { RuntimeEnvService } from '../app-config/runtime-env.service';
+import { isDemoUserId } from '../common/demo-write';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
 import { adminRequired } from '../../mcp/tools/_shared';
 import { CategoriesService } from './categories.service';
@@ -31,9 +33,15 @@ import { CategoriesService } from './categories.service';
 export class CategoriesMcp {
   constructor(
     private readonly categories: CategoriesService,
-    private readonly auth: AuthService,
+    private readonly db: DatabaseService,
+    private readonly env: RuntimeEnvService,
     private readonly guards: McpToolGuardsService,
   ) {}
+
+  /** The AuthService.isDemoUser check without the auth graph (demo-write.ts). */
+  private isDemoUser(userId: number): boolean {
+    return isDemoUserId(this.env, this.db, userId);
+  }
 
   @Tool({
     name: 'list_categories',
@@ -59,7 +67,7 @@ export class CategoriesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async createCategory({ name, color, icon }: { name: string; color?: string; icon?: string }, ctx: McpContext) {
-    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
     // The palette is instance-wide; the REST route restricts management to admins. Match it.
     if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
     const category = this.categories.create(ctx.userId, name, color, icon);
@@ -79,7 +87,7 @@ export class CategoriesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async updateCategory({ categoryId, name, color, icon }: { categoryId: number; name?: string; color?: string; icon?: string }, ctx: McpContext) {
-    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
     if (!this.categories.getById(categoryId)) return errorResult('Category not found');
     const category = this.categories.update(categoryId, name, color, icon);
@@ -96,7 +104,7 @@ export class CategoriesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async deleteCategory({ categoryId }: { categoryId: number }, ctx: McpContext) {
-    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
     if (!this.categories.getById(categoryId)) return errorResult('Category not found');
     this.categories.remove(categoryId);

--- a/server/src/nest/categories/categories.mcp.ts
+++ b/server/src/nest/categories/categories.mcp.ts
@@ -1,7 +1,14 @@
 import {
   McpController, Tool, Resource, type McpContext,
-  TOOL_ANNOTATIONS_READONLY, ok,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE,
+  TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+  demoDenied, errorResult, ok,
 } from '../../nest-mcp';
+import { z } from 'zod';
+import { createCategoryRequestSchema, updateCategoryRequestSchema } from '@trek/shared';
+import { AuthService } from '../auth/auth.service';
+import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { adminRequired } from '../../mcp/tools/_shared';
 import { CategoriesService } from './categories.service';
 
 /**
@@ -12,10 +19,21 @@ import { CategoriesService } from './categories.service';
  * src/mcp/resources.ts (first production @Resource; intentionally ungated —
  * the legacy registration was unconditional, safe for any authenticated
  * session — and the payload reproduces the legacy jsonContent shape verbatim).
+ *
+ * The three write tools mirror POST/PUT/DELETE /api/categories, which sit
+ * behind JwtAuthGuard + AdminGuard: the palette is instance-wide, not
+ * trip-scoped, so there is no trip to check access against and the admin role
+ * is the whole gate. Bodies reuse the same @trek/shared contracts the
+ * controller's DTOs wrap, so `color` stays hex-only on both surfaces (it is
+ * interpolated into a style="…" attribute of hand-built marker HTML).
  */
 @McpController()
 export class CategoriesMcp {
-  constructor(private readonly categories: CategoriesService) {}
+  constructor(
+    private readonly categories: CategoriesService,
+    private readonly auth: AuthService,
+    private readonly guards: McpToolGuardsService,
+  ) {}
 
   @Tool({
     name: 'list_categories',
@@ -27,6 +45,62 @@ export class CategoriesMcp {
   async listCategories(_args: Record<string, never>, _ctx: McpContext) {
     const categories = this.categories.list();
     return ok({ categories });
+  }
+
+  @Tool({
+    name: 'create_category',
+    description: 'Add a new place category to the instance-wide palette. Admin only. Prefer an existing category from list_categories: this mints one every trip on the instance will see, so only reach for it when nothing in the palette fits.',
+    inputSchema: {
+      name: createCategoryRequestSchema.shape.name.describe('Category label, e.g. "Street food"'),
+      color: createCategoryRequestSchema.shape.color.describe('Hex colour for the map marker (defaults to #6366f1)'),
+      icon: createCategoryRequestSchema.shape.icon.describe('Emoji shown on the marker (defaults to 📍)'),
+    },
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    access: { group: 'places', mode: 'write' },
+  })
+  async createCategory({ name, color, icon }: { name: string; color?: string; icon?: string }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    // The palette is instance-wide; the REST route restricts management to admins. Match it.
+    if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
+    const category = this.categories.create(ctx.userId, name, color, icon);
+    return ok({ category });
+  }
+
+  @Tool({
+    name: 'update_category',
+    description: 'Rename an existing place category or change its colour or icon. Admin only. Every place already carrying the category follows the change, so use this to fix a palette entry rather than to reclassify places.',
+    inputSchema: {
+      categoryId: z.number().int().positive().describe('Category ID from list_categories'),
+      name: updateCategoryRequestSchema.shape.name,
+      color: updateCategoryRequestSchema.shape.color.describe('Hex colour for the map marker'),
+      icon: updateCategoryRequestSchema.shape.icon.describe('Emoji shown on the marker'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'places', mode: 'write' },
+  })
+  async updateCategory({ categoryId, name, color, icon }: { categoryId: number; name?: string; color?: string; icon?: string }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
+    if (!this.categories.getById(categoryId)) return errorResult('Category not found');
+    const category = this.categories.update(categoryId, name, color, icon);
+    return ok({ category });
+  }
+
+  @Tool({
+    name: 'delete_category',
+    description: 'Remove a place category from the instance-wide palette. Admin only. Places keep their data but lose the category, across every trip on the instance. Use update_category when the entry only needs fixing.',
+    inputSchema: {
+      categoryId: z.number().int().positive().describe('Category ID from list_categories'),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'places', mode: 'write' },
+  })
+  async deleteCategory({ categoryId }: { categoryId: number }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.guards.isAdminUser(ctx.userId)) return adminRequired();
+    if (!this.categories.getById(categoryId)) return errorResult('Category not found');
+    this.categories.remove(categoryId);
+    return ok({ success: true });
   }
 
   @Resource({

--- a/server/src/nest/categories/categories.module.ts
+++ b/server/src/nest/categories/categories.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
+import { AppConfigModule } from '../app-config/app-config.module';
 import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 import { CategoriesController } from './categories.controller';
 import { CategoriesMcp } from './categories.mcp';
@@ -8,9 +8,12 @@ import { CategoriesRpc } from './categories.rpc';
 
 /** Categories domain (L4 leaf module). Registered in AppModule. */
 @Module({
-  // CategoriesMcp gates its three admin tools on AuthService, and McpSharedModule
-  // is deliberately not @Global, so both are imported rather than inherited.
-  imports: [AuthModule, McpSharedModule],
+  // AuthModule is deliberately absent: CategoriesMcp's demo guard reads
+  // RuntimeEnvService and the users table rather than AuthService, which keeps
+  // the partial e2e TestingModule for this domain down to two tables.
+  // McpSharedModule is not @Global, and AppConfigModule is imported explicitly
+  // for the same reason budget/ does it.
+  imports: [McpSharedModule, AppConfigModule],
   controllers: [CategoriesController],
   providers: [CategoriesService, CategoriesMcp, CategoriesRpc],
   // For in-container consumers (CategoriesRpc).

--- a/server/src/nest/categories/categories.module.ts
+++ b/server/src/nest/categories/categories.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 import { CategoriesController } from './categories.controller';
 import { CategoriesMcp } from './categories.mcp';
 import { CategoriesService } from './categories.service';
@@ -6,6 +8,9 @@ import { CategoriesRpc } from './categories.rpc';
 
 /** Categories domain (L4 leaf module). Registered in AppModule. */
 @Module({
+  // CategoriesMcp gates its three admin tools on AuthService, and McpSharedModule
+  // is deliberately not @Global, so both are imported rather than inherited.
+  imports: [AuthModule, McpSharedModule],
   controllers: [CategoriesController],
   providers: [CategoriesService, CategoriesMcp, CategoriesRpc],
   // For in-container consumers (CategoriesRpc).

--- a/server/src/nest/collab/collab.mcp.ts
+++ b/server/src/nest/collab/collab.mcp.ts
@@ -57,7 +57,9 @@ function jsonContent(uri: string, data: unknown) {
  * read/write access markers (the legacy `if (R)` / `if (W)` checks, resolved
  * by trekMcpAccessPolicy). The list tools check only trip access (as legacy);
  * vote_collab_poll gained the demo-user gate the legacy registrar was missing,
- * matching every other collab write tool.
+ * matching every other collab write tool. The two note write tools have since
+ * gained `website`, which the REST route has always accepted and the note card
+ * renders as a link preview.
  */
 @McpController()
 export class CollabMcp {
@@ -79,6 +81,7 @@ export class CollabMcp {
       content: z.string().max(10000).optional(),
       category: z.string().max(100).optional().describe('Note category (e.g. "Ideas", "To-do", "General")'),
       color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().describe('Hex color for the note card'),
+      website: z.string().max(500).nullable().optional().describe('Link to attach to the note; the card renders it as a preview thumbnail. Pass null to remove it'),
       pinned: z.boolean().optional().default(false).describe('Pin the note to the top'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
@@ -86,15 +89,15 @@ export class CollabMcp {
     access: { group: 'collab', mode: 'write' },
   })
   async createCollabNote(
-    { tripId, title, content, category, color, pinned }: {
-      tripId: number; title: string; content?: string; category?: string; color?: string; pinned?: boolean;
+    { tripId, title, content, category, color, website, pinned }: {
+      tripId: number; title: string; content?: string; category?: string; color?: string; website?: string | null; pinned?: boolean;
     },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.collab.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('collab_edit', tripId, ctx.userId)) return permissionDenied();
-    const note = this.collab.createNote(tripId, ctx.userId, { title, content, category, color, pinned });
+    const note = this.collab.createNote(tripId, ctx.userId, { title, content, category, color, website, pinned });
     this.guards.safeBroadcast(tripId, 'collab:note:created', { note });
     return ok({ note });
   }
@@ -109,6 +112,7 @@ export class CollabMcp {
       content: z.string().max(10000).optional(),
       category: z.string().max(100).optional(),
       color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().describe('Hex color for the note card'),
+      website: z.string().max(500).nullable().optional().describe('Link to attach to the note, or null to remove the one it has'),
       pinned: z.boolean().optional().describe('Pin the note to the top'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
@@ -116,15 +120,15 @@ export class CollabMcp {
     access: { group: 'collab', mode: 'write' },
   })
   async updateCollabNote(
-    { tripId, noteId, title, content, category, color, pinned }: {
-      tripId: number; noteId: number; title?: string; content?: string; category?: string; color?: string; pinned?: boolean;
+    { tripId, noteId, title, content, category, color, website, pinned }: {
+      tripId: number; noteId: number; title?: string; content?: string; category?: string; color?: string; website?: string | null; pinned?: boolean;
     },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.collab.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('collab_edit', tripId, ctx.userId)) return permissionDenied();
-    const note = this.collab.updateNote(tripId, noteId, { title, content, category, color, pinned });
+    const note = this.collab.updateNote(tripId, noteId, { title, content, category, color, website, pinned });
     if (!note) return errorResult('Note not found.');
     this.guards.safeBroadcast(tripId, 'collab:note:updated', { note });
     return ok({ note });

--- a/server/src/nest/collections/collections.mcp.ts
+++ b/server/src/nest/collections/collections.mcp.ts
@@ -14,13 +14,14 @@ import {
   collectionSavePlaceRequestSchema, collectionPlaceUpdateRequestSchema,
   collectionCopyToTripRequestSchema, collectionLabelCreateRequestSchema,
   collectionLabelUpdateRequestSchema, collectionLabelAssignRequestSchema,
-  collectionInviteRequestSchema, COLLECTION_STATUSES, COLLECTION_ROLES,
+  collectionInviteRequestSchema, collectionSetStatusFromTripRequestSchema,
+  COLLECTION_STATUSES, COLLECTION_ROLES,
 } from '@trek/shared';
 import type {
   CollectionCreateRequest, CollectionUpdateRequest, CollectionSavePlaceRequest,
   CollectionPlaceUpdateRequest, CollectionCopyToTripRequest, CollectionInviteRequest,
   CollectionLabelCreateRequest, CollectionLabelUpdateRequest, CollectionLabelAssignRequest,
-  CollectionStatus, CollectionRole,
+  CollectionSetStatusFromTripRequest, CollectionStatus, CollectionRole,
 } from '@trek/shared';
 import { addonGate } from '../addons/addon-gate';
 import { AddonsService } from '../addons/addons.service';
@@ -109,6 +110,27 @@ export class CollectionsMcp {
       }
       return ok({ users: this.collections.availableUsers(ctx.userId, collectionId) });
     } catch (err) { return fail(err); }
+  }
+
+  @Tool({
+    name: 'find_place_in_collections',
+    description: 'Answer "is this place already on one of my lists?" across the whole library in one call, and name the lists it is on with its status in each. Prefer this over walking get_collection list by list: it applies the same provider-id and coordinate-proximity match the app\'s own saved indicator uses, which a name comparison over the returned places cannot reproduce. Identify the place by google_place_id / google_ftid (from search_place) or by lat+lng; without one of those there is no signal strong enough to claim it is the same place and nothing is reported as saved.',
+    inputSchema: {
+      google_place_id: z.string().max(200).optional().describe('Google Places id of the place to look up'),
+      google_ftid: z.string().max(200).optional().describe('Google feature id (ftid) of the place to look up'),
+      name: z.string().max(200).optional().describe('Place name. Carried for parity with the REST lookup and never matched on alone, since every repeated name (any "Starbucks") would answer to it.'),
+      lat: z.number().min(-90).max(90).optional().describe('Latitude; pass together with lng to match by location'),
+      lng: z.number().min(-180).max(180).optional().describe('Longitude; pass together with lat to match by location'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    when: collectionsAddonOn,
+    access: { group: 'collections', mode: 'read' },
+  })
+  async findPlaceInCollections(
+    query: { google_place_id?: string; google_ftid?: string; name?: string; lat?: number; lng?: number },
+    ctx: McpContext,
+  ) {
+    try { return ok(this.collections.findMembership(ctx.userId, query)); } catch (err) { return fail(err); }
   }
 
   // ── Collections CRUD ─────────────────────────────────────────────────
@@ -225,6 +247,22 @@ export class CollectionsMcp {
   async setCollectionPlaceStatus({ placeId, status }: { placeId: number; status: CollectionStatus }, ctx: McpContext) {
     const demo = this.denyDemo(ctx.userId); if (demo) return demo;
     try { return ok({ place: this.collections.setStatus(ctx.userId, placeId, status) }); } catch (err) { return fail(err); }
+  }
+
+  @Tool({
+    name: 'set_collection_place_status_from_trip',
+    description: 'Set a status on every saved copy of the given TRIP places, in every list they are on. Use this after a day out to mark places visited: set_collection_place_status takes one collection_places id, so the same trip place saved to three lists would need three calls and a lookup to find them. Ids here are trip place ids. Lists the user may only read are skipped rather than refused. Returns how many saved places changed and how many of the trip places were found in at least one list.',
+    inputSchema: collectionSetStatusFromTripRequestSchema.shape,
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    when: collectionsAddonOn,
+    access: { group: 'collections', mode: 'write' },
+  })
+  async setCollectionPlaceStatusFromTrip(
+    { trip_id, place_ids, status }: CollectionSetStatusFromTripRequest,
+    ctx: McpContext,
+  ) {
+    const demo = this.denyDemo(ctx.userId); if (demo) return demo;
+    try { return ok(this.collections.setStatusFromTrip(ctx.userId, trip_id, place_ids, status)); } catch (err) { return fail(err); }
   }
 
   @Tool({

--- a/server/src/nest/day-notes/day-notes.mcp.ts
+++ b/server/src/nest/day-notes/day-notes.mcp.ts
@@ -5,9 +5,18 @@ import {
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
 import { z } from 'zod';
+import { NOTE_COLORS, type NoteColor } from '@trek/shared';
 import { AuthService } from '../auth/auth.service';
 import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
 import { DayNotesService } from './day-notes.service';
+
+/**
+ * The palette itself rather than the REST contract's `z.string().max(9)`.
+ * normalizeNoteColor() stores anything off-palette as "no colour", so a loose
+ * string would let a caller send #ff0000, get a success back and never learn the
+ * colour was dropped. An enum is also how the tool tells a model what it may pick.
+ */
+const noteColorSchema = z.enum(NOTE_COLORS);
 
 function parseId(value: string | string[]): number | null {
   const n = Number(Array.isArray(value) ? value[0] : value);
@@ -23,6 +32,11 @@ function parseId(value: string | string[]): number | null {
  * trips write/read access markers (registerDayTools' whole-registrar
  * `canWrite(scopes, 'trips')` early return and the resource's canReadTrips
  * check, resolved by trekMcpAccessPolicy). No addon gate — day notes are core.
+ *
+ * The write tools have since gained `color` and `sort_order`, which the REST
+ * contract carried all along: without them an MCP note could not be coloured
+ * and landed at the bottom of the day's merged timeline whatever the caller
+ * meant.
  */
 @McpController()
 export class DayNotesMcp {
@@ -41,19 +55,23 @@ export class DayNotesMcp {
       text: z.string().min(1).max(500),
       time: z.string().max(250).optional().describe('Time label (e.g. "09:00" or "Morning")'),
       icon: z.string().max(64).optional().describe('Emoji icon for the note'),
+      color: noteColorSchema.nullable().optional().describe('Card colour from the note palette; null or omitted leaves the neutral card'),
+      sort_order: z.number().optional().describe('Position in the day, lowest first, interleaved with the places of that day. Omit to append at the bottom'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     access: { group: 'trips', mode: 'write' },
   })
   async createDayNote(
-    { tripId, dayId, text, time, icon }: { tripId: number; dayId: number; text: string; time?: string; icon?: string },
+    { tripId, dayId, text, time, icon, color, sort_order }: {
+      tripId: number; dayId: number; text: string; time?: string; icon?: string; color?: NoteColor | null; sort_order?: number;
+    },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.notes.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
     if (!this.notes.dayExists(dayId, tripId)) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
-    const note = this.notes.create(dayId, tripId, text, time, icon);
+    const note = this.notes.create(dayId, tripId, text, time, icon, sort_order, color);
     this.guards.safeBroadcast(tripId, 'dayNote:created', { dayId, note });
     return ok({ note });
   }
@@ -68,12 +86,16 @@ export class DayNotesMcp {
       text: z.string().min(1).max(500).optional(),
       time: z.string().max(250).nullable().optional().describe('Time label (e.g. "09:00" or "Morning"), or null to clear'),
       icon: z.string().max(64).optional().describe('Emoji icon for the note'),
+      color: noteColorSchema.nullable().optional().describe('Card colour from the note palette, or null to go back to the neutral card'),
+      sort_order: z.number().optional().describe('New position in the day, lowest first, interleaved with the places of that day'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     access: { group: 'trips', mode: 'write' },
   })
   async updateDayNote(
-    { tripId, dayId, noteId, text, time, icon }: { tripId: number; dayId: number; noteId: number; text?: string; time?: string | null; icon?: string },
+    { tripId, dayId, noteId, text, time, icon, color, sort_order }: {
+      tripId: number; dayId: number; noteId: number; text?: string; time?: string | null; icon?: string; color?: NoteColor | null; sort_order?: number;
+    },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
@@ -81,7 +103,7 @@ export class DayNotesMcp {
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
     const existing = this.notes.getNote(noteId, dayId, tripId);
     if (!existing) return { content: [{ type: 'text' as const, text: 'Note not found.' }], isError: true };
-    const note = this.notes.update(noteId, existing, { text, time: time !== undefined ? time : undefined, icon });
+    const note = this.notes.update(noteId, existing, { text, time: time !== undefined ? time : undefined, icon, color, sort_order });
     this.guards.safeBroadcast(tripId, 'dayNote:updated', { dayId, note });
     return ok({ note });
   }

--- a/server/src/nest/days/days.mcp.ts
+++ b/server/src/nest/days/days.mcp.ts
@@ -1,13 +1,17 @@
 import {
   McpController, Tool, ResourceTemplate, type McpContext,
   TOOL_ANNOTATIONS_WRITE, TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
-  demoDenied, ok,
+  demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
 import { z } from 'zod';
 import { AuthService } from '../auth/auth.service';
 import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
-import { DaysService } from './days.service';
+import {
+  dayCreateRequestSchema, dayReorderRequestSchema, dayUpdateRequestSchema,
+} from '@trek/shared';
+import type { DayCreateRequest, DayReorderRequest, DayUpdateRequest } from '@trek/shared';
+import { DaysService, DayReorderError } from './days.service';
 
 function parseId(value: string | string[]): number | null {
   const n = Number(Array.isArray(value) ? value[0] : value);
@@ -25,6 +29,11 @@ function parseId(value: string | string[]): number | null {
  * trips:delete / trips:share-only tokens; the declarative read marker is
  * marginally narrower for those, same trade day-notes made). No addon gate —
  * days are core.
+ *
+ * reorder_days, create_day's `position` and update_day's `notes` sit outside
+ * that port: the REST controller has carried all three since #589, and until
+ * they landed here a model could append and rename days but not move one, slot
+ * one in mid-trip, or write a day's notes.
  */
 @McpController()
 export class DaysMcp {
@@ -36,50 +45,101 @@ export class DaysMcp {
 
   @Tool({
     name: 'update_day',
-    description: 'Set the title of a day in a trip (e.g. "Arrival in Paris", "Free day").',
+    description: 'Set the title and/or the notes of a day in a trip (e.g. "Arrival in Paris", "Free day"). An omitted field keeps its current value, so the title and the notes can be changed independently.',
     inputSchema: {
       tripId: z.number().int().positive(),
       dayId: z.number().int().positive(),
-      title: z.string().max(200).nullable().describe('Day title, or null to clear it'),
+      // The shared contract leaves title unbounded, as the raw-body route it
+      // replaced did; the tool keeps the cap it was ported with so a model
+      // cannot park a paragraph in a day header.
+      title: z.string().max(200).nullable().optional().describe('Day title, or null to clear it'),
+      notes: dayUpdateRequestSchema.shape.notes.describe('Free-text notes for the day; an empty string clears them'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     access: { group: 'trips', mode: 'write' },
   })
   async updateDay(
-    { tripId, dayId, title }: { tripId: number; dayId: number; title: string | null },
+    { tripId, dayId, ...fields }: { tripId: number; dayId: number } & DayUpdateRequest,
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
     const current = this.days.getDay(dayId, tripId);
-    if (!current) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
-    const updated = this.days.update(dayId, current, { title });
+    if (!current) return errorResult('Day not found.');
+    // The rest spread carries only the keys the caller actually sent, which is
+    // what update()'s presence sentinels need: naming the two fields here would
+    // hand it an undefined notes on a title-only call and wipe the day's notes.
+    const updated = this.days.update(dayId, current, fields);
     this.guards.safeBroadcast(tripId, 'day:updated', { day: updated });
     return ok({ day: updated });
   }
 
   @Tool({
     name: 'create_day',
-    description: 'Add a new day to a trip (optionally with a specific date and notes).',
+    description: 'Add a day to a trip. Without `position` the day is appended at the end, optionally with a date and notes. With `position` an empty day is slotted in at that place instead, which is the way to add a day in the middle of an itinerary that already has days.',
     inputSchema: {
       tripId: z.number().int().positive(),
-      date: z.string().optional().describe('ISO date string YYYY-MM-DD, optional for dateless trips'),
-      notes: z.string().optional(),
+      date: dayCreateRequestSchema.shape.date.describe('ISO date string YYYY-MM-DD, optional for dateless trips'),
+      notes: dayCreateRequestSchema.shape.notes,
+      position: dayCreateRequestSchema.shape.position.describe('1-based slot to insert an empty day at; omit to append at the end. On a dated trip the days keep their calendar slots, so the trip gains one day at its end and bookings move with the day they sit on. date and notes are ignored when this is set, as on the REST route.'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     access: { group: 'trips', mode: 'write' },
   })
   async createDay(
-    { tripId, date, notes }: { tripId: number; date?: string; notes?: string },
+    { tripId, date, notes, position }: { tripId: number } & DayCreateRequest,
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
-    const day = this.days.create(tripId, date, notes);
-    this.guards.safeBroadcast(tripId, 'day:created', { day });
-    return ok({ day });
+    if (position === undefined) {
+      const day = this.days.create(tripId, date, notes);
+      this.guards.safeBroadcast(tripId, 'day:created', { day });
+      return ok({ day });
+    }
+    try {
+      const day = this.days.insert(tripId, position);
+      // An insert renumbers and re-dates every later day, so collaborators get
+      // the list-wide event and refetch, the same one the REST create route sends.
+      this.guards.safeBroadcast(tripId, 'day:reordered', { day });
+      return ok({ day });
+    } catch (err) {
+      // REST lets this bubble into a 500; a tool caller can act on the sentence.
+      if (err instanceof DayReorderError) return errorResult(err.message);
+      throw err;
+    }
+  }
+
+  @Tool({
+    name: 'reorder_days',
+    description: 'Reorder the days of a trip by listing every one of its day IDs in the desired order. This moves whole days of the itinerary; to move places around inside a single day use reorder_day_assignments instead. Each day keeps its places, notes, stays and bookings, and on a dated trip the calendar dates stay pinned to their slots, so the content moves across the dates.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      orderedIds: dayReorderRequestSchema.shape.orderedIds.min(1).describe('Every day ID of the trip, in the desired order'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async reorderDays(
+    { tripId, orderedIds }: { tripId: number } & DayReorderRequest,
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
+    try {
+      this.days.reorder(tripId, orderedIds);
+    } catch (err) {
+      // A non-permutation and an inverted stay are both the caller's input, so
+      // they come back as tool errors rather than a throw the SDK has to dress up.
+      if (err instanceof DayReorderError) return errorResult(err.message);
+      throw err;
+    }
+    // REST parity shape ({ orderedIds }): the client refetches the day list off it.
+    this.guards.safeBroadcast(tripId, 'day:reordered', { orderedIds });
+    return ok({ success: true });
   }
 
   @Tool({
@@ -96,7 +156,7 @@ export class DaysMcp {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
-    if (!this.days.getDay(dayId, tripId)) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
+    if (!this.days.getDay(dayId, tripId)) return errorResult('Day not found.');
     this.days.remove(dayId);
     // REST parity shape ({ dayId }) — the client reads payload.dayId, so the { id }
     // variant never removed the day from collaborator screens.
@@ -122,7 +182,7 @@ export class DaysMcp {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.days.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('day_edit', tripId, ctx.userId)) return permissionDenied();
-    if (!this.days.getDay(dayId, tripId)) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
+    if (!this.days.getDay(dayId, tripId)) return errorResult('Day not found.');
     const day = this.days.setDefaultTransportMode(dayId, transport_mode ?? null);
     this.guards.safeBroadcast(tripId, 'day:updated', { day });
     return ok({ day });

--- a/server/src/nest/feeds/feeds.mcp.ts
+++ b/server/src/nest/feeds/feeds.mcp.ts
@@ -1,0 +1,184 @@
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE, TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+  demoDenied, ok,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import { getAppUrl } from '../../app-config';
+import { DatabaseService } from '../database/database.service';
+import { RuntimeEnvService } from '../app-config/runtime-env.service';
+import { isDemoUserId } from '../common/demo-write';
+import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
+import { FeedsService } from './feeds.service';
+
+/**
+ * Calendar-feed MCP surface, mirroring the two authenticated token controllers
+ * in feeds.controller.ts. Not a port of a legacy registrar: the feeds domain
+ * never had MCP tools, so an assistant could produce a one-shot .ics snapshot
+ * (export_trip_ics) but could not switch on the live subscription the web UI
+ * offers, and the all-trips feed had no MCP counterpart at all.
+ *
+ * The two consumer routes (GET /api/feed/{trip,user}/:token.ics) stay out on
+ * purpose: they are the anonymous endpoints a calendar app polls, not something
+ * a model should call, and their only credential is the token in the URL.
+ *
+ * All eight ride `trips:share`. For the per-trip feed that follows the route,
+ * which requires share_manage on every verb including GET; the payload is the
+ * credential itself, and the credential is an anonymous read of the trip. The
+ * all-trips feed has no trip to hold a permission on (its routes are
+ * JwtAuthGuard only), but minting it publishes every trip the user can open
+ * behind one unauthenticated URL, so it takes the share scope rather than a
+ * read one.
+ */
+@McpController()
+export class FeedsMcp {
+  constructor(
+    private readonly feeds: FeedsService,
+    private readonly db: DatabaseService,
+    private readonly env: RuntimeEnvService,
+    private readonly guards: McpToolGuardsService,
+  ) {}
+
+  /** The AuthService.isDemoUser check without the auth graph (demo-write.ts). */
+  private isDemoUser(userId: number): boolean {
+    return isDemoUserId(this.env, this.db, userId);
+  }
+
+  /**
+   * The REST routes take the base URL from APP_URL and fall back to the calling
+   * request's own Host header. A tool call has no request to fall back to, so it
+   * uses the instance's canonical base-URL resolution (APP_URL, then the first
+   * allowed origin, then localhost) and always hands back an absolute,
+   * subscribable URL instead of a bare path.
+   */
+  private base(): string {
+    return getAppUrl();
+  }
+
+  /** Trip access first (404-equivalent), then share_manage, exactly as TripFeedTokenController is gated. */
+  private denyTripFeed(tripId: number, userId: number) {
+    if (!this.db.canAccessTrip(tripId, userId)) return noAccess();
+    if (!this.guards.hasTripPermission('share_manage', tripId, userId)) return permissionDenied();
+    return null;
+  }
+
+  // ── One trip's feed ──────────────────────────────────────────────────────
+
+  @Tool({
+    name: 'get_trip_calendar_feed',
+    description: 'Get the subscribable calendar feed URL of one trip, or null when the feed is switched off. This is a live subscription a calendar app re-reads hourly, so it keeps up with the itinerary. Prefer export_trip_ics when the user wants a one-off .ics file to import once and be done.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async getTripCalendarFeed({ tripId }: { tripId: number }, ctx: McpContext) {
+    const denied = this.denyTripFeed(tripId, ctx.userId);
+    if (denied) return denied;
+    return ok(this.feeds.getTripToken(String(tripId), ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'enable_trip_calendar_feed',
+    description: 'Switch on the subscribable calendar feed of one trip and return its URL. Safe to repeat: a trip that already has a feed keeps the URL it has, so subscriptions somebody already set up survive. The URL carries a secret token and asks for no login, so whoever holds it can read the trip\'s dates.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async enableTripCalendarFeed({ tripId }: { tripId: number }, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    const denied = this.denyTripFeed(tripId, ctx.userId);
+    if (denied) return denied;
+    return ok(this.feeds.generateTripToken(String(tripId), ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'rotate_trip_calendar_feed',
+    description: 'Issue a fresh URL for one trip\'s calendar feed. Every calendar subscribed to the old URL silently stops updating, so use this when the old link leaked or the user asked to cut it off, not to switch the feed on: enable_trip_calendar_feed does that without breaking anything.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async rotateTripCalendarFeed({ tripId }: { tripId: number }, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    const denied = this.denyTripFeed(tripId, ctx.userId);
+    if (denied) return denied;
+    return ok(this.feeds.rotateTripToken(String(tripId), ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'disable_trip_calendar_feed',
+    description: 'Switch off one trip\'s calendar feed. The URL stops resolving and every subscription to it breaks. Calling enable_trip_calendar_feed afterwards hands out a different URL, so everybody has to subscribe again.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async disableTripCalendarFeed({ tripId }: { tripId: number }, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    const denied = this.denyTripFeed(tripId, ctx.userId);
+    if (denied) return denied;
+    this.feeds.disableTripToken(String(tripId), ctx.userId);
+    // Matches the route, which answers the cleared token as a null URL.
+    return ok({ feed_url: null });
+  }
+
+  // ── The all-trips feed ───────────────────────────────────────────────────
+  // Per user, not per trip: one URL covering every unarchived trip the user
+  // owns or is a member of. No trip id, so no trip permission to check either.
+
+  @Tool({
+    name: 'get_all_trips_calendar_feed',
+    description: 'Get the subscribable calendar feed URL covering every trip the user can open, or null when it is switched off. One feed for the whole travel calendar; get_trip_calendar_feed is the per-trip one.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async getAllTripsCalendarFeed(_input: Record<string, never>, ctx: McpContext) {
+    return ok(this.feeds.getUserToken(ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'enable_all_trips_calendar_feed',
+    description: 'Switch on the calendar feed covering every trip the user can open and return its URL. Safe to repeat: an existing feed keeps its URL. The URL needs no login and follows the user\'s trips as they change, so a trip added later shows up in it without anyone re-subscribing.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async enableAllTripsCalendarFeed(_input: Record<string, never>, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    return ok(this.feeds.generateUserToken(ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'rotate_all_trips_calendar_feed',
+    description: 'Issue a fresh URL for the all-trips calendar feed. Every calendar subscribed to the old URL stops updating. Use it when that link leaked; enable_all_trips_calendar_feed is the way to switch the feed on without breaking existing subscriptions.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async rotateAllTripsCalendarFeed(_input: Record<string, never>, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    return ok(this.feeds.rotateUserToken(ctx.userId, this.base()));
+  }
+
+  @Tool({
+    name: 'disable_all_trips_calendar_feed',
+    description: 'Switch off the all-trips calendar feed. The URL stops resolving and every subscription to it breaks. Per-trip feeds are unaffected: disable_trip_calendar_feed switches those off one at a time.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'trips', mode: 'share' },
+  })
+  async disableAllTripsCalendarFeed(_input: Record<string, never>, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    this.feeds.disableUserToken(ctx.userId);
+    return ok({ feed_url: null });
+  }
+}

--- a/server/src/nest/feeds/feeds.module.ts
+++ b/server/src/nest/feeds/feeds.module.ts
@@ -1,16 +1,24 @@
 import { Module } from '@nestjs/common';
+import { AppConfigModule } from '../app-config/app-config.module';
 import { CalendarModule } from '../calendar/calendar.module';
 import { DatabaseModule } from '../database/database.module';
+import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { FeedsService } from './feeds.service';
+import { FeedsMcp } from './feeds.mcp';
 import { FeedsPublicController, TripFeedTokenController, UserFeedTokenController } from './feeds.controller';
 
 @Module({
   // Calendars, not the trip aggregate: feeds only ever needed an ICS string, and
   // importing TripsModule for it pulled budget, packing, places and the rest in.
   // Permissions comes in for TripAccessGuard, which gates the trip feed token.
-  imports: [CalendarModule, DatabaseModule, PermissionsModule],
+  // The last three are FeedsMcp's: McpSharedModule for the RBAC check the route
+  // gets from its guard, AppConfigModule and RealtimeModule because a module
+  // graph assembled without AppModule (the e2e harnesses) has to instantiate
+  // those two @Global modules itself before anything can inject out of them.
+  imports: [CalendarModule, DatabaseModule, PermissionsModule, McpSharedModule, AppConfigModule, RealtimeModule],
   controllers: [FeedsPublicController, TripFeedTokenController, UserFeedTokenController],
-  providers: [FeedsService],
+  providers: [FeedsService, FeedsMcp],
 })
 export class FeedsModule {}

--- a/server/src/nest/files/files.mcp.ts
+++ b/server/src/nest/files/files.mcp.ts
@@ -1,0 +1,218 @@
+import { z } from 'zod';
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE,
+  demoDenied, errorResult, ok,
+} from '../../nest-mcp';
+import { fileLinkRequestSchema, fileUpdateRequestSchema } from '@trek/shared';
+import type { FileLinkRequest, FileUpdateRequest } from '@trek/shared';
+import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
+import { AuthService } from '../auth/auth.service';
+import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { FilesService, FileContentError, FILE_CONTENT_MAX } from './files.service';
+
+const CONTENT_MAX_MB = Math.round(FILE_CONTENT_MAX / (1024 * 1024));
+
+/**
+ * Bytes worth handing over as text. Everything else goes back base64: a model
+ * can pass those on to a converter, but it cannot read them, and decoding a PDF
+ * as UTF-8 would spend the whole payload on replacement characters.
+ */
+function isTextual(mimetype: string): boolean {
+  return mimetype.startsWith('text/') || mimetype === 'application/json';
+}
+
+/** The MCP wording for a refused content read; the plugin RPC has its own for the same reasons. */
+function contentRefusal(err: FileContentError): string {
+  if (err.reason === 'too-large') {
+    return `File is too large to read here (over ${CONTENT_MAX_MB} MB). Ask the user to open it in TREK instead.`;
+  }
+  if (err.reason === 'not-accessible') return 'File contents are not available.';
+  return 'File not found.';
+}
+
+/**
+ * Trip-file MCP surface, mirroring /api/trips/:tripId/files. New rather than
+ * ported: the domain had no MCP tools at all, so an assistant could see a trip's
+ * bookings but not the confirmation PDF attached to one.
+ *
+ * Each tool reproduces its REST route's gates in the route's own order: trip
+ * access first (the 404 that keeps a stranger from learning a trip exists), then
+ * the file_edit right for the writes, then the row lookup scoped by :tripId. The
+ * two listing tools carry no file_* right because the routes they mirror carry
+ * none either; trip access is the whole gate there.
+ *
+ * There is no upload tool on purpose. MCP has no file transport, and an upload
+ * faked through base64 would be a second, unpoliced ingestion path beside the
+ * multipart route with its extension filter and per-type size caps.
+ */
+@McpController()
+export class FilesMcp {
+  constructor(
+    private readonly files: FilesService,
+    private readonly auth: AuthService,
+    private readonly guards: McpToolGuardsService,
+  ) {}
+
+  @Tool({
+    name: 'list_trip_files',
+    description: 'List the documents on a trip: name, type, size, who uploaded it, what it is attached to, whether it is starred, and when it was moved to the trash. This is the way to find a file ID; to read what is inside one, follow up with read_trip_file. Set trash to true to list the trip\'s deleted files instead of its live ones.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      trash: z.boolean().optional().default(false).describe('List the trash instead of the live files'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'files', mode: 'read' },
+  })
+  async listTripFiles({ tripId, trash }: { tripId: number; trash?: boolean }, ctx: McpContext) {
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    return ok({ files: this.files.listFiles(tripId, trash === true) });
+  }
+
+  @Tool({
+    name: 'read_trip_file',
+    description: `Read what is inside one uploaded document, e.g. a booking confirmation or a ticket. Text files come back as readable text, anything else base64-encoded, with "encoding" saying which. Files over ${CONTENT_MAX_MB} MB are refused outright, so point the user at the file in TREK rather than retrying. Reading contents is a separate permission from listing files, so this can be refused on a trip where list_trip_files works.`,
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      fileId: z.number().int().positive().describe('File ID from list_trip_files'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    // Not files:read. Listing what a trip carries and reading the bytes of a
+    // passport scan are different privileges, and the plugin host draws the same
+    // line (db:read:files vs db:read:files:content).
+    access: { group: 'files', mode: 'content' },
+  })
+  async readTripFile({ tripId, fileId }: { tripId: number; fileId: number }, ctx: McpContext) {
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    try {
+      const { name, mimetype, bytes } = await this.files.readContent(tripId, fileId);
+      const asText = isTextual(mimetype);
+      return ok({
+        file: {
+          id: fileId,
+          name,
+          mimetype,
+          size: bytes.length,
+          encoding: asText ? 'utf8' : 'base64',
+          content: bytes.toString(asText ? 'utf8' : 'base64'),
+        },
+      });
+    } catch (err) {
+      if (err instanceof FileContentError) return errorResult(contentRefusal(err));
+      throw err;
+    }
+  }
+
+  @Tool({
+    name: 'update_trip_file',
+    description: 'Set a file\'s description and attach it to a booking or a place. Fields left out keep their current value, null detaches. place_id and reservation_id are the file\'s primary attachment, the one the file manager shows next to it. To attach one document to several bookings or places at once, use link_trip_file instead.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      fileId: z.number().int().positive(),
+      description: fileUpdateRequestSchema.shape.description.describe('Free-text description, or an empty string to clear it'),
+      place_id: fileUpdateRequestSchema.shape.place_id.describe('Place on the same trip to attach the file to, or null to detach it'),
+      reservation_id: fileUpdateRequestSchema.shape.reservation_id.describe('Booking on the same trip to attach the file to, or null to detach it'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'files', mode: 'write' },
+  })
+  async updateTripFile(
+    { tripId, fileId, ...fields }: { tripId: number; fileId: number } & FileUpdateRequest,
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('file_edit', tripId, ctx.userId)) return permissionDenied();
+    const current = this.files.getFileById(fileId, tripId);
+    if (!current) return errorResult('File not found.');
+    // Same enforcement as the REST route's assertLinkTargets, through the same
+    // service method: a foreign reservation id would otherwise come back with its
+    // title attached the next time this file is listed.
+    const foreign = this.files.findForeignLinkTarget(tripId, {
+      reservation_id: fields.reservation_id,
+      place_id: fields.place_id,
+    });
+    if (foreign) return errorResult(`Linked item does not belong to this trip (${foreign}).`);
+    // The rest spread carries only the keys the caller actually sent, which is what
+    // updateFile's presence sentinels need: naming the fields here would hand it an
+    // undefined description on a link-only call and wipe the description.
+    const file = this.files.updateFile(fileId, current, fields);
+    this.guards.safeBroadcast(tripId, 'file:updated', { file });
+    return ok({ file });
+  }
+
+  @Tool({
+    name: 'link_trip_file',
+    description: 'Attach a file to one more booking, place or day assignment on the same trip, keeping every attachment it already has. Prefer update_trip_file when the document belongs to a single booking or place; use this one for a document that covers several, such as one group ticket or one rental agreement. Returns every link the file now carries.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      fileId: z.number().int().positive(),
+      reservation_id: fileLinkRequestSchema.shape.reservation_id.describe('Booking on the same trip'),
+      assignment_id: fileLinkRequestSchema.shape.assignment_id.describe('Day assignment (a place scheduled on a specific day) on the same trip'),
+      place_id: fileLinkRequestSchema.shape.place_id.describe('Place on the same trip'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'files', mode: 'write' },
+  })
+  async linkTripFile(
+    { tripId, fileId, ...targets }: { tripId: number; fileId: number } & FileLinkRequest,
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('file_edit', tripId, ctx.userId)) return permissionDenied();
+    if (!this.files.getFileById(fileId, tripId)) return errorResult('File not found.');
+    // The REST body allows all three to be absent and stores a link row pointing at
+    // nothing. A tool caller that gets here with no target made a mistake, and saying
+    // so is more useful than a success that attached the file to nothing.
+    if (!targets.reservation_id && !targets.assignment_id && !targets.place_id) {
+      return errorResult('Pass at least one of reservation_id, assignment_id or place_id.');
+    }
+    const foreign = this.files.findForeignLinkTarget(tripId, targets);
+    if (foreign) return errorResult(`Linked item does not belong to this trip (${foreign}).`);
+    const links = this.files.createFileLink(fileId, targets);
+    return ok({ success: true, links });
+  }
+
+  @Tool({
+    name: 'unlink_trip_file',
+    description: 'Remove one attachment between a file and a booking, place or day assignment. The file itself stays on the trip and its other attachments are untouched. Take linkId from list_trip_file_links, it is not the booking or place ID.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      fileId: z.number().int().positive(),
+      linkId: z.number().int().positive().describe('Link ID from list_trip_file_links'),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'files', mode: 'write' },
+  })
+  async unlinkTripFile(
+    { tripId, fileId, linkId }: { tripId: number; fileId: number; linkId: number },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('file_edit', tripId, ctx.userId)) return permissionDenied();
+    // deleteFileLink scopes by (linkId, fileId) only, so the file has to be resolved
+    // against :tripId first, exactly as the REST route does it. Otherwise a member of
+    // any trip could drop a link row belonging to a foreign trip's file.
+    if (!this.files.getFileById(fileId, tripId)) return errorResult('File not found.');
+    this.files.deleteFileLink(linkId, fileId);
+    return ok({ success: true });
+  }
+
+  @Tool({
+    name: 'list_trip_file_links',
+    description: 'List everything one file is attached to: bookings (with their title), places and day assignments, each with the linkId that unlink_trip_file needs. list_trip_files already reports the linked booking and place IDs, so reach for this one when you need the link IDs themselves.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      fileId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'files', mode: 'read' },
+  })
+  async listTripFileLinks({ tripId, fileId }: { tripId: number; fileId: number }, ctx: McpContext) {
+    if (!this.files.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.files.getFileById(fileId, tripId)) return errorResult('File not found.');
+    return ok({ links: this.files.getFileLinks(fileId) });
+  }
+}

--- a/server/src/nest/files/files.module.ts
+++ b/server/src/nest/files/files.module.ts
@@ -3,6 +3,9 @@ import { FilesController } from './files.controller';
 import { FilesDownloadController } from './files-download.controller';
 import { FilesService } from './files.service';
 import { FilesRpc } from './files.rpc';
+import { FilesMcp } from './files.mcp';
+import { AuthModule } from '../auth/auth.module';
+import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 import { PluginGuardsModule } from '../plugins/host/plugin-guards.module';
 import { RealtimeModule } from '../realtime/realtime.module';
 import { PermissionsModule } from '../permissions/permissions.module';
@@ -33,9 +36,12 @@ import { MAX_VIDEO_SIZE } from './files.constants';
         }),
     }),
     StorageModule,
-    EphemeralTokenModule, PermissionsModule, AppConfigModule, RealtimeModule, PluginGuardsModule],
+    // AuthModule + McpSharedModule feed FilesMcp's demo and RBAC guards. Neither is
+    // @Global, and AuthModule reaches this domain only through the leaf
+    // AllowedFileTypesModule, so importing it here stays cycle-free.
+    EphemeralTokenModule, PermissionsModule, AppConfigModule, RealtimeModule, PluginGuardsModule, AuthModule, McpSharedModule],
   controllers: [FilesController, FilesDownloadController],
-  providers: [FilesService, FilesRpc],
+  providers: [FilesService, FilesRpc, FilesMcp],
   exports: [FilesService],
 })
 export class FilesModule {}

--- a/server/src/nest/files/files.rpc.ts
+++ b/server/src/nest/files/files.rpc.ts
@@ -11,25 +11,15 @@ import { DatabaseService } from '../database/database.service';
 import { readEnv } from '../../app-config';
 import { isDemoEmail } from '../common/demo';
 import { BLOCKED_EXTENSIONS } from './files.constants';
-import { FilesService } from './files.service';
+// The read cap is the same number on both byte paths, so the upload side of
+// this surface reads it off the service that owns the read side.
+import { FilesService, FileContentError, FILE_CONTENT_MAX as CONTENT_MAX } from './files.service';
 import { StorageService } from '../storage/storage.service';
-import { StorageNotFoundError, StorageInvalidKeyError, type ObjectStat } from '../storage/storage.types';
 
 /** Files use three separate rights, one per operation, unlike every other domain. */
 const UPLOAD_ACTION = 'file_upload';
 const EDIT_ACTION = 'file_edit';
 const DELETE_ACTION = 'file_delete';
-
-/** Decoded bytes a plugin may read or write in one call. */
-const CONTENT_MAX = 10 * 1024 * 1024;
-
-type FileRow = {
-  filename: string;
-  original_name: string;
-  mime_type: string | null;
-  file_size: number | null;
-  deleted_at: string | null;
-};
 
 type CreateInput = {
   name: string;
@@ -77,53 +67,22 @@ export class FilesRpc {
   }
 
   /**
-   * Size-capped BEFORE the read, so a 500MB video cannot be pulled through the IPC
-   * pipe as ~667MB of base64. The bytes come from the storage layer, so this read
-   * works on remote backends too. The read itself runs off the event loop: 10MB of
-   * readFile plus base64 on the host thread would stall every other plugin RPC and
-   * every HTTP request for its duration.
+   * The cap, the storage read and the off-thread buffering live on FilesService,
+   * because the MCP read tool has to obey exactly the same rules and a second
+   * copy of them would drift. What stays here is the IPC wire shape and the two
+   * error types the plugin boundary knows how to encode: a refusal the caller
+   * caused (too large) is BAD_PARAMS, everything else RESOURCE_FORBIDDEN.
    */
   private async readContent(tripId: number, fileId: number): Promise<unknown> {
-    const file = this.files.getFileById(fileId, tripId) as FileRow | undefined;
-    if (!file || file.deleted_at) throw new ForbiddenResource(`no file ${fileId} on trip ${tripId}`);
-    if ((file.file_size ?? 0) > CONTENT_MAX) {
-      throw new BadParams(`file too large to read (>${CONTENT_MAX} bytes); use the download UI`);
-    }
-    let stream: Readable;
-    let stat: ObjectStat;
     try {
-      ({ stream, stat } = await this.storage.getStream('files', pathMod.basename(file.filename)));
+      const { name, mimetype, bytes } = await this.files.readContent(tripId, fileId);
+      return { name, mimetype, size: bytes.length, content_base64: bytes.toString('base64') };
     } catch (err) {
-      if (err instanceof StorageNotFoundError || err instanceof StorageInvalidKeyError) {
-        throw new ForbiddenResource('file path is not accessible');
+      if (err instanceof FileContentError) {
+        throw err.reason === 'too-large' ? new BadParams(err.message) : new ForbiddenResource(err.message);
       }
       throw err;
     }
-    // Re-checked against the OBJECT, not the DB row: file_size can drift.
-    if (stat.size > CONTENT_MAX) {
-      stream.destroy();
-      throw new BadParams(`file too large to read (>${CONTENT_MAX} bytes); use the download UI`);
-    }
-    const chunks: Buffer[] = [];
-    let total = 0;
-    for await (const chunk of stream) {
-      const part = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
-      total += part.length;
-      // A driver whose stat under-reports must not push an oversized payload
-      // through the IPC pipe: abort as soon as the running total crosses the cap.
-      if (total > CONTENT_MAX) {
-        stream.destroy();
-        throw new BadParams('file too large to read');
-      }
-      chunks.push(part);
-    }
-    const buf = Buffer.concat(chunks);
-    return {
-      name: file.original_name,
-      mimetype: file.mime_type ?? 'application/octet-stream',
-      size: buf.length,
-      content_base64: buf.toString('base64'),
-    };
   }
 
   @PluginMethod('files.create', { permission: 'db:write:files' })

--- a/server/src/nest/files/files.service.ts
+++ b/server/src/nest/files/files.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import path from 'path';
+import type { Readable } from 'node:stream';
 import type { Request } from 'express';
 import type { TrekWsPayload, TrekWsTripEventName } from '@trek/shared';
 import { RealtimeService } from '../realtime/realtime.service';
@@ -11,6 +12,7 @@ import type { User, TripFile } from '../../types';
 import { DatabaseService, type TripAccess } from '../database/database.service';
 import { DEFAULT_ALLOWED_EXTENSIONS } from './files.constants';
 import { StorageService } from '../storage/storage.service';
+import { StorageNotFoundError, StorageInvalidKeyError, type ObjectStat } from '../storage/storage.types';
 
 type Trip = TripAccess;
 type FilePermission = 'file_upload' | 'file_edit' | 'file_delete';
@@ -35,6 +37,21 @@ export interface FileLink {
   file_id: number;
   reservation_id: number | null;
   place_id: number | null;
+}
+
+/**
+ * Decoded bytes one non-HTTP caller may pull out of a file in a single read.
+ * The browser download streams instead and is not bound by this.
+ */
+export const FILE_CONTENT_MAX = 10 * 1024 * 1024;
+
+/** Why a content read was refused. Each caller maps it onto its own error shape. */
+export type FileContentRefusal = 'not-found' | 'too-large' | 'not-accessible';
+
+export class FileContentError extends Error {
+  constructor(readonly reason: FileContentRefusal, message: string) {
+    super(message);
+  }
 }
 
 /**
@@ -144,6 +161,64 @@ export class FilesService {
 
   getDeletedFile(id: string | number, tripId: string | number): TripFile | undefined {
     return this.db.get<TripFile>('SELECT * FROM trip_files WHERE id = ? AND trip_id = ? AND deleted_at IS NOT NULL', id, tripId);
+  }
+
+  /**
+   * A file's bytes for a caller that is not the browser download.
+   *
+   * Shared by the plugin RPC (ctx.files.getContent) and the MCP read tool so the
+   * rules exist once. Three of them matter. The size is capped BEFORE the read,
+   * so a 500MB video is never pulled into memory just to be refused afterwards.
+   * The bytes come from the storage layer rather than from disk, so this keeps
+   * working on S3 or a mirrored pair. And the read runs off the event loop:
+   * 10MB of readFile on the host thread stalls every other request for its
+   * duration.
+   *
+   * Access is the caller's job. REST-side that is trip access plus the file
+   * row being on the trip, which the getFileById lookup below re-checks.
+   */
+  async readContent(
+    tripId: string | number,
+    fileId: string | number,
+  ): Promise<{ name: string; mimetype: string; bytes: Buffer }> {
+    const file = this.getFileById(fileId, tripId);
+    if (!file || file.deleted_at) throw new FileContentError('not-found', `no file ${fileId} on trip ${tripId}`);
+    if ((file.file_size ?? 0) > FILE_CONTENT_MAX) {
+      throw new FileContentError('too-large', `file too large to read (>${FILE_CONTENT_MAX} bytes); use the download UI`);
+    }
+    let stream: Readable;
+    let stat: ObjectStat;
+    try {
+      ({ stream, stat } = await this.storage.getStream('files', path.basename(file.filename)));
+    } catch (err) {
+      if (err instanceof StorageNotFoundError || err instanceof StorageInvalidKeyError) {
+        throw new FileContentError('not-accessible', 'file path is not accessible');
+      }
+      throw err;
+    }
+    // Re-checked against the OBJECT, not the DB row: file_size can drift.
+    if (stat.size > FILE_CONTENT_MAX) {
+      stream.destroy();
+      throw new FileContentError('too-large', `file too large to read (>${FILE_CONTENT_MAX} bytes); use the download UI`);
+    }
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of stream) {
+      const part = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+      total += part.length;
+      // A driver whose stat under-reports must not hand back an oversized
+      // payload: abort as soon as the running total crosses the cap.
+      if (total > FILE_CONTENT_MAX) {
+        stream.destroy();
+        throw new FileContentError('too-large', 'file too large to read');
+      }
+      chunks.push(part);
+    }
+    return {
+      name: file.original_name,
+      mimetype: file.mime_type ?? 'application/octet-stream',
+      bytes: Buffer.concat(chunks),
+    };
   }
 
   listFiles(tripId: string | number, showTrash: boolean) {

--- a/server/src/nest/help/help.mcp.ts
+++ b/server/src/nest/help/help.mcp.ts
@@ -1,0 +1,95 @@
+import { McpController, Tool, TOOL_ANNOTATIONS_READONLY, errorResult, ok, type McpContext } from '../../nest-mcp';
+import { z } from 'zod';
+import { getWikiIndex, getWikiPage, WikiNotFound, type WikiPage } from './wiki';
+
+/**
+ * Help MCP surface over the bundled wiki, reading through the same functions
+ * HelpController does (GET /api/help/index, GET /api/help/page/:slug).
+ *
+ * Neither tool declares an `access` marker, so both stay registered for every
+ * session. Both routes are @Public and serve versioned product documentation
+ * with no user data in it, so there is no permission to mirror; borrowing some
+ * other domain's read scope would hide the manual from tokens that were never
+ * meant to be denied it, and protect nothing. list_trips and get_trip_summary
+ * are registered the same way, for the same reason: a client needs them to find
+ * its bearings before it knows what else to ask for.
+ *
+ * No injected service, like airports.mcp.ts: the help domain is a set of plain
+ * readers over the `wiki/` directory rather than a provider.
+ *
+ * GET /api/help/asset/* has no tool on purpose. It answers with image bytes for
+ * an <img> tag, which is not something a tool result carries.
+ */
+
+/**
+ * Plugin-Development.md alone is 100 KB, and a tool result lands directly in a
+ * model's context window. Hand back a slice and let the caller ask for the rest
+ * rather than deciding on its behalf that the tail does not matter.
+ */
+const HELP_PAGE_CHARS = 40_000;
+
+@McpController()
+export class HelpMcp {
+  @Tool({
+    name: 'list_help_topics',
+    description:
+      'List the table of contents of the TREK user manual bundled with this instance: sections, page titles, and the slugs get_help_page takes. Start here when the user asks how something in TREK works or how to do something in the app, then read the matching page. This is documentation about the product, never the user\'s own data: for that use list_trips or get_trip_summary.',
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+  })
+  async listHelpTopics(_args: Record<string, never>, _ctx: McpContext) {
+    try {
+      const { sections } = await getWikiIndex();
+      return ok({ sections });
+    } catch {
+      // The route lets this reach the global error envelope; a tool has to
+      // answer, and a missing sidebar reads to a model like any other
+      // unavailability.
+      return errorResult('Help contents unavailable.');
+    }
+  }
+
+  @Tool({
+    name: 'get_help_page',
+    description:
+      'Read one page of the bundled TREK user manual as markdown, addressed by a slug from list_help_topics. Prefer it over answering from memory whenever the user asks how a TREK feature behaves: the pages ship with the running version, so they describe this instance rather than some other release. Long pages arrive in chunks, so when the result says truncated, call again with next_offset.',
+    inputSchema: {
+      slug: z.string().min(1).max(120).describe('Page slug as reported by list_help_topics, e.g. "Quick-Start"'),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Character offset to resume from after a truncated result. Defaults to 0, the start of the page.'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+  })
+  async getHelpPage({ slug, offset }: { slug: string; offset?: number }, _ctx: McpContext) {
+    const from = offset ?? 0;
+    let page: WikiPage;
+    try {
+      page = await getWikiPage(slug);
+    } catch (err) {
+      // The route collapses both into "Help page unavailable" with a 404/502
+      // split in the status. A model cannot read the status, and only one of
+      // the two is worth retrying with a different slug, so say which it is.
+      if (err instanceof WikiNotFound)
+        return errorResult(`No help page named "${slug}". Call list_help_topics for the slugs this instance ships.`);
+      return errorResult('Help page unavailable.');
+    }
+
+    const full = page.markdown;
+    if (from > 0 && from >= full.length)
+      return errorResult(`Offset ${from} is past the end of "${page.slug}", which is ${full.length} characters long.`);
+
+    const markdown = full.slice(from, from + HELP_PAGE_CHARS);
+    const truncated = from + markdown.length < full.length;
+    return ok({
+      slug: page.slug,
+      title: page.title,
+      markdown,
+      truncated,
+      next_offset: truncated ? from + markdown.length : null,
+    });
+  }
+}

--- a/server/src/nest/help/help.module.ts
+++ b/server/src/nest/help/help.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
 import { HelpController } from './help.controller';
+import { HelpMcp } from './help.mcp';
 
-/** /api/help — the bundled `wiki/` directory, read via ./wiki. */
+/**
+ * /api/help serves the bundled `wiki/` directory, read via ./wiki. HelpMcp puts the
+ * same index and page reads on the MCP surface; it injects nothing, so the
+ * module stays a leaf.
+ */
 @Module({
   controllers: [HelpController],
+  providers: [HelpMcp],
 })
 export class HelpModule {}

--- a/server/src/nest/integrations/airtrail.mcp.ts
+++ b/server/src/nest/integrations/airtrail.mcp.ts
@@ -1,0 +1,117 @@
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+  errorResult, ok,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import type { AirtrailFlight } from '@trek/shared';
+import { ADDON_IDS } from '../../addons';
+import { addonGate } from '../addons/addon-gate';
+import { AddonsService } from '../addons/addons.service';
+import { AirtrailService } from './airtrail.service';
+
+/** Same gate as the controller's @RequireAddon(ADDON_IDS.AIRTRAIL): no addon, no tool. */
+const airtrailAddonOn = addonGate(ADDON_IDS.AIRTRAIL);
+
+/**
+ * An AirTrail history grows for years, and the whole of it in one tool result
+ * is context a model pays for on every turn. The picker in the browser can
+ * afford the full list because a human scrolls it; a tool caller gets a window
+ * and is told when the window cut something off.
+ */
+const DEFAULT_FLIGHT_LIMIT = 100;
+const MAX_FLIGHT_LIMIT = 500;
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use an ISO date, YYYY-MM-DD');
+
+/** The calendar day a flight belongs to, preferring AirTrail's own `date` over the departure instant. */
+function flightDate(flight: AirtrailFlight): string | null {
+  return flight.date ?? (flight.departure ? flight.departure.slice(0, 10) : null);
+}
+
+/**
+ * Chronological, undated flights last. The window and the cap are only
+ * meaningful over a stable order, and AirTrail returns its list in whatever
+ * order its query produced.
+ */
+function byDeparture(a: AirtrailFlight, b: AirtrailFlight): number {
+  const left = a.departure ?? a.date;
+  const right = b.departure ?? b.date;
+  if (!left && !right) return 0;
+  if (!left) return 1;
+  if (!right) return -1;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/**
+ * AirTrail MCP surface: the read half of the flight import, mirroring
+ * GET /api/integrations/airtrail/flights (airtrail.controller.ts). Same
+ * per-user scoping the route has (the flights are fetched with the caller's
+ * own stored key, so a tool can only ever see that caller's own history), and
+ * the same addon gate, expressed as `when:` so a disabled addon hides the tool
+ * instead of answering it.
+ *
+ * The write half is not here: the import is trip-scoped and lives on the
+ * /api/trips/:tripId/reservations/import prefix, so its tool sits in
+ * reservation-import/ with the controller that owns that route.
+ *
+ * The connection settings routes (GET/PUT settings, status, test, sync) stay
+ * off MCP on purpose: they take an API key, and the key is exactly the thing
+ * settings:write promises never to touch.
+ */
+@McpController()
+export class AirtrailMcp {
+  constructor(
+    private readonly airtrail: AirtrailService,
+    readonly addons: AddonsService,
+  ) {}
+
+  @Tool({
+    name: 'list_airtrail_flights',
+    description: 'List the flights in the caller\'s connected AirTrail account, which are the ones available to import into a trip. Each entry carries the id that import_airtrail_flights takes, plus route, times, airline and flight number, so call this first and pass the ids you picked to that tool. Use it for flights that have already been flown or booked and recorded in AirTrail; a flight that exists nowhere yet is created with create_transport instead. Narrow it with from/to to the trip window rather than pulling a whole flight history.',
+    inputSchema: {
+      from: isoDate.optional().describe('Only flights departing on or after this date'),
+      to: isoDate.optional().describe('Only flights departing on or before this date'),
+      limit: z.number().int().min(1).max(MAX_FLIGHT_LIMIT).optional()
+        .describe(`Maximum flights to return, oldest departure first (default ${DEFAULT_FLIGHT_LIMIT}, max ${MAX_FLIGHT_LIMIT})`),
+    },
+    // Reads a remote AirTrail instance, not TREK's own database.
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    // The flights are candidate bookings and the import writes reservations, so
+    // the pair rides one group. There is no airtrail scope, and settings:read
+    // covers preferences rather than travel data.
+    access: { group: 'reservations', mode: 'read' },
+    when: airtrailAddonOn,
+  })
+  async listAirtrailFlights(
+    { from, to, limit }: { from?: string; to?: string; limit?: number },
+    ctx: McpContext,
+  ) {
+    let flights: AirtrailFlight[];
+    try {
+      flights = await this.airtrail.getFlightsForPicker(ctx.userId);
+    } catch (err) {
+      // The route dresses this as a 400 or a 502; a tool caller can act on the
+      // sentence, which already says whether AirTrail is unconnected or unreachable.
+      return errorResult((err as Error)?.message || 'Could not load AirTrail flights');
+    }
+
+    // A flight with no date at all cannot be proven outside the window, and
+    // dropping it would lose it silently, so it stays in and sorts last.
+    const matched = flights.filter(flight => {
+      const date = flightDate(flight);
+      if (!date) return true;
+      if (from && date < from) return false;
+      if (to && date > to) return false;
+      return true;
+    }).sort(byDeparture);
+
+    const cap = limit ?? DEFAULT_FLIGHT_LIMIT;
+    const page = matched.slice(0, cap);
+    return ok({
+      flights: page,
+      total: matched.length,
+      truncated: matched.length > page.length,
+    });
+  }
+}

--- a/server/src/nest/integrations/airtrail.module.ts
+++ b/server/src/nest/integrations/airtrail.module.ts
@@ -4,6 +4,7 @@ import { AirtrailCoreModule } from './airtrail-core.module';
 import { AirtrailSyncService } from './airtrail-sync.service';
 import { AirtrailSyncJob } from './airtrail-sync.job';
 import { AirtrailImportService } from './airtrail-import.service';
+import { AirtrailMcp } from './airtrail.mcp';
 import { SchedulingModule } from '../scheduling/scheduling.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { AddonsModule } from '../addons/addons.module';
@@ -26,7 +27,7 @@ import { ReservationsModule } from '../reservations/reservations.module';
 @Module({
   imports: [AirtrailCoreModule, PermissionsModule, AddonsModule, AuditModule, ReservationsModule, SchedulingModule],
   controllers: [AirtrailController],
-  providers: [AirtrailSyncService, AirtrailSyncJob, AirtrailImportService],
+  providers: [AirtrailSyncService, AirtrailSyncJob, AirtrailImportService, AirtrailMcp],
   exports: [AirtrailSyncService, AirtrailImportService],
 })
 export class AirtrailModule {}

--- a/server/src/nest/journey/journey.mcp.ts
+++ b/server/src/nest/journey/journey.mcp.ts
@@ -45,6 +45,28 @@ function jsonContent(uri: string, data: unknown) {
   };
 }
 
+/*
+ * The three entry fields with a fixed set of values. `journey_entries.type` and
+ * `.visibility` are plain TEXT columns and the REST route forwards whatever the
+ * client sent, but the row type (JourneyEntry in src/types) only ever models
+ * these, so the tools name them rather than take a free string: a model that
+ * invents "friends-only" would write a value nothing reads.
+ */
+const ENTRY_TYPE = z.enum(['entry', 'checkin', 'skeleton']);
+const ENTRY_VISIBILITY = z.enum(['private', 'shared', 'public']);
+type EntryType = z.infer<typeof ENTRY_TYPE>;
+type EntryVisibility = z.infer<typeof ENTRY_VISIBILITY>;
+
+/**
+ * The verdict on a place. Either side defaults to empty so a caller can send
+ * only the half it has, which is what the entry editor does when a place was
+ * all good or all bad. The service stores nothing when both come back empty.
+ */
+const PROS_CONS = z.object({
+  pros: z.array(z.string()).default([]),
+  cons: z.array(z.string()).default([]),
+});
+
 /**
  * Journey MCP surface — ported 1:1 from the legacy registrar
  * src/mcp/tools/journey.ts (23 tools): identical names, descriptions, zod input
@@ -55,6 +77,11 @@ function jsonContent(uri: string, data: unknown) {
  * marker could not express, and folding it into a predicate would have put it
  * out of reach of the boot-time scope gate. The registration-time addon
  * early-return becomes the `when:` gate.
+ *
+ * Since the port the surface has grown past the legacy 23: the two entry tools
+ * take the rest of the columns their REST routes always accepted (a place, its
+ * coordinates, weather, tags, the verdict), and get_journey_stats answers what
+ * GET /api/journeys/:id/stats answers.
  */
 @McpController()
 export class JourneyMcp {
@@ -91,6 +118,28 @@ export class JourneyMcp {
     const journey = this.journey.getJourneyFull(journeyId, ctx.userId);
     if (!journey) return notFound('Journey not found or access denied.');
     return ok({ journey });
+  }
+
+  @Tool({
+    name: 'get_journey_stats',
+    description: 'What a journey adds up to: distance travelled in metres, calendar days spanned, countries in visit order, the furthest point reached, and entry, photo and place counts. Prefer this over get_journey whenever the question is about totals, since the stats get_journey carries are three counts and nothing else.',
+    inputSchema: {
+      journeyId: z.number().int().positive(),
+      include_route: z.boolean().optional().describe('Also return the route itself, up to 400 stops with coordinates. Off by default: the totals and the country list do not need it.'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    when: journeyAddonOn,
+    access: { group: 'journey', mode: 'read' },
+  })
+  getJourneyStats({ journeyId, include_route }: { journeyId: number; include_route?: boolean }, ctx: McpContext) {
+    const stats = this.journey.journeyStats(journeyId, ctx.userId);
+    if (!stats) return notFound('Journey not found or access denied.');
+    // Same payload as GET /api/journeys/:id/stats. The route is left out unless
+    // it was asked for: 400 coordinate pairs answer a different question than
+    // the totals do, and Studio is the caller that actually draws them.
+    if (include_route) return ok({ stats });
+    const { points: _route, ...totals } = stats;
+    return ok({ stats: totals });
   }
 
   @Tool({
@@ -237,7 +286,7 @@ export class JourneyMcp {
 
   @Tool({
     name: 'create_journey_entry',
-    description: 'Create a new entry in a journey.',
+    description: 'Create a new entry in a journey. Give location_lat/location_lng whenever the place is known, otherwise the entry is text-only and never appears on the journey map or in its distance.',
     inputSchema: {
       journeyId: z.number().int().positive(),
       entry_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Entry date (YYYY-MM-DD)'),
@@ -245,7 +294,14 @@ export class JourneyMcp {
       story: z.string().optional(),
       entry_time: z.string().optional().describe('Time of day (e.g. "14:30")'),
       location_name: z.string().optional(),
+      location_lat: z.number().min(-90).max(90).optional().describe('Latitude; needed, with location_lng, to place the entry on the journey map'),
+      location_lng: z.number().min(-180).max(180).optional(),
       mood: z.string().optional(),
+      weather: z.string().max(100).optional().describe('Weather as the traveller recorded it (e.g. "sunny", "24C and windy")'),
+      tags: z.array(z.string()).optional(),
+      pros_cons: PROS_CONS.optional().describe('The verdict on the place: what was worth it and what was not'),
+      visibility: ENTRY_VISIBILITY.optional().describe('Defaults to private; "shared" and "public" expose the entry through the journey share link'),
+      type: ENTRY_TYPE.optional().describe('Defaults to "entry"; "skeleton" is the stub TREK derives from a trip place and hides behind the hide-skeletons preference'),
       sort_order: z.number().int().min(0).optional(),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
@@ -253,7 +309,12 @@ export class JourneyMcp {
     access: { group: 'journey', mode: 'write' },
   })
   createJourneyEntry(
-    { journeyId, ...data }: { journeyId: number; entry_date: string; title?: string; story?: string; entry_time?: string; location_name?: string; mood?: string; sort_order?: number },
+    { journeyId, ...data }: {
+      journeyId: number; entry_date: string; title?: string; story?: string; entry_time?: string;
+      location_name?: string; location_lat?: number; location_lng?: number; mood?: string; weather?: string;
+      tags?: string[]; pros_cons?: { pros: string[]; cons: string[] }; visibility?: EntryVisibility;
+      type?: EntryType; sort_order?: number;
+    },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
@@ -266,21 +327,36 @@ export class JourneyMcp {
 
   @Tool({
     name: 'update_journey_entry',
-    description: 'Update an existing journey entry.',
+    description: 'Update an existing journey entry: its text, date, place, coordinates, weather, tags, verdict or visibility. Fields left out keep their value; pass null to clear one. To move an entry within its day use reorder_journey_entries rather than setting sort_order here.',
     inputSchema: {
       entryId: z.number().int().positive(),
-      title: z.string().max(300).optional(),
-      story: z.string().optional(),
+      title: z.string().max(300).nullable().optional(),
+      story: z.string().nullable().optional(),
       entry_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-      entry_time: z.string().optional(),
-      mood: z.string().optional(),
+      entry_time: z.string().nullable().optional(),
+      location_name: z.string().nullable().optional(),
+      location_lat: z.number().min(-90).max(90).nullable().optional().describe('Latitude, or null to take the entry off the journey map'),
+      location_lng: z.number().min(-180).max(180).nullable().optional(),
+      mood: z.string().nullable().optional(),
+      weather: z.string().max(100).nullable().optional(),
+      tags: z.array(z.string()).nullable().optional(),
+      pros_cons: PROS_CONS.nullable().optional().describe('Replaces the whole verdict; null clears it'),
+      visibility: ENTRY_VISIBILITY.optional(),
+      type: ENTRY_TYPE.optional().describe('Promote a trip-derived "skeleton" to a real "entry" once it has been written up'),
+      sort_order: z.number().int().min(0).optional(),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     when: journeyAddonOn,
     access: { group: 'journey', mode: 'write' },
   })
   updateJourneyEntry(
-    { entryId, ...data }: { entryId: number; title?: string; story?: string; entry_date?: string; entry_time?: string; mood?: string },
+    { entryId, ...data }: {
+      entryId: number; title?: string | null; story?: string | null; entry_date?: string;
+      entry_time?: string | null; location_name?: string | null; location_lat?: number | null;
+      location_lng?: number | null; mood?: string | null; weather?: string | null;
+      tags?: string[] | null; pros_cons?: { pros: string[]; cons: string[] } | null;
+      visibility?: EntryVisibility; type?: EntryType; sort_order?: number;
+    },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();

--- a/server/src/nest/journey/journey.mcp.ts
+++ b/server/src/nest/journey/journey.mcp.ts
@@ -12,6 +12,7 @@ import type { JourneyContributor } from '../../types';
 import { addonGate } from '../addons/addon-gate';
 import { AddonsService } from '../addons/addons.service';
 import { AuthService } from '../auth/auth.service';
+import { PhotoCaptureBackfillService } from '../memories/photo-capture-backfill.service';
 
 /** Legacy registrar gate: the whole journey surface rode the journey addon. */
 const journeyAddonOn = addonGate(ADDON_IDS.JOURNEY);
@@ -68,6 +69,20 @@ const PROS_CONS = z.object({
 });
 
 /**
+ * The photo backends a journey can reference. The REST route forwards whatever
+ * `provider` string the body carried straight into `trek_photos.provider`, which
+ * would let a model persist a row no resolver can ever match to a backend.
+ */
+const PHOTO_PROVIDER = z.enum(['immich', 'synologyphotos']);
+
+/**
+ * How many provider assets one call may attach. The REST route takes an
+ * unbounded array, but it is driven by a picker where every id was clicked;
+ * a tool call is not, and each id is a row plus a detached provider lookup.
+ */
+const MAX_PROVIDER_PHOTOS_PER_CALL = 100;
+
+/**
  * Journey MCP surface — ported 1:1 from the legacy registrar
  * src/mcp/tools/journey.ts (23 tools): identical names, descriptions, zod input
  * schemas, annotations, and error/payload shapes. The legacy `if (R)` / `if (W)`
@@ -82,6 +97,11 @@ const PROS_CONS = z.object({
  * take the rest of the columns their REST routes always accepted (a place, its
  * coordinates, weather, tags, the verdict), and get_journey_stats answers what
  * GET /api/journeys/:id/stats answers.
+ *
+ * So does add_journey_provider_photos, which brings across
+ * POST /api/journeys/entries/:entryId/provider-photos and its gallery twin
+ * POST /api/journeys/:id/gallery/provider-photos. Finding the asset ids it takes
+ * is the memories domain's half of the same job, in memories/memories.mcp.ts.
  */
 @McpController()
 export class JourneyMcp {
@@ -90,6 +110,7 @@ export class JourneyMcp {
     private readonly share: JourneyShareService,
     readonly addons: AddonsService,
     private readonly auth: AuthService,
+    private readonly captureBackfill: PhotoCaptureBackfillService,
   ) {}
 
   // ── Read ────────────────────────────────────────────────────────────────
@@ -478,6 +499,61 @@ export class JourneyMcp {
     if (!result) return notFound('Journey not found or access denied.');
     // Return the service result ({ hide_skeletons }), matching the REST route.
     return ok(result);
+  }
+
+  @Tool({
+    name: 'add_journey_provider_photos',
+    description: 'Attach photos from a connected library (Immich or Synology Photos) to a journey: to one entry when entryId is given, otherwise to the journey gallery only. Find the asset ids first with search_provider_photos or list_provider_album_photos. No image data passes through here, the journey stores a reference and the app fetches the picture, so this also works for photos far too large to hand to a model. An asset already attached is skipped rather than duplicated, which makes re-running the same call safe.',
+    inputSchema: {
+      journeyId: z.number().int().positive(),
+      entryId: z.number().int().positive().optional().describe('Attach to this entry, which must belong to journeyId. The photo lands in the journey gallery either way; omitting this adds it to the gallery alone'),
+      provider: PHOTO_PROVIDER.describe('The library the asset ids came from'),
+      asset_ids: z.array(z.string().min(1)).min(1).max(MAX_PROVIDER_PHOTOS_PER_CALL).describe('Provider asset ids, as returned by the search and album tools'),
+      media_types: z.array(z.enum(['image', 'video'])).optional().describe('Parallel to asset_ids; anything not named here counts as an image'),
+      caption: z.string().max(500).optional().describe('Stored only when entryId is given, matching the REST routes: the gallery add records no caption'),
+      passphrase: z.string().min(1).optional().describe('Only for a Synology Photos album shared with the user: the passphrase list_provider_albums returned for that album'),
+    },
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    when: journeyAddonOn,
+    access: { group: 'journey', mode: 'write' },
+  })
+  addJourneyProviderPhotos(
+    { journeyId, entryId, provider, asset_ids, media_types, caption, passphrase }: {
+      journeyId: number; entryId?: number; provider: z.infer<typeof PHOTO_PROVIDER>;
+      asset_ids: string[]; media_types?: Array<'image' | 'video'>; caption?: string; passphrase?: string;
+    },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    // The REST routes derive the journey from the entry and let each per-asset
+    // add answer for itself, which in the array branch means a caller with no
+    // access gets an empty 200. Checking up front instead turns that silence
+    // into a sentence, and is what makes journeyId worth asking for: the entry
+    // has to be shown to belong to it before anything is written.
+    if (!this.journey.canEdit(journeyId, ctx.userId)) return notFound('Journey not found or access denied.');
+    if (entryId !== undefined && !this.journey.listEntries(journeyId, ctx.userId)?.some(e => e.id === entryId)) {
+      return notFound('Entry not found in this journey.');
+    }
+
+    const photos: unknown[] = [];
+    asset_ids.forEach((assetId, i) => {
+      const mediaType = media_types?.[i] === 'video' ? 'video' : 'image';
+      const photo = entryId === undefined
+        ? this.journey.addProviderPhotoToGallery(journeyId, ctx.userId, provider, assetId, undefined, passphrase, mediaType)
+        : this.journey.addProviderPhoto(entryId, ctx.userId, provider, assetId, caption, passphrase, mediaType);
+      if (photo) photos.push(photo);
+    });
+
+    // Detached, exactly as the REST routes schedule it: the provider is asked
+    // when and where each photo was taken, and without that answer an attached
+    // photo can never appear on the journey map (#1614).
+    this.captureBackfill.schedule(
+      photos.map(p => (p as { photo_id?: number }).photo_id).filter((id): id is number => typeof id === 'number'),
+      ctx.userId,
+    );
+    // `skipped` is what tells a caller that a shortfall was duplicates rather
+    // than a failure; the REST body carries only photos and added.
+    return ok({ photos, added: photos.length, skipped: asset_ids.length - photos.length });
   }
 
   // ── Share links (journey:share, not implied by journey:write) ────────────

--- a/server/src/nest/maps/maps.mcp.ts
+++ b/server/src/nest/maps/maps.mcp.ts
@@ -1,5 +1,6 @@
-import { McpController, Tool, TOOL_ANNOTATIONS_READONLY, ok, type McpContext } from '../../nest-mcp';
+import { McpController, Tool, TOOL_ANNOTATIONS_READONLY, errorResult, ok, type McpContext } from '../../nest-mcp';
 import { z } from 'zod';
+import { POI_CATEGORY_KEYS } from './maps.helpers';
 import { MapsService } from './maps.service';
 
 /**
@@ -16,16 +17,38 @@ export class MapsMcp {
 
   @Tool({
     name: 'get_place_details',
-    description: 'Fetch detailed information about a place by its Google Place ID.',
+    description: 'Fetch detailed information about a place by its Google Place ID. The plain lookup returns name, address, coordinates, rating, opening hours, phone and website, and always answers with an empty review list. Set expand only when visitor reviews or the editorial summary are what was actually asked for: that field mask bills as a Google Enterprise SKU and costs the instance owner several times a plain lookup.',
     inputSchema: {
       placeId: z.string().describe('Google Place ID'),
       lang: z.string().optional().default('en'),
+      expand: z.boolean().optional().default(false).describe('Also fetch up to five visitor reviews and the editorial summary. Billed as an Enterprise SKU, so leave it off unless the answer needs them'),
+      refresh: z.boolean().optional().default(false).describe('Bypass the cached expanded payload and re-fetch from the provider. Only does anything together with expand, and pays the expanded price again'),
     },
     annotations: TOOL_ANNOTATIONS_READONLY,
     access: { group: 'geo', mode: 'read' },
   })
-  async getPlaceDetails({ placeId, lang }: { placeId: string; lang?: string }, ctx: McpContext) {
-    const details = await this.maps.getPlaceDetails(ctx.userId, placeId, lang ?? 'en');
+  async getPlaceDetails(
+    { placeId, lang, expand, refresh }: { placeId: string; lang?: string; expand?: boolean; refresh?: boolean },
+    ctx: McpContext,
+  ) {
+    // The admin kill switch, checked before either path. An instance owner who
+    // turns Place Details off does it to stop Google billing them, and an
+    // assistant reaching the provider anyway would bill them from the one
+    // surface the switch does not cover. REST answers { place: null, disabled }
+    // rather than an error, so this does too, with a line the model can act on.
+    if (this.maps.detailsDisabled()) {
+      return ok({
+        details: null,
+        disabled: true,
+        note: 'Place Details is turned off on this instance by an administrator. Nothing was fetched.',
+      });
+    }
+
+    // Same split the REST route makes, and for the same reason: the expanded
+    // field mask is the expensive one, so nothing reaches it unless it was asked for.
+    const details = expand
+      ? await this.maps.getPlaceDetailsExpanded(ctx.userId, placeId, lang ?? 'en', refresh ?? false)
+      : await this.maps.getPlaceDetails(ctx.userId, placeId, lang ?? 'en');
     return ok({ details });
   }
 
@@ -57,5 +80,42 @@ export class MapsMcp {
   async resolveMapsUrl({ url }: { url: string }, _ctx: McpContext) {
     const result = await this.maps.resolveGoogleMapsUrl(url);
     return ok(result);
+  }
+
+  /**
+   * The MCP side of GET /api/maps/pois, the "explore" pill on the trip map. Not
+   * part of the 1:1 move above: the route had no tool at all, which left the
+   * whole discover-what-is-here half of the map unreachable from a conversation.
+   */
+  @Tool({
+    name: 'search_pois',
+    description: 'List OpenStreetMap points of interest of one category inside a map rectangle, with address, opening hours, website, phone and cuisine wherever OSM carries them. This is the discovery tool: use it to answer "what is around here" for a neighbourhood or a whole city district. Prefer search_place when the user already named the place they mean. Never calls Google, so it costs nothing and works on an instance with no Places key.',
+    inputSchema: {
+      category: z.enum(POI_CATEGORY_KEYS).describe('Which kind of place to look for'),
+      bbox: z.object({
+        south: z.number().min(-90).max(90).describe('Southern edge, latitude'),
+        west: z.number().min(-180).max(180).describe('Western edge, longitude'),
+        north: z.number().min(-90).max(90).describe('Northern edge, latitude'),
+        east: z.number().min(-180).max(180).describe('Eastern edge, longitude'),
+      }).describe('The rectangle to search. Anything wider than 0.5 degrees is narrowed to a centred window so the query stays fast; the answer reports that as `clamped`'),
+      lang: z.string().max(35).optional().describe('Language for the POI names, e.g. "de" or "ja". Falls back to the OSM international name and then the local one'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'geo', mode: 'read' },
+  })
+  async searchPois(
+    { category, bbox, lang }: {
+      category: string;
+      bbox: { south: number; west: number; north: number; east: number };
+      lang?: string;
+    },
+    _ctx: McpContext,
+  ) {
+    try {
+      return ok(await this.maps.pois(category, bbox, lang));
+    } catch {
+      // Overpass is a set of public mirrors; an outage there is not a bad request.
+      return errorResult('POI search failed.');
+    }
   }
 }

--- a/server/src/nest/mcp-transport/mcp-transport.constants.ts
+++ b/server/src/nest/mcp-transport/mcp-transport.constants.ts
@@ -69,6 +69,7 @@ The following features are optional and may not be available on every TREK insta
 - When the user asks to "add X to day Y", resolve both the place (search + create if needed) and the day ID before calling \`assign_place_to_day\`.
 - Do not batch destructive operations (delete trip, delete day, delete place) without explicit user confirmation for each.
 - Present budget amounts with the trip's currency. Use \`get_trip_summary\` to read the currency field.
+- Read \`get_display_settings\` before rendering a temperature, a distance or a clock time: the user has picked units, a time format and a default currency, and guessing at them contradicts what they see in the app.
 - For group trips, always check member IDs via \`list_trip_members\` before calling tools that require a \`userId\` (e.g. budget splits, assignment participants).
 `.trim();
 

--- a/server/src/nest/memories/memories.mcp.ts
+++ b/server/src/nest/memories/memories.mcp.ts
@@ -1,0 +1,183 @@
+import {
+  McpController, Tool, TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+  errorResult, ok, type McpContext,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import { DatabaseService } from '../database/database.service';
+import { ImmichService } from './immich.service';
+import { SynologyService } from './synology.service';
+
+/**
+ * The photo backends TREK can talk to, named rather than taken as a free
+ * string. `trek_photos.provider` stores whatever it is handed, so a typo would
+ * persist a row no resolver can ever match to a backend.
+ */
+const PROVIDER = z.enum(['immich', 'synologyphotos']);
+type ProviderId = z.infer<typeof PROVIDER>;
+
+const ISO_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+/**
+ * Immich's REST route already clamps a search page to 200, so this only newly
+ * binds Synology, whose route takes an unbounded `limit`. A tool answers into a
+ * context window rather than into a scrolling grid, so both get the ceiling.
+ */
+const MAX_PAGE_SIZE = 200;
+
+/** The two provider defaults, kept apart because the REST routes differ. */
+const IMMICH_DEFAULT_SIZE = 50;
+const SYNOLOGY_DEFAULT_LIMIT = 100;
+
+/**
+ * Availability gate. With every `photo_providers` row switched off the admin has
+ * turned the whole integration off, and the settings page stops offering it at
+ * all: nothing here has anything left to browse. Which of the two providers is
+ * on is a per-call question, answered by providerRefusal().
+ */
+const anyPhotoProviderEnabled = (_ctx: McpContext, self: MemoriesMcp): boolean =>
+  self.enabledProviderIds().length > 0;
+
+/**
+ * Memories MCP surface: finding photos in a connected Immich or Synology Photos
+ * library so their asset ids can be handed to add_journey_provider_photos.
+ *
+ * Read-only and metadata-only by design. The routes that stream thumbnails and
+ * originals stay off this surface: they are `<img>` targets that answer with
+ * bytes, and a tool result carries text.
+ *
+ * The three tools mirror POST /search, GET /albums and GET /albums/:id/photos
+ * under /api/integrations/memories/{immich,synologyphotos}. Those routes carry
+ * no trip scoping to mirror: a provider library belongs to the calling user and
+ * is reached with that user's own stored credentials, so the session's userId is
+ * the whole of the scoping, exactly as the JwtAuthGuard-only controllers have it.
+ *
+ * They ride journey:read because that is the consent this surface exists to
+ * serve: a model searches a library in order to attach what it finds to a
+ * journey entry or gallery, which is the write half in journey.mcp.ts. There is
+ * no memories scope group and adding one is a central decision, not a domain one.
+ */
+@McpController()
+export class MemoriesMcp {
+  constructor(
+    private readonly immich: ImmichService,
+    private readonly synology: SynologyService,
+    private readonly db: DatabaseService,
+  ) {}
+
+  /**
+   * Public because the `when:` gate above is a module-level function rather than
+   * a method, the same reason the addon gates need a public `addons`.
+   */
+  enabledProviderIds(): string[] {
+    return this.db.all<{ id: string }>('SELECT id FROM photo_providers WHERE enabled = 1').map((row) => row.id);
+  }
+
+  /**
+   * The admin toggle the trip-side add already enforces (the `_validProvider`
+   * check in UnifiedMemoriesService), reused down to its two sentences so a
+   * disabled provider refuses the same way on both surfaces. The browse routes
+   * themselves never checked it, so this only ever narrows what REST allows.
+   */
+  private providerRefusal(provider: ProviderId) {
+    const row = this.db.get<{ enabled: number }>('SELECT enabled FROM photo_providers WHERE id = ?', provider);
+    if (!row) return errorResult(`Provider: "${provider}" is not supported`);
+    if (row.enabled !== 1) return errorResult(`Provider: "${provider}" is not enabled, contact server administrator`);
+    return null;
+  }
+
+  @Tool({
+    name: 'search_provider_photos',
+    description: 'Search a connected photo library (Immich or Synology Photos) by capture date and return the matching asset ids with their capture time, place and coordinates. Start here when the user asks for the photos of a trip, a journey or a single day, then pass the ids on to add_journey_provider_photos. Prefer list_provider_albums when the user names an album instead of a date range. Metadata only: no image data crosses the wire, and the pictures themselves are fetched by the app, not by this tool.',
+    inputSchema: {
+      provider: PROVIDER.describe('Which connected library to search'),
+      from: ISO_DATE.optional().describe('Earliest capture date, YYYY-MM-DD, inclusive'),
+      to: ISO_DATE.optional().describe('Latest capture date, YYYY-MM-DD, inclusive'),
+      page: z.number().int().min(1).optional().describe('1-based page number, defaults to 1. Page forward while hasMore is true'),
+      size: z.number().int().min(1).max(MAX_PAGE_SIZE).optional().describe(`Photos per page, at most ${MAX_PAGE_SIZE}. Defaults to ${IMMICH_DEFAULT_SIZE} for Immich and ${SYNOLOGY_DEFAULT_LIMIT} for Synology Photos, as the REST routes do`),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    when: anyPhotoProviderEnabled,
+    access: { group: 'journey', mode: 'read' },
+  })
+  async searchProviderPhotos(
+    { provider, from, to, page, size }: { provider: ProviderId; from?: string; to?: string; page?: number; size?: number },
+    ctx: McpContext,
+  ) {
+    const refused = this.providerRefusal(provider);
+    if (refused) return refused;
+
+    if (provider === 'immich') {
+      // Same coercion the REST route performs on the body before calling.
+      const result = await this.immich.searchPhotos(ctx.userId, from, to, Math.max(1, page ?? 1), Math.min(size ?? IMMICH_DEFAULT_SIZE, MAX_PAGE_SIZE));
+      if (result.error) return errorResult(result.error);
+      return ok({ provider, assets: result.assets ?? [], hasMore: !!result.hasMore });
+    }
+
+    // Synology paginates by offset. Its route derives one from a 1-based page
+    // and the effective limit, which is what keeps a single `page` argument
+    // meaning the same thing for both providers.
+    const limit = size && size > 0 ? size : SYNOLOGY_DEFAULT_LIMIT;
+    const pageIndex = (page ?? 1) - 1;
+    const result = await this.synology.searchSynologyPhotos(ctx.userId, from, to, pageIndex > 0 ? pageIndex * limit : 0, limit);
+    if ('error' in result) return errorResult(result.error.message);
+    return ok({ provider, assets: result.data.assets, total: result.data.total, hasMore: result.data.hasMore });
+  }
+
+  @Tool({
+    name: 'list_provider_albums',
+    description: 'List the albums of a connected photo library (Immich or Synology Photos), with each album id, name and photo count. Use this when the user names an album ("the Rome album") rather than a date range, then read its photos with list_provider_album_photos. For "photos from that week" use search_provider_photos instead.',
+    inputSchema: {
+      provider: PROVIDER.describe('Which connected library to list albums from'),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    when: anyPhotoProviderEnabled,
+    access: { group: 'journey', mode: 'read' },
+  })
+  async listProviderAlbums({ provider }: { provider: ProviderId }, ctx: McpContext) {
+    const refused = this.providerRefusal(provider);
+    if (refused) return refused;
+
+    if (provider === 'immich') {
+      const result = await this.immich.listAlbums(ctx.userId);
+      if (result.error) return errorResult(result.error);
+      return ok({ provider, albums: result.albums ?? [] });
+    }
+
+    const result = await this.synology.listSynologyAlbums(ctx.userId);
+    if ('error' in result) return errorResult(result.error.message);
+    // A Synology album that was shared with the user carries a passphrase, and
+    // list_provider_album_photos cannot open it without one. The REST route
+    // hands it to the picker for the same reason.
+    return ok({ provider, albums: result.data.albums });
+  }
+
+  @Tool({
+    name: 'list_provider_album_photos',
+    description: 'List every photo in one album of a connected library, with asset ids, capture times and coordinates. Follow list_provider_albums with this once the right album is known, then hand the asset ids to add_journey_provider_photos. Metadata only, and unpaginated: a large album comes back whole.',
+    inputSchema: {
+      provider: PROVIDER.describe('Which connected library the album lives in'),
+      album_id: z.string().min(1).describe('Album id as returned by list_provider_albums'),
+      passphrase: z.string().min(1).optional().describe('Only for a Synology Photos album that was shared with the user: pass back the passphrase list_provider_albums returned for it, otherwise the album cannot be opened'),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    when: anyPhotoProviderEnabled,
+    access: { group: 'journey', mode: 'read' },
+  })
+  async listProviderAlbumPhotos(
+    { provider, album_id, passphrase }: { provider: ProviderId; album_id: string; passphrase?: string },
+    ctx: McpContext,
+  ) {
+    const refused = this.providerRefusal(provider);
+    if (refused) return refused;
+
+    if (provider === 'immich') {
+      const result = await this.immich.getAlbumPhotos(ctx.userId, album_id);
+      if (result.error) return errorResult(result.error);
+      return ok({ provider, album_id, assets: result.assets ?? [] });
+    }
+
+    const result = await this.synology.getSynologyAlbumPhotos(ctx.userId, album_id, passphrase);
+    if ('error' in result) return errorResult(result.error.message);
+    return ok({ provider, album_id, assets: result.data.assets, total: result.data.total });
+  }
+}

--- a/server/src/nest/memories/memories.module.ts
+++ b/server/src/nest/memories/memories.module.ts
@@ -14,6 +14,7 @@ import { SchedulingModule } from '../scheduling/scheduling.module';
 import { UnifiedMemoriesController } from './unified.controller';
 import { ImmichMemoriesController } from './immich.controller';
 import { SynologyMemoriesController } from './synology.controller';
+import { MemoriesMcp } from './memories.mcp';
 import { AddonsModule } from '../addons/addons.module';
 import { AuditModule } from '../audit/audit.module';
 import { TrekPhotosModule } from '../photos/trek-photos.module';
@@ -63,6 +64,7 @@ import { StorageModule } from '../storage/storage.module';
     ImmichPhotoProvider,
     SynologyPhotoProvider,
     PhotoProviderRegistry,
+    MemoriesMcp,
     {
       provide: PHOTO_PROVIDERS,
       useFactory: (immich: ImmichPhotoProvider, synology: SynologyPhotoProvider) => [immich, synology],

--- a/server/src/nest/packing/packing.mcp.ts
+++ b/server/src/nest/packing/packing.mcp.ts
@@ -10,6 +10,13 @@ import { AuthService } from '../auth/auth.service';
 import { ADDON_IDS } from '../../addons';
 import { noAccess, permissionDenied, adminRequired } from '../../mcp/tools/_shared';
 import { PackingService } from './packing.service';
+import {
+  packingCreateItemRequestSchema,
+  packingSetSharingRequestSchema,
+  packingUpdateBagRequestSchema,
+  packingUpdateItemRequestSchema,
+  type PackingVisibility,
+} from '@trek/shared';
 import { addonGate } from '../addons/addon-gate';
 import { AddonsService } from '../addons/addons.service';
 
@@ -32,6 +39,10 @@ function parseId(value: string | string[]): number | null {
  * read/write access markers (the legacy `if (R)` / `if (W)` checks, resolved
  * by trekMcpAccessPolicy). The two template-management tools keep their inline
  * admin gate (isAdminUser), matching the REST routes.
+ *
+ * set_packing_item_sharing is the one tool with no legacy ancestor: PUT
+ * /:id/sharing had no counterpart here, so the whole three-tier sharing model
+ * (#858) was invisible to an assistant.
  */
 @McpController()
 export class PackingMcp {
@@ -46,24 +57,38 @@ export class PackingMcp {
 
   @Tool({
     name: 'create_packing_item',
-    description: 'Add an item to the packing checklist for a trip.',
+    description: 'Add an item to the packing checklist for a trip. It lands on the common list everyone shares unless visibility says otherwise; use set_packing_item_sharing to move an existing item between those tiers.',
     inputSchema: {
       tripId: z.number().int().positive(),
       name: z.string().min(1).max(200),
       category: z.string().max(100).optional().describe('Packing category (e.g. Clothes, Electronics)'),
+      checked: packingCreateItemRequestSchema.shape.checked.describe('Create the item already ticked off'),
+      is_private: packingCreateItemRequestSchema.shape.is_private.describe('Keep the item to yourself; visibility says the same thing with more nuance'),
+      visibility: packingCreateItemRequestSchema.shape.visibility.describe("Which list the item belongs to: 'common' (the group pool, the default), 'personal' (yours alone), or 'shared' (yours plus recipient_ids)"),
+      recipient_ids: packingCreateItemRequestSchema.shape.recipient_ids.describe("For visibility 'shared': the trip members the item is brought for. Ignored otherwise, and ids outside the trip roster are dropped"),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     when: packingAddonOn,
     access: { group: 'packing', mode: 'write' },
   })
-  async createPackingItem({ tripId, name, category }: { tripId: number; name: string; category?: string }, ctx: McpContext) {
+  async createPackingItem(
+    { tripId, name, category, checked, is_private, visibility, recipient_ids }: { tripId: number; name: string; category?: string; checked?: boolean | number; is_private?: boolean; visibility?: PackingVisibility; recipient_ids?: number[] },
+    ctx: McpContext,
+  ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.packing.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('packing_edit', tripId, ctx.userId)) return permissionDenied();
-    const item = this.packing.createItem(tripId, { name, category: category || 'General' }, ctx.userId);
-    // A tool-made item is Common today, so this asks the room. Routed through
-    // viewersOf anyway, so the day createItem learns to make a restricted one
-    // this does not have to be remembered a second time.
+    const item = this.packing.createItem(tripId, {
+      name,
+      category: category || 'General',
+      // checked takes a boolean or the legacy 0/1, exactly as the REST body does.
+      checked: checked === undefined ? undefined : !!checked,
+      is_private,
+      visibility,
+      recipient_ids,
+    }, ctx.userId);
+    // A restricted item (#858) reaches its owner and recipients only; a Common
+    // one answers null here and goes to the whole room.
     this.guards.safeBroadcast(tripId, 'packing:created', { item }, this.packing.viewersOf(item));
     return ok({ item });
   }
@@ -119,25 +144,88 @@ export class PackingMcp {
 
   @Tool({
     name: 'update_packing_item',
-    description: 'Rename a packing item or change its category.',
+    description: 'Change a packing item: rename it, recategorise it, move it into a bag, set how many are needed, record its weight, or flip it between the common list and your own. Ticking it off is toggle_packing_item; choosing who a private item is shared with is set_packing_item_sharing.',
     inputSchema: {
       tripId: z.number().int().positive(),
       itemId: z.number().int().positive(),
       name: z.string().min(1).max(200).optional(),
       category: z.string().max(100).optional(),
+      bag_id: packingUpdateItemRequestSchema.shape.bag_id.describe('Bag to pack the item into (ids come from list_packing_bags); null takes it out of its bag'),
+      quantity: packingUpdateItemRequestSchema.shape.quantity.describe('How many to pack, clamped to 1-999'),
+      weight_grams: packingUpdateItemRequestSchema.shape.weight_grams.describe('Weight in grams, which feeds the bag fill bar; null clears it'),
+      is_private: packingUpdateItemRequestSchema.shape.is_private.describe('true takes the item off the common list and onto the caller\'s own'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     when: packingAddonOn,
     access: { group: 'packing', mode: 'write' },
   })
-  async updatePackingItem({ tripId, itemId, name, category }: { tripId: number; itemId: number; name?: string; category?: string }, ctx: McpContext) {
+  async updatePackingItem(
+    { tripId, itemId, name, category, bag_id, quantity, weight_grams, is_private }: { tripId: number; itemId: number; name?: string; category?: string; bag_id?: number | null; quantity?: number; weight_grams?: number | null; is_private?: boolean },
+    ctx: McpContext,
+  ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.packing.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('packing_edit', tripId, ctx.userId)) return permissionDenied();
-    const bodyKeys = ['name', 'category'].filter(k => k === 'name' ? name !== undefined : category !== undefined);
-    const item = this.packing.updateItem(tripId, itemId, { name, category }, bodyKeys, undefined, ctx.userId);
+    const fields = { name, category, bag_id, quantity, weight_grams, is_private };
+    // The service reads presence from bodyKeys, so a field has to be named there
+    // for an explicit null to clear it rather than read as "leave it alone".
+    const bodyKeys = Object.keys(fields).filter(k => fields[k as keyof typeof fields] !== undefined);
+    // Privacy state before the write, so a public↔private flip routes the
+    // broadcast the way the REST route does instead of leaking a freshly
+    // privatized item (or leaving a stale copy on everyone else's screen).
+    const wasPrivate = !!this.packing.getItemPrivacy(tripId, itemId)?.is_private;
+    const item = this.packing.updateItem(tripId, itemId, fields, bodyKeys, undefined, ctx.userId);
     if (!item) return errorResult('Packing item not found.');
-    this.guards.safeBroadcast(tripId, 'packing:updated', { item }, this.packing.viewersOf(item));
+    this.broadcastItemUpdate(tripId, itemId, item, wasPrivate);
+    return ok({ item });
+  }
+
+  /**
+   * The four privacy transitions of an item update (#858), as
+   * PackingService.broadcastUpdate does them for REST, but over safeBroadcast so
+   * the events keep the MCP marker and the tool survives a broadcast failure.
+   */
+  private broadcastItemUpdate(tripId: number, itemId: number, item: { is_private?: number; owner_id?: number | null; recipients?: { user_id: number }[] }, wasPrivate: boolean) {
+    const viewers = this.packing.viewersOf(item);
+    if (item.is_private) {
+      // Newly restricted: take it off the room's screens first, then hand it
+      // back to the people who may still see it.
+      if (!wasPrivate) this.guards.safeBroadcast(tripId, 'packing:deleted', { itemId });
+      this.guards.safeBroadcast(tripId, wasPrivate ? 'packing:updated' : 'packing:created', { item }, viewers);
+      return;
+    }
+    // Newly common: the members who never had the row need it created, not updated.
+    if (wasPrivate) this.guards.safeBroadcast(tripId, 'packing:created', { item });
+    this.guards.safeBroadcast(tripId, 'packing:updated', { item });
+  }
+
+  @Tool({
+    name: 'set_packing_item_sharing',
+    description: 'Move an existing packing item between the three sharing tiers: the common list the whole trip pools into, the owner\'s own list, or shared with named trip members. Only the item\'s owner may change this. Everything else about an item is update_packing_item.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      itemId: z.number().int().positive(),
+      visibility: packingSetSharingRequestSchema.shape.visibility.describe("'common' puts the item in the group pool, 'personal' keeps it to the owner, 'shared' covers the people in recipient_ids"),
+      recipient_ids: packingSetSharingRequestSchema.shape.recipient_ids.describe("For 'shared': the trip members the item is brought for. Ids outside the trip roster are dropped, and any previous recipients are replaced"),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    when: packingAddonOn,
+    access: { group: 'packing', mode: 'write' },
+  })
+  async setPackingItemSharing(
+    { tripId, itemId, visibility, recipient_ids }: { tripId: number; itemId: number; visibility: PackingVisibility; recipient_ids?: number[] },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.packing.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('packing_edit', tripId, ctx.userId)) return permissionDenied();
+    const item = this.packing.setItemSharing(tripId, itemId, ctx.userId, visibility, recipient_ids ?? []);
+    if (!item) return errorResult('Packing item not found.');
+    if ((item as { forbidden?: boolean }).forbidden) return errorResult('Only the owner can change sharing.');
+    // The viewer set just changed: drop the item from the whole room, then hand
+    // it back to whoever may see it now, as the REST route does.
+    this.guards.safeBroadcast(tripId, 'packing:deleted', { itemId });
+    this.guards.safeBroadcast(tripId, 'packing:created', { item }, this.packing.viewersOf(item));
     return ok({ item });
   }
 
@@ -204,25 +292,34 @@ export class PackingMcp {
 
   @Tool({
     name: 'update_packing_bag',
-    description: 'Rename or recolor a packing bag.',
+    description: 'Rename or recolor a packing bag, give it a weight limit, or hand it to one traveller. Who else packs into it is set_bag_members.',
     inputSchema: {
       tripId: z.number().int().positive(),
       bagId: z.number().int().positive(),
       name: z.string().optional(),
       color: z.string().optional(),
+      weight_limit_grams: packingUpdateBagRequestSchema.shape.weight_limit_grams.describe('Allowance in grams the bag is measured against (the fill bar); null lifts the limit'),
+      user_id: packingUpdateBagRequestSchema.shape.user_id.describe('Trip member the bag belongs to; null leaves it unassigned, and an id outside the trip roster unassigns it too'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     when: packingAddonOn,
     access: { group: 'packing', mode: 'write' },
   })
-  async updatePackingBag({ tripId, bagId, name, color }: { tripId: number; bagId: number; name?: string; color?: string }, ctx: McpContext) {
+  async updatePackingBag(
+    { tripId, bagId, name, color, weight_limit_grams, user_id }: { tripId: number; bagId: number; name?: string; color?: string; weight_limit_grams?: number | null; user_id?: number | null },
+    ctx: McpContext,
+  ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.packing.verifyTripAccess(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('packing_edit', tripId, ctx.userId)) return permissionDenied();
-    const fields: Record<string, unknown> = {};
+    const fields: { name?: string; color?: string; weight_limit_grams?: number | null; user_id?: number | null } = {};
     const bodyKeys: string[] = [];
     if (name !== undefined) { fields.name = name; bodyKeys.push('name'); }
     if (color !== undefined) { fields.color = color; bodyKeys.push('color'); }
+    // Both follow the presence protocol: an omitted key leaves the value alone,
+    // an explicit null clears it.
+    if (weight_limit_grams !== undefined) { fields.weight_limit_grams = weight_limit_grams; bodyKeys.push('weight_limit_grams'); }
+    if (user_id !== undefined) { fields.user_id = user_id; bodyKeys.push('user_id'); }
     const updated = this.packing.updateBag(tripId, bagId, fields, bodyKeys);
     if (!updated) return errorResult('Bag not found.');
     // Hydrate with the members array (matches create_packing_bag, listBags, and the schema).

--- a/server/src/nest/places/places.mcp.ts
+++ b/server/src/nest/places/places.mcp.ts
@@ -2,10 +2,15 @@ import {
   McpController, Tool, ResourceTemplate, type McpContext,
   TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE,
   TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
-  demoDenied, ok,
+  demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
-import { placeWebsiteSchema } from '@trek/shared';
+import {
+  mapsSearchRequestSchema,
+  placeImageUrlSchema,
+  placeImportListRequestSchema,
+  placeWebsiteSchema,
+} from '@trek/shared';
 import { z } from 'zod';
 import { AuthService } from '../auth/auth.service';
 import { AssignmentsService } from '../assignments/assignments.service';
@@ -66,6 +71,7 @@ export class PlacesMcp {
       notes: z.string().max(2000).optional(),
       website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
+      image_url: placeImageUrlSchema.optional().describe('Thumbnail for the place: an /uploads/ path, an /api/maps/place-photo/ path, an inline data: image, or an https URL'),
       price: z.number().nonnegative().optional().describe('Cost of this place/activity (e.g. ticket price, entry fee)'),
       currency: z.string().length(3).optional().describe('ISO 4217 currency code (e.g. "EUR", "USD")'),
     },
@@ -73,17 +79,17 @@ export class PlacesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async createPlace(
-    { tripId, name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes, website, phone, price, currency }: {
+    { tripId, name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes, website, phone, image_url, price, currency }: {
       tripId: number; name: string; description?: string; lat?: number; lng?: number; address?: string;
       category_id?: number; google_place_id?: string; google_ftid?: string; osm_id?: string;
-      notes?: string; website?: string; phone?: string; price?: number; currency?: string;
+      notes?: string; website?: string; phone?: string; image_url?: string; price?: number; currency?: string;
     },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('place_edit', tripId, ctx.userId)) return permissionDenied();
-    const place = this.places.create(String(tripId), { name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes, website, phone, price, currency });
+    const place = this.places.create(String(tripId), { name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes, website, phone, image_url, price, currency });
     this.guards.safeBroadcast(tripId, 'place:created', { place });
     return ok({ place });
   }
@@ -106,6 +112,7 @@ export class PlacesMcp {
       place_notes: z.string().max(2000).optional().describe('Notes for the place'),
       website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
+      image_url: placeImageUrlSchema.optional().describe('Thumbnail for the place: an /uploads/ path, an /api/maps/place-photo/ path, an inline data: image, or an https URL'),
       assignment_notes: z.string().max(500).optional().describe('Notes for this day assignment'),
       price: z.number().nonnegative().optional().describe('Cost of this place/activity (e.g. ticket price, entry fee)'),
       currency: z.string().length(3).optional().describe('ISO 4217 currency code (e.g. "EUR", "USD")'),
@@ -114,10 +121,10 @@ export class PlacesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async createAndAssignPlace(
-    { tripId, dayId, name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, place_notes, website, phone, assignment_notes, price, currency }: {
+    { tripId, dayId, name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, place_notes, website, phone, image_url, assignment_notes, price, currency }: {
       tripId: number; dayId: number; name: string; description?: string; lat?: number; lng?: number; address?: string;
       category_id?: number; google_place_id?: string; google_ftid?: string; osm_id?: string;
-      place_notes?: string; website?: string; phone?: string; assignment_notes?: string;
+      place_notes?: string; website?: string; phone?: string; image_url?: string; assignment_notes?: string;
       price?: number; currency?: string;
     },
     ctx: McpContext,
@@ -128,7 +135,7 @@ export class PlacesMcp {
     if (!this.assignments.dayExists(dayId, tripId)) return { content: [{ type: 'text' as const, text: 'Day not found.' }], isError: true };
     try {
       const result = this.db.transaction(() => {
-        const place = this.places.create(String(tripId), { name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes: place_notes, website, phone, price, currency });
+        const place = this.places.create(String(tripId), { name, description, lat, lng, address, category_id, google_place_id, google_ftid, osm_id, notes: place_notes, website, phone, image_url, price, currency });
         const assignment = this.assignments.createAssignment(dayId, place.id, assignment_notes ?? null);
         return { place, assignment };
       });
@@ -161,6 +168,7 @@ export class PlacesMcp {
       notes: z.string().max(2000).optional(),
       website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
+      image_url: placeImageUrlSchema.nullable().optional().describe('Thumbnail for the place: an /uploads/ path, an /api/maps/place-photo/ path, an inline data: image, or an https URL. Pass null to remove the current picture'),
       transport_mode: z.enum(['walking', 'driving', 'cycling', 'transit', 'flight']).optional(),
       osm_id: z.string().optional().describe('OpenStreetMap ID (e.g. "way:12345")'),
       google_place_id: z.string().optional().describe('Google Place ID (e.g. "ChIJd8BlQ2BZwokRAFUEcm_qrcA")'),
@@ -170,10 +178,11 @@ export class PlacesMcp {
     access: { group: 'places', mode: 'write' },
   })
   async updatePlace(
-    { tripId, placeId, name, description, lat, lng, address, category_id, price, currency, place_time, end_time, duration_minutes, notes, website, phone, transport_mode, osm_id, google_place_id, google_ftid }: {
+    { tripId, placeId, name, description, lat, lng, address, category_id, price, currency, place_time, end_time, duration_minutes, notes, website, phone, image_url, transport_mode, osm_id, google_place_id, google_ftid }: {
       tripId: number; placeId: number; name?: string; description?: string; lat?: number; lng?: number;
       address?: string; category_id?: number; price?: number; currency?: string; place_time?: string;
       end_time?: string; duration_minutes?: number; notes?: string; website?: string; phone?: string;
+      image_url?: string | null;
       transport_mode?: 'walking' | 'driving' | 'cycling' | 'transit' | 'flight'; osm_id?: string;
       google_place_id?: string; google_ftid?: string;
     },
@@ -182,7 +191,7 @@ export class PlacesMcp {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('place_edit', tripId, ctx.userId)) return permissionDenied();
-    const place = await this.places.update(String(tripId), String(placeId), { name, description, lat, lng, address, category_id, price, currency, place_time, end_time, duration_minutes, notes, website, phone, transport_mode, osm_id, google_place_id, google_ftid });
+    const place = await this.places.update(String(tripId), String(placeId), { name, description, lat, lng, address, category_id, price, currency, place_time, end_time, duration_minutes, notes, website, phone, image_url, transport_mode, osm_id, google_place_id, google_ftid });
     if (!place) return { content: [{ type: 'text' as const, text: 'Place not found.' }], isError: true };
     this.guards.safeBroadcast(tripId, 'place:updated', { place });
     return ok({ place });
@@ -274,19 +283,26 @@ export class PlacesMcp {
 
   @Tool({
     name: 'search_place',
-    description: 'Search for a real-world place by name or address. Returns results with osm_id (and google_place_id/google_ftid if configured). Use these IDs when calling create_place so the app can display opening hours, ratings, and map links.',
+    description: 'Search for a real-world place by name or address. Returns results with osm_id (and google_place_id/google_ftid if configured). Use these IDs when calling create_place so the app can display opening hours, ratings, and map links. Pass locationBias whenever the trip has a destination: a bare name like "Central Station" or "Museum of Modern Art" otherwise resolves wherever the provider guesses, which is regularly the wrong continent.',
     inputSchema: {
       query: z.string().min(1).max(500).describe('Place name or address to search for'),
+      locationBias: mapsSearchRequestSchema.shape.locationBias.describe('Centre the search on a coordinate: { lat, lng, radius? } with radius in metres (default 50000). Only the Google provider honours it; the OpenStreetMap fallback ignores it'),
+      lang: z.string().max(35).optional().describe('BCP 47 language for the result names, e.g. "de" or "ja". Defaults to English'),
     },
     annotations: TOOL_ANNOTATIONS_READONLY,
     access: { group: 'places', mode: 'read' },
   })
-  async searchPlace({ query }: { query: string }, ctx: McpContext) {
+  async searchPlace(
+    { query, locationBias, lang }: {
+      query: string; locationBias?: { lat: number; lng: number; radius?: number }; lang?: string;
+    },
+    ctx: McpContext,
+  ) {
     try {
-      const result = await this.maps.searchPlaces(ctx.userId, query);
+      const result = await this.maps.searchPlaces(ctx.userId, query, lang, locationBias);
       return ok(result);
     } catch {
-      return { content: [{ type: 'text' as const, text: 'Place search failed.' }], isError: true };
+      return errorResult('Place search failed.');
     }
   }
 
@@ -297,21 +313,25 @@ export class PlacesMcp {
       tripId: z.number().int().positive(),
       url: z.string().url().describe('Publicly shared Google Maps list URL (maps.app.goo.gl/...) or Naver Maps list URL'),
       source: z.enum(['google-list', 'naver-list']).describe('List source: "google-list" for Google Maps saved places, "naver-list" for Naver Maps'),
+      enrich: placeImportListRequestSchema.shape.enrich.describe('Re-resolve every imported place through the Places API afterwards to fill in photo, address, website and phone (#886). Needs a Google Maps key on the instance, costs a lookup per place, and runs in the background: the tool returns the bare import and the places fill in over the websocket. Off by default'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     access: { group: 'places', mode: 'write' },
   })
   async importPlacesFromUrl(
-    { tripId, url, source }: { tripId: number; url: string; source: 'google-list' | 'naver-list' },
+    { tripId, url, source, enrich }: { tripId: number; url: string; source: 'google-list' | 'naver-list'; enrich?: boolean },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('place_edit', tripId, ctx.userId)) return permissionDenied();
 
+    // Same opts the REST route builds: the enrichment pass is keyed on the calling
+    // user because it spends that user's Places credential.
+    const opts = { enrich: enrich ?? false, userId: ctx.userId };
     const result = source === 'google-list'
-      ? await this.places.importGoogleList(String(tripId), url)
-      : await this.places.importNaverList(String(tripId), url);
+      ? await this.places.importGoogleList(String(tripId), url, opts)
+      : await this.places.importNaverList(String(tripId), url, opts);
 
     if ('error' in result) {
       return { content: [{ type: 'text' as const, text: result.error }], isError: true };
@@ -321,6 +341,32 @@ export class PlacesMcp {
       this.guards.safeBroadcast(tripId, 'place:created', { place });
     }
     return ok({ places: result.places, count: result.places.length, listName: result.listName, skipped: result.skipped });
+  }
+
+  @Tool({
+    name: 'export_trip_gpx',
+    description: 'Export a trip as GPX text: its places as waypoints, any imported routes as tracks, and each planned day as a route in visiting order. This is the format handhelds and offline map apps (Organic Maps, OsmAnd, Garmin) read. Prefer export_trip_ics when the user wants the itinerary in a calendar instead.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      waypoints: z.boolean().optional().default(true).describe('Write every place with coordinates as a <wpt>'),
+      tracks: z.boolean().optional().default(true).describe('Write places that carry an imported route geometry as a <trk>'),
+      dayRoutes: z.boolean().optional().default(true).describe('Write each planned day as a <rte> through its stops in order'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'places', mode: 'read' },
+  })
+  async exportTripGpx(
+    { tripId, waypoints, tracks, dayRoutes }: {
+      tripId: number; waypoints?: boolean; tracks?: boolean; dayRoutes?: boolean;
+    },
+    ctx: McpContext,
+  ) {
+    // A read, like the REST route: seeing the trip is enough, no place_edit.
+    if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    if (!waypoints && !tracks && !dayRoutes) return errorResult('No export types selected.');
+    const result = this.places.exportGpx(String(tripId), { waypoints, tracks, dayRoutes });
+    if (!result) return errorResult('Nothing to export.');
+    return ok({ gpx: result.gpx, filename: result.filename });
   }
 
   @Tool({
@@ -369,17 +415,18 @@ export class PlacesMcp {
       notes: z.string().max(2000).optional(),
       website: placeWebsiteSchema.optional(),
       phone: z.string().max(50).optional(),
+      image_url: placeImageUrlSchema.nullable().optional().describe('Thumbnail for every listed place: an /uploads/ path, an /api/maps/place-photo/ path, an inline data: image, or an https URL. Pass null to strip the pictures off a batch at once'),
       description: z.string().max(2000).optional(),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     access: { group: 'places', mode: 'write' },
   })
   async bulkUpdatePlaces(
-    { tripId, placeIds, category_id, price, currency, transport_mode, place_time, end_time, duration_minutes, notes, website, phone, description }: {
+    { tripId, placeIds, category_id, price, currency, transport_mode, place_time, end_time, duration_minutes, notes, website, phone, image_url, description }: {
       tripId: number; placeIds: number[]; category_id?: number; price?: number; currency?: string;
       transport_mode?: 'walking' | 'driving' | 'cycling' | 'transit' | 'flight'; place_time?: string;
       end_time?: string; duration_minutes?: number; notes?: string; website?: string; phone?: string;
-      description?: string;
+      image_url?: string | null; description?: string;
     },
     ctx: McpContext,
   ) {
@@ -387,7 +434,7 @@ export class PlacesMcp {
     if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('place_edit', tripId, ctx.userId)) return permissionDenied();
 
-    const fields = { category_id, price, currency, transport_mode, place_time, end_time, duration_minutes, notes, website, phone, description };
+    const fields = { category_id, price, currency, transport_mode, place_time, end_time, duration_minutes, notes, website, phone, image_url, description };
     if (Object.values(fields).every(v => v === undefined)) {
       return { content: [{ type: 'text' as const, text: 'Provide at least one field to update.' }], isError: true };
     }

--- a/server/src/nest/plugins/contributions/plugin-contributions.module.ts
+++ b/server/src/nest/plugins/contributions/plugin-contributions.module.ts
@@ -4,6 +4,7 @@ import { AddonsModule } from '../../addons/addons.module';
 import { JourneyDomainModule } from '../../journey/journey-domain.module';
 import { PlaceDetailsController } from './place-details.controller';
 import { TripWarningsController } from './trip-warnings.controller';
+import { TripWarningsMcp } from './trip-warnings.mcp';
 import { ViewContributionsController } from './view-contributions.controller';
 import { TripCardContributionsController } from './trip-card-contributions.controller';
 import { PluginPhotosController } from './plugin-photos.controller';
@@ -46,5 +47,9 @@ import { JournalEntryRowsController } from './journal-entry-rows.controller';
     AtlasLayersController,
     JournalEntryRowsController,
   ],
+  // The only contribution with an MCP counterpart so far. It belongs to this module
+  // rather than to the trip read model because the plugin runtime and the trip
+  // aggregate already import each other's modules; see trip-warnings.mcp.ts.
+  providers: [TripWarningsMcp],
 })
 export class PluginContributionsModule {}

--- a/server/src/nest/plugins/contributions/trip-warnings.mcp.ts
+++ b/server/src/nest/plugins/contributions/trip-warnings.mcp.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+import { McpController, Tool, TOOL_ANNOTATIONS_READONLY, ok, type McpContext, type McpTextResult } from '../../../nest-mcp';
+import { noAccess } from '../../../mcp/tools/_shared';
+import { DatabaseService } from '../../database/database.service';
+import { pluginsEnabled } from '../kill-switch';
+import { PluginHooks } from '../plugin-hooks.service';
+import { stripEmoji } from '../text-sanitize';
+
+/**
+ * The MCP half of GET /api/trip-warnings/:tripId (#1429).
+ *
+ * The web UI shows plugin warnings as a banner on the trip it belongs to, so a user
+ * reviewing a trip sees "this hotel booking has no check-out day" without asking for
+ * it. An assistant reviewing the same trip saw nothing: get_trip_summary loads the
+ * trip's own rows and a warning is not a row, it is a plugin's live verdict on them.
+ *
+ * It is a tool of its own rather than a section of get_trip_summary because the two
+ * have incompatible costs and dependencies. The summary is a synchronous SQLite read
+ * out of TripReadModelService; a warning is an IPC round trip into every installed
+ * warning provider, each with a 5 s budget. Folding it in would make the documented
+ * "call this once to load the trip" loader wait on third-party child processes, and
+ * would need TripReadModelModule to import the plugin runtime, which imports
+ * TripsModule, which imports TripReadModelModule.
+ */
+type Level = 'info' | 'warning' | 'error';
+interface Warning {
+  pluginId: string;
+  level: Level;
+  message: string;
+  dayId?: number;
+  placeId?: number;
+}
+
+// Same two caps the REST route applies, for the same reason: one provider must not be
+// able to flood the answer, and a warning is a banner line rather than a document.
+const MAX_WARNINGS = 20;
+const MESSAGE_MAX = 300;
+
+@McpController()
+export class TripWarningsMcp {
+  constructor(
+    private readonly hooks: PluginHooks,
+    private readonly dbs: DatabaseService,
+  ) {}
+
+  @Tool({
+    name: 'get_trip_warnings',
+    description: 'Problems installed plugins report about a trip: a plugin flagging that something is wrong with the itinerary, such as an accommodation with no check-out, a day that cannot be travelled in the time it allows, or a place closed on the day it is planned for. get_trip_summary returns the trip\'s stored data and never these verdicts, so call this as well before reviewing a trip, reporting on it, or telling the user it looks fine. Returns an empty list when no installed plugin contributes warnings, which is the normal case.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'trips', mode: 'read' },
+  })
+  async getTripWarnings({ tripId }: { tripId: number }, ctx: McpContext): Promise<McpTextResult> {
+    // Access first, so the answer to "may I look at this trip" does not depend on
+    // whether an admin has the plugin system switched on.
+    if (!this.dbs.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    if (!pluginsEnabled()) return ok({ warnings: [] });
+
+    const ids = this.hooks.providersOf('warningProvider');
+    const perProvider = await Promise.all(
+      ids.map(async (id): Promise<Warning[]> => {
+        try {
+          const raw = (await this.hooks.tripWarnings(id, tripId, ctx.userId)) as unknown;
+          const list = Array.isArray(raw) ? (raw as unknown[]) : [];
+          // Drop non-object elements BEFORE the cap: one null in the array would throw
+          // inside map() and the catch below would discard everything this provider
+          // returned, and the cap should count valid entries only.
+          return list
+            .filter((w): w is Record<string, unknown> => !!w && typeof w === 'object')
+            .slice(0, MAX_WARNINGS)
+            .map((w) => ({
+              pluginId: id,
+              level: w.level === 'error' || w.level === 'info' ? (w.level as Level) : 'warning',
+              message: stripEmoji(String(w.message ?? '')).slice(0, MESSAGE_MAX),
+              dayId: typeof w.dayId === 'number' ? w.dayId : undefined,
+              placeId: typeof w.placeId === 'number' ? w.placeId : undefined,
+            }));
+        } catch {
+          return []; // a slow or failing provider contributes nothing, it does not fail the tool
+        }
+      }),
+    );
+    return ok({ warnings: perProvider.flat().filter((w) => w.message) });
+  }
+}

--- a/server/src/nest/reservation-import/reservation-import.mcp.ts
+++ b/server/src/nest/reservation-import/reservation-import.mcp.ts
@@ -1,0 +1,106 @@
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_OPEN_WORLD_NON_IDEMPOTENT,
+  demoDenied, errorResult, ok,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import { airtrailImportSchema } from '@trek/shared';
+import { ADDON_IDS } from '../../addons';
+import { addonGate } from '../addons/addon-gate';
+import { AddonsService } from '../addons/addons.service';
+import { AuthService } from '../auth/auth.service';
+import { DatabaseService } from '../database/database.service';
+import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
+import { AirtrailImportService } from '../integrations/airtrail-import.service';
+
+/** The handler's own @RequireAddon(ADDON_IDS.AIRTRAIL), as an availability gate. */
+const airtrailAddonOn = addonGate(ADDON_IDS.AIRTRAIL);
+
+/**
+ * The picker sends whatever a human ticked; a model can name a hundred ids off
+ * one hallucinated list, and each one becomes a reservation and a broadcast.
+ * The same reasoning as MAX_MCP_TRIP_DAYS: the tool surface caps a bulk write
+ * the REST route leaves open, and says how to continue.
+ */
+const MAX_MCP_AIRTRAIL_FLIGHTS = 50;
+
+/**
+ * MCP surface for /api/trips/:tripId/reservations/import.
+ *
+ * Only the AirTrail half is here. The booking-file routes on the same prefix
+ * take an uploaded EML/PDF/PKPass body, and MCP has no file to hand them; the
+ * job-status route is the recovery path for a client that missed a WebSocket
+ * push, which a tool caller never has.
+ *
+ * The guard chain on the controller is AddonGuard, JwtAuthGuard,
+ * TripAccessGuard plus @RequirePermission('reservation_edit'), so the tool runs
+ * the same three checks in the same order: demo, trip access (the 404
+ * equivalent), then the identical permission action.
+ */
+@McpController()
+export class ReservationImportMcp {
+  constructor(
+    private readonly airtrailImport: AirtrailImportService,
+    private readonly db: DatabaseService,
+    private readonly auth: AuthService,
+    private readonly guards: McpToolGuardsService,
+    readonly addons: AddonsService,
+  ) {}
+
+  @Tool({
+    name: 'import_airtrail_flights',
+    description: 'Import flights from the caller\'s connected AirTrail account into a trip as flight bookings, keeping them linked to AirTrail for two-way sync. Get the ids from list_airtrail_flights first; this tool only accepts ids that account already holds, so it cannot invent a flight. Prefer it over create_transport whenever the flight is already recorded in AirTrail: the route, times, airline and aircraft come across without retyping. Flights already on the trip are reported as skipped rather than duplicated.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      flightIds: airtrailImportSchema.shape.flightIds
+        .describe(`AirTrail flight ids from list_airtrail_flights, at most ${MAX_MCP_AIRTRAIL_FLIGHTS} per call`),
+      connections: airtrailImportSchema.shape.connections
+        .describe('Chains of the ids above to import as ONE multi-leg booking each, with the connection airports as layover stops, e.g. [["12","13"]] for a flight with one change. Every id in a chain must also be in flightIds. A chain whose legs do not actually connect is imported as separate flights instead.'),
+    },
+    // Creating the same flights twice does not duplicate them (the dedupe
+    // reports them skipped), but a call still creates rows, and it reaches out
+    // to the AirTrail instance to re-read the flights it is given.
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_NON_IDEMPOTENT,
+    access: { group: 'reservations', mode: 'write' },
+    when: airtrailAddonOn,
+  })
+  async importAirtrailFlights(
+    { tripId, flightIds, connections }: { tripId: number; flightIds: string[]; connections?: string[][] },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.db.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('reservation_edit', tripId, ctx.userId)) return permissionDenied();
+
+    if (flightIds.length > MAX_MCP_AIRTRAIL_FLIGHTS) {
+      return errorResult(
+        `Too many flights in one call (${flightIds.length}). Import at most ${MAX_MCP_AIRTRAIL_FLIGHTS} at a time.`,
+      );
+    }
+
+    // The service quietly degrades a chain it cannot resolve to individual
+    // imports, which is right for a picker that only ever sends ids it just
+    // rendered. A model assembling the chain itself gets told instead, because
+    // the silent version looks like a successful multi-leg import.
+    const selected = new Set(flightIds);
+    for (const chain of connections ?? []) {
+      const stray = chain.find(id => !selected.has(id));
+      if (stray !== undefined) {
+        return errorResult(`Connection references flight ${stray}, which is not in flightIds.`);
+      }
+    }
+
+    try {
+      // socketId is undefined: there is no originating browser socket to spare
+      // from the echo, so every member including the caller's own session gets
+      // the reservation:created events the service broadcasts.
+      const result = await this.airtrailImport.importAirtrailFlights(
+        tripId, ctx.userId, flightIds, undefined, connections ?? [],
+      );
+      return ok(result);
+    } catch (err) {
+      return errorResult((err as Error)?.message || 'AirTrail import failed');
+    }
+  }
+}

--- a/server/src/nest/reservation-import/reservation-import.module.ts
+++ b/server/src/nest/reservation-import/reservation-import.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ReservationImportController } from './reservation-import.controller';
+import { ReservationImportMcp } from './reservation-import.mcp';
 import { BookingImportModule } from '../booking-import/booking-import.module';
 import { AirtrailModule } from '../integrations/airtrail.module';
 import { AddonsModule } from '../addons/addons.module';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { AuthModule } from '../auth/auth.module';
+import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 
 /**
  * The one route prefix that turns something external into reservations.
@@ -11,10 +14,15 @@ import { PermissionsModule } from '../permissions/permissions.module';
  * It owns the controller and nothing else: the file-upload pipeline stays in
  * booking-import/ and the AirTrail pipeline in integrations/, because those are
  * where their own domains live. What moved here is the HTTP surface they were
- * both declaring separately.
+ * both declaring separately. ReservationImportMcp is the second surface over
+ * the same prefix, so it lives with the controller for the same reason.
+ *
+ * AuthModule and McpSharedModule are the tool's demo check and its
+ * permission/broadcast guards; neither is @Global, so both are named here.
  */
 @Module({
-  imports: [BookingImportModule, AirtrailModule, AddonsModule, PermissionsModule],
+  imports: [BookingImportModule, AirtrailModule, AddonsModule, PermissionsModule, AuthModule, McpSharedModule],
   controllers: [ReservationImportController],
+  providers: [ReservationImportMcp],
 })
 export class ReservationImportModule {}

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -458,6 +458,34 @@ export class ReservationsMcp {
   }
 
   @Tool({
+    name: 'set_reservation_travelers',
+    description: 'Set who is travelling on a booking, replacing the current list. Pass the user IDs of trip members or guests from list_trip_members; an empty array clears the list. Somebody who is not on the trip is ignored rather than added — use add_trip_member for a person with a TREK account, or create_trip_guest for one without.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      reservationId: z.number().int().positive(),
+      user_ids: z.array(z.number().int().positive()).describe('User IDs of the travellers, from list_trip_members. Replaces the whole list; [] clears it.'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'reservations', mode: 'write' },
+  })
+  async setReservationTravelers(
+    { tripId, reservationId, user_ids }: { tripId: number; reservationId: number; user_ids: number[] },
+    ctx: McpContext,
+  ) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.reservations.verifyTripAccess(tripId, ctx.userId)) return noAccess();
+    if (!this.guards.hasTripPermission('reservation_edit', tripId, ctx.userId)) return permissionDenied();
+
+    // The service filters the ids against the trip roster on its own, so an
+    // off-trip id cannot be attached; a missing booking is the only failure.
+    const result = this.reservations.setTravelers(String(reservationId), String(tripId), user_ids);
+    if (!result) return errorResult('Reservation not found.');
+
+    this.guards.safeBroadcast(tripId, 'reservation:travelers-updated', { reservationId, travelers: result.travelers });
+    return ok({ travelers: result.travelers });
+  }
+
+  @Tool({
     name: 'reorder_reservations',
     description: 'Update the display order of reservations within a day.',
     inputSchema: {

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -15,17 +15,26 @@ import type { EndpointInput } from './reservations.service';
 import { AssignmentsService } from '../assignments/assignments.service';
 import { transportLegsInputSchema, type TransportLegInput } from '@trek/shared';
 
-// The type picker in the planner (client/src/components/Planner/TransportModal.tsx)
-// offers ten transport modes and ReservationsPanel renders all of them; the tools
-// below used to accept four, so a bus or a ferry could be planned in the UI and not
-// through an assistant. Both lists are the picker's, in the picker's order.
+// What counts as a transport booking, for the update_transport gate. Every value
+// ReservationsPanel renders with a transport icon, so a stored `transit` row is
+// editable through the transport tools like any other.
 const TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transit', 'transport_other'] as const;
+// What a caller may ASK for, which is the transport form's own picker
+// (client/src/components/Planner/TransportModal.tsx), in its order. The tools
+// below used to accept four of these nine, so a bus or a ferry could be planned
+// in the UI and not through an assistant.
+//
+// `transit` is deliberately absent: the picker does not offer it either. A transit
+// booking carries a provider itinerary in metadata.transit, and create_transit_journey
+// is what writes one — a hand-made `transit` row would be a shape the transit UI
+// does not expect.
+const CREATABLE_TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transport_other'] as const;
 /** Only these two carry per-segment detail: the transport form writes metadata.legs for a flight or a train and for nothing else. */
 const LEG_TRANSPORT_TYPES = ['flight', 'train'] as const;
 /** Everything the picker offers that is not a transport — create_reservation's half. */
 const BOOKING_TYPES = ['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other'] as const;
 
-type TransportType = typeof TRANSPORT_TYPES[number];
+type TransportType = typeof CREATABLE_TRANSPORT_TYPES[number];
 type BookingType = typeof BOOKING_TYPES[number];
 
 const endpointObjectSchema = z.object({
@@ -309,7 +318,7 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_reservation',
-    description: 'Recommend a reservation for a trip. Created as pending — the user must confirm it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit, transport_other — use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Recommend a reservation for a trip. Created as pending — the user must confirm it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other — use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
       title: z.string().min(1).max(200),
@@ -388,7 +397,7 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'update_reservation',
-    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit, transport_other — use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
+    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other — use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
@@ -482,7 +491,14 @@ export class ReservationsMcp {
     if (!result) return errorResult('Reservation not found.');
 
     this.guards.safeBroadcast(tripId, 'reservation:travelers-updated', { reservationId, travelers: result.travelers });
-    return ok({ travelers: result.travelers });
+    // Report what the roster filter dropped. Silently succeeding with a shorter
+    // list reads as "done" to a caller that guessed an id for a name it could
+    // not resolve, which is exactly what an importer does.
+    const attached = new Set(result.travelers.map(t => t.user_id));
+    const ignored = [...new Set(user_ids)].filter(uid => !attached.has(uid));
+    return ok(ignored.length > 0
+      ? { travelers: result.travelers, ignored_user_ids: ignored, note: 'Ignored ids are not on this trip. Add them with add_trip_member or create_trip_guest first.' }
+      : { travelers: result.travelers });
   }
 
   @Tool({
@@ -608,10 +624,10 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_transport',
-    description: 'Create a transport booking for a trip — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit or transport_other. Use endpoints[] to record origin/destination and intermediate stops — for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending — confirm with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Create a transport booking for a trip — flight, train, bus, car, taxi, bicycle, cruise, ferry or transport_other. For scheduled public transit use create_transit_journey, which attaches the provider itinerary. Use endpoints[] to record origin/destination and intermediate stops — for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending — confirm with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
-      type: z.enum(TRANSPORT_TYPES),
+      type: z.enum(CREATABLE_TRANSPORT_TYPES),
       title: z.string().min(1).max(200),
       status: z.enum(['pending', 'confirmed', 'cancelled']).optional().default('pending'),
       start_day_id: z.number().int().positive().optional().describe('Departure day'),
@@ -720,7 +736,7 @@ export class ReservationsMcp {
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
-      type: z.enum(TRANSPORT_TYPES).optional(),
+      type: z.enum(CREATABLE_TRANSPORT_TYPES).optional(),
       title: z.string().min(1).max(200).optional(),
       status: z.enum(['pending', 'confirmed', 'cancelled']).optional(),
       start_day_id: z.number().int().positive().optional().describe('Departure day'),

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -1,6 +1,7 @@
 import {
   McpController, Tool, ResourceTemplate, type McpContext,
-  TOOL_ANNOTATIONS_WRITE, TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE, TOOL_ANNOTATIONS_DELETE,
+  TOOL_ANNOTATIONS_NON_IDEMPOTENT,
   demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
@@ -26,12 +27,12 @@ const TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cr
 //
 // `transit` is deliberately absent: the picker does not offer it either. A transit
 // booking carries a provider itinerary in metadata.transit, and create_transit_journey
-// is what writes one — a hand-made `transit` row would be a shape the transit UI
+// is what writes one. A hand-made `transit` row would be a shape the transit UI
 // does not expect.
 const CREATABLE_TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transport_other'] as const;
 /** Only these two carry per-segment detail: the transport form writes metadata.legs for a flight or a train and for nothing else. */
 const LEG_TRANSPORT_TYPES = ['flight', 'train'] as const;
-/** Everything the picker offers that is not a transport — create_reservation's half. */
+/** Everything the picker offers that is not a transport: create_reservation's half. */
 const BOOKING_TYPES = ['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other'] as const;
 
 /**
@@ -41,7 +42,7 @@ const BOOKING_TYPES = ['hotel', 'restaurant', 'event', 'tour', 'activity', 'park
  * as an href.
  */
 const urlField = reservationUrlSchema.max(2000).optional()
-  .describe('Link to the booking — the airline/hotel confirmation page, the ticket. Shown as a link on the booking.');
+  .describe('Link to the booking: the airline/hotel confirmation page, the ticket. Shown as a link on the booking.');
 
 type TransportType = typeof CREATABLE_TRANSPORT_TYPES[number];
 type BookingType = typeof BOOKING_TYPES[number];
@@ -327,13 +328,13 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_reservation',
-    description: 'Recommend a reservation for a trip. Created as pending — the user must confirm it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other — use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Recommend a reservation for a trip. Created as pending, so the user must confirm it. For anything travelled ON (flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other) use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
       title: z.string().min(1).max(200),
       type: z.enum(BOOKING_TYPES).describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string'),
-      reservation_end_time: z.string().optional().describe('When it ends — a dinner from 19:00 to 21:30, a tour that runs all afternoon. Ignored for hotels, whose span is the check-in/check-out days.'),
+      reservation_end_time: z.string().optional().describe('When it ends: a dinner from 19:00 to 21:30, a tour that runs all afternoon. Ignored for hotels, whose span is the check-in/check-out days.'),
       url: urlField,
       location: z.string().max(500).optional(),
       confirmation_number: z.string().max(100).optional(),
@@ -408,7 +409,7 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'update_reservation',
-    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other — use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
+    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For anything travelled ON (flight, train, bus, car, taxi, bicycle, cruise, ferry, transport_other) use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
@@ -481,7 +482,7 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'set_reservation_travelers',
-    description: 'Set who is travelling on a booking, replacing the current list. Pass the user IDs of trip members or guests from list_trip_members; an empty array clears the list. Somebody who is not on the trip is ignored rather than added — use add_trip_member for a person with a TREK account, or create_trip_guest for one without.',
+    description: 'Set who is travelling on a booking, replacing the current list. Pass the user IDs of trip members or guests from list_trip_members; an empty array clears the list. Somebody who is not on the trip is ignored rather than added: use add_trip_member for a person with a TREK account, or create_trip_guest for one without.',
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
@@ -596,6 +597,29 @@ export class ReservationsMcp {
     return ok({ reservation, accommodation_id: reservation?.accommodation_id ?? null });
   }
 
+  // -------------------------------------------------------------------------
+  // Cross-trip reads
+  //
+  // Every other entry here is trip-scoped and checks verifyTripAccess against
+  // the tripId it was handed. This one has no tripId: the visible_trips CTE in
+  // listUpcoming is the access check, exactly as for GET /api/reservations/upcoming,
+  // so a booking on a trip the caller neither owns nor is a member of is never
+  // in the result set to begin with.
+  // -------------------------------------------------------------------------
+
+  @Tool({
+    name: 'list_upcoming_reservations',
+    description: 'The next bookings across ALL of the user\'s trips, soonest first: "what is coming up?", "when is my next flight?". Prefer this over get_trip_summary when no particular trip is in question, or when the trip is unknown. Hotel stays appear as their check-in and check-out moments (the stay itself covers a range and is not a point in time), which no per-trip reservation list reports. Cancelled bookings and archived trips are left out.',
+    inputSchema: {
+      limit: z.number().int().min(1).max(50).optional().describe('How many entries to return, soonest first (default 6, the dashboard widget\'s size)'),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'reservations', mode: 'read' },
+  })
+  async listUpcomingReservations({ limit }: { limit?: number }, ctx: McpContext) {
+    return ok({ reservations: this.reservations.listUpcoming(ctx.userId, limit) });
+  }
+
   @ResourceTemplate({
     name: 'trip-reservations',
     uriTemplate: 'trek://trips/{tripId}/reservations',
@@ -637,7 +661,7 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_transport',
-    description: 'Create a transport booking for a trip — flight, train, bus, car, taxi, bicycle, cruise, ferry or transport_other. For scheduled public transit use create_transit_journey, which attaches the provider itinerary. Use endpoints[] to record origin/destination and intermediate stops — for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending — confirm with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Create a transport booking for a trip: flight, train, bus, car, taxi, bicycle, cruise, ferry or transport_other. For scheduled public transit use create_transit_journey, which attaches the provider itinerary. Use endpoints[] to record origin/destination and intermediate stops; for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending, so confirm it with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
       type: z.enum(CREATABLE_TRANSPORT_TYPES),

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -15,9 +15,18 @@ import type { EndpointInput } from './reservations.service';
 import { AssignmentsService } from '../assignments/assignments.service';
 import { transportLegsInputSchema, type TransportLegInput } from '@trek/shared';
 
-const TRANSPORT_TYPES = ['flight', 'train', 'car', 'cruise'] as const;
-/** Only these two carry per-segment detail; a car or cruise has no legs. */
+// The type picker in the planner (client/src/components/Planner/TransportModal.tsx)
+// offers ten transport modes and ReservationsPanel renders all of them; the tools
+// below used to accept four, so a bus or a ferry could be planned in the UI and not
+// through an assistant. Both lists are the picker's, in the picker's order.
+const TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transit', 'transport_other'] as const;
+/** Only these two carry per-segment detail: the transport form writes metadata.legs for a flight or a train and for nothing else. */
 const LEG_TRANSPORT_TYPES = ['flight', 'train'] as const;
+/** Everything the picker offers that is not a transport — create_reservation's half. */
+const BOOKING_TYPES = ['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other'] as const;
+
+type TransportType = typeof TRANSPORT_TYPES[number];
+type BookingType = typeof BOOKING_TYPES[number];
 
 const endpointObjectSchema = z.object({
   role: z.enum(['from', 'to', 'stop']).describe('Endpoint role: "from" (origin), "to" (destination), or "stop" (intermediate)'),
@@ -300,11 +309,11 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_reservation',
-    description: 'Recommend a reservation for a trip. Created as pending — the user must confirm it. For flights, trains, cars, and cruises, use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Recommend a reservation for a trip. Created as pending — the user must confirm it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit, transport_other — use create_transport instead. Linking: hotel → use place_id + start_day_id + end_day_id (all three required to create the accommodation link); restaurant/event/tour/activity/parking/other → use assignment_id. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
       title: z.string().min(1).max(200),
-      type: z.enum(['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other']).describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
+      type: z.enum(BOOKING_TYPES).describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string'),
       location: z.string().max(500).optional(),
       confirmation_number: z.string().max(100).optional(),
@@ -324,7 +333,7 @@ export class ReservationsMcp {
   })
   async createReservation(
     { tripId, title, type, reservation_time, location, confirmation_number, notes, day_id, place_id, start_day_id, end_day_id, check_in, check_out, assignment_id, price, budget_category }: {
-      tripId: number; title: string; type: 'hotel' | 'restaurant' | 'event' | 'tour' | 'activity' | 'parking' | 'other';
+      tripId: number; title: string; type: BookingType;
       reservation_time?: string; location?: string; confirmation_number?: string; notes?: string;
       day_id?: number; place_id?: number; start_day_id?: number; end_day_id?: number;
       check_in?: string; check_out?: string; assignment_id?: number; price?: number; budget_category?: string;
@@ -379,12 +388,12 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'update_reservation',
-    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For flights, trains, cars, and cruises, use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
+    description: 'Update an existing reservation in a trip. Use status "confirmed" to confirm a pending recommendation, or "pending" to revert it. For anything travelled ON — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit, transport_other — use update_transport instead. Linking: hotel → use place_id to link to an accommodation place; restaurant/event/tour/activity/parking/other → use assignment_id to link to a day assignment.',
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
       title: z.string().min(1).max(200).optional(),
-      type: z.enum(['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other']).optional().describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
+      type: z.enum(BOOKING_TYPES).optional().describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string'),
       location: z.string().max(500).optional(),
       confirmation_number: z.string().max(100).optional(),
@@ -399,7 +408,7 @@ export class ReservationsMcp {
   async updateReservation(
     { tripId, reservationId, title, type, reservation_time, location, confirmation_number, notes, status, place_id, assignment_id }: {
       tripId: number; reservationId: number; title?: string;
-      type?: 'hotel' | 'restaurant' | 'event' | 'tour' | 'activity' | 'parking' | 'other';
+      type?: BookingType;
       reservation_time?: string; location?: string; confirmation_number?: string; notes?: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; place_id?: number | null; assignment_id?: number | null;
     },
@@ -571,10 +580,10 @@ export class ReservationsMcp {
 
   @Tool({
     name: 'create_transport',
-    description: 'Create a transport booking (flight, train, car, or cruise) for a trip. Use endpoints[] to record origin/destination and intermediate stops — for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending — confirm with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
+    description: 'Create a transport booking for a trip — flight, train, bus, car, taxi, bicycle, cruise, ferry, transit or transport_other. Use endpoints[] to record origin/destination and intermediate stops — for flights, set code to the IATA airport code (use search_airports first). For a booking WITH STOPOVERS also pass legs[] (one entry per segment, one fewer than endpoints[]), otherwise every segment inherits the stop time as both its arrival and its departure. The top-level confirmation_number is the booking reference; when a single segment was booked under its own reference, put that one on the leg instead. Created as pending — confirm with update_transport. Set price to record the cost; it will appear on the booking and in the Budget tab.',
     inputSchema: {
       tripId: z.number().int().positive(),
-      type: z.enum(['flight', 'train', 'car', 'cruise']),
+      type: z.enum(TRANSPORT_TYPES),
       title: z.string().min(1).max(200),
       status: z.enum(['pending', 'confirmed', 'cancelled']).optional().default('pending'),
       start_day_id: z.number().int().positive().optional().describe('Departure day'),
@@ -595,7 +604,7 @@ export class ReservationsMcp {
   })
   async createTransport(
     { tripId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, notes, metadata, endpoints, legs, needs_review, price, budget_category }: {
-      tripId: number; type: 'flight' | 'train' | 'car' | 'cruise'; title: string;
+      tripId: number; type: TransportType; title: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; start_day_id?: number; end_day_id?: number;
       reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; notes?: string;
       metadata?: Record<string, string>; endpoints?: TransportEndpoint[]; legs?: TransportLegInput[]; needs_review?: boolean;
@@ -683,7 +692,7 @@ export class ReservationsMcp {
     inputSchema: {
       tripId: z.number().int().positive(),
       reservationId: z.number().int().positive(),
-      type: z.enum(['flight', 'train', 'car', 'cruise']).optional(),
+      type: z.enum(TRANSPORT_TYPES).optional(),
       title: z.string().min(1).max(200).optional(),
       status: z.enum(['pending', 'confirmed', 'cancelled']).optional(),
       start_day_id: z.number().int().positive().optional().describe('Departure day'),
@@ -702,7 +711,7 @@ export class ReservationsMcp {
   })
   async updateTransport(
     { tripId, reservationId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, notes, metadata, endpoints, legs, needs_review }: {
-      tripId: number; reservationId: number; type?: 'flight' | 'train' | 'car' | 'cruise'; title?: string;
+      tripId: number; reservationId: number; type?: TransportType; title?: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; start_day_id?: number; end_day_id?: number;
       reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; notes?: string;
       metadata?: Record<string, string>; endpoints?: TransportEndpoint[]; legs?: TransportLegInput[]; needs_review?: boolean;

--- a/server/src/nest/reservations/reservations.mcp.ts
+++ b/server/src/nest/reservations/reservations.mcp.ts
@@ -13,7 +13,7 @@ import { DaysService } from '../days/days.service';
 import { findByIata } from '../airports/airports.data';
 import type { EndpointInput } from './reservations.service';
 import { AssignmentsService } from '../assignments/assignments.service';
-import { transportLegsInputSchema, type TransportLegInput } from '@trek/shared';
+import { transportLegsInputSchema, reservationUrlSchema, type TransportLegInput } from '@trek/shared';
 
 // What counts as a transport booking, for the update_transport gate. Every value
 // ReservationsPanel renders with a transport icon, so a stored `transit` row is
@@ -33,6 +33,15 @@ const CREATABLE_TRANSPORT_TYPES = ['flight', 'train', 'bus', 'car', 'taxi', 'bic
 const LEG_TRANSPORT_TYPES = ['flight', 'train'] as const;
 /** Everything the picker offers that is not a transport — create_reservation's half. */
 const BOOKING_TYPES = ['hotel', 'restaurant', 'event', 'tour', 'activity', 'parking', 'other'] as const;
+
+/**
+ * The booking link. Same refinement the REST contract applies
+ * (shared/src/reservation/reservation.schema.ts), so a javascript:/data:/vbscript:
+ * URL is refused on this surface too rather than being stored and later rendered
+ * as an href.
+ */
+const urlField = reservationUrlSchema.max(2000).optional()
+  .describe('Link to the booking — the airline/hotel confirmation page, the ticket. Shown as a link on the booking.');
 
 type TransportType = typeof CREATABLE_TRANSPORT_TYPES[number];
 type BookingType = typeof BOOKING_TYPES[number];
@@ -324,6 +333,8 @@ export class ReservationsMcp {
       title: z.string().min(1).max(200),
       type: z.enum(BOOKING_TYPES).describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string'),
+      reservation_end_time: z.string().optional().describe('When it ends — a dinner from 19:00 to 21:30, a tour that runs all afternoon. Ignored for hotels, whose span is the check-in/check-out days.'),
+      url: urlField,
       location: z.string().max(500).optional(),
       confirmation_number: z.string().max(100).optional(),
       notes: z.string().max(1000).optional(),
@@ -341,9 +352,9 @@ export class ReservationsMcp {
     access: { group: 'reservations', mode: 'write' },
   })
   async createReservation(
-    { tripId, title, type, reservation_time, location, confirmation_number, notes, day_id, place_id, start_day_id, end_day_id, check_in, check_out, assignment_id, price, budget_category }: {
+    { tripId, title, type, reservation_time, reservation_end_time, url, location, confirmation_number, notes, day_id, place_id, start_day_id, end_day_id, check_in, check_out, assignment_id, price, budget_category }: {
       tripId: number; title: string; type: BookingType;
-      reservation_time?: string; location?: string; confirmation_number?: string; notes?: string;
+      reservation_time?: string; reservation_end_time?: string; url?: string; location?: string; confirmation_number?: string; notes?: string;
       day_id?: number; place_id?: number; start_day_id?: number; end_day_id?: number;
       check_in?: string; check_out?: string; assignment_id?: number; price?: number; budget_category?: string;
     },
@@ -372,7 +383,7 @@ export class ReservationsMcp {
     const metadata = price != null ? { price: String(price) } : undefined;
 
     const { reservation, accommodationCreated } = this.reservations.create(tripId, {
-      title, type, reservation_time, location, confirmation_number,
+      title, type, reservation_time, reservation_end_time, url, location, confirmation_number,
       notes, day_id, place_id, assignment_id,
       create_accommodation: createAccommodation,
       metadata,
@@ -404,6 +415,8 @@ export class ReservationsMcp {
       title: z.string().min(1).max(200).optional(),
       type: z.enum(BOOKING_TYPES).optional().describe('Reservation type: "hotel", "restaurant", "event", "tour", "activity", "parking", or "other"'),
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string'),
+      reservation_end_time: z.string().optional().describe('When it ends. Ignored for hotels, whose span is the check-in/check-out days.'),
+      url: urlField,
       location: z.string().max(500).optional(),
       confirmation_number: z.string().max(100).optional(),
       notes: z.string().max(1000).optional(),
@@ -415,10 +428,10 @@ export class ReservationsMcp {
     access: { group: 'reservations', mode: 'write' },
   })
   async updateReservation(
-    { tripId, reservationId, title, type, reservation_time, location, confirmation_number, notes, status, place_id, assignment_id }: {
+    { tripId, reservationId, title, type, reservation_time, reservation_end_time, url, location, confirmation_number, notes, status, place_id, assignment_id }: {
       tripId: number; reservationId: number; title?: string;
       type?: BookingType;
-      reservation_time?: string; location?: string; confirmation_number?: string; notes?: string;
+      reservation_time?: string; reservation_end_time?: string; url?: string; location?: string; confirmation_number?: string; notes?: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; place_id?: number | null; assignment_id?: number | null;
     },
     ctx: McpContext,
@@ -435,7 +448,7 @@ export class ReservationsMcp {
       return errorResult('assignment_id does not belong to this trip.');
 
     const { reservation } = this.reservations.update(reservationId, tripId, {
-      title, type, reservation_time, location, confirmation_number, notes, status,
+      title, type, reservation_time, reservation_end_time, url, location, confirmation_number, notes, status,
       place_id: place_id !== undefined ? place_id ?? undefined : undefined,
       assignment_id: assignment_id !== undefined ? assignment_id ?? undefined : undefined,
     }, existing);
@@ -635,6 +648,7 @@ export class ReservationsMcp {
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string for departure'),
       reservation_end_time: z.string().optional().describe('ISO 8601 datetime or time string for arrival'),
       confirmation_number: z.string().max(100).optional(),
+      url: urlField,
       notes: z.string().max(1000).optional(),
       metadata: z.record(z.string(), z.string()).optional().describe('Type-specific metadata: flights → { airline, flight_number, departure_airport, arrival_airport }; trains → { train_number, platform, seat }. Values are plain strings, so per-segment detail belongs in legs[], not here.'),
       endpoints: endpointSchema,
@@ -647,10 +661,10 @@ export class ReservationsMcp {
     access: { group: 'reservations', mode: 'write' },
   })
   async createTransport(
-    { tripId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, notes, metadata, endpoints, legs, needs_review, price, budget_category }: {
+    { tripId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, url, notes, metadata, endpoints, legs, needs_review, price, budget_category }: {
       tripId: number; type: TransportType; title: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; start_day_id?: number; end_day_id?: number;
-      reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; notes?: string;
+      reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; url?: string; notes?: string;
       metadata?: Record<string, string>; endpoints?: TransportEndpoint[]; legs?: TransportLegInput[]; needs_review?: boolean;
       price?: number; budget_category?: string;
     },
@@ -708,6 +722,7 @@ export class ReservationsMcp {
       reservation_end_time: arrivalTime,
       location: undefined,
       confirmation_number,
+      url,
       notes,
       day_id: dayId,
       end_day_id: spanEndDayId ?? dayId,
@@ -744,6 +759,7 @@ export class ReservationsMcp {
       reservation_time: z.string().optional().describe('ISO 8601 datetime or time string for departure'),
       reservation_end_time: z.string().optional().describe('ISO 8601 datetime or time string for arrival'),
       confirmation_number: z.string().max(100).optional(),
+      url: urlField,
       notes: z.string().max(1000).optional(),
       metadata: z.record(z.string(), z.string()).optional().describe('Type-specific metadata: flights → { airline, flight_number, departure_airport, arrival_airport }; trains → { train_number, platform, seat }. Replaces the stored metadata wholesale. Values are plain strings, so per-segment detail belongs in legs[], not here.'),
       endpoints: endpointSchema,
@@ -754,10 +770,10 @@ export class ReservationsMcp {
     access: { group: 'reservations', mode: 'write' },
   })
   async updateTransport(
-    { tripId, reservationId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, notes, metadata, endpoints, legs, needs_review }: {
+    { tripId, reservationId, type, title, status, start_day_id, end_day_id, reservation_time, reservation_end_time, confirmation_number, url, notes, metadata, endpoints, legs, needs_review }: {
       tripId: number; reservationId: number; type?: TransportType; title?: string;
       status?: 'pending' | 'confirmed' | 'cancelled'; start_day_id?: number; end_day_id?: number;
-      reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; notes?: string;
+      reservation_time?: string; reservation_end_time?: string; confirmation_number?: string; url?: string; notes?: string;
       metadata?: Record<string, string>; endpoints?: TransportEndpoint[]; legs?: TransportLegInput[]; needs_review?: boolean;
     },
     ctx: McpContext,
@@ -834,6 +850,7 @@ export class ReservationsMcp {
       reservation_time: departureTime,
       reservation_end_time: arrivalTime,
       confirmation_number,
+      url,
       notes,
       day_id: dayId,
       end_day_id: spanEndDayId,

--- a/server/src/nest/settings/settings.mcp.ts
+++ b/server/src/nest/settings/settings.mcp.ts
@@ -1,0 +1,170 @@
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE,
+  demoDenied, errorResult, ok,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import { MASKED_SETTING_VALUE, SUPPORTED_LANGUAGE_CODES, settingsBulkRequestSchema } from '@trek/shared';
+import { AuthService } from '../auth/auth.service';
+import { SettingsService } from './settings.service';
+
+/**
+ * The only settings keys this surface may read or write.
+ *
+ * An allow-list rather than a deny-list, because `settings` is one flat
+ * key/value table that also holds credentials: ENCRYPTED_SETTING_KEYS in
+ * settings.service.ts covers webhook_url, ntfy_token, mapbox_access_token,
+ * carto_api_key and llm_api_key, and getUserSettings masks only three of those
+ * and hands the rest back decrypted. Exposing that accessor as a tool would
+ * turn a `settings:read` token into a credential reader. A deny-list would put
+ * the burden on whoever adds the next secret key to remember this file; an
+ * allow-list leaves anything new invisible until somebody names it here.
+ *
+ * The membership is what DisplaySettingsTab.tsx offers, plus dark_mode (its
+ * own control, in AppearanceSettingsTab and the navbar theme toggle). Keys from
+ * DEFAULTABLE_USER_SETTING_KEYS that are credentials or renderer plumbing
+ * (map_tile_url, map_provider, mapbox_*, maplibre_style, llm_*, carto_api_key)
+ * are left off on purpose: they configure the install, not how a person reads
+ * a temperature, and every one of them is on MANAGED_LOCKED_SETTING_KEYS or
+ * next to something that is.
+ *
+ * Each value schema is at most as permissive as what the REST route stores
+ * today, which validates nothing here. Narrowing is deliberate: a model gets a
+ * refusal it can act on instead of parking 'kelvin' in a row the client then
+ * silently ignores.
+ */
+const DISPLAY_PREFERENCES = {
+  start_page: z.enum(['dashboard', 'active_trip']),
+  // The planner falls back to its plan view for a tab that does not exist, and
+  // trip-page plugins are addressable as `plugin:<id>`, so the id set is not
+  // closed. Core ids are named in the tool description instead.
+  start_trip_tab: z.string().min(1).max(64),
+  default_currency: z.union([z.literal(''), z.string().regex(/^[A-Z]{3}$/, 'Expected a three-letter uppercase ISO 4217 code, e.g. EUR, or "" to clear it')]),
+  language: z.string().refine(
+    (value) => SUPPORTED_LANGUAGE_CODES.includes(value),
+    { message: `Expected one of: ${SUPPORTED_LANGUAGE_CODES.join(', ')}` },
+  ),
+  temperature_unit: z.enum(['celsius', 'fahrenheit']),
+  distance_unit: z.enum(['metric', 'imperial']),
+  time_format: z.enum(['12h', '24h']),
+  // Booleans are the pre-'auto' form and still sit in older rows, so they stay
+  // writable: this is exactly the VALID_VALUES.dark_mode set the admin-defaults
+  // path accepts, and refusing them here would make a value TREK itself wrote
+  // unwritable through this tool.
+  dark_mode: z.union([z.enum(['light', 'dark', 'auto']), z.boolean()]),
+  map_booking_labels: z.boolean(),
+  map_always_show_routes: z.boolean(),
+  map_poi_pill_enabled: z.boolean(),
+  blur_booking_codes: z.boolean(),
+  optimize_from_accommodation: z.boolean(),
+} satisfies Record<string, z.ZodType>;
+
+type DisplayPreferenceKey = keyof typeof DISPLAY_PREFERENCES;
+
+export const DISPLAY_PREFERENCE_KEYS = Object.keys(DISPLAY_PREFERENCES) as DisplayPreferenceKey[];
+
+// Set rather than `key in DISPLAY_PREFERENCES`: `in` walks the prototype chain,
+// so 'toString' and 'constructor' would both pass for an object literal.
+const ALLOWED = new Set<string>(DISPLAY_PREFERENCE_KEYS);
+
+const KEY_LIST = DISPLAY_PREFERENCE_KEYS.join(', ');
+
+/**
+ * Settings MCP surface: the display half of /api/settings, and nothing else.
+ *
+ * New surface rather than a port, so there is no legacy registrar to match.
+ * It exists because an assistant had no way to learn whether the person it is
+ * answering reads celsius or fahrenheit, kilometres or miles, 24h or 12h: the
+ * session instructions name the trip currency and nothing more, so every
+ * rendered temperature and distance was a guess.
+ *
+ * Both tools are user-scoped, like the routes they mirror (JwtAuthGuard, no
+ * trip in the path), so the trip-access/permission pair does not apply. The
+ * write carries the demo gate the other write tools carry.
+ *
+ * The controller's own two refusals stay out of reach by construction rather
+ * than by being repeated: assertMayWriteLlmEndpoint guards llm_base_url and
+ * llm_provider, and isManagedLockedKey guards the operator-owned keys, and not
+ * one name from either list is on the allow-list above. tools-settings.test.ts
+ * asserts that intersection is empty instead of trusting the reading.
+ */
+@McpController()
+export class SettingsMcp {
+  constructor(
+    private readonly settings: SettingsService,
+    private readonly auth: AuthService,
+  ) {}
+
+  /**
+   * getUserSettings resolves admin defaults and the managed-install token
+   * injection before this filter runs, so the caller sees the same effective
+   * value the web UI does, minus everything not named on the allow-list.
+   */
+  private readDisplayPreferences(userId: number): Record<string, unknown> {
+    const all = this.settings.getUserSettings(userId);
+    const picked: Record<string, unknown> = {};
+    for (const key of DISPLAY_PREFERENCE_KEYS) {
+      if (Object.hasOwn(all, key)) picked[key] = all[key];
+    }
+    return picked;
+  }
+
+  @Tool({
+    name: 'get_display_settings',
+    description: `Read the current user's display preferences: ${KEY_LIST}. Call this before rendering a temperature, a distance, a time of day or an amount, so the answer matches what the person sees inside TREK instead of being guessed, and call it before update_display_settings whenever the request is relative ("switch me back", "use the other unit"). Only keys that are actually set are returned; TREK's own fallbacks for the rest are celsius, metric, 24h, language en, start_page dashboard, start_trip_tab plan, and no personal default currency, which means amounts fall back to the currency of the trip they belong to. Stored credentials (map tokens, LLM API keys, webhook URLs, SMTP) are deliberately not part of this surface and never appear in the result.`,
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: { group: 'settings', mode: 'read' },
+  })
+  async getDisplaySettings(_input: Record<string, never>, ctx: McpContext) {
+    return ok({ settings: this.readDisplayPreferences(ctx.userId) });
+  }
+
+  @Tool({
+    name: 'update_display_settings',
+    description: `Change one or more of the current user's display preferences. Pass a settings object holding only the keys to change; anything left out keeps its current value. Writable keys: ${KEY_LIST}. start_page is dashboard or active_trip, start_trip_tab is one of plan, transports, buchungen, listen, finanzplan, dateien, collab (the ids are the planner's internal German ones) or plugin:<id> for a plugin tab, default_currency is a three-letter ISO code or "" to fall back to each trip's own currency, dark_mode is light, dark or auto. Every other key is refused, including API keys, map tokens, LLM endpoint settings and SMTP: those belong to the account owner or to whoever operates the instance and are set in TREK itself, not here. Prefer get_display_settings when you only need to read a value.`,
+    inputSchema: {
+      settings: settingsBulkRequestSchema.shape.settings
+        .describe(`Object of preference key to new value, e.g. {"temperature_unit": "fahrenheit", "distance_unit": "imperial"}. At least one key, and every key must be one of: ${KEY_LIST}.`),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'settings', mode: 'write' },
+  })
+  async updateDisplaySettings({ settings }: { settings: Record<string, unknown> }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+
+    const entries = Object.entries(settings);
+    if (entries.length === 0) {
+      return errorResult(`No preference given. Pass at least one of: ${KEY_LIST}.`);
+    }
+
+    const rejected = entries.map(([key]) => key).filter((key) => !ALLOWED.has(key));
+    if (rejected.length > 0) {
+      return errorResult(`Not a display preference: ${rejected.join(', ')}. This tool writes only ${KEY_LIST}. Credentials and instance configuration (API keys, map tokens, LLM endpoints, SMTP) are not reachable from MCP at all.`);
+    }
+
+    // Everything is validated before anything is written, so a bad key in a
+    // multi-key call cannot leave half the preferences changed. The service
+    // wraps its own writes in a transaction, but it never sees this call.
+    const validated: Record<string, unknown> = {};
+    for (const [key, value] of entries) {
+      // The client echoes redacted secrets back as this sentinel and
+      // bulkUpsertSettings skips them, which for a display preference would be
+      // a silent no-op rather than the refusal a caller can learn from.
+      if (value === MASKED_SETTING_VALUE) {
+        return errorResult(`Invalid value for ${key}: ${MASKED_SETTING_VALUE} is the placeholder TREK shows in place of a redacted secret, not a value.`);
+      }
+      const parsed = DISPLAY_PREFERENCES[key as DisplayPreferenceKey].safeParse(value);
+      if (!parsed.success) {
+        const reason = parsed.error.issues[0]?.message ?? 'not accepted';
+        return errorResult(`Invalid value for ${key}: ${JSON.stringify(value)}. ${reason}`);
+      }
+      validated[key] = parsed.data;
+    }
+
+    const updated = this.settings.bulkUpsertSettings(ctx.userId, validated);
+    // Read back rather than echoing the input: an admin default or the managed
+    // token injection can still shape what the user ends up seeing.
+    return ok({ success: true, updated, settings: this.readDisplayPreferences(ctx.userId) });
+  }
+}

--- a/server/src/nest/settings/settings.module.ts
+++ b/server/src/nest/settings/settings.module.ts
@@ -3,14 +3,16 @@ import { AdminDefaultUserSettingsController, SettingsController } from './settin
 import { AuthModule } from '../auth/auth.module';
 import { AuditModule } from '../audit/audit.module';
 import { SettingsService } from './settings.service';
+import { SettingsMcp } from './settings.mcp';
 import { AppConfigModule } from '../app-config/app-config.module';
 
 /** Exports SettingsService for in-container consumers (admin, share, llm-parse). */
 @Module({
-  // AuthModule for the admin gate on the defaults routes.
+  // AuthModule for the admin gate on the defaults routes, and for the
+  // AuthService that SettingsMcp's demo gate injects.
   imports: [AppConfigModule, AuthModule, AuditModule],
   controllers: [SettingsController, AdminDefaultUserSettingsController],
-  providers: [SettingsService],
+  providers: [SettingsService, SettingsMcp],
   exports: [SettingsService],
 })
 export class SettingsModule {}

--- a/server/src/nest/settings/settings.service.ts
+++ b/server/src/nest/settings/settings.service.ts
@@ -4,7 +4,12 @@ import { decrypt_api_key, maybe_encrypt_api_key } from '../common/crypto/apiKeyC
 import { MASKED_SETTING_VALUE, normalizeAppearance } from '@trek/shared';
 import { readEnv } from '../../app-config';
 
-const ENCRYPTED_SETTING_KEYS = new Set([
+/**
+ * Exported so a caller that hands settings to somebody else can assert its own
+ * allow-list against the live values rather than a copy: a sixth key added here
+ * has to fail that assertion, which a hand-typed list would not.
+ */
+export const ENCRYPTED_SETTING_KEYS = new Set([
   'webhook_url',
   'ntfy_token',
   'mapbox_access_token',
@@ -13,7 +18,7 @@ const ENCRYPTED_SETTING_KEYS = new Set([
 ]);
 // Encrypted keys that are masked (••••••••) when returned to the client.
 // Keys not in this set but in ENCRYPTED_SETTING_KEYS are decrypted and returned.
-const MASKED_SETTING_KEYS = new Set(['webhook_url', 'ntfy_token', 'llm_api_key']);
+export const MASKED_SETTING_KEYS = new Set(['webhook_url', 'ntfy_token', 'llm_api_key']);
 
 export const DEFAULTABLE_USER_SETTING_KEYS = [
   'temperature_unit',

--- a/server/src/nest/trip-invite/trip-invite.mcp.ts
+++ b/server/src/nest/trip-invite/trip-invite.mcp.ts
@@ -1,0 +1,137 @@
+import {
+  McpController, Tool, type McpContext,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+  demoDenied, ok,
+} from '../../nest-mcp';
+import { z } from 'zod';
+import { getAppUrl } from '../../app-config';
+import { AuditService } from '../audit/audit.service';
+import { DatabaseService } from '../database/database.service';
+import { RuntimeEnvService } from '../app-config/runtime-env.service';
+import { isDemoUserId } from '../common/demo-write';
+import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { canShareTrips, canWrite } from '../../mcp/scopes';
+import { noAccess, permissionDenied } from '../../mcp/tools/_shared';
+import { tripInviteLinkCreateRequestSchema } from '@trek/shared';
+import type { TripInviteLinkCreateRequest } from '@trek/shared';
+import { TripInviteService, type TripInviteInfo } from './trip-invite.service';
+
+/**
+ * Invite-link MCP surface, mirroring TripInviteLinkController. The join half of
+ * the domain (GET /api/trip-invites/:token and its accept route) stays out:
+ * following an invite is a person deciding to join somebody else's trip, and
+ * putting the accept route on a tool would let an assistant walk its user into
+ * a trip on the strength of a token it found somewhere.
+ *
+ * Both scopes, not either: the invite link is managed like the public share
+ * link (share_manage on every verb, GET included, because the payload is the
+ * credential) but it hands out trip MEMBERSHIP, which is what `trips:write`
+ * covers. Requiring both keeps a share-scoped token from adding members and a
+ * write-scoped token from minting an anonymous link, and it can only ever be
+ * narrower than the route.
+ */
+@McpController()
+export class TripInviteMcp {
+  constructor(
+    private readonly invites: TripInviteService,
+    private readonly db: DatabaseService,
+    private readonly env: RuntimeEnvService,
+    private readonly guards: McpToolGuardsService,
+    private readonly audit: AuditService,
+  ) {}
+
+  /** The AuthService.isDemoUser check without the auth graph (demo-write.ts). */
+  private isDemoUser(userId: number): boolean {
+    return isDemoUserId(this.env, this.db, userId);
+  }
+
+  /** Trip access first (404-equivalent), then share_manage, which is requireManage() in the controller. */
+  private denyManage(tripId: number, userId: number) {
+    if (!this.invites.verifyTripAccess(String(tripId), userId)) return noAccess();
+    if (!this.guards.hasTripPermission('share_manage', tripId, userId)) return permissionDenied();
+    return null;
+  }
+
+  /** The link the client builds around the raw token (client/src/App.tsx: /join/:token). */
+  private describe(info: TripInviteInfo) {
+    return { ...info, url: `${getAppUrl()}/join/${info.token}` };
+  }
+
+  @Tool({
+    name: 'get_trip_invite_link',
+    description: 'Get the trip\'s current invite link, the one that adds whoever opens it to the trip as a member. Returns null when the trip has none. This is not the read-only public view link: get_share_link is that one.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    access: (ctx) => canShareTrips(ctx.scopes) && canWrite(ctx.scopes, 'trips'),
+  })
+  async getTripInviteLink({ tripId }: { tripId: number }, ctx: McpContext) {
+    const denied = this.denyManage(tripId, ctx.userId);
+    if (denied) return denied;
+    const info = this.invites.get(tripId);
+    return ok({ invite_link: info ? this.describe(info) : null });
+  }
+
+  @Tool({
+    name: 'create_trip_invite_link',
+    description: 'Create the trip\'s invite link, or rotate it: a trip has exactly one, so calling this again issues a fresh token and the previous link stops working immediately. Anyone with a TREK account who opens the link and signs in becomes a member of the trip, which makes it a different and far stronger thing than create_share_link, whose link only shows a read-only public view. Use add_trip_member instead when the person already has an account and is known by name or email.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      expires_in_days: tripInviteLinkCreateRequestSchema.shape.expires_in_days
+        .describe('Days until the link stops working; omit, null or 0 leaves it valid until it is rotated or deleted'),
+    },
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    access: (ctx) => canShareTrips(ctx.scopes) && canWrite(ctx.scopes, 'trips'),
+  })
+  async createTripInviteLink(
+    { tripId, expires_in_days }: { tripId: number } & TripInviteLinkCreateRequest,
+    ctx: McpContext,
+  ) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    const denied = this.denyManage(tripId, ctx.userId);
+    if (denied) return denied;
+    // The route's own coercion, kept verbatim: the shared contract admits a
+    // digits-only string as well as a number, and anything that does not parse
+    // to a finite value means no expiry rather than an error.
+    const parsed = expires_in_days != null && String(expires_in_days).trim() !== ''
+      ? Number.parseInt(String(expires_in_days))
+      : null;
+    const days = Number.isFinite(parsed as number) ? parsed : null;
+    const info = this.invites.createOrRotate(tripId, ctx.userId, days);
+    // Minting a membership credential is audited wherever it happens, so an
+    // admin reading the log sees the same row for a link made through an
+    // assistant as for one made in the planner. No request here, hence no ip.
+    this.audit.writeAudit({
+      userId: ctx.userId,
+      action: 'trip.invite_link_create',
+      resource: String(tripId),
+      ip: null,
+      details: { expires_in_days: days },
+    });
+    return ok({ invite_link: this.describe(info) });
+  }
+
+  @Tool({
+    name: 'delete_trip_invite_link',
+    description: 'Revoke the trip\'s invite link. The URL stops working at once, so nobody else can join through it. Members who already joined stay on the trip: remove_trip_member is what takes somebody off it.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: (ctx) => canShareTrips(ctx.scopes) && canWrite(ctx.scopes, 'trips'),
+  })
+  async deleteTripInviteLink({ tripId }: { tripId: number }, ctx: McpContext) {
+    if (this.isDemoUser(ctx.userId)) return demoDenied();
+    const denied = this.denyManage(tripId, ctx.userId);
+    if (denied) return denied;
+    this.invites.remove(tripId);
+    this.audit.writeAudit({
+      userId: ctx.userId,
+      action: 'trip.invite_link_delete',
+      resource: String(tripId),
+      ip: null,
+    });
+    return ok({ success: true });
+  }
+}

--- a/server/src/nest/trip-invite/trip-invite.module.ts
+++ b/server/src/nest/trip-invite/trip-invite.module.ts
@@ -2,13 +2,21 @@ import { RateLimitModule } from '../common/rate-limit.module';
 import { Module } from '@nestjs/common';
 import { TripInviteLinkController, TripInviteController } from './trip-invite.controller';
 import { TripInviteService } from './trip-invite.service';
+import { TripInviteMcp } from './trip-invite.mcp';
+import { AppConfigModule } from '../app-config/app-config.module';
+import { McpSharedModule } from '../mcp-shared/mcp-shared.module';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { RealtimeModule } from '../realtime/realtime.module';
 import { AuditModule } from '../audit/audit.module';
 import { TripMembershipModule } from '../trip-membership/trip-membership.module';
 
 @Module({
-  imports: [RateLimitModule, PermissionsModule, AuditModule, TripMembershipModule],
+  // The last three carry TripInviteMcp: McpSharedModule for the RBAC check the
+  // controller does inline, and the two @Global modules it injects out of,
+  // which a graph assembled without AppModule (the e2e harness) must
+  // instantiate itself.
+  imports: [RateLimitModule, PermissionsModule, AuditModule, TripMembershipModule, McpSharedModule, AppConfigModule, RealtimeModule],
   controllers: [TripInviteLinkController, TripInviteController],
-  providers: [TripInviteService],
+  providers: [TripInviteService, TripInviteMcp],
 })
 export class TripInviteModule {}

--- a/server/src/nest/trips/trips.mcp.ts
+++ b/server/src/nest/trips/trips.mcp.ts
@@ -333,6 +333,92 @@ export class TripsMcp {
     return ok({ success: true });
   }
 
+  // --- GUESTS (#1362) ---
+  //
+  // add_trip_member resolves an existing account by username or email, so a
+  // travelling companion who has never signed up could be put on a trip in the
+  // planner and not through an assistant. These three mirror the owner-only
+  // /api/trips/:id/guests routes (trip-members.controller.ts): a guest is a
+  // credential-less users row assignable to budget splits, packing and day
+  // participants exactly like a member, so importing a past trip no longer has
+  // to drop who was on it.
+
+  @Tool({
+    name: 'create_trip_guest',
+    description: 'Add a travelling companion who has no TREK account to a trip. Use this when the person cannot be found by username or email — a guest can be assigned to budget splits, packing items, to-dos and day participants like any member, but never signs in and is never emailed. Only the trip owner can do this.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      name: z.string().min(1).max(50).describe('Display name of the guest, e.g. "Anna"'),
+    },
+    annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async createTripGuest({ tripId, name }: { tripId: number; name: string }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    const ownerRow = this.trips.getOwner(tripId);
+    if (!ownerRow || ownerRow.user_id !== ctx.userId)
+      return { content: [{ type: 'text' as const, text: 'Only the trip owner can manage guests.' }], isError: true };
+    try {
+      // No notifyInvite: a guest has no inbox.
+      const { member } = this.members.createGuest(tripId, name, ctx.userId);
+      this.guards.safeBroadcast(tripId, 'member:added', { member });
+      return ok({ member });
+    } catch (err) {
+      const msg = err instanceof ValidationError ? err.message : 'Failed to create guest.';
+      return { content: [{ type: 'text' as const, text: msg }], isError: true };
+    }
+  }
+
+  @Tool({
+    name: 'rename_trip_guest',
+    description: 'Rename a guest on a trip. Only the trip owner can do this.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      guestId: z.number().int().positive().describe('User ID of the guest, from list_trip_members'),
+      name: z.string().min(1).max(50).describe('New display name'),
+    },
+    annotations: TOOL_ANNOTATIONS_WRITE,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async renameTripGuest({ tripId, guestId, name }: { tripId: number; guestId: number; name: string }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    const ownerRow = this.trips.getOwner(tripId);
+    if (!ownerRow || ownerRow.user_id !== ctx.userId)
+      return { content: [{ type: 'text' as const, text: 'Only the trip owner can manage guests.' }], isError: true };
+    try {
+      if (!this.members.renameGuest(tripId, guestId, name))
+        return { content: [{ type: 'text' as const, text: 'Guest not found.' }], isError: true };
+    } catch (err) {
+      const msg = err instanceof ValidationError ? err.message : 'Failed to rename guest.';
+      return { content: [{ type: 'text' as const, text: msg }], isError: true };
+    }
+    return ok({ success: true });
+  }
+
+  @Tool({
+    name: 'delete_trip_guest',
+    description: 'Remove a guest from a trip. This deletes the guest outright — they exist only for this trip — and re-splits any expenses they were part of. Only the trip owner can do this.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+      guestId: z.number().int().positive().describe('User ID of the guest, from list_trip_members'),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async deleteTripGuest({ tripId, guestId }: { tripId: number; guestId: number }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    const ownerRow = this.trips.getOwner(tripId);
+    if (!ownerRow || ownerRow.user_id !== ctx.userId)
+      return { content: [{ type: 'text' as const, text: 'Only the trip owner can manage guests.' }], isError: true };
+    if (!this.members.deleteGuest(tripId, guestId))
+      return { content: [{ type: 'text' as const, text: 'Guest not found.' }], isError: true };
+    this.guards.safeBroadcast(tripId, 'member:removed', { userId: guestId });
+    return ok({ success: true });
+  }
+
   @Tool({
     name: 'copy_trip',
     description: 'Duplicate a trip (all days, places, itinerary, packing, budget, reservations, day notes). Packing items and to-dos are reset to unchecked. Returns the new trip.',

--- a/server/src/nest/trips/trips.mcp.ts
+++ b/server/src/nest/trips/trips.mcp.ts
@@ -1,8 +1,8 @@
 import {
   McpController, Tool, Resource, ResourceTemplate, Prompt, type McpContext,
-  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE,
+  TOOL_ANNOTATIONS_READONLY, TOOL_ANNOTATIONS_WRITE, TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
   TOOL_ANNOTATIONS_DELETE, TOOL_ANNOTATIONS_NON_IDEMPOTENT,
-  demoDenied, ok,
+  demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
 import { z } from 'zod';
@@ -13,7 +13,7 @@ import { TripReadModelService } from '../trip-read-model/trip-read-model.service
 import { ADDON_IDS } from '../../addons';
 import { MAX_MCP_TRIP_DAYS, noAccess, permissionDenied } from '../../mcp/tools/_shared';
 import { canRead, canReadTrips, canDeleteTrips } from '../../mcp/scopes';
-import { TripsService, NotFoundError, ValidationError } from './trips.service';
+import { TripsService, MAX_TRIP_DAYS, NotFoundError, ValidationError } from './trips.service';
 import { TodoService } from '../todo/todo.service';
 import { CollabService } from '../collab/collab.service';
 import { AddonsService } from '../addons/addons.service';
@@ -87,13 +87,18 @@ export class TripsMcp {
       start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('Start date (YYYY-MM-DD)'),
       end_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('End date (YYYY-MM-DD)'),
       currency: z.string().length(3).optional().describe('Currency code (e.g. EUR, USD)'),
+      day_count: z.number().int().min(1).max(MAX_TRIP_DAYS).optional().describe(
+        'How many days a trip without dates gets (default 7). Ignored when start_date and end_date are both set, because the range decides the count.'),
+      reminder_days: z.number().int().min(0).max(30).optional().describe(
+        'How many days before departure the pre-trip reminder fires (default 3). 0 turns the reminder off.'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     access: { group: 'trips', mode: 'write' },
   })
   async createTrip(
-    { title, description, start_date, end_date, currency }: {
+    { title, description, start_date, end_date, currency, day_count, reminder_days }: {
       title: string; description?: string; start_date?: string; end_date?: string; currency?: string;
+      day_count?: number; reminder_days?: number;
     },
     ctx: McpContext,
   ) {
@@ -111,7 +116,7 @@ export class TripsMcp {
     if (start_date && end_date && new Date(end_date) < new Date(start_date)) {
       return { content: [{ type: 'text' as const, text: 'End date must be after start date.' }], isError: true };
     }
-    const { trip } = this.trips.create(ctx.userId, { title, description, start_date, end_date, currency }, MAX_MCP_TRIP_DAYS);
+    const { trip } = this.trips.create(ctx.userId, { title, description, start_date, end_date, currency, day_count, reminder_days }, MAX_MCP_TRIP_DAYS);
     return ok({ trip });
   }
 
@@ -121,12 +126,18 @@ export class TripsMcp {
     inputSchema: {
       tripId: z.number().int().positive(),
       title: z.string().min(1).max(200).optional(),
-      description: z.string().max(2000).optional(),
+      description: z.string().max(2000).nullable().optional().describe('Trip description; null removes it'),
       start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
       end_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+      clear_dates: z.boolean().optional().describe(
+        'Drop both dates and turn the trip back into a dateless one. Cannot be combined with start_date or end_date; pair it with day_count to say how many days the dateless trip keeps'),
       currency: z.string().length(3).optional(),
       is_archived: z.boolean().optional().describe('Archive (true) or unarchive (false) the trip'),
-      cover_image: z.string().optional().describe('Cover image path, e.g. /uploads/covers/abc.jpg'),
+      cover_image: z.string().nullable().optional().describe('Cover image path, e.g. /uploads/covers/abc.jpg; null removes the cover'),
+      day_count: z.number().int().min(1).max(MAX_TRIP_DAYS).optional().describe(
+        'Resize a trip without dates to this many days. Days that still hold content are never trimmed. Ignored while the trip has a date range, because the range decides the count'),
+      reminder_days: z.number().int().min(0).max(30).optional().describe(
+        'How many days before departure the pre-trip reminder fires. 0 turns the reminder off'),
       date_shift_mode: z.enum(['keep_bookings', 'shift_all']).optional().describe(
         'When changing dates: keep_bookings (default) keeps dated reservations/accommodations on their dates while day plans move; shift_all moves the whole itinerary, bookings included'),
     },
@@ -134,15 +145,18 @@ export class TripsMcp {
     access: { group: 'trips', mode: 'write' },
   })
   async updateTrip(
-    { tripId, title, description, start_date, end_date, currency, is_archived, cover_image, date_shift_mode }: {
-      tripId: number; title?: string; description?: string; start_date?: string; end_date?: string;
-      currency?: string; is_archived?: boolean; cover_image?: string; date_shift_mode?: 'keep_bookings' | 'shift_all';
+    { tripId, title, description, start_date, end_date, clear_dates, currency, is_archived, cover_image, day_count, reminder_days, date_shift_mode }: {
+      tripId: number; title?: string; description?: string | null; start_date?: string; end_date?: string;
+      clear_dates?: boolean; currency?: string; is_archived?: boolean; cover_image?: string | null;
+      day_count?: number; reminder_days?: number; date_shift_mode?: 'keep_bookings' | 'shift_all';
     },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
     if (!this.guards.hasTripPermission('trip_edit', tripId, ctx.userId)) return permissionDenied();
+    if (clear_dates && (start_date || end_date))
+      return errorResult('clear_dates cannot be combined with start_date or end_date.');
     if (start_date) {
       const d = new Date(start_date + 'T00:00:00Z');
       if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== start_date)
@@ -153,11 +167,38 @@ export class TripsMcp {
       if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== end_date)
         return { content: [{ type: 'text' as const, text: 'end_date is not a valid calendar date.' }], isError: true };
     }
+    // updateTrip reads every field with a `!== undefined` presence sentinel, so a
+    // dated trip only goes back to dateless once an explicit null reaches it. A flag
+    // rather than a nullable start_date/end_date: clients that serialise an omitted
+    // optional as null would otherwise wipe the dates of every trip they touched.
+    const dates: { start_date?: string | null; end_date?: string | null } = clear_dates
+      ? { start_date: null, end_date: null }
+      : { start_date, end_date };
     // update() re-anchors the budget before the trip row moves off the old
     // currency (#1543) and then runs the legacy updateTrip core.
-    const { updatedTrip } = await this.trips.update(tripId, ctx.userId, { title, description, start_date, end_date, currency, is_archived, cover_image, date_shift_mode }, 'user');
+    const { updatedTrip } = await this.trips.update(tripId, ctx.userId, { title, description, ...dates, currency, is_archived, cover_image, day_count, reminder_days, date_shift_mode }, 'user');
     this.guards.safeBroadcast(tripId, 'trip:updated', { trip: updatedTrip });
     return ok({ trip: updatedTrip });
+  }
+
+  @Tool({
+    name: 'search_cover_images',
+    description: 'Search Unsplash for candidate cover photos and return their URLs, thumbnails and photographer credits. Use this when the user wants a cover image but has no URL of their own, then pass the chosen photo\'s url back as update_trip\'s cover_image. Nothing is saved to a trip here.',
+    inputSchema: {
+      query: z.string().min(1).max(200).describe('What the cover should show, e.g. "Lisbon rooftops at sunset"'),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    access: (ctx) => canReadTrips(ctx.scopes),
+  })
+  async searchCoverImages({ query }: { query: string }, ctx: McpContext) {
+    try {
+      const result = await this.trips.searchCoverImages(query, ctx.userId);
+      if ('error' in result) return errorResult(result.error);
+      return ok({ photos: result.photos });
+    } catch (err) {
+      console.error('Unsplash cover image error:', err);
+      return errorResult('Error searching for cover images');
+    }
   }
 
   @Tool({
@@ -288,7 +329,7 @@ export class TripsMcp {
 
   @Tool({
     name: 'add_trip_member',
-    description: 'Add a user to a trip by their username or email address. Only the trip owner can do this.',
+    description: 'Add a user to a trip by their username or email address. Needs the member_manage permission, which by default only the trip owner holds. Use create_trip_guest instead for a companion who has no TREK account.',
     inputSchema: {
       tripId: z.number().int().positive(),
       identifier: z.string().min(1).describe('Username or email of the user to add'),
@@ -300,8 +341,11 @@ export class TripsMcp {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
     const ownerRow = this.trips.getOwner(tripId);
-    if (!ownerRow || ownerRow.user_id !== ctx.userId)
-      return { content: [{ type: 'text' as const, text: 'Only the trip owner can add members.' }], isError: true };
+    if (!ownerRow) return noAccess();
+    // member_manage rather than a hardcoded owner test: the action is admin-lowerable
+    // in the permission matrix, and POST /api/trips/:id/members has always honoured
+    // that setting (and the admin bypass inside checkPermission) where this did not.
+    if (!this.guards.hasTripPermission('member_manage', tripId, ctx.userId)) return permissionDenied();
     try {
       const result = this.members.addMember(tripId, identifier, ownerRow.user_id, ctx.userId);
       this.guards.safeBroadcast(tripId, 'member:added', { member: result.member });
@@ -314,7 +358,7 @@ export class TripsMcp {
 
   @Tool({
     name: 'remove_trip_member',
-    description: 'Remove a member from a trip. Only the trip owner can do this.',
+    description: 'Remove somebody else from a trip. Needs the member_manage permission, which by default only the trip owner holds. When the user means themselves, prefer leave_trip: it says so plainly and needs no permission.',
     inputSchema: {
       tripId: z.number().int().positive(),
       memberId: z.number().int().positive().describe('User ID of the member to remove'),
@@ -325,11 +369,35 @@ export class TripsMcp {
   async removeTripMember({ tripId, memberId }: { tripId: number; memberId: number }, ctx: McpContext) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
-    const ownerRow = this.trips.getOwner(tripId);
-    if (!ownerRow || ownerRow.user_id !== ctx.userId)
-      return { content: [{ type: 'text' as const, text: 'Only the trip owner can remove members.' }], isError: true };
+    // Giving up your own access is not member management, so it carries no permission
+    // requirement: the same self-removal bypass DELETE /api/trips/:id/members/:userId has.
+    if (memberId !== ctx.userId && !this.guards.hasTripPermission('member_manage', tripId, ctx.userId))
+      return permissionDenied();
     this.members.removeMember(tripId, memberId);
     this.guards.safeBroadcast(tripId, 'member:removed', { userId: memberId });
+    return ok({ success: true });
+  }
+
+  @Tool({
+    name: 'leave_trip',
+    description: 'Leave a trip you were invited to, giving up your own access to it. Prefer this over remove_trip_member whenever the user means themselves. The owner cannot leave their own trip.',
+    inputSchema: {
+      tripId: z.number().int().positive(),
+    },
+    annotations: TOOL_ANNOTATIONS_DELETE,
+    access: { group: 'trips', mode: 'write' },
+  })
+  async leaveTrip({ tripId }: { tripId: number }, ctx: McpContext) {
+    if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
+    if (!this.trips.canAccessTrip(tripId, ctx.userId)) return noAccess();
+    const ownerRow = this.trips.getOwner(tripId);
+    if (!ownerRow) return noAccess();
+    // removeMember only deletes a trip_members row, and the owner has none, so an
+    // owner calling this would get a success that changed nothing. Say so instead.
+    if (ownerRow.user_id === ctx.userId)
+      return errorResult('You own this trip, so you cannot leave it. Hand it to another member first, or delete it.');
+    this.members.removeMember(tripId, ctx.userId);
+    this.guards.safeBroadcast(tripId, 'member:removed', { userId: ctx.userId });
     return ok({ success: true });
   }
 
@@ -345,7 +413,7 @@ export class TripsMcp {
 
   @Tool({
     name: 'create_trip_guest',
-    description: 'Add a travelling companion who has no TREK account to a trip. Use this when the person cannot be found by username or email — a guest can be assigned to budget splits, packing items, to-dos and day participants like any member, but never signs in and is never emailed. Only the trip owner can do this.',
+    description: 'Add a travelling companion who has no TREK account to a trip. Use this when the person cannot be found by username or email. A guest can be assigned to budget splits, packing items, to-dos and day participants like any member, but never signs in and is never emailed. Only the trip owner can do this.',
     inputSchema: {
       tripId: z.number().int().positive(),
       name: z.string().min(1).max(50).describe('Display name of the guest, e.g. "Anna"'),
@@ -399,7 +467,7 @@ export class TripsMcp {
 
   @Tool({
     name: 'delete_trip_guest',
-    description: 'Remove a guest from a trip. This deletes the guest outright — they exist only for this trip — and re-splits any expenses they were part of. Only the trip owner can do this.',
+    description: 'Remove a guest from a trip. This deletes the guest outright (they exist only for this trip) and re-splits any expenses they were part of. Only the trip owner can do this.',
     inputSchema: {
       tripId: z.number().int().positive(),
       guestId: z.number().int().positive().describe('User ID of the guest, from list_trip_members'),

--- a/server/src/nest/vacay/vacay.mcp.ts
+++ b/server/src/nest/vacay/vacay.mcp.ts
@@ -6,6 +6,12 @@ import {
   demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { z } from 'zod';
+import {
+  vacayAddHolidayCalendarRequestSchema,
+  vacayToggleEntryRequestSchema,
+  vacayUpdatePlanRequestSchema,
+} from '@trek/shared';
+import type { VacayUpdatePlanRequest } from '@trek/shared';
 import { AuthService } from '../auth/auth.service';
 import { ADDON_IDS } from '../../addons';
 import { VacayService } from './vacay.service';
@@ -14,6 +20,42 @@ import { AddonsService } from '../addons/addons.service';
 
 /** Legacy registrar gate: the whole vacay surface rides the vacay addon. */
 const vacayAddonOn = addonGate(ADDON_IDS.VACAY);
+
+/** The controller derives the openholidaysapi response language the same way. */
+function schoolHolidayLanguage(country: string): string {
+  return country.toUpperCase() === 'DE' ? 'DE' : 'EN';
+}
+
+/** One node of the provider's region tree; children nest arbitrarily deep. */
+interface RegionNode { code?: string; shortName?: string; children?: RegionNode[] | null }
+
+function flattenRegionCodes(items: RegionNode[] | undefined): string[] {
+  const out: string[] = [];
+  for (const item of items ?? []) {
+    const code = item.code ?? item.shortName;
+    if (code) out.push(code);
+    out.push(...flattenRegionCodes(item.children ?? undefined));
+  }
+  return out;
+}
+
+/**
+ * The region strings add_holiday_calendar has to be given, which are not always
+ * the provider's own codes. A group is stored as `<COUNTRY>|group:<CODE>`, and
+ * the reader (parseCalendarRegion in the client's vacay store) treats a bare
+ * code as a subdivision, so handing back the raw group code produces a calendar
+ * that queries nothing. Belgium and the Netherlands are the countries that use
+ * groups; deriving it from which list came back populated keeps the country
+ * table in the one place it already lives, on the client.
+ */
+function calendarRegionCodes(country: string, data: unknown): { region: string; kind: 'group' | 'subdivision' }[] {
+  const payload = (data ?? {}) as { groups?: RegionNode[]; subdivisions?: RegionNode[] };
+  const upper = country.toUpperCase();
+  return [
+    ...flattenRegionCodes(payload.groups).map(code => ({ region: `${upper}|group:${code}`, kind: 'group' as const })),
+    ...flattenRegionCodes(payload.subdivisions).map(code => ({ region: code, kind: 'subdivision' as const })),
+  ];
+}
 
 /**
  * Vacay MCP surface — ported 1:1 from the legacy registrars: the 26 tools from
@@ -26,8 +68,12 @@ const vacayAddonOn = addonGate(ADDON_IDS.VACAY);
  * `if (W)` checks, resolved by trekMcpAccessPolicy). Vacay is plan-scoped, not
  * trip-scoped, so there is no trip-permission layer; the only per-call guard is
  * the demo-user check on every write (including decline_vacay_invite, which the
- * legacy registrar missed). The two nager.at-backed lookups carry the
- * open-world readonly annotation.
+ * legacy registrar missed). The nager.at- and openholidaysapi-backed lookups
+ * carry the open-world readonly annotation.
+ *
+ * Tools past the original 26 close REST surface the legacy registrar never had:
+ * the leave-year window, the school-holiday lookups behind a school_holiday
+ * calendar, and the share picker (a different query from the fusion picker).
  */
 @McpController()
 export class VacayMcp {
@@ -51,30 +97,44 @@ export class VacayMcp {
   }
 
   @Tool({
+    name: 'get_vacay_year_settings',
+    description: "Get the caller's leave-year window: 'calendar' runs January to December, 'fiscal' starts on a configured month and day, 'anniversary' on the hire date's month and day. Read this before interpreting a year in get_vacay_stats or get_vacay_entries, which count over that window rather than the calendar year.",
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    when: vacayAddonOn,
+    access: { group: 'vacay', mode: 'read' },
+  })
+  async getVacayYearSettings(_args: Record<string, never>, ctx: McpContext) {
+    return ok({ settings: this.vacay.getYearSettings(ctx.userId) });
+  }
+
+  @Tool({
     name: 'update_vacay_plan',
-    description: 'Update vacation plan settings (weekends blocking, holidays, carry-over).',
+    description: 'Update vacation plan settings (weekend blocking and which weekdays count as weekend, public and school holidays, company holidays, carry-over).',
     inputSchema: {
-      block_weekends: z.boolean().optional(),
-      holidays_enabled: z.boolean().optional(),
-      holidays_region: z.string().nullable().optional(),
-      company_holidays_enabled: z.boolean().optional(),
-      carry_over_enabled: z.boolean().optional(),
+      ...vacayUpdatePlanRequestSchema.shape,
+      weekend_days: vacayUpdatePlanRequestSchema.shape.weekend_days.describe("Comma-separated weekday numbers that count as weekend, 0 is Sunday (e.g. '0,6')"),
+      week_start: vacayUpdatePlanRequestSchema.shape.week_start.describe('First column of the calendar grid: 0 for Sunday, anything else for Monday'),
     },
     annotations: TOOL_ANNOTATIONS_WRITE,
     when: vacayAddonOn,
     access: { group: 'vacay', mode: 'write' },
   })
   async updateVacayPlan(
-    { block_weekends, holidays_enabled, holidays_region, company_holidays_enabled, carry_over_enabled }: {
-      block_weekends?: boolean; holidays_enabled?: boolean; holidays_region?: string | null; company_holidays_enabled?: boolean; carry_over_enabled?: boolean;
-    },
+    {
+      block_weekends, holidays_enabled, holidays_region, school_holidays_enabled,
+      company_holidays_enabled, carry_over_enabled, weekend_days, week_start,
+    }: VacayUpdatePlanRequest,
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     const planId = this.vacay.getActivePlanId(ctx.userId);
     // updatePlan already returns the fully-hydrated { plan }; surface it so the
     // AI consumer sees the updated plan, matching get_vacay_plan.
-    const result = await this.vacay.updatePlan(planId, { block_weekends, holidays_enabled, holidays_region, company_holidays_enabled, carry_over_enabled }, undefined);
+    const result = await this.vacay.updatePlan(planId, {
+      block_weekends, holidays_enabled, holidays_region, school_holidays_enabled,
+      company_holidays_enabled, carry_over_enabled, weekend_days, week_start,
+    }, undefined);
     return ok(result);
   }
 
@@ -260,18 +320,33 @@ export class VacayMcp {
 
   @Tool({
     name: 'toggle_vacay_entry',
-    description: 'Toggle a day on or off as a vacation day for the current user.',
+    description: 'Toggle a day in the vacation calendar. Repeating a date with the same fraction and kind clears it, a different fraction or kind converts the day in place. Defaults to a full vacation day for the calling user.',
     inputSchema: {
       date: z.string().describe('ISO date YYYY-MM-DD'),
+      fraction: vacayToggleEntryRequestSchema.shape.fraction.describe('0.5 for a half day, 1 (the default) for a full day'),
+      kind: vacayToggleEntryRequestSchema.shape.kind.describe("'comp' for a flex/comp day, which does not draw on the entitlement; 'vacation' is the default"),
+      targetUserId: z.number().int().positive().optional().describe('Log the day for another member of the shared plan instead of the caller'),
     },
     annotations: TOOL_ANNOTATIONS_NON_IDEMPOTENT,
     when: vacayAddonOn,
     access: { group: 'vacay', mode: 'write' },
   })
-  async toggleVacayEntry({ date }: { date: string }, ctx: McpContext) {
+  async toggleVacayEntry(
+    { date, fraction, kind, targetUserId }: { date: string; fraction?: 0.5 | 1; kind?: 'vacation' | 'comp'; targetUserId?: number },
+    ctx: McpContext,
+  ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     const planId = this.vacay.getActivePlanId(ctx.userId);
-    const result = this.vacay.toggleEntry(ctx.userId, planId, date, 1, 'vacation', undefined);
+    let userId = ctx.userId;
+    if (targetUserId !== undefined && targetUserId !== ctx.userId) {
+      // Same gate as POST /entries/toggle: booking for someone else reaches only
+      // the members of the caller's own plan, and nobody outside it.
+      if (!this.vacay.getPlanUsers(planId).find((u) => u.id === targetUserId)) {
+        return errorResult('User not in plan');
+      }
+      userId = targetUserId;
+    }
+    const result = this.vacay.toggleEntry(userId, planId, date, fraction, kind, undefined);
     if (result.error) return errorResult(result.error);
     return ok(result);
   }
@@ -330,9 +405,10 @@ export class VacayMcp {
 
   @Tool({
     name: 'add_holiday_calendar',
-    description: 'Add a public holiday calendar (by region code) to the vacation plan.',
+    description: "Add a holiday calendar (by region code) to the vacation plan. Public holidays take a country or country-region code from list_holiday_countries; a school-holiday calendar needs type 'school_holiday' plus a subdivision code from list_school_holiday_regions, and only shows up once update_vacay_plan has school_holidays_enabled set.",
     inputSchema: {
-      region: z.string().describe('Country/region code e.g. US, GB, DE'),
+      region: z.string().describe("Country/region code e.g. US, GB, DE, or a subdivision like DE-BY. For a school-holiday calendar take calendar_regions[].region from list_school_holiday_regions verbatim, including the COUNTRY|group:CODE form that Belgium and the Netherlands use."),
+      type: vacayAddHolidayCalendarRequestSchema.shape.type.describe("'school_holiday', or 'public_holiday' (the default)"),
       label: z.string().nullable().optional(),
       color: z.string().optional(),
       sortOrder: z.number().int().optional(),
@@ -342,12 +418,14 @@ export class VacayMcp {
     access: { group: 'vacay', mode: 'write' },
   })
   async addHolidayCalendar(
-    { region, label, color, sortOrder }: { region: string; label?: string | null; color?: string; sortOrder?: number },
+    { region, type, label, color, sortOrder }: { region: string; type?: 'public_holiday' | 'school_holiday'; label?: string | null; color?: string; sortOrder?: number },
     ctx: McpContext,
   ) {
     if (this.auth.isDemoUser(ctx.userId)) return demoDenied();
     const planId = this.vacay.getActivePlanId(ctx.userId);
-    const calendar = this.vacay.addHolidayCalendar(planId, region, label ?? null, color, sortOrder, undefined);
+    // An omitted type stays undefined so the service default (and the default
+    // colour that goes with it) applies, exactly as on the REST route.
+    const calendar = this.vacay.addHolidayCalendar(planId, region, label ?? null, color, sortOrder, undefined, type);
     return ok({ calendar });
   }
 
@@ -423,6 +501,44 @@ export class VacayMcp {
   }
 
   @Tool({
+    name: 'list_school_holiday_regions',
+    description: "List a country's school-holiday regions. Use calendar_regions[].region verbatim as add_holiday_calendar's region: a group is stored as COUNTRY|group:CODE and a bare group code would be read back as a subdivision, leaving the calendar empty. The raw provider payload is alongside it under regions, and its plain codes are what list_school_holidays filters by. Public holiday calendars use list_holiday_countries instead.",
+    inputSchema: {
+      country: z.string().describe('ISO 3166-1 alpha-2 code'),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    when: vacayAddonOn,
+    access: { group: 'vacay', mode: 'read' },
+  })
+  async listSchoolHolidayRegions({ country }: { country: string }, _ctx: McpContext) {
+    const result = await this.vacay.getSchoolHolidayRegions(country, schoolHolidayLanguage(country));
+    if (result.error) return errorResult(result.error);
+    return ok({ regions: result.data, calendar_regions: calendarRegionCodes(country, result.data) });
+  }
+
+  @Tool({
+    name: 'list_school_holidays',
+    description: 'List school holidays for a country and year, narrowed to a subdivision or group code from list_school_holiday_regions. School holidays are term breaks, so prefer list_holidays for the public holidays a day off is normally counted against.',
+    inputSchema: {
+      country: z.string().describe('ISO 3166-1 alpha-2 code'),
+      year: z.number().int(),
+      subdivision: z.string().optional().describe('Subdivision code from list_school_holiday_regions, e.g. DE-BY'),
+      group: z.string().optional().describe('Group code from list_school_holiday_regions'),
+    },
+    annotations: TOOL_ANNOTATIONS_OPEN_WORLD_READONLY,
+    when: vacayAddonOn,
+    access: { group: 'vacay', mode: 'read' },
+  })
+  async listSchoolHolidays(
+    { country, year, subdivision, group }: { country: string; year: number; subdivision?: string; group?: string },
+    _ctx: McpContext,
+  ) {
+    const result = await this.vacay.getSchoolHolidays(String(year), country, subdivision, schoolHolidayLanguage(country), group);
+    if (result.error) return errorResult(result.error);
+    return ok({ holidays: result.data });
+  }
+
+  @Tool({
     name: 'list_vacay_shares',
     description: 'List read-only calendar shares: who the current user shares their vacation calendar with, and which calendars are shared with them.',
     inputSchema: {},
@@ -432,6 +548,18 @@ export class VacayMcp {
   })
   async listVacayShares(_args: Record<string, never>, ctx: McpContext) {
     return ok(this.vacay.listShares(ctx.userId));
+  }
+
+  @Tool({
+    name: 'get_shareable_vacay_users',
+    description: "List the users the caller can share their calendar with, for share_vacay_calendar's targetUserId. This is a wider set than get_available_vacay_users, which lists candidates for merging plans and therefore leaves out everyone who already sits in a plan of their own.",
+    inputSchema: {},
+    annotations: TOOL_ANNOTATIONS_READONLY,
+    when: vacayAddonOn,
+    access: { group: 'vacay', mode: 'read' },
+  })
+  async getShareableVacayUsers(_args: Record<string, never>, ctx: McpContext) {
+    return ok({ users: this.vacay.getShareAvailableUsers(ctx.userId) });
   }
 
   @Tool({

--- a/server/tests/e2e/categories.e2e.test.ts
+++ b/server/tests/e2e/categories.e2e.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../src/db/database', () => ({ db, closeDb: () => {}, reinitialize: (
 
 import { CategoriesModule } from '../../src/nest/categories/categories.module';
 import { DatabaseModule } from '../../src/nest/database/database.module';
+import { RealtimeModule } from '../../src/nest/realtime/realtime.module';
 import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
 import { ZodValidationPipe } from '../../src/nest/common/zod-validation.pipe';
 
@@ -49,7 +50,10 @@ describe('Categories e2e (real JwtAuthGuard + AdminGuard + temp SQLite)', () => 
   let app: Awaited<ReturnType<typeof build>>;
 
   async function build() {
-    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, CategoriesModule] }).compile();
+    // RealtimeModule is @Global in the app graph but not in a partial container,
+// and CategoriesModule now pulls McpSharedModule in for the admin tools, whose
+// guard service takes it. days.e2e.test.ts imports it for the same reason.
+    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, RealtimeModule, CategoriesModule] }).compile();
     const nest = moduleRef.createNestApplication();
     nest.use(cookieParser());
     nest.useGlobalFilters(new TrekExceptionFilter());

--- a/server/tests/helpers/mcp-test-controllers.ts
+++ b/server/tests/helpers/mcp-test-controllers.ts
@@ -40,6 +40,7 @@ import { ReservationsReadRepository } from '../../src/nest/reservations/reservat
 import { TagsMcp } from '../../src/nest/tags/tags.mcp';
 import { TagsService } from '../../src/nest/tags/tags.service';
 import { SettingsService } from '../../src/nest/settings/settings.service';
+import { SettingsMcp } from '../../src/nest/settings/settings.mcp';
 import { ShareMcp } from '../../src/nest/share/share.mcp';
 import { ShareService } from '../../src/nest/share/share.service';
 import { TodoMcp } from '../../src/nest/todo/todo.mcp';
@@ -47,6 +48,7 @@ import { TodoService } from '../../src/nest/todo/todo.service';
 import { TransitMcp } from '../../src/nest/transit/transit.mcp';
 import { TransitService } from '../../src/nest/transit/transit.service';
 import { FilesService } from '../../src/nest/files/files.service';
+import { FilesMcp } from '../../src/nest/files/files.mcp';
 import { TripsMcp } from '../../src/nest/trips/trips.mcp';
 import { TripsService } from '../../src/nest/trips/trips.service';
 import { VacayMcp } from '../../src/nest/vacay/vacay.mcp';
@@ -64,6 +66,10 @@ import { WebauthnConfigService } from '../../src/nest/auth/webauthn-config.servi
 import { TripMembershipService } from '../../src/nest/trip-membership/trip-membership.service';
 import { MailerService } from '../../src/nest/notifications/mailer/mailer.service';
 import { CalendarService } from '../../src/nest/calendar/calendar.service';
+import { FeedsMcp } from '../../src/nest/feeds/feeds.mcp';
+import { FeedsService } from '../../src/nest/feeds/feeds.service';
+import { TripInviteMcp } from '../../src/nest/trip-invite/trip-invite.mcp';
+import { TripInviteService } from '../../src/nest/trip-invite/trip-invite.service';
 import { AccommodationsService } from '../../src/nest/accommodations/accommodations.service';
 import { AccommodationsMcp } from '../../src/nest/accommodations/accommodations.mcp';
 import { TripMembersService } from '../../src/nest/trip-members/trip-members.service';
@@ -76,7 +82,32 @@ import { AddonsService } from '../../src/nest/addons/addons.service';
 import { notificationsStub } from './notifications';
 import { EphemeralTokenService } from '../../src/nest/auth/ephemeral-token.service';
 import { AllowedFileTypesService } from '../../src/nest/files/allowed-file-types.service';
+import { MemoriesMcp } from '../../src/nest/memories/memories.mcp';
+import { ImmichService } from '../../src/nest/memories/immich.service';
+import { SynologyService } from '../../src/nest/memories/synology.service';
+import { MemoriesAccessService } from '../../src/nest/memories/memories-access.service';
+import { PhotoCaptureBackfillService } from '../../src/nest/memories/photo-capture-backfill.service';
+import { PhotoResolverService } from '../../src/nest/memories/photo-resolver.service';
+import { ThumbnailService } from '../../src/nest/memories/thumbnail.service';
+import { TrekPhotoCacheService } from '../../src/nest/memories/trek-photo-cache.service';
+import { PhotoProviderRegistry } from '../../src/nest/memories/photo-provider.registry';
+import { ImmichPhotoProvider } from '../../src/nest/memories/providers/immich.provider';
+import { SynologyPhotoProvider } from '../../src/nest/memories/providers/synology.provider';
+import { AuditService } from '../../src/nest/audit/audit.service';
 import { makeStorageFixture } from './storage-fixture';
+// No plugin supervisor in this harness, so PluginHooks is built over an inert runtime
+// and the warnings tool answers empty by default; the trip-warnings suite spies on
+// PluginHooks.prototype to play the provider fan-out.
+import { TripWarningsMcp } from '../../src/nest/plugins/contributions/trip-warnings.mcp';
+import { PluginHooks } from '../../src/nest/plugins/plugin-hooks.service';
+import type { PluginRuntimeService } from '../../src/nest/plugins/plugin-runtime.service';
+import { AirtrailMcp } from '../../src/nest/integrations/airtrail.mcp';
+import { AirtrailService } from '../../src/nest/integrations/airtrail.service';
+import { AirtrailClient } from '../../src/nest/integrations/airtrail.client';
+import { AirtrailImportService } from '../../src/nest/integrations/airtrail-import.service';
+import { ReservationImportMcp } from '../../src/nest/reservation-import/reservation-import.mcp';
+import { HelpMcp } from '../../src/nest/help/help.mcp';
+import { AddonsMcp } from '../../src/nest/addons/addons.mcp';
 
 /**
  * Hand-wired counterpart of the boot-time discovery in McpRegistryService,
@@ -157,10 +188,19 @@ export function createMcpTestRegistry(): McpRegistry {
   const addonsService = new AddonsService(dbService);
   // One instance, three consumers: AssignmentsMcp, ReservationsMcp and PlacesMcp.
   const assignmentsService = new AssignmentsService(dbService, permissionsService, realtimeService, queryHelpersService, journeyDomain);
+  // The two photo providers, shared by MemoriesMcp (which browses them) and by
+  // the capture backfill JourneyMcp schedules after a provider photo is attached
+  // (which asks them when and where it was taken). Built for real rather than
+  // stubbed: an empty provider registry would make the backfill answer "unknown
+  // provider" for every id and hide a wiring mistake behind a caught error.
+  const immichService = new ImmichService(dbService, new AuditService(dbService), new MemoriesAccessService(dbService), generalStorage);
+  const synologyService = new SynologyService(dbService, new MemoriesAccessService(dbService), notificationsStub());
+  const trekPhotos = new TrekPhotosRepository(dbService);
+  const captureBackfill = new PhotoCaptureBackfillService(new PhotoResolverService(trekPhotos, new ThumbnailService(addonsService, generalStorage, dbService), new TrekPhotoCacheService(dbService, generalStorage), new PhotoProviderRegistry([new ImmichPhotoProvider(immichService), new SynologyPhotoProvider(synologyService)]), generalStorage), trekPhotos, generalStorage);
   return createTestRegistry(
     [
       new TagsMcp(new TagsService(dbService), authService),
-      new CategoriesMcp(new CategoriesService(dbService), authService, guards),
+      new CategoriesMcp(new CategoriesService(dbService), dbService, new RuntimeEnvService(), guards),
       // The weather and airport tools left the legacy mapsWeather registrar.
       new WeatherMcp(new WeatherService()),
       new AirportsMcp(),
@@ -171,6 +211,7 @@ export function createMcpTestRegistry(): McpRegistry {
       new ReservationsMcp(reservationsService, daysService, budgetService, authService, assignmentsService, guards),
       new DayNotesMcp(new DayNotesService(dbService, permissionsService, realtimeService), authService, guards),
       new DaysMcp(daysService, authService, guards),
+      new FilesMcp(new FilesService(dbService, permissionsService, realtimeService, new EphemeralTokenService(), generalStorage), authService, guards),
       new AccommodationsMcp(accommodationsService, dbService, placesService, authService, guards),
       new AssignmentsMcp(assignmentsService, daysService, authService, guards),
       new CollabMcp(collabService, authService, addonsService, guards),
@@ -178,13 +219,21 @@ export function createMcpTestRegistry(): McpRegistry {
       new TripsMcp(tripsService, todoService, collabService, authService, calendarService, membersService, readModelService, addonsService, guards),
       new TripPromptsMcp(tripsService, readModelService, packingService, addonsService),
       new ShareMcp(new ShareService(dbService, new SettingsService(dbService), permissionsService, queryHelpersService, placePhotoCache), authService, guards),
+      new FeedsMcp(new FeedsService(dbService, calendarService), dbService, new RuntimeEnvService(), guards),
+      new TripInviteMcp(new TripInviteService(dbService, permissionsService, new TripMembershipService(dbService)), dbService, new RuntimeEnvService(), guards, new AuditService(dbService)),
       new MapsMcp(mapsService),
       new PlacesMcp(placesService, mapsService, dbService, authService, journeyDomain, assignmentsService, guards),
       new CollectionsMcp(new CollectionsService(dbService, permissionsService, realtimeService, notificationsStub(), generalStorage), dbService, authService, addonsService),
       new TransitMcp(new TransitService(), daysService, reservationsService, dbService, authService, guards),
       new AtlasMcp(new AtlasService(dbService), addonsService, authService),
-      new JourneyMcp(journeyDomain, new JourneyShareService(dbService, journeyDomain, new SettingsService(dbService)), addonsService, authService),
+      new JourneyMcp(journeyDomain, new JourneyShareService(dbService, journeyDomain, new SettingsService(dbService)), addonsService, authService, captureBackfill),
+      new MemoriesMcp(immichService, synologyService, dbService),
       new NotificationsMcp(makeNotificationsService(dbService, realtimeService), authService),
+      new AirtrailMcp(new AirtrailService(dbService, new AuditService(dbService), new AirtrailClient()), addonsService),
+      new ReservationImportMcp(new AirtrailImportService(dbService, realtimeService, reservationsService, new AirtrailClient(), new AirtrailService(dbService, new AuditService(dbService), new AirtrailClient())), dbService, authService, guards, addonsService),
+      new SettingsMcp(new SettingsService(dbService), authService),
+      new HelpMcp(), new AddonsMcp(addonsService),
+      new TripWarningsMcp(new PluginHooks({ providersOf: () => [], invokeHook: async () => [] } as unknown as PluginRuntimeService), dbService),
     ],
     { accessPolicy: trekMcpAccessPolicy, validateAccess: trekMcpValidateAccess },
   );

--- a/server/tests/helpers/mcp-test-controllers.ts
+++ b/server/tests/helpers/mcp-test-controllers.ts
@@ -160,7 +160,7 @@ export function createMcpTestRegistry(): McpRegistry {
   return createTestRegistry(
     [
       new TagsMcp(new TagsService(dbService), authService),
-      new CategoriesMcp(new CategoriesService(dbService)),
+      new CategoriesMcp(new CategoriesService(dbService), authService, guards),
       // The weather and airport tools left the legacy mapsWeather registrar.
       new WeatherMcp(new WeatherService()),
       new AirportsMcp(),

--- a/server/tests/helpers/test-db.ts
+++ b/server/tests/helpers/test-db.ts
@@ -68,6 +68,7 @@ const RESET_TABLES = [
   'days',
   // Trip
   'share_tokens',
+  'trip_invite_tokens',
   'trip_members',
   'trips',
   // Journey

--- a/server/tests/unit/files/files.rpc.test.ts
+++ b/server/tests/unit/files/files.rpc.test.ts
@@ -17,7 +17,7 @@ import { createTestPluginRegistry } from '../../../src/nest/plugins/host/rpc-kit
 import { PluginGuards } from '../../../src/nest/plugins/host/plugin-guards.service';
 import { FilesRpc } from '../../../src/nest/files/files.rpc';
 import { FilesModule } from '../../../src/nest/files/files.module';
-import type { FilesService } from '../../../src/nest/files/files.service';
+import { FilesService } from '../../../src/nest/files/files.service';
 import type { RealtimeService } from '../../../src/nest/realtime/realtime.service';
 import type { DatabaseService } from '../../../src/nest/database/database.service';
 import type { PermissionsService } from '../../../src/nest/permissions/permissions.service';
@@ -60,6 +60,12 @@ function build(opts: { file?: Record<string, unknown> | undefined; foreign?: str
     })),
     put: vi.fn(async () => undefined),
   } as unknown as StorageService & Record<string, ReturnType<typeof vi.fn>>;
+  // readContent moved onto FilesService (the MCP read tool obeys the same cap and
+  // the same storage rules), and the RPC only maps its refusals onto the two wire
+  // error types. Bind the real implementation onto this double so the cases below
+  // keep exercising that code rather than a stub of it.
+  (files as unknown as { readContent: FilesService['readContent'] }).readContent =
+    FilesService.prototype.readContent.bind({ getFileById: files.getFileById, storage } as unknown as FilesService);
   const rpc = new FilesRpc(files, realtime, db, guards, storage);
   const host = (...grants: string[]) => new PluginRpcHost('p', new Set(grants), makeDeps(), createTestPluginRegistry([rpc]));
   return { files, realtime, permissions, storage, host };
@@ -110,6 +116,15 @@ describe('FilesRpc reads', () => {
     (f.storage.getStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new StorageInvalidKeyError('..'));
     const res = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
     expect(res.error.message).toBe('file path is not accessible');
+  });
+
+  it('FILES-RPC-005e an unexpected storage failure keeps its own taxonomy', async () => {
+    const f = build();
+    // Only the two storage errors become an accessibility refusal; a backend
+    // outage must not be reported to the plugin as a missing file.
+    (f.storage.getStream as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('backend down'));
+    const res = (await f.host('db:read:files:content').dispatch(req('files.getContent', { tripId: 1, fileId: 2 }), 42)) as RpcError;
+    expect(res.error.code).toBe('HOST_ERROR');
   });
 
   it('FILES-RPC-005b an object whose stat exceeds the cap is refused before buffering', async () => {

--- a/server/tests/unit/mcp/scopes.test.ts
+++ b/server/tests/unit/mcp/scopes.test.ts
@@ -46,7 +46,7 @@ describe('ALL_SCOPES', () => {
     expect(ALL_SCOPES.length).toBeGreaterThan(0);
   });
 
-  it('derives exactly the 14 known scope groups (ScopeGroup lockstep)', () => {
+  it('derives exactly the 16 known scope groups (ScopeGroup lockstep)', () => {
     // The runtime half of the ScopeGroup lockstep — the type half is
     // MCP_ACCESS_GROUPS_MATCH_SCOPE_GROUPS in src/mcp/nest-mcp-policy.ts,
     // covered by `npm run typecheck`. If this list changes, the MCP
@@ -57,12 +57,14 @@ describe('ALL_SCOPES', () => {
       'budget',
       'collab',
       'collections',
+      'files',
       'geo',
       'journey',
       'notifications',
       'packing',
       'places',
       'reservations',
+      'settings',
       'todos',
       'trips',
       'vacay',

--- a/server/tests/unit/mcp/tools-airtrail.test.ts
+++ b/server/tests/unit/mcp/tools-airtrail.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Unit tests for the AirTrail import pair: AirtrailMcp.list_airtrail_flights
+ * (mirrors GET /api/integrations/airtrail/flights) and
+ * ReservationImportMcp.import_airtrail_flights (mirrors
+ * POST /api/trips/:tripId/reservations/import/airtrail).
+ *
+ * The AirTrail instance is the only thing stubbed: the credentials are read out
+ * of the real users row, the mapper and the dedupe run for real, and the
+ * reservations land in the test DB.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb, setAddonEnabled } from '../../helpers/test-db';
+import { createUser, createTrip, addTripMember } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { ADDON_IDS } from '../../../src/addons';
+import { AirtrailClient, AirtrailRequestError, type AirtrailFlightRaw } from '../../../src/nest/integrations/airtrail.client';
+import { AirtrailImportService } from '../../../src/nest/integrations/airtrail-import.service';
+import { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import { DatabaseService } from '../../../src/nest/database/database.service';
+
+// The permissions cache is module-scoped, so a write through any instance is
+// what the tool's own checkPermission call reads back.
+const permissionsService = new PermissionsService(new DatabaseService(testDb));
+const savePermissions = permissionsService.savePermissions.bind(permissionsService);
+
+// The registry builds its own AirtrailClient per harness, so the stub goes on
+// the prototype. Everything below listFlights (creds, mapper, dedupe) is real.
+const listFlightsMock = vi.spyOn(AirtrailClient.prototype, 'listFlights');
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  broadcastMock.mockClear();
+  listFlightsMock.mockReset();
+  listFlightsMock.mockResolvedValue([]);
+  delete process.env.DEMO_MODE;
+  // resetTestDb leaves the addons table alone, and both tools are gated on the
+  // airtrail addon, so every case restates the toggle it needs.
+  setAddonEnabled(testDb, ADDON_IDS.AIRTRAIL, true);
+  savePermissions({ reservation_edit: 'trip_member' });
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>, scopes: string[] | null = null) {
+  const h = await createMcpHarness({ userId, withResources: false, scopes });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+/** The stored connection, plaintext key: decrypt_api_key passes legacy plaintext straight through. */
+function connectAirtrail(userId: number, url = 'https://airtrail.example.com') {
+  testDb.prepare('UPDATE users SET airtrail_url = ?, airtrail_api_key = ? WHERE id = ?').run(url, 'plain-test-key', userId);
+}
+
+const ZRH = { id: 1, icao: 'LSZH', iata: 'ZRH', name: 'Zurich', lat: 47.458, lon: 8.548, tz: 'Europe/Zurich', country: 'CH' };
+const FRA = { id: 2, icao: 'EDDF', iata: 'FRA', name: 'Frankfurt', lat: 50.033, lon: 8.571, tz: 'Europe/Berlin', country: 'DE' };
+const JFK = { id: 3, icao: 'KJFK', iata: 'JFK', name: 'New York JFK', lat: 40.641, lon: -73.778, tz: 'America/New_York', country: 'US' };
+
+function flight(overrides: Partial<AirtrailFlightRaw> & { id: number }): AirtrailFlightRaw {
+  return {
+    from: ZRH,
+    to: FRA,
+    date: '2026-09-10',
+    datePrecision: 'day',
+    departure: '2026-09-10T06:00:00Z',
+    arrival: '2026-09-10T07:10:00Z',
+    departureScheduled: null,
+    arrivalScheduled: null,
+    airline: { icao: 'DLH', iata: 'LH', name: 'Lufthansa' },
+    flightNumber: 'LH1201',
+    aircraft: { icao: 'A320' },
+    aircraftReg: 'D-AIZA',
+    note: null,
+    seats: [{ userId: 'u1', guestName: null, seat: null, seatNumber: '14A', seatClass: 'economy' }],
+    ...overrides,
+  };
+}
+
+function reservationRows(tripId: number) {
+  return testDb.prepare(
+    'SELECT id, title, type, external_source, external_id, external_owner_user_id, sync_enabled, metadata FROM reservations WHERE trip_id = ? ORDER BY id',
+  ).all(tripId) as {
+    id: number; title: string; type: string; external_source: string | null; external_id: string | null;
+    external_owner_user_id: number | null; sync_enabled: number | null; metadata: string | null;
+  }[];
+}
+
+// ---------------------------------------------------------------------------
+// list_airtrail_flights
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_airtrail_flights', () => {
+  it('returns the caller flights, normalized and oldest departure first', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    listFlightsMock.mockResolvedValue([
+      flight({ id: 22, date: '2026-09-20', departure: '2026-09-20T06:00:00Z', flightNumber: 'LH400', from: FRA, to: JFK }),
+      flight({ id: 11 }),
+    ]);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect(data.flights.map((f: any) => f.id)).toEqual(['11', '22']);
+      expect(data.total).toBe(2);
+      expect(data.truncated).toBe(false);
+      expect(data.flights[0]).toMatchObject({
+        id: '11', fromCode: 'ZRH', toCode: 'FRA', airline: 'Lufthansa', flightNumber: 'LH1201', seatClass: 'economy',
+      });
+    });
+
+    // The stored connection is what reaches the client, so a tool can only ever
+    // read the caller's own AirTrail account.
+    expect(listFlightsMock).toHaveBeenCalledWith({
+      baseUrl: 'https://airtrail.example.com', apiKey: 'plain-test-key', allowInsecureTls: false,
+    });
+  });
+
+  it('narrows to a date window and keeps undated flights', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    listFlightsMock.mockResolvedValue([
+      flight({ id: 1, date: '2026-08-01', departure: '2026-08-01T06:00:00Z' }),
+      flight({ id: 2, date: '2026-09-10', departure: null }),
+      flight({ id: 3, date: '2026-10-01', departure: '2026-10-01T06:00:00Z' }),
+      flight({ id: 4, date: null, departure: null, arrival: null }),
+      flight({ id: 5, date: null, departure: null, arrival: null }),
+      flight({ id: 6 }),
+      flight({ id: 7 }),
+    ]);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_airtrail_flights',
+        arguments: { from: '2026-09-01', to: '2026-09-30' },
+      });
+      const data = parseToolResult(result) as any;
+      // Dated first in departure order (6 and 7 share an instant and keep their
+      // input order), then the two that carry no date at all.
+      expect(data.flights.map((f: any) => f.id)).toEqual(['2', '6', '7', '4', '5']);
+      expect(data.total).toBe(5);
+    });
+  });
+
+  it('falls back to its own wording when AirTrail fails without a message', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    listFlightsMock.mockRejectedValue(new Error(''));
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toBe('Could not load AirTrail flights');
+    });
+  });
+
+  it('caps the result and says it was truncated', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    listFlightsMock.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => flight({ id: i + 1, departure: `2026-09-1${i}T06:00:00Z` })),
+    );
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: { limit: 2 } });
+      const data = parseToolResult(result) as any;
+      expect(data.flights.map((f: any) => f.id)).toEqual(['1', '2']);
+      expect(data.total).toBe(5);
+      expect(data.truncated).toBe(true);
+    });
+  });
+
+  it('reports an unconnected account instead of an empty list', async () => {
+    const { user } = createUser(testDb);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('AirTrail is not connected');
+    });
+    expect(listFlightsMock).not.toHaveBeenCalled();
+  });
+
+  it('passes an upstream failure through as the tool error', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    listFlightsMock.mockRejectedValue(new AirtrailRequestError('AirTrail list failed (HTTP 500)', 500));
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('AirTrail list failed (HTTP 500)');
+    });
+  });
+
+  it('is hidden while the airtrail addon is off', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    setAddonEnabled(testDb, ADDON_IDS.AIRTRAIL, false);
+
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).not.toContain('list_airtrail_flights');
+      const result = await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('not found');
+    });
+  });
+
+  it('rides reservations:read and is hidden from a token without it', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).toContain('list_airtrail_flights');
+    }, ['reservations:read']);
+
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).not.toContain('list_airtrail_flights');
+    }, ['places:read']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// import_airtrail_flights
+// ---------------------------------------------------------------------------
+
+describe('Tool: import_airtrail_flights', () => {
+  it('imports the listed flights as linked flight bookings', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    listFlightsMock.mockResolvedValue([flight({ id: 11 }), flight({ id: 12, flightNumber: 'LH1202' })]);
+
+    await withHarness(user.id, async (h) => {
+      // The ids the list tool hands back are exactly what the import tool takes.
+      const listed = parseToolResult(await h.client.callTool({ name: 'list_airtrail_flights', arguments: {} })) as any;
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: listed.flights.map((f: any) => f.id) },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect([...data.imported].sort()).toEqual(['11', '12']);
+      expect(data.skipped).toEqual([]);
+    });
+
+    const rows = reservationRows(trip.id);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      title: 'LH1201', type: 'flight', external_source: 'airtrail', external_id: '11',
+      external_owner_user_id: user.id, sync_enabled: 1,
+    });
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(broadcastMock.mock.calls[0][1]).toBe('reservation:created');
+  });
+
+  it('skips a flight that is already linked to the trip', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    listFlightsMock.mockResolvedValue([flight({ id: 11 })]);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'import_airtrail_flights', arguments: { tripId: trip.id, flightIds: ['11'] } });
+      const again = await h.client.callTool({ name: 'import_airtrail_flights', arguments: { tripId: trip.id, flightIds: ['11'] } });
+      const data = parseToolResult(again) as any;
+      expect(data.imported).toEqual([]);
+      expect(data.skipped).toEqual([{ flightId: '11', reason: 'already-imported' }]);
+    });
+    expect(reservationRows(trip.id)).toHaveLength(1);
+  });
+
+  it('joins a connection into one multi-leg booking detached from sync', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    listFlightsMock.mockResolvedValue([
+      flight({ id: 11 }),
+      flight({
+        id: 12, from: FRA, to: JFK, flightNumber: 'LH400',
+        departure: '2026-09-10T09:00:00Z', arrival: '2026-09-10T18:00:00Z',
+      }),
+    ]);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: ['11', '12'], connections: [['11', '12']] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.imported).toEqual(['11', '12']);
+    });
+
+    const rows = reservationRows(trip.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sync_enabled).toBe(0);
+    expect(JSON.parse(rows[0].metadata ?? '{}').airtrail_ids).toEqual(['11', '12']);
+  });
+
+  it('refuses a connection naming a flight that is not being imported', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    listFlightsMock.mockResolvedValue([flight({ id: 11 })]);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: ['11'], connections: [['11', '99']] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('flight 99');
+    });
+    expect(reservationRows(trip.id)).toHaveLength(0);
+    expect(listFlightsMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses more than fifty flights in one call', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: Array.from({ length: 51 }, (_, i) => String(i + 1)) },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('at most 50');
+    });
+    expect(reservationRows(trip.id)).toHaveLength(0);
+    expect(listFlightsMock).not.toHaveBeenCalled();
+  });
+
+  it('reports an unconnected account', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: ['11'] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('AirTrail is not connected');
+    });
+    expect(reservationRows(trip.id)).toHaveLength(0);
+  });
+
+  it('falls back to its own wording when the import fails without a message', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    const importMock = vi.spyOn(AirtrailImportService.prototype, 'importAirtrailFlights')
+      .mockRejectedValue(new Error(''));
+
+    try {
+      await withHarness(user.id, async (h) => {
+        const result = await h.client.callTool({
+          name: 'import_airtrail_flights',
+          arguments: { tripId: trip.id, flightIds: ['11'] },
+        });
+        expect(result.isError).toBe(true);
+        expect((result.content as any)[0].text).toBe('AirTrail import failed');
+      });
+    } finally {
+      // Nothing auto-restores spies in this config, so an escaped stub would
+      // silently answer for every later case in the file.
+      importMock.mockRestore();
+    }
+  });
+
+  it('enforces demo, trip access and the reservation permission', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: demo } = createUser(testDb, { email: 'demo@trek.app' });
+    const { user: stranger } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    addTripMember(testDb, trip.id, demo.id);
+    addTripMember(testDb, trip.id, member.id);
+    for (const u of [owner, demo, stranger, member]) connectAirtrail(u.id);
+    listFlightsMock.mockResolvedValue([flight({ id: 11 })]);
+
+    process.env.DEMO_MODE = 'true';
+    await withHarness(demo.id, async (h) => {
+      const result = await h.client.callTool({ name: 'import_airtrail_flights', arguments: { tripId: trip.id, flightIds: ['11'] } });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('demo mode');
+    });
+    delete process.env.DEMO_MODE;
+
+    await withHarness(stranger.id, async (h) => {
+      const result = await h.client.callTool({ name: 'import_airtrail_flights', arguments: { tripId: trip.id, flightIds: ['11'] } });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('access denied');
+    });
+
+    savePermissions({ reservation_edit: 'trip_owner' });
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({ name: 'import_airtrail_flights', arguments: { tripId: trip.id, flightIds: ['11'] } });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('permission');
+    });
+
+    expect(reservationRows(trip.id)).toHaveLength(0);
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(listFlightsMock).not.toHaveBeenCalled();
+  });
+
+  it('is hidden while the airtrail addon is off', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-09-10', end_date: '2026-09-12' });
+    setAddonEnabled(testDb, ADDON_IDS.AIRTRAIL, false);
+
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).not.toContain('import_airtrail_flights');
+      const result = await h.client.callTool({
+        name: 'import_airtrail_flights',
+        arguments: { tripId: trip.id, flightIds: ['11'] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain('not found');
+    });
+    expect(reservationRows(trip.id)).toHaveLength(0);
+  });
+
+  it('rides reservations:write and is hidden from a read-only token', async () => {
+    const { user } = createUser(testDb);
+    connectAirtrail(user.id);
+
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).toContain('import_airtrail_flights');
+    }, ['reservations:write']);
+
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).not.toContain('import_airtrail_flights');
+    }, ['reservations:read']);
+  });
+});

--- a/server/tests/unit/mcp/tools-atlas-expanded.test.ts
+++ b/server/tests/unit/mcp/tools-atlas-expanded.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for MCP atlas expanded tools (atlas addon-gated):
- * get_atlas_stats, list_visited_regions, mark_region_visited, unmark_region_visited,
- * get_country_atlas_places, update_bucket_list_item.
+ * get_atlas_stats, list_visited_regions, locate_atlas_region, mark_region_visited,
+ * unmark_region_visited, get_country_atlas_places, update_bucket_list_item.
  * Also covers resources trek://atlas/stats and trek://atlas/regions.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
@@ -39,7 +39,7 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createBucketListItem, createVisitedCountry } from '../../helpers/factories';
+import { createUser, createBucketListItem, createVisitedCountry, createTrip, createReservation } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 import { setAddonEnabled } from '../../helpers/test-db';
 import { ADDON_IDS } from '../../../src/addons';
@@ -73,6 +73,33 @@ async function withResourceHarness(userId: number, fn: (h: McpHarness) => Promis
   try { await fn(h); } finally { await h.cleanup(); }
 }
 
+// A place carrying an address and coordinates, which createPlace does not write.
+function insertPlace(tripId: number, name: string, address: string | null, lat: number, lng: number): number {
+  const r = testDb
+    .prepare('INSERT INTO places (trip_id, name, address, lat, lng) VALUES (?, ?, ?, ?, ?)')
+    .run(tripId, name, address, lat, lng);
+  return r.lastInsertRowid as number;
+}
+
+// The geocoder's answer for a place, pre-seeded so visitedRegions() reads the cache
+// and never reaches for Nominatim (same trick as ATLAS-UNIT-020).
+function cacheRegion(placeId: number, countryCode: string, regionCode: string, regionName: string): void {
+  testDb
+    .prepare('INSERT OR REPLACE INTO place_regions (place_id, country_code, region_code, region_name) VALUES (?, ?, ?, ?)')
+    .run(placeId, countryCode, regionCode, regionName);
+}
+
+function insertEndpoint(reservationId: number, role: 'from' | 'to', sequence: number, lat: number, lng: number): void {
+  testDb
+    .prepare('INSERT INTO reservation_endpoints (reservation_id, role, sequence, name, lat, lng) VALUES (?, ?, ?, ?, ?, ?)')
+    .run(reservationId, role, sequence, `Endpoint ${sequence}`, lat, lng);
+}
+
+// Trips have to sit in the past for their countries and regions to count as
+// visited rather than planned (#1048).
+const PAST_START = '2023-05-01';
+const PAST_END = '2023-05-10';
+
 // ---------------------------------------------------------------------------
 // get_atlas_stats
 // ---------------------------------------------------------------------------
@@ -85,6 +112,65 @@ describe('Tool: get_atlas_stats', () => {
       expect(result.isError).toBeFalsy();
       const data = parseToolResult(result) as any;
       expect(data.stats).toBeDefined();
+      expect(data.travel).toEqual({
+        countries: [],
+        cities: [],
+        totalTrips: 0,
+        totalDays: 0,
+        totalPlaces: 0,
+        totalDistanceKm: 0,
+      });
+    });
+  });
+
+  it('carries the passport figures REST answers with: the cities by name and the distance flown', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Rome', start_date: PAST_START, end_date: PAST_END });
+    insertPlace(trip.id, 'Colosseum', 'Colosseum, Rome, Italy', 41.8902, 12.4922);
+    const flight = createReservation(testDb, trip.id, { type: 'flight', title: 'FCO-JFK' });
+    insertEndpoint(flight.id, 'from', 0, 41.8003, 12.2389);
+    insertEndpoint(flight.id, 'to', 1, 40.6413, -73.7781);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_atlas_stats', arguments: {} });
+      const data = parseToolResult(result) as any;
+      // The count was always there; the names behind it were not.
+      expect(data.stats.stats.totalCities).toBe(1);
+      expect(data.travel.cities).toEqual(['Rome']);
+      expect(data.travel.countries).toContain('IT');
+      expect(data.travel.countries).toContain('US');
+      // Rome to New York, so a four-figure number rather than a rounding artefact.
+      expect(data.travel.totalDistanceKm).toBeGreaterThan(6000);
+      const places = testDb.prepare('SELECT COUNT(*) AS c FROM places WHERE trip_id = ?').get(trip.id) as { c: number };
+      expect(data.travel.totalPlaces).toBe(places.c);
+      // Rendering data stays out unless asked for.
+      expect(data.travel.coords).toBeUndefined();
+    });
+  });
+
+  it('include_coords adds the per-place coordinates the dashboard map plots', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Rome', start_date: PAST_START, end_date: PAST_END });
+    insertPlace(trip.id, 'Colosseum', 'Colosseum, Rome, Italy', 41.8902, 12.4922);
+    insertPlace(trip.id, 'Pantheon', 'Pantheon, Rome, Italy', 41.8986, 12.4769);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_atlas_stats', arguments: { include_coords: true } });
+      const data = parseToolResult(result) as any;
+      const withCoords = testDb
+        .prepare('SELECT COUNT(*) AS c FROM places WHERE trip_id = ? AND lat IS NOT NULL AND lng IS NOT NULL')
+        .get(trip.id) as { c: number };
+      expect(data.travel.coords).toHaveLength(withCoords.c);
+      expect(data.travel.coords[0]).toEqual({ lat: 41.8902, lng: 12.4922 });
+    });
+  });
+
+  it('refuses a non-boolean include_coords', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_atlas_stats', arguments: { include_coords: 'yes' } });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as any).text).toContain('include_coords');
     });
   });
 });
@@ -94,16 +180,16 @@ describe('Tool: get_atlas_stats', () => {
 // ---------------------------------------------------------------------------
 
 describe('Tool: list_visited_regions', () => {
-  it('returns empty array initially', async () => {
+  it('returns an empty grouping initially', async () => {
     const { user } = createUser(testDb);
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'list_visited_regions', arguments: {} });
       const data = parseToolResult(result) as any;
-      expect(data.regions).toEqual([]);
+      expect(data.regions).toEqual({});
     });
   });
 
-  it('returns regions after they have been inserted', async () => {
+  it('groups a manual mark under its country, in the shape the map reads', async () => {
     const { user } = createUser(testDb);
     testDb.prepare(
       'INSERT INTO visited_regions (user_id, region_code, region_name, country_code) VALUES (?, ?, ?, ?)'
@@ -111,8 +197,113 @@ describe('Tool: list_visited_regions', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'list_visited_regions', arguments: {} });
       const data = parseToolResult(result) as any;
-      expect(data.regions).toHaveLength(1);
-      expect(data.regions[0].region_code).toBe('FR-75');
+      expect(data.regions.FR).toEqual([
+        { code: 'FR-75', name: 'Paris', placeCount: 0, status: 'visited', manuallyMarked: true },
+      ]);
+    });
+  });
+
+  it('reports regions derived from trip places, which the manual table never held', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Rome', start_date: PAST_START, end_date: PAST_END });
+    cacheRegion(insertPlace(trip.id, 'Colosseum', null, 41.8902, 12.4922), 'IT', 'IT-62', 'Lazio');
+    cacheRegion(insertPlace(trip.id, 'Pantheon', null, 41.8986, 12.4769), 'IT', 'IT-62', 'Lazio');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_visited_regions', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.regions.IT).toEqual([{ code: 'IT-62', name: 'Lazio', placeCount: 2, status: 'visited' }]);
+      // Nothing was ever marked by hand, so the old manual-only read had no row
+      // to answer with at all.
+      const marked = testDb.prepare('SELECT COUNT(*) AS c FROM visited_regions WHERE user_id = ?').get(user.id) as { c: number };
+      expect(marked.c).toBe(0);
+    });
+  });
+
+  it('drops a region the user dismissed, matching the map', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Rome', start_date: PAST_START, end_date: PAST_END });
+    cacheRegion(insertPlace(trip.id, 'Colosseum', null, 41.8902, 12.4922), 'IT', 'IT-62', 'Lazio');
+
+    await withHarness(user.id, async (h) => {
+      const unmark = await h.client.callTool({ name: 'unmark_region_visited', arguments: { regionCode: 'IT-62' } });
+      expect(parseToolResult(unmark)).toEqual({ success: true });
+      const tombstone = testDb
+        .prepare('SELECT region_code FROM hidden_regions WHERE user_id = ? AND region_code = ?')
+        .get(user.id, 'IT-62');
+      expect(tombstone).toBeTruthy();
+
+      const result = await h.client.callTool({ name: 'list_visited_regions', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.regions.IT).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// locate_atlas_region
+// ---------------------------------------------------------------------------
+
+describe('Tool: locate_atlas_region', () => {
+  it('resolves a coordinate to the country and the region the map can highlight', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'locate_atlas_region',
+        arguments: { lat: 41.9028, lng: 12.4964 },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      // Rome. Italy has admin1 coverage in the bundle, so the region resolves too,
+      // and the code comes back in the form mark_region_visited takes.
+      expect(data.country_code).toBe('IT');
+      expect(typeof data.region_code).toBe('string');
+      expect(typeof data.region_name).toBe('string');
+    });
+  });
+
+  it('feeds mark_region_visited without the caller knowing any codes', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const located = parseToolResult(
+        await h.client.callTool({ name: 'locate_atlas_region', arguments: { lat: 41.9028, lng: 12.4964 } }),
+      ) as any;
+      expect(typeof located.region_code).toBe('string');
+
+      await h.client.callTool({
+        name: 'mark_region_visited',
+        arguments: {
+          regionCode: located.region_code,
+          regionName: located.region_name,
+          countryCode: located.country_code,
+        },
+      });
+      const row = testDb
+        .prepare('SELECT region_code, country_code FROM visited_regions WHERE user_id = ?')
+        .get(user.id) as { region_code: string; country_code: string };
+      expect(row).toEqual({ region_code: located.region_code, country_code: 'IT' });
+    });
+  });
+
+  it('answers with nulls out at sea rather than failing', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'locate_atlas_region', arguments: { lat: 0, lng: -140 } });
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result)).toEqual({ country_code: null, region_code: null, region_name: null });
+    });
+  });
+
+  it('refuses an out-of-range coordinate, like the REST route does', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const badLat = await h.client.callTool({ name: 'locate_atlas_region', arguments: { lat: 91, lng: 12.5 } });
+      expect(badLat.isError).toBe(true);
+      expect((badLat.content[0] as any).text).toContain('lat');
+
+      const badLng = await h.client.callTool({ name: 'locate_atlas_region', arguments: { lat: 41.9, lng: 181 } });
+      expect(badLng.isError).toBe(true);
+      expect((badLng.content[0] as any).text).toContain('lng');
     });
   });
 });
@@ -348,25 +539,30 @@ describe('Resource: trek://atlas/stats', () => {
 // ---------------------------------------------------------------------------
 
 describe('Resource: trek://atlas/regions', () => {
-  it('returns regions array', async () => {
+  it('returns the country grouping', async () => {
     const { user } = createUser(testDb);
     await withResourceHarness(user.id, async (h) => {
       const result = await h.client.readResource({ uri: 'trek://atlas/regions' });
       const data = parseResourceResult(result) as any;
-      expect(Array.isArray(data)).toBe(true);
+      expect(data).toEqual({});
     });
   });
 
-  it('returns inserted regions', async () => {
+  it('returns marked and derived regions together, as the tool does', async () => {
     const { user } = createUser(testDb);
     testDb.prepare(
       'INSERT INTO visited_regions (user_id, region_code, region_name, country_code) VALUES (?, ?, ?, ?)'
     ).run(user.id, 'ES-CT', 'Catalonia', 'ES');
+    const trip = createTrip(testDb, user.id, { title: 'Rome', start_date: PAST_START, end_date: PAST_END });
+    cacheRegion(insertPlace(trip.id, 'Colosseum', null, 41.8902, 12.4922), 'IT', 'IT-62', 'Lazio');
+
     await withResourceHarness(user.id, async (h) => {
       const result = await h.client.readResource({ uri: 'trek://atlas/regions' });
       const data = parseResourceResult(result) as any;
-      expect(data).toHaveLength(1);
-      expect(data[0].region_code).toBe('ES-CT');
+      expect(data.ES).toEqual([
+        { code: 'ES-CT', name: 'Catalonia', placeCount: 0, status: 'visited', manuallyMarked: true },
+      ]);
+      expect(data.IT).toEqual([{ code: 'IT-62', name: 'Lazio', placeCount: 1, status: 'visited' }]);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-budget.test.ts
+++ b/server/tests/unit/mcp/tools-budget.test.ts
@@ -1,5 +1,8 @@
 /**
- * Unit tests for MCP budget tools: create_budget_item, update_budget_item, delete_budget_item.
+ * Unit tests for MCP budget tools: create_budget_item, update_budget_item,
+ * delete_budget_item, plus the settlement cases that turn on the currency the
+ * payment was made in (the rest of the settlement surface lives in
+ * tools-budget-advanced.test.ts).
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 
@@ -35,7 +38,7 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createBudgetItem, addTripMember } from '../../helpers/factories';
+import { createUser, createTrip, createBudgetItem, createPlace, addTripMember } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 
 beforeAll(() => {
@@ -47,15 +50,71 @@ beforeEach(() => {
   resetTestDb(testDb);
   broadcastMock.mockClear();
   delete process.env.DEMO_MODE;
+  // Freezing the FX rate of a foreign currency is a real fetch to
+  // api.frankfurter.dev with a 10 s abort. Fail closed by default; the cases
+  // that assert a frozen rate install their own rate stub.
+  vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
 });
 
 afterAll(() => {
+  vi.unstubAllGlobals();
   testDb.close();
 });
 
 async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
   const h = await createMcpHarness({ userId, withResources: false });
   try { await fn(h); } finally { await h.cleanup(); }
+}
+
+function errorText(result: Awaited<ReturnType<McpHarness['client']['callTool']>>): string {
+  const text = (result.content as { type: string; text?: string }[]).find((c) => c.type === 'text');
+  return text?.text ?? '';
+}
+
+function tripWithTwo() {
+  const { user } = createUser(testDb);
+  const { user: other } = createUser(testDb);
+  const trip = createTrip(testDb, user.id);
+  addTripMember(testDb, trip.id, other.id);
+  return { user, other, trip };
+}
+
+function memberRows(itemId: number) {
+  return testDb.prepare('SELECT user_id, amount FROM budget_item_members WHERE budget_item_id = ? ORDER BY user_id')
+    .all(itemId) as { user_id: number; amount: number | null }[];
+}
+
+function itemRow(itemId: number) {
+  return testDb.prepare('SELECT total_price, currency, exchange_rate, persons, expense_date, place_id FROM budget_items WHERE id = ?')
+    .get(itemId) as {
+      total_price: number; currency: string | null; exchange_rate: number | null;
+      persons: number | null; expense_date: string | null; place_id: number | null;
+    };
+}
+
+function itemCount(tripId: number): number {
+  return (testDb.prepare('SELECT COUNT(*) AS count FROM budget_items WHERE trip_id = ?').get(tripId) as { count: number }).count;
+}
+
+function settlementRow(id: number) {
+  return testDb.prepare('SELECT amount, currency, exchange_rate FROM budget_settlements WHERE id = ?')
+    .get(id) as { amount: number; currency: string | null; exchange_rate: number | null };
+}
+
+// budget_settlements is not one of the tables the reset clears, and trip ids are
+// reused, so a count is only ever compared against the count taken in the same test.
+function settlementCount(tripId: number): number {
+  return (testDb.prepare('SELECT COUNT(*) AS count FROM budget_settlements WHERE trip_id = ?').get(tripId) as { count: number }).count;
+}
+
+/** Frankfurter's shape: one entry per quote, the base's own rate omitted. */
+function stubRates(rates: Record<string, number>): void {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    text: async () => JSON.stringify(
+      Object.entries(rates).map(([quote, rate]) => ({ date: '2026-08-28', base: 'EUR', quote, rate })),
+    ),
+  })));
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +392,564 @@ describe('Resource: trek://trips/{tripId}/budget', () => {
       const result = await h.client.readResource({ uri: `trek://trips/${trip.id}/budget` });
       const data = parseResourceResult(result) as { error?: string };
       expect(data.error).toBeTruthy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Uneven splits: members carries what each participant owes, the way the REST
+// body has since the Costs rework. member_ids alone always meant an equal share.
+// ---------------------------------------------------------------------------
+
+describe('Tool: create_budget_item (uneven split)', () => {
+  it('persists what each member owes', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Dinner', total_price: 100,
+          members: [{ user_id: user.id, amount: 70 }, { user_id: other.id, amount: 30 }],
+        },
+      });
+      const data = parseToolResult(result) as any;
+      expect(memberRows(data.item.id)).toEqual([
+        { user_id: user.id, amount: 70 },
+        { user_id: other.id, amount: 30 },
+      ]);
+      expect(itemRow(data.item.id).persons).toBe(2);
+    });
+  });
+
+  it('refuses a split that does not add up to the total', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Dinner', total_price: 100,
+          members: [{ user_id: user.id, amount: 60 }, { user_id: other.id, amount: 30 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('does not add up');
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+
+  it('measures the split against the payer sum, not the stated total', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Groceries', total_price: 100,
+          payers: [{ user_id: user.id, amount: 90 }],
+          members: [{ user_id: user.id, amount: 60 }, { user_id: other.id, amount: 30 }],
+        },
+      });
+      const data = parseToolResult(result) as any;
+      expect(itemRow(data.item.id).total_price).toBe(90);
+      expect(memberRows(data.item.id).map(m => m.amount)).toEqual([60, 30]);
+    });
+  });
+
+  it('refuses a split that matches the stated total but not what the payers paid', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Groceries', total_price: 100,
+          payers: [{ user_id: user.id, amount: 90 }],
+          members: [{ user_id: user.id, amount: 70 }, { user_id: other.id, amount: 30 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+
+  it('refuses a member who is not on the trip', async () => {
+    const { user, trip } = tripWithTwo();
+    const { user: stranger } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Dinner', total_price: 100,
+          members: [{ user_id: user.id, amount: 50 }, { user_id: stranger.id, amount: 50 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('not on this trip');
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+
+  it('refuses members alongside member_ids', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Dinner', total_price: 100,
+          member_ids: [user.id, other.id],
+          members: [{ user_id: user.id, amount: 50 }, { user_id: other.id, amount: 50 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('not both');
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+});
+
+describe('Tool: update_budget_item (uneven split)', () => {
+  function itemWithEqualSplit(tripId: number, userIds: number[]) {
+    const item = createBudgetItem(testDb, tripId, { name: 'Dinner', total_price: 100 });
+    const insert = testDb.prepare('INSERT INTO budget_item_members (budget_item_id, user_id, paid, amount) VALUES (?, ?, 0, NULL)');
+    for (const id of userIds) insert.run(item.id, id);
+    testDb.prepare('UPDATE budget_items SET persons = ? WHERE id = ?').run(userIds.length, item.id);
+    return item;
+  }
+
+  it('replaces the equal split with per-member amounts', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const item = itemWithEqualSplit(trip.id, [user.id, other.id]);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: {
+          tripId: trip.id, itemId: item.id,
+          members: [{ user_id: user.id, amount: 40 }, { user_id: other.id, amount: 60 }],
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(memberRows(item.id)).toEqual([
+        { user_id: user.id, amount: 40 },
+        { user_id: other.id, amount: 60 },
+      ]);
+      expect(itemRow(item.id).persons).toBe(2);
+    });
+  });
+
+  it('measures the split against the stored total when the call does not restate it', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const item = itemWithEqualSplit(trip.id, [user.id, other.id]);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: {
+          tripId: trip.id, itemId: item.id,
+          members: [{ user_id: user.id, amount: 40 }, { user_id: other.id, amount: 50 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('100.00');
+      expect(memberRows(item.id)).toEqual([
+        { user_id: user.id, amount: null },
+        { user_id: other.id, amount: null },
+      ]);
+    });
+  });
+
+  it('refuses the same member twice', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const item = itemWithEqualSplit(trip.id, [user.id, other.id]);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: {
+          tripId: trip.id, itemId: item.id,
+          members: [{ user_id: user.id, amount: 50 }, { user_id: user.id, amount: 50 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('twice');
+      expect(memberRows(item.id).map(m => m.amount)).toEqual([null, null]);
+    });
+  });
+
+  it('refuses members alongside member_ids', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const item = itemWithEqualSplit(trip.id, [user.id, other.id]);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: {
+          tripId: trip.id, itemId: item.id,
+          member_ids: [user.id],
+          members: [{ user_id: user.id, amount: 100 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('not both');
+      expect(memberRows(item.id)).toHaveLength(2);
+    });
+  });
+
+  it('reports a missing item before it looks at the split', async () => {
+    const { user, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: 99999, members: [{ user_id: user.id, amount: 10 }] },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('Budget item not found.');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Currency and date on an existing expense
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_budget_item (currency)', () => {
+  it('changes the currency and freezes the rate at entry time', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id, { total_price: 100 });
+    stubRates({ USD: 1.1 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, currency: 'USD' },
+      });
+      expect(result.isError).toBeFalsy();
+      const row = itemRow(item.id);
+      expect(row.currency).toBe('USD');
+      expect(row.exchange_rate).toBe(1.1);
+    });
+  });
+
+  it('clears the currency back to the trip currency', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id, { total_price: 100 });
+    testDb.prepare('UPDATE budget_items SET currency = ?, exchange_rate = ? WHERE id = ?').run('USD', 1.1, item.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, currency: null },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(itemRow(item.id).currency).toBeNull();
+    });
+  });
+
+  it('refuses a currency that is not a code', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id, { total_price: 100 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, currency: 'United States Dollars' },
+      });
+      expect(result.isError).toBe(true);
+      expect(itemRow(item.id).currency).toBeNull();
+    });
+  });
+});
+
+describe('Tool: update_budget_item (expense date)', () => {
+  it('moves the expense to another date', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, expense_date: '2026-09-14' },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(itemRow(item.id).expense_date).toBe('2026-09-14');
+    });
+  });
+
+  it('clears the expense date', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id);
+    testDb.prepare('UPDATE budget_items SET expense_date = ? WHERE id = ?').run('2026-09-14', item.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, expense_date: null },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(itemRow(item.id).expense_date).toBeNull();
+    });
+  });
+
+  it('refuses a date that is not a string', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createBudgetItem(testDb, trip.id);
+    testDb.prepare('UPDATE budget_items SET expense_date = ? WHERE id = ?').run('2026-09-14', item.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, expense_date: 20260915 },
+      });
+      expect(result.isError).toBe(true);
+      expect(itemRow(item.id).expense_date).toBe('2026-09-14');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expenses linked to a place (#1298), the place-side twin of reservation_id
+// ---------------------------------------------------------------------------
+
+describe('Budget tools: place link', () => {
+  it('create_budget_item links the expense to a place on the trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Louvre' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: { tripId: trip.id, name: 'Louvre tickets', total_price: 34, place_id: place.id },
+      });
+      const data = parseToolResult(result) as any;
+      expect(itemRow(data.item.id).place_id).toBe(place.id);
+    });
+  });
+
+  it('create_budget_item refuses a place from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const elsewhere = createTrip(testDb, user.id);
+    const place = createPlace(testDb, elsewhere.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: { tripId: trip.id, name: 'Tickets', total_price: 34, place_id: place.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('place_id does not belong to this trip.');
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+
+  it('create_budget_item_with_members links the expense to a place on the trip', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const place = createPlace(testDb, trip.id, { name: 'Louvre' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item_with_members',
+        arguments: { tripId: trip.id, name: 'Louvre tickets', total_price: 68, userIds: [user.id, other.id], place_id: place.id },
+      });
+      const data = parseToolResult(result) as any;
+      expect(itemRow(data.item.id).place_id).toBe(place.id);
+    });
+  });
+
+  it('create_budget_item_with_members refuses a place from another trip', async () => {
+    const { user, trip } = tripWithTwo();
+    const elsewhere = createTrip(testDb, user.id);
+    const place = createPlace(testDb, elsewhere.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item_with_members',
+        arguments: { tripId: trip.id, name: 'Tickets', total_price: 68, place_id: place.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('place_id does not belong to this trip.');
+      expect(itemCount(trip.id)).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settle-up payments made in another currency (the #1445 freeze)
+// ---------------------------------------------------------------------------
+
+describe('Tool: create_settlement (currency)', () => {
+  it('records the payment in the currency it was made in and freezes its rate', async () => {
+    const { user, other, trip } = tripWithTwo();
+    stubRates({ USD: 1.1 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_settlement',
+        arguments: { tripId: trip.id, from_user_id: other.id, to_user_id: user.id, amount: 20, currency: 'USD' },
+      });
+      const data = parseToolResult(result) as any;
+      const row = settlementRow(data.settlement.id);
+      expect(row.currency).toBe('USD');
+      expect(row.exchange_rate).toBe(1.1);
+      expect(row.amount).toBe(20);
+    });
+  });
+
+  it('books the payment in the trip currency when none is given', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_settlement',
+        arguments: { tripId: trip.id, from_user_id: other.id, to_user_id: user.id, amount: 20 },
+      });
+      const data = parseToolResult(result) as any;
+      const row = settlementRow(data.settlement.id);
+      expect(row.currency).toBeNull();
+      expect(row.exchange_rate).toBe(1);
+    });
+  });
+
+  it('refuses a currency that is not a code', async () => {
+    const { user, other, trip } = tripWithTwo();
+    const before = settlementCount(trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_settlement',
+        arguments: { tripId: trip.id, from_user_id: other.id, to_user_id: user.id, amount: 20, currency: 'United States Dollars' },
+      });
+      expect(result.isError).toBe(true);
+      expect(settlementCount(trip.id)).toBe(before);
+    });
+  });
+});
+
+describe('Tool: update_settlement (currency)', () => {
+  it('changes the currency the payment was made in and freezes its rate', async () => {
+    const { user, other, trip } = tripWithTwo();
+    await withHarness(user.id, async (h) => {
+      const created = parseToolResult(await h.client.callTool({
+        name: 'create_settlement',
+        arguments: { tripId: trip.id, from_user_id: other.id, to_user_id: user.id, amount: 20 },
+      })) as any;
+      stubRates({ USD: 1.1 });
+      const result = await h.client.callTool({
+        name: 'update_settlement',
+        arguments: { tripId: trip.id, settlementId: created.settlement.id, from_user_id: other.id, to_user_id: user.id, amount: 20, currency: 'USD' },
+      });
+      expect(result.isError).toBeFalsy();
+      const row = settlementRow(created.settlement.id);
+      expect(row.currency).toBe('USD');
+      expect(row.exchange_rate).toBe(1.1);
+    });
+  });
+
+  it('clears the currency back to the trip currency', async () => {
+    const { user, other, trip } = tripWithTwo();
+    stubRates({ USD: 1.1 });
+    await withHarness(user.id, async (h) => {
+      const created = parseToolResult(await h.client.callTool({
+        name: 'create_settlement',
+        arguments: { tripId: trip.id, from_user_id: other.id, to_user_id: user.id, amount: 20, currency: 'USD' },
+      })) as any;
+      const result = await h.client.callTool({
+        name: 'update_settlement',
+        arguments: { tripId: trip.id, settlementId: created.settlement.id, from_user_id: other.id, to_user_id: user.id, amount: 20, currency: null },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(settlementRow(created.settlement.id).currency).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The split has to reconcile against the total that is actually stored
+//
+// writeItemPayers drops a payer who is not on the trip and then derives
+// total_price from what survived, so certifying a split against the payers as
+// GIVEN would pass a check the stored row fails. An empty payer list is the
+// same trap from the other side: it means "no payers", so the derived total is
+// zero, not the previous one.
+// ---------------------------------------------------------------------------
+
+describe('Budget tools: a custom split cannot be certified against a total the row will not get', () => {
+  it('refuses a payer who is not on the trip rather than storing an unbalanced split', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Dinner', total_price: 100,
+          members: [{ user_id: owner.id, amount: 100 }],
+          payers: [{ user_id: stranger.id, amount: 50 }, { user_id: owner.id, amount: 50 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('not on this trip');
+      expect(testDb.prepare('SELECT COUNT(*) AS n FROM budget_items WHERE trip_id = ?').get(trip.id)).toEqual({ n: 0 });
+    });
+  });
+
+  it('refuses an empty payer list under a non-zero split, because the stored total becomes zero', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: friend } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
+    await withHarness(owner.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: { tripId: trip.id, name: 'Taxi', total_price: 100, member_ids: [owner.id, friend.id] },
+      });
+      const { item } = parseToolResult(created) as { item: { id: number } };
+
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: {
+          tripId: trip.id, itemId: item.id,
+          payers: [],
+          members: [{ user_id: owner.id, amount: 60 }, { user_id: friend.id, amount: 40 }],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('does not add up');
+      // The item is untouched: the refusal happens before the write.
+      const row = testDb.prepare('SELECT total_price FROM budget_items WHERE id = ?').get(item.id) as any;
+      expect(row.total_price).toBe(100);
+    });
+  });
+
+  it('accepts an empty payer list when the split is empty too', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: { tripId: trip.id, name: 'Placeholder', total_price: 50, member_ids: [] },
+      });
+      const { item } = parseToolResult(created) as { item: { id: number } };
+
+      const result = await h.client.callTool({
+        name: 'update_budget_item',
+        arguments: { tripId: trip.id, itemId: item.id, payers: [], members: [] },
+      });
+      expect(result.isError).toBeFalsy();
+      const row = testDb.prepare('SELECT total_price FROM budget_items WHERE id = ?').get(item.id) as any;
+      expect(row.total_price).toBe(0);
+    });
+  });
+
+  it('still certifies a split against the payer sum when every payer is on the trip', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: friend } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_budget_item',
+        arguments: {
+          tripId: trip.id, name: 'Hotel', total_price: 999,
+          payers: [{ user_id: owner.id, amount: 70 }, { user_id: friend.id, amount: 30 }],
+          members: [{ user_id: owner.id, amount: 60 }, { user_id: friend.id, amount: 40 }],
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      // total_price came from the payers, not from the stated 999.
+      const row = testDb.prepare('SELECT total_price FROM budget_items WHERE id = ?').get(data.item.id) as any;
+      expect(row.total_price).toBe(100);
+      const shares = testDb.prepare('SELECT user_id, amount FROM budget_item_members WHERE budget_item_id = ? ORDER BY user_id').all(data.item.id) as any[];
+      expect(shares.map(s => s.amount)).toEqual([60, 40]);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-categories.test.ts
+++ b/server/tests/unit/mcp/tools-categories.test.ts
@@ -1,9 +1,10 @@
 /**
  * Unit tests for the categories MCP surface (CategoriesMcp, DI-discovered):
- * the list_categories tool and the trek://categories resource.
+ * the list_categories tool, the create/update/delete_category admin tools and
+ * the trek://categories resource.
  *
- * Both attach via the nest-mcp registry inside registerTools, so every harness
- * here keeps withTools on (the resource is NOT registered by the legacy
+ * They all attach via the nest-mcp registry inside registerTools, so every
+ * harness here keeps withTools on (the resource is NOT registered by the legacy
  * registerResources fan-out anymore).
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
@@ -32,11 +33,31 @@ vi.mock('../../../src/config', () => ({
   updateJwtSecret: () => {},
 }));
 
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { Client } from '@modelcontextprotocol/sdk/client/index';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory';
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser } from '../../helpers/factories';
+import { createUser, createAdmin } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
+import { createTestRegistry } from '../../../src/nest-mcp';
+import { trekMcpAccessPolicy, trekMcpValidateAccess } from '../../../src/mcp/nest-mcp-policy';
+import { CategoriesMcp } from '../../../src/nest/categories/categories.mcp';
+import { CategoriesService } from '../../../src/nest/categories/categories.service';
+import { DatabaseService } from '../../../src/nest/database/database.service';
+import { PermissionsService } from '../../../src/nest/permissions/permissions.service';
+import { RealtimeService } from '../../../src/nest/realtime/realtime.service';
+import { McpToolGuardsService } from '../../../src/nest/mcp-shared/mcp-tool-guards.service';
+import { AuthService } from '../../../src/nest/auth/auth.service';
+import { BudgetService } from '../../../src/nest/budget/budget.service';
+import { ExchangeRatesService } from '../../../src/nest/budget/exchange-rates.service';
+import { TripMembershipService } from '../../../src/nest/trip-membership/trip-membership.service';
+import { WebauthnConfigService } from '../../../src/nest/auth/webauthn-config.service';
+import { UserCleanupService } from '../../../src/nest/auth/user-cleanup.service';
+import { MailerService } from '../../../src/nest/notifications/mailer/mailer.service';
+import { EphemeralTokenService } from '../../../src/nest/auth/ephemeral-token.service';
+import { AllowedFileTypesService } from '../../../src/nest/files/allowed-file-types.service';
 
 beforeAll(() => {
   createTables(testDb);
@@ -45,6 +66,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   resetTestDb(testDb);
+  delete process.env.DEMO_MODE;
 });
 
 afterAll(() => {
@@ -58,6 +80,46 @@ async function withHarness(
 ) {
   const h = await createMcpHarness({ userId, withResources: false, scopes });
   try { await fn(h); } finally { await h.cleanup(); }
+}
+
+// The write tools reach the auth and guard collaborators, so they run against a
+// controller wired here rather than through the shared harness. Everything
+// points at this file's DB, which is what lets the admin gate and the demo gate
+// be driven from the users table instead of from a stub.
+const categoriesDb = new DatabaseService(testDb);
+const categoriesMcp = new CategoriesMcp(
+  new CategoriesService(categoriesDb),
+  new AuthService(
+    categoriesDb,
+    new PermissionsService(categoriesDb),
+    new TripMembershipService(categoriesDb),
+    new WebauthnConfigService(categoriesDb),
+    new UserCleanupService(categoriesDb, new BudgetService(categoriesDb, new PermissionsService(categoriesDb), new ExchangeRatesService(), new RealtimeService())),
+    new MailerService(categoriesDb),
+    new EphemeralTokenService(),
+    new AllowedFileTypesService(categoriesDb),
+  ),
+  new McpToolGuardsService(categoriesDb, new PermissionsService(categoriesDb), new RealtimeService()),
+);
+
+async function withWriteHarness(userId: number, fn: (client: Client) => Promise<void>) {
+  const server = new McpServer({ name: 'trek-test', version: '1.0.0' });
+  createTestRegistry([categoriesMcp], { accessPolicy: trekMcpAccessPolicy, validateAccess: trekMcpValidateAccess })
+    .attach(server, { userId, scopes: null, isStaticToken: false });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    await fn(client);
+  } finally {
+    try { await client.close(); } catch { /* ignore */ }
+    try { await server.close(); } catch { /* ignore */ }
+  }
+}
+
+function insertCategory(name: string, color = '#111111', icon = '🅰️'): number {
+  return Number(testDb.prepare('INSERT INTO categories (name, color, icon) VALUES (?, ?, ?)').run(name, color, icon).lastInsertRowid);
 }
 
 // ---------------------------------------------------------------------------
@@ -96,10 +158,191 @@ describe('Tool: list_categories', () => {
 });
 
 // ---------------------------------------------------------------------------
-// list_categories scope gating (places:read, registration-time)
+// create_category (admin only, mirroring POST /api/categories)
 // ---------------------------------------------------------------------------
 
-describe('Tool: list_categories — scope gating', () => {
+describe('Tool: create_category', () => {
+  it('persists the new category and credits the admin who minted it', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({
+        name: 'create_category',
+        arguments: { name: 'Street food', color: '#16a34a', icon: '🍜' },
+      });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT name, color, icon, user_id FROM categories WHERE id = ?').get(data.category.id) as any;
+      expect(row).toEqual({ name: 'Street food', color: '#16a34a', icon: '🍜', user_id: admin.id });
+    });
+  });
+
+  it('falls back to the palette defaults when color and icon are omitted', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'create_category', arguments: { name: 'Bare minimum' } });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT color, icon FROM categories WHERE id = ?').get(data.category.id) as any;
+      expect(row).toEqual({ color: '#6366f1', icon: '📍' });
+    });
+  });
+
+  it('refuses a non-admin and writes nothing', async () => {
+    const { user } = createUser(testDb);
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'create_category', arguments: { name: 'Sneaky' } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE name = ?').get('Sneaky')).toBeUndefined();
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createAdmin(testDb, { email: 'demo@trek.app' });
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'create_category', arguments: { name: 'Demo made this' } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE name = ?').get('Demo made this')).toBeUndefined();
+    });
+  });
+
+  it('refuses a color that is not a hex value', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'create_category', arguments: { name: 'Bad colour', color: 'rebeccapurple' } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE name = ?').get('Bad colour')).toBeUndefined();
+    });
+  });
+
+  it('refuses an empty name', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'create_category', arguments: { name: '' } });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_category (admin only, mirroring PUT /api/categories/:id)
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_category', () => {
+  it('renames and recolours an existing category', async () => {
+    const { user: admin } = createAdmin(testDb);
+    const id = insertCategory('Old name', '#111111', '🅰️');
+    await withWriteHarness(admin.id, async (client) => {
+      await client.callTool({ name: 'update_category', arguments: { categoryId: id, name: 'New name', color: '#dc2626' } });
+      const row = testDb.prepare('SELECT name, color, icon FROM categories WHERE id = ?').get(id) as any;
+      expect(row).toEqual({ name: 'New name', color: '#dc2626', icon: '🅰️' });
+    });
+  });
+
+  it('leaves the fields it was not given alone', async () => {
+    const { user: admin } = createAdmin(testDb);
+    const id = insertCategory('Keep me', '#0891b2', '🚕');
+    await withWriteHarness(admin.id, async (client) => {
+      await client.callTool({ name: 'update_category', arguments: { categoryId: id, icon: '🚗' } });
+      const row = testDb.prepare('SELECT name, color, icon FROM categories WHERE id = ?').get(id) as any;
+      expect(row).toEqual({ name: 'Keep me', color: '#0891b2', icon: '🚗' });
+    });
+  });
+
+  it('reports an unknown category', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'update_category', arguments: { categoryId: 999999, name: 'Nope' } });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('refuses a non-admin and leaves the row untouched', async () => {
+    const { user } = createUser(testDb);
+    const id = insertCategory('Not yours', '#9333ea', '🔒');
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'update_category', arguments: { categoryId: id, name: 'Hijacked' } });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT name FROM categories WHERE id = ?').get(id) as any).name).toBe('Not yours');
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createAdmin(testDb, { email: 'demo@trek.app' });
+    const id = insertCategory('Demo untouchable', '#ea580c', '🙅');
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'update_category', arguments: { categoryId: id, name: 'Changed' } });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT name FROM categories WHERE id = ?').get(id) as any).name).toBe('Demo untouchable');
+    });
+  });
+
+  it('refuses a color that is not a hex value', async () => {
+    const { user: admin } = createAdmin(testDb);
+    const id = insertCategory('Colour guard', '#2563eb', '🎨');
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'update_category', arguments: { categoryId: id, color: 'goldenrod' } });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT color FROM categories WHERE id = ?').get(id) as any).color).toBe('#2563eb');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete_category (admin only, mirroring DELETE /api/categories/:id)
+// ---------------------------------------------------------------------------
+
+describe('Tool: delete_category', () => {
+  it('removes the category and unassigns the places that carried it', async () => {
+    const { user: admin } = createAdmin(testDb);
+    const id = insertCategory('Doomed', '#d97706', '💀');
+    const trip = Number(testDb.prepare('INSERT INTO trips (user_id, title) VALUES (?, ?)').run(admin.id, 'Trip').lastInsertRowid);
+    const place = Number(testDb.prepare('INSERT INTO places (trip_id, name, category_id) VALUES (?, ?, ?)').run(trip, 'Somewhere', id).lastInsertRowid);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'delete_category', arguments: { categoryId: id } });
+      expect((parseToolResult(result) as any).success).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE id = ?').get(id)).toBeUndefined();
+      expect((testDb.prepare('SELECT category_id FROM places WHERE id = ?').get(place) as any).category_id).toBeNull();
+    });
+  });
+
+  it('reports an unknown category', async () => {
+    const { user: admin } = createAdmin(testDb);
+    await withWriteHarness(admin.id, async (client) => {
+      const result = await client.callTool({ name: 'delete_category', arguments: { categoryId: 999999 } });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('refuses a non-admin and keeps the row', async () => {
+    const { user } = createUser(testDb);
+    const id = insertCategory('Survivor', '#16a34a', '🌿');
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'delete_category', arguments: { categoryId: id } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE id = ?').get(id)).toBeDefined();
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createAdmin(testDb, { email: 'demo@trek.app' });
+    const id = insertCategory('Demo survivor', '#0891b2', '🛟');
+    await withWriteHarness(user.id, async (client) => {
+      const result = await client.callTool({ name: 'delete_category', arguments: { categoryId: id } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM categories WHERE id = ?').get(id)).toBeDefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope gating (places:read for the listing, places:write for the palette
+// writes, both registration-time via the declarative access markers)
+// ---------------------------------------------------------------------------
+
+describe('Category tools: scope gating', () => {
+  const WRITE_TOOLS = ['create_category', 'update_category', 'delete_category'];
+
   async function listToolNames(userId: number, scopes: string[] | null): Promise<string[]> {
     const h = await createMcpHarness({ userId, withResources: false, scopes });
     try {
@@ -111,7 +354,9 @@ describe('Tool: list_categories — scope gating', () => {
 
   it('registers with null scopes (full access)', async () => {
     const { user } = createUser(testDb);
-    expect(await listToolNames(user.id, null)).toContain('list_categories');
+    const names = await listToolNames(user.id, null);
+    expect(names).toContain('list_categories');
+    for (const tool of WRITE_TOOLS) expect(names).toContain(tool);
   });
 
   it('registers with places:read', async () => {
@@ -119,9 +364,23 @@ describe('Tool: list_categories — scope gating', () => {
     expect(await listToolNames(user.id, ['places:read'])).toContain('list_categories');
   });
 
+  it('registers no palette writes with places:read only', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['places:read']);
+    for (const tool of WRITE_TOOLS) expect(names).not.toContain(tool);
+  });
+
+  it('registers the palette writes with places:write', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['places:write']);
+    for (const tool of WRITE_TOOLS) expect(names).toContain(tool);
+  });
+
   it('does not register for an unrelated scope', async () => {
     const { user } = createUser(testDb);
-    expect(await listToolNames(user.id, ['budget:read'])).not.toContain('list_categories');
+    const names = await listToolNames(user.id, ['budget:read']);
+    expect(names).not.toContain('list_categories');
+    for (const tool of WRITE_TOOLS) expect(names).not.toContain(tool);
   });
 });
 

--- a/server/tests/unit/mcp/tools-categories.test.ts
+++ b/server/tests/unit/mcp/tools-categories.test.ts
@@ -46,18 +46,10 @@ import { trekMcpAccessPolicy, trekMcpValidateAccess } from '../../../src/mcp/nes
 import { CategoriesMcp } from '../../../src/nest/categories/categories.mcp';
 import { CategoriesService } from '../../../src/nest/categories/categories.service';
 import { DatabaseService } from '../../../src/nest/database/database.service';
+import { RuntimeEnvService } from '../../../src/nest/app-config/runtime-env.service';
 import { PermissionsService } from '../../../src/nest/permissions/permissions.service';
 import { RealtimeService } from '../../../src/nest/realtime/realtime.service';
 import { McpToolGuardsService } from '../../../src/nest/mcp-shared/mcp-tool-guards.service';
-import { AuthService } from '../../../src/nest/auth/auth.service';
-import { BudgetService } from '../../../src/nest/budget/budget.service';
-import { ExchangeRatesService } from '../../../src/nest/budget/exchange-rates.service';
-import { TripMembershipService } from '../../../src/nest/trip-membership/trip-membership.service';
-import { WebauthnConfigService } from '../../../src/nest/auth/webauthn-config.service';
-import { UserCleanupService } from '../../../src/nest/auth/user-cleanup.service';
-import { MailerService } from '../../../src/nest/notifications/mailer/mailer.service';
-import { EphemeralTokenService } from '../../../src/nest/auth/ephemeral-token.service';
-import { AllowedFileTypesService } from '../../../src/nest/files/allowed-file-types.service';
 
 beforeAll(() => {
   createTables(testDb);
@@ -82,23 +74,15 @@ async function withHarness(
   try { await fn(h); } finally { await h.cleanup(); }
 }
 
-// The write tools reach the auth and guard collaborators, so they run against a
-// controller wired here rather than through the shared harness. Everything
-// points at this file's DB, which is what lets the admin gate and the demo gate
-// be driven from the users table instead of from a stub.
+// The write tools reach the guard collaborator, so they run against a controller
+// wired here rather than through the shared harness. Everything points at this
+// file's DB, which is what lets the admin gate and the demo gate be driven from
+// the users table instead of from a stub.
 const categoriesDb = new DatabaseService(testDb);
 const categoriesMcp = new CategoriesMcp(
   new CategoriesService(categoriesDb),
-  new AuthService(
-    categoriesDb,
-    new PermissionsService(categoriesDb),
-    new TripMembershipService(categoriesDb),
-    new WebauthnConfigService(categoriesDb),
-    new UserCleanupService(categoriesDb, new BudgetService(categoriesDb, new PermissionsService(categoriesDb), new ExchangeRatesService(), new RealtimeService())),
-    new MailerService(categoriesDb),
-    new EphemeralTokenService(),
-    new AllowedFileTypesService(categoriesDb),
-  ),
+  categoriesDb,
+  new RuntimeEnvService(),
   new McpToolGuardsService(categoriesDb, new PermissionsService(categoriesDb), new RealtimeService()),
 );
 

--- a/server/tests/unit/mcp/tools-collections.test.ts
+++ b/server/tests/unit/mcp/tools-collections.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests for the collections MCP surface (CollectionsMcp, DI-discovered):
  * the 25 tools ported 1:1 from the legacy src/mcp/tools/collections.ts
- * registrar. New with the DI fold — the legacy registrar had no tool-level
+ * registrar, plus the two later additions that closed the gap to REST
+ * (find_place_in_collections, set_collection_place_status_from_trip).
+ * New with the DI fold: the legacy registrar had no tool-level
  * suite — so this is a characterization of the ported behavior: payload
  * shapes, error texts (the service's thrown httpError messages surfaced via
  * fail()), the owner-only available-users gate, demo denial on writes, the
@@ -103,8 +105,17 @@ function addMember(colId: number, userId: number, role: 'viewer' | 'editor' | 'a
 
 function seedPlace(colId: number, ownerId: number, name: string, extra: Record<string, unknown> = {}): number {
   return Number(testDb.prepare(
-    'INSERT INTO collection_places (collection_id, owner_id, saved_by, name, lat, lng, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
-  ).run(colId, ownerId, ownerId, name, extra.lat ?? null, extra.lng ?? null, extra.status ?? 'idea').lastInsertRowid);
+    `INSERT INTO collection_places (collection_id, owner_id, saved_by, name, lat, lng, status, google_place_id, source_trip_id, source_place_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    colId, ownerId, ownerId, name,
+    extra.lat ?? null, extra.lng ?? null, extra.status ?? 'idea',
+    extra.google_place_id ?? null, extra.source_trip_id ?? null, extra.source_place_id ?? null,
+  ).lastInsertRowid);
+}
+
+function statusOf(placeId: number): string | undefined {
+  return (testDb.prepare('SELECT status FROM collection_places WHERE id = ?').get(placeId) as { status: string } | undefined)?.status;
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +190,79 @@ describe('Tool: available_collection_users', () => {
       const result = await h.client.callTool({ name: 'available_collection_users', arguments: { collectionId: col } });
       expect(result.isError).toBe(true);
       expect(errorText(result)).toBe('Collection not found');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Library-wide membership rollup
+//
+// The inspector's "already saved" lookup (GET /addons/collections/membership)
+// had no tool behind it, and walking get_collection cannot stand in for it: the
+// match runs on provider ids and a coordinate tolerance, not on the names a
+// caller could compare itself. The cases below pin the signals, not just the
+// payload shape.
+// ---------------------------------------------------------------------------
+
+describe('Tool: find_place_in_collections', () => {
+  it('names every visible list holding the place, with its per-list status and edit right', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const mine = seedCollection(user.id, 'Paris');
+    const shared = seedCollection(other.id, 'Their museums');
+    const hidden = seedCollection(other.id, 'Not shared');
+    addMember(shared, user.id, 'viewer');
+    seedPlace(mine, user.id, 'Louvre', { google_place_id: 'g-louvre', status: 'want' });
+    seedPlace(shared, other.id, 'Louvre', { google_place_id: 'g-louvre' });
+    seedPlace(hidden, other.id, 'Louvre', { google_place_id: 'g-louvre' });
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'find_place_in_collections',
+        arguments: { google_place_id: 'g-louvre' },
+      })) as { saved: boolean; lists: { collection_id: number; name: string; status: string; can_edit: boolean }[] };
+
+      expect(data.saved).toBe(true);
+      const byId = new Map(data.lists.map((l) => [l.collection_id, l]));
+      expect([...byId.keys()].sort((a, b) => a - b)).toEqual([mine, shared].sort((a, b) => a - b));
+      expect(byId.get(mine)).toMatchObject({ name: 'Paris', status: 'want', can_edit: true });
+      expect(byId.get(shared)).toMatchObject({ name: 'Their museums', status: 'idea', can_edit: false });
+    });
+  });
+
+  it('matches by coordinates within the dedup tolerance and not outside it', async () => {
+    const { user } = createUser(testDb);
+    const col = seedCollection(user.id, 'Rome');
+    seedPlace(col, user.id, 'Pantheon', { lat: 41.8986, lng: 12.4769 });
+
+    await withHarness(user.id, async (h) => {
+      const near = parseToolResult(await h.client.callTool({
+        name: 'find_place_in_collections',
+        arguments: { lat: 41.89865, lng: 12.4769 },
+      })) as { saved: boolean; lists: unknown[] };
+      expect(near.saved).toBe(true);
+      expect(near.lists).toHaveLength(1);
+
+      const far = parseToolResult(await h.client.callTool({
+        name: 'find_place_in_collections',
+        arguments: { lat: 41.899, lng: 12.4769 },
+      })) as { saved: boolean; lists: unknown[] };
+      expect(far.saved).toBe(false);
+      expect(far.lists).toEqual([]);
+    });
+  });
+
+  it('reports nothing for a name-only query, since a repeated name is not a match signal', async () => {
+    const { user } = createUser(testDb);
+    const col = seedCollection(user.id, 'Coffee');
+    seedPlace(col, user.id, 'Starbucks', { lat: 47.6062, lng: -122.3321 });
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'find_place_in_collections',
+        arguments: { name: 'Starbucks' },
+      })) as { saved: boolean; lists: unknown[] };
+      expect(data).toEqual({ saved: false, lists: [] });
     });
   });
 });
@@ -294,6 +378,114 @@ describe('Tool: update_collection_place / set_collection_place_status / rate_col
       const cleared = parseToolResult(await h.client.callTool({ name: 'rate_collection_place', arguments: { placeId: pid } })) as { place: { rating_avg: number | null; rating_count: number } };
       expect(cleared.place.rating_avg).toBeNull();
       expect(cleared.place.rating_count).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bulk status from the trip side
+//
+// set_collection_place_status takes one collection_places id, so "we went there
+// today" had to be repeated per list after finding the copies. This one names
+// TRIP place ids and resolves the copies the way the membership lookup does.
+// ---------------------------------------------------------------------------
+
+describe('Tool: set_collection_place_status_from_trip', () => {
+  it('marks every saved copy of a trip place across the lists holding it', async () => {
+    const { user } = createUser(testDb);
+    createCategory(testDb);
+    const trip = createTrip(testDb, user.id);
+    const louvre = createPlace(testDb, trip.id, { name: 'Louvre', lat: 48.8606, lng: 2.3376 });
+    const orsay = createPlace(testDb, trip.id, { name: "Musee d'Orsay", lat: 48.86, lng: 2.3266 });
+    const paris = seedCollection(user.id, 'Paris');
+    const museums = seedCollection(user.id, 'Museums');
+    // Two different match signals: coordinates in one list, the source link the
+    // saved-from-trip path writes in the other.
+    const byCoords = seedPlace(paris, user.id, 'Louvre', { lat: 48.8606, lng: 2.3376 });
+    const bySource = seedPlace(museums, user.id, 'Louvre', { source_trip_id: trip.id, source_place_id: louvre.id });
+    const untouched = seedPlace(paris, user.id, 'Eiffel Tower', { lat: 48.8584, lng: 2.2945 });
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'set_collection_place_status_from_trip',
+        arguments: { trip_id: trip.id, place_ids: [louvre.id, orsay.id], status: 'visited' },
+      }));
+      // Orsay is saved nowhere, so it counts towards neither number.
+      expect(data).toEqual({ updated: 2, places: 1 });
+    });
+
+    expect(statusOf(byCoords)).toBe('visited');
+    expect(statusOf(bySource)).toBe('visited');
+    expect(statusOf(untouched)).toBe('idea');
+  });
+
+  it('skips a list the user may only read instead of refusing the batch', async () => {
+    const { user } = createUser(testDb);
+    const { user: owner } = createUser(testDb);
+    createCategory(testDb);
+    const trip = createTrip(testDb, user.id);
+    const prado = createPlace(testDb, trip.id, { name: 'Prado', lat: 40.4138, lng: -3.6921 });
+    const own = seedCollection(user.id, 'Madrid');
+    const readOnly = seedCollection(owner.id, 'Their list');
+    addMember(readOnly, user.id, 'viewer');
+    const mine = seedPlace(own, user.id, 'Prado', { lat: 40.4138, lng: -3.6921 });
+    const theirs = seedPlace(readOnly, owner.id, 'Prado', { lat: 40.4138, lng: -3.6921 });
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'set_collection_place_status_from_trip',
+        arguments: { trip_id: trip.id, place_ids: [prado.id], status: 'visited' },
+      }));
+      expect(data).toEqual({ updated: 1, places: 1 });
+    });
+
+    expect(statusOf(mine)).toBe('visited');
+    expect(statusOf(theirs)).toBe('idea');
+  });
+
+  it('surfaces the 404 text for a trip the user cannot access, leaving statuses alone', async () => {
+    const { user } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    createCategory(testDb);
+    const trip = createTrip(testDb, stranger.id);
+    const place = createPlace(testDb, trip.id, { name: 'Alhambra', lat: 37.176, lng: -3.5881 });
+    const col = seedCollection(user.id, 'Spain');
+    const saved = seedPlace(col, user.id, 'Alhambra', { lat: 37.176, lng: -3.5881 });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_collection_place_status_from_trip',
+        arguments: { trip_id: trip.id, place_ids: [place.id], status: 'visited' },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('Trip not found');
+    });
+    expect(statusOf(saved)).toBe('idea');
+  });
+
+  it('refuses an empty place_ids, and falls back to idea on an unknown status like the REST contract', async () => {
+    const { user } = createUser(testDb);
+    createCategory(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Sagrada Familia', lat: 41.4036, lng: 2.1744 });
+    const col = seedCollection(user.id, 'Barcelona');
+    const saved = seedPlace(col, user.id, 'Sagrada Familia', { lat: 41.4036, lng: 2.1744, status: 'want' });
+
+    await withHarness(user.id, async (h) => {
+      const empty = await h.client.callTool({
+        name: 'set_collection_place_status_from_trip',
+        arguments: { trip_id: trip.id, place_ids: [], status: 'visited' },
+      });
+      expect(empty.isError).toBe(true);
+      expect(statusOf(saved)).toBe('want');
+
+      // collectionStatusSchema carries .catch('idea'), so REST coerces rather
+      // than rejects; the tool shares the contract and behaves the same.
+      await h.client.callTool({
+        name: 'set_collection_place_status_from_trip',
+        arguments: { trip_id: trip.id, place_ids: [place.id], status: 'teleported' },
+      });
+      expect(statusOf(saved)).toBe('idea');
     });
   });
 });
@@ -466,11 +658,12 @@ describe('Sharing tools', () => {
 // Scope gating (collections read/write, registration-time)
 // ---------------------------------------------------------------------------
 
-const READ_TOOLS = ['list_collections', 'get_collection', 'available_collection_users'];
+const READ_TOOLS = ['list_collections', 'get_collection', 'available_collection_users', 'find_place_in_collections'];
 const WRITE_TOOLS = [
   'create_collection', 'update_collection', 'delete_collection', 'reorder_collections',
   'save_place_to_collection', 'save_trip_places_to_collection', 'update_collection_place',
-  'set_collection_place_status', 'rate_collection_place', 'delete_collection_place',
+  'set_collection_place_status', 'set_collection_place_status_from_trip',
+  'rate_collection_place', 'delete_collection_place',
   'copy_collection_places_to_trip', 'create_collection_label', 'update_collection_label',
   'delete_collection_label', 'assign_collection_labels', 'invite_to_collection',
   'set_collection_member_role', 'remove_collection_member', 'cancel_collection_invite',
@@ -487,7 +680,7 @@ describe('Collection tools — scope gating', () => {
     }
   }
 
-  it('registers all 25 tools with null scopes (full access)', async () => {
+  it('registers all 27 tools with null scopes (full access)', async () => {
     const { user } = createUser(testDb);
     const names = await listToolNames(user.id, null);
     for (const tool of [...READ_TOOLS, ...WRITE_TOOLS]) expect(names).toContain(tool);

--- a/server/tests/unit/mcp/tools-days.test.ts
+++ b/server/tests/unit/mcp/tools-days.test.ts
@@ -1,7 +1,8 @@
 /**
- * Unit tests for the DI-discovered DaysMcp: the update_day tool and the
- * trek://trips/{tripId}/days resource (moved from resources.test.ts when the
- * legacy registrar was ported).
+ * Unit tests for the DI-discovered DaysMcp: the update_day and reorder_days
+ * tools, create_day's mid-trip insert, and the trek://trips/{tripId}/days
+ * resource (moved from resources.test.ts when the legacy registrar was ported).
+ * create_day's plain append is covered in tools-days-accommodations.test.ts.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 
@@ -37,7 +38,9 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createDay, createPlace, createDayAssignment } from '../../helpers/factories';
+import {
+  createUser, createTrip, createDay, createPlace, createDayAssignment, createDayAccommodation,
+} from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 
 beforeAll(() => {
@@ -58,6 +61,23 @@ afterAll(() => {
 async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
   const h = await createMcpHarness({ userId, withResources: false });
   try { await fn(h); } finally { await h.cleanup(); }
+}
+
+/** The stored day row, which is what a tool's echo can disagree with. */
+function dayRow(dayId: number) {
+  return testDb.prepare('SELECT title, notes, day_number, date FROM days WHERE id = ?').get(dayId) as
+    { title: string | null; notes: string | null; day_number: number; date: string | null };
+}
+
+/** Day ids of a trip in stored order, so a reorder can be read back positionally. */
+function dayIdsInOrder(tripId: number): number[] {
+  return (testDb.prepare('SELECT id FROM days WHERE trip_id = ? ORDER BY day_number').all(tripId) as { id: number }[])
+    .map(r => r.id);
+}
+
+function dayDatesInOrder(tripId: number): (string | null)[] {
+  return (testDb.prepare('SELECT date FROM days WHERE trip_id = ? ORDER BY day_number').all(tripId) as { date: string | null }[])
+    .map(r => r.date);
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +131,71 @@ describe('Tool: update_day', () => {
     });
   });
 
+  it('writes notes without being sent a title, and keeps the title', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id, { title: 'Arrival in Paris' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_day',
+        arguments: { tripId: trip.id, dayId: day.id, notes: 'Ferry leaves at 08:00' },
+      });
+      const data = parseToolResult(result) as { day: { notes: string } };
+      expect(data.day.notes).toBe('Ferry leaves at 08:00');
+    });
+
+    expect(dayRow(day.id)).toMatchObject({ title: 'Arrival in Paris', notes: 'Ferry leaves at 08:00' });
+  });
+
+  it('sets a title and notes in one call', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_day',
+        arguments: { tripId: trip.id, dayId: day.id, title: 'Free day', notes: 'Nothing booked' },
+      });
+    });
+
+    expect(dayRow(day.id)).toMatchObject({ title: 'Free day', notes: 'Nothing booked' });
+  });
+
+  it('clears the notes with an empty string', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id, { title: 'Arrival' });
+    testDb.prepare('UPDATE days SET notes = ? WHERE id = ?').run('Ferry leaves at 08:00', day.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_day',
+        arguments: { tripId: trip.id, dayId: day.id, notes: '' },
+      });
+    });
+
+    expect(dayRow(day.id)).toMatchObject({ title: 'Arrival', notes: null });
+  });
+
+  it('refuses a non-string notes value', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_day',
+        arguments: { tripId: trip.id, dayId: day.id, notes: 42 },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('Invalid arguments');
+    });
+
+    expect(dayRow(day.id).notes).toBeNull();
+  });
+
   it('broadcasts day:updated event', async () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
@@ -156,6 +241,312 @@ describe('Tool: update_day', () => {
       const result = await h.client.callTool({ name: 'update_day', arguments: { tripId: trip.id, dayId: day.id, title: 'X' } });
       expect(result.isError).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_day with a position (the mid-trip insert behind POST /days)
+// ---------------------------------------------------------------------------
+
+describe('Tool: create_day (position)', () => {
+  it('inserts an empty day into the middle of a dateless trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+    const d3 = createDay(testDb, trip.id);
+
+    let insertedId = 0;
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day',
+        arguments: { tripId: trip.id, position: 2 },
+      });
+      insertedId = (parseToolResult(result) as { day: { id: number } }).day.id;
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, insertedId, d2.id, d3.id]);
+    expect(dayRow(insertedId)).toMatchObject({ day_number: 2, date: null });
+  });
+
+  it('re-pins the dates and extends the trip when inserting into a dated trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2025-06-01', end_date: '2025-06-03' });
+    const [d1, d2, d3] = dayIdsInOrder(trip.id);
+
+    let insertedId = 0;
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day',
+        // date and notes are ignored next to a position, exactly as on REST.
+        arguments: { tripId: trip.id, position: 2, date: '2030-01-01', notes: 'ignored' },
+      });
+      insertedId = (parseToolResult(result) as { day: { id: number } }).day.id;
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1, insertedId, d2, d3]);
+    expect(dayDatesInOrder(trip.id)).toEqual(['2025-06-01', '2025-06-02', '2025-06-03', '2025-06-04']);
+    expect(dayRow(insertedId)).toMatchObject({ date: '2025-06-02', notes: null });
+    expect(testDb.prepare('SELECT end_date FROM trips WHERE id = ?').get(trip.id)).toEqual({ end_date: '2025-06-04' });
+  });
+
+  it('appends when position is omitted and still honours date and notes', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+
+    let appendedId = 0;
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day',
+        arguments: { tripId: trip.id, date: '2025-06-15', notes: 'Arrival day' },
+      });
+      appendedId = (parseToolResult(result) as { day: { id: number } }).day.id;
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, appendedId]);
+    expect(dayRow(appendedId)).toMatchObject({ date: '2025-06-15', notes: 'Arrival day' });
+  });
+
+  it('broadcasts day:reordered for an insert and day:created for an append', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'create_day', arguments: { tripId: trip.id, position: 1 } });
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'day:reordered', expect.any(Object));
+      expect(broadcastMock).not.toHaveBeenCalledWith(trip.id, 'day:created', expect.any(Object));
+
+      broadcastMock.mockClear();
+      await h.client.callTool({ name: 'create_day', arguments: { tripId: trip.id } });
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'day:created', expect.any(Object));
+    });
+  });
+
+  it('refuses a position below 1', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day',
+        arguments: { tripId: trip.id, position: 0 },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('Invalid arguments');
+    });
+
+    expect(dayIdsInOrder(trip.id)).toHaveLength(1);
+  });
+
+  it('refuses an insert that would invert a stay, leaving the trip untouched', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2025-06-01', end_date: '2025-06-03' });
+    const [d1, d2, d3] = dayIdsInOrder(trip.id);
+    const place = createPlace(testDb, trip.id);
+    // The stay ends on the last day, so pushing a day in front of its start
+    // cannot invert it; anchoring it the other way round is what does.
+    createDayAccommodation(testDb, trip.id, place.id, d3, d1);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day',
+        arguments: { tripId: trip.id, position: 2 },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('accommodation');
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1, d2, d3]);
+    expect(dayDatesInOrder(trip.id)).toEqual(['2025-06-01', '2025-06-02', '2025-06-03']);
+  });
+
+  it('blocks demo user on an insert', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_day', arguments: { tripId: trip.id, position: 1 } });
+      expect(result.isError).toBe(true);
+    });
+    expect(dayIdsInOrder(trip.id)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorder_days
+// ---------------------------------------------------------------------------
+
+describe('Tool: reorder_days', () => {
+  it('renumbers the days and carries each day content along', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id, { title: 'First' });
+    const d2 = createDay(testDb, trip.id, { title: 'Second' });
+    const d3 = createDay(testDb, trip.id, { title: 'Third' });
+    const place = createPlace(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, d3.id, place.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d3.id, d1.id, d2.id] },
+      });
+      expect(parseToolResult(result)).toEqual({ success: true });
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d3.id, d1.id, d2.id]);
+    expect(dayRow(d3.id)).toMatchObject({ day_number: 1, title: 'Third' });
+    expect(testDb.prepare('SELECT day_id FROM day_assignments WHERE id = ?').get(assignment.id))
+      .toEqual({ day_id: d3.id });
+  });
+
+  it('keeps the dates pinned to their slots so the content moves across them', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2025-06-01', end_date: '2025-06-03' });
+    const [d1, d2, d3] = dayIdsInOrder(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d3, d1, d2] },
+      });
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d3, d1, d2]);
+    expect(dayDatesInOrder(trip.id)).toEqual(['2025-06-01', '2025-06-02', '2025-06-03']);
+    expect(dayRow(d3).date).toBe('2025-06-01');
+  });
+
+  it('broadcasts day:reordered with the ordered ids', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'reorder_days', arguments: { tripId: trip.id, orderedIds: [d2.id, d1.id] } });
+    });
+
+    expect(broadcastMock).toHaveBeenCalledWith(
+      trip.id,
+      'day:reordered',
+      expect.objectContaining({ orderedIds: [d2.id, d1.id] }),
+    );
+  });
+
+  it('refuses a list that is not a permutation of the trip days', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+    const d3 = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d2.id, d1.id] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('permutation');
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, d2.id, d3.id]);
+    expect(broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a day id from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const other = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+    const foreign = createDay(testDb, other.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d1.id, foreign.id] },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, d2.id]);
+    expect(dayRow(foreign.id).day_number).toBe(1);
+  });
+
+  it('refuses a move that would make a stay end before it starts, and rolls back', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2025-06-01', end_date: '2025-06-03' });
+    const [d1, d2, d3] = dayIdsInOrder(trip.id);
+    const place = createPlace(testDb, trip.id);
+    createDayAccommodation(testDb, trip.id, place.id, d1, d2);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d2, d1, d3] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('accommodation');
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1, d2, d3]);
+    expect(broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty list', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toContain('Invalid arguments');
+    });
+  });
+
+  it('returns access denied for non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d2.id, d1.id] },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, d2.id]);
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    const d1 = createDay(testDb, trip.id);
+    const d2 = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'reorder_days',
+        arguments: { tripId: trip.id, orderedIds: [d2.id, d1.id] },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    expect(dayIdsInOrder(trip.id)).toEqual([d1.id, d2.id]);
   });
 });
 

--- a/server/tests/unit/mcp/tools-feeds-invite.test.ts
+++ b/server/tests/unit/mcp/tools-feeds-invite.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Unit tests for the two link-management MCP surfaces that had no tools at all
+ * before: FeedsMcp (the subscribable ICS calendar feed, per trip and for all
+ * trips) and TripInviteMcp (the invite link that grants trip membership).
+ *
+ * Both mirror routes whose payload IS the credential, so the gates are the
+ * interesting part: trip access before permission, share_manage on reads as
+ * well as writes, and demo mode refused on every write.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: number | string, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: number | string, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+vi.mock('../../../src/websocket', () => ({ broadcast: vi.fn() }));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb } from '../../helpers/test-db';
+import { createUser, createTrip, addTripMember } from '../../helpers/factories';
+import { invalidatePermissionsCache } from '../../../src/nest/permissions/permissions-cache';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+
+const BASE = 'https://trek.example';
+
+type ToolResult = Awaited<ReturnType<McpHarness['client']['callTool']>>;
+
+/** Typed view on a successful tool payload. */
+function payload<T>(result: ToolResult): T {
+  return parseToolResult(result) as T;
+}
+
+/** The raw text of a result, for the error sentences that are not JSON. */
+function textOf(result: ToolResult): string {
+  const { content } = result as { content: { type: string; text?: string }[] };
+  return content.find((c) => c.type === 'text')?.text ?? '';
+}
+
+function tripToken(tripId: number): string | null {
+  const row = testDb.prepare('SELECT feed_token FROM trips WHERE id = ?').get(tripId) as { feed_token: string | null } | undefined;
+  return row?.feed_token ?? null;
+}
+
+function userToken(userId: number): string | null {
+  const row = testDb.prepare('SELECT feed_token FROM users WHERE id = ?').get(userId) as { feed_token: string | null } | undefined;
+  return row?.feed_token ?? null;
+}
+
+function inviteRow(tripId: number) {
+  return testDb.prepare('SELECT token, expires_at, created_by FROM trip_invite_tokens WHERE trip_id = ?').get(tripId) as
+    | { token: string; expires_at: string | null; created_by: number }
+    | undefined;
+}
+
+interface FeedResult { feed_url: string | null }
+interface InviteLink { token: string; expires_at: string | null; created_at: string; url: string }
+interface InviteResult { invite_link: InviteLink | null }
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  // trip_invite_tokens is not in the shared helper's RESET_TABLES, and trip ids
+  // restart after a DELETE-based reset, so a leftover row would attach itself
+  // to the next test's trip.
+  testDb.exec('DELETE FROM trip_invite_tokens');
+  // The permission levels are cached in module state that resetTestDb knows
+  // nothing about, so the one test that lowers share_manage would otherwise
+  // keep the lowered level alive for every test after it.
+  invalidatePermissionsCache();
+  delete process.env.DEMO_MODE;
+  process.env.APP_URL = BASE;
+});
+
+afterAll(() => {
+  delete process.env.APP_URL;
+  testDb.close();
+});
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
+  const h = await createMcpHarness({ userId, withResources: false });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// One trip's calendar feed
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_trip_calendar_feed', () => {
+  it('answers null while the feed is off and the subscribable URL once it is on', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const off = payload<FeedResult>(await h.client.callTool({ name: 'get_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      expect(off.feed_url).toBeNull();
+
+      await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } });
+      const on = payload<FeedResult>(await h.client.callTool({ name: 'get_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      expect(on.feed_url).toBe(`${BASE}/api/feed/trip/${tripToken(trip.id)}.ics`);
+    });
+  });
+
+  it('reads the feed of a trip the user is a member of once share_manage is lowered to trip_member', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    testDb.prepare("INSERT INTO app_settings (key, value) VALUES ('perm_share_manage', 'trip_member')").run();
+    await withHarness(owner.id, async (h) => {
+      await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } });
+    });
+    await withHarness(member.id, async (h) => {
+      const result = payload<FeedResult>(await h.client.callTool({ name: 'get_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      expect(result.feed_url).toBe(`${BASE}/api/feed/trip/${tripToken(trip.id)}.ics`);
+    });
+  });
+});
+
+describe('Tool: enable_trip_calendar_feed', () => {
+  it('mints one token and hands back the same URL on a second call', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const first = payload<FeedResult>(await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      const minted = tripToken(trip.id);
+      expect(minted).toBeTruthy();
+      expect(first.feed_url).toBe(`${BASE}/api/feed/trip/${minted}.ics`);
+
+      const second = payload<FeedResult>(await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      expect(second.feed_url).toBe(first.feed_url);
+      expect(tripToken(trip.id)).toBe(minted);
+    });
+  });
+});
+
+describe('Tool: rotate_trip_calendar_feed', () => {
+  it('replaces the token so the old URL stops resolving', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } });
+      const before = tripToken(trip.id);
+      const rotated = payload<FeedResult>(await h.client.callTool({ name: 'rotate_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      const after = tripToken(trip.id);
+      expect(after).not.toBe(before);
+      expect(rotated.feed_url).toBe(`${BASE}/api/feed/trip/${after}.ics`);
+    });
+  });
+});
+
+describe('Tool: disable_trip_calendar_feed', () => {
+  it('clears the token and answers a null URL', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'enable_trip_calendar_feed', arguments: { tripId: trip.id } });
+      const result = payload<FeedResult>(await h.client.callTool({ name: 'disable_trip_calendar_feed', arguments: { tripId: trip.id } }));
+      expect(result.feed_url).toBeNull();
+      expect(tripToken(trip.id)).toBeNull();
+    });
+  });
+});
+
+describe('trip calendar feed gates', () => {
+  const TRIP_FEED_TOOLS = [
+    'get_trip_calendar_feed',
+    'enable_trip_calendar_feed',
+    'rotate_trip_calendar_feed',
+    'disable_trip_calendar_feed',
+  ];
+
+  it.each(TRIP_FEED_TOOLS)('%s refuses a trip the user cannot reach', async (name) => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const foreign = createTrip(testDb, other.id);
+    testDb.prepare('UPDATE trips SET feed_token = ? WHERE id = ?').run('foreign-token', foreign.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: foreign.id } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('Trip not found or access denied.');
+      // The service scopes its own UPDATE, but the tool must refuse before it:
+      // generate/rotate answer a URL for a token they never wrote.
+      expect(tripToken(foreign.id)).toBe('foreign-token');
+    });
+  });
+
+  it.each(TRIP_FEED_TOOLS)('%s refuses a trip id that does not exist', async (name) => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: 987654 } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('Trip not found or access denied.');
+    });
+  });
+
+  it.each(TRIP_FEED_TOOLS)('%s refuses a member without share_manage', async (name) => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    testDb.prepare('UPDATE trips SET feed_token = ? WHERE id = ?').run('owner-token', trip.id);
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('You do not have permission to perform this action on this trip.');
+      expect(tripToken(trip.id)).toBe('owner-token');
+    });
+  });
+
+  it.each(['enable_trip_calendar_feed', 'rotate_trip_calendar_feed', 'disable_trip_calendar_feed'])(
+    '%s refuses a demo account',
+    async (name) => {
+      process.env.DEMO_MODE = 'true';
+      const { user: demo } = createUser(testDb, { email: 'demo@trek.app' });
+      const trip = createTrip(testDb, demo.id);
+      testDb.prepare('UPDATE trips SET feed_token = ? WHERE id = ?').run('demo-token', trip.id);
+      await withHarness(demo.id, async (h) => {
+        const result = await h.client.callTool({ name, arguments: { tripId: trip.id } });
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe('Write operations are disabled in demo mode.');
+        expect(tripToken(trip.id)).toBe('demo-token');
+      });
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The all-trips calendar feed
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_all_trips_calendar_feed', () => {
+  it('answers null while the feed is off and the user URL once it is on', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const off = payload<FeedResult>(await h.client.callTool({ name: 'get_all_trips_calendar_feed', arguments: {} }));
+      expect(off.feed_url).toBeNull();
+
+      await h.client.callTool({ name: 'enable_all_trips_calendar_feed', arguments: {} });
+      const on = payload<FeedResult>(await h.client.callTool({ name: 'get_all_trips_calendar_feed', arguments: {} }));
+      expect(on.feed_url).toBe(`${BASE}/api/feed/user/${userToken(user.id)}.ics`);
+    });
+  });
+});
+
+describe('Tool: enable_all_trips_calendar_feed', () => {
+  it('mints the calling user their own token and leaves everybody else alone', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const first = payload<FeedResult>(await h.client.callTool({ name: 'enable_all_trips_calendar_feed', arguments: {} }));
+      const minted = userToken(user.id);
+      expect(first.feed_url).toBe(`${BASE}/api/feed/user/${minted}.ics`);
+      expect(userToken(other.id)).toBeNull();
+
+      const second = payload<FeedResult>(await h.client.callTool({ name: 'enable_all_trips_calendar_feed', arguments: {} }));
+      expect(second.feed_url).toBe(first.feed_url);
+      expect(userToken(user.id)).toBe(minted);
+    });
+  });
+});
+
+describe('Tool: rotate_all_trips_calendar_feed', () => {
+  it('replaces the token so the old URL stops resolving', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'enable_all_trips_calendar_feed', arguments: {} });
+      const before = userToken(user.id);
+      const rotated = payload<FeedResult>(await h.client.callTool({ name: 'rotate_all_trips_calendar_feed', arguments: {} }));
+      const after = userToken(user.id);
+      expect(after).not.toBe(before);
+      expect(rotated.feed_url).toBe(`${BASE}/api/feed/user/${after}.ics`);
+    });
+  });
+});
+
+describe('Tool: disable_all_trips_calendar_feed', () => {
+  it('clears the token and answers a null URL', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'enable_all_trips_calendar_feed', arguments: {} });
+      const result = payload<FeedResult>(await h.client.callTool({ name: 'disable_all_trips_calendar_feed', arguments: {} }));
+      expect(result.feed_url).toBeNull();
+      expect(userToken(user.id)).toBeNull();
+    });
+  });
+});
+
+describe('all-trips calendar feed gates', () => {
+  it.each(['enable_all_trips_calendar_feed', 'rotate_all_trips_calendar_feed', 'disable_all_trips_calendar_feed'])(
+    '%s refuses a demo account',
+    async (name) => {
+      process.env.DEMO_MODE = 'true';
+      const { user: demo } = createUser(testDb, { email: 'demo@trek.app' });
+      testDb.prepare('UPDATE users SET feed_token = ? WHERE id = ?').run('demo-user-token', demo.id);
+      await withHarness(demo.id, async (h) => {
+        const result = await h.client.callTool({ name, arguments: {} });
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe('Write operations are disabled in demo mode.');
+        expect(userToken(demo.id)).toBe('demo-user-token');
+      });
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Trip invite link
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_trip_invite_link', () => {
+  it('answers null without a link, then the token and the join URL', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const none = payload<InviteResult>(await h.client.callTool({ name: 'get_trip_invite_link', arguments: { tripId: trip.id } }));
+      expect(none.invite_link).toBeNull();
+
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } });
+      const link = payload<InviteResult>(await h.client.callTool({ name: 'get_trip_invite_link', arguments: { tripId: trip.id } }));
+      expect(link.invite_link?.token).toBe(inviteRow(trip.id)?.token);
+      expect(link.invite_link?.url).toBe(`${BASE}/join/${inviteRow(trip.id)?.token}`);
+      expect(link.invite_link?.expires_at).toBeNull();
+    });
+  });
+});
+
+describe('Tool: create_trip_invite_link', () => {
+  it('stores the token against the trip and audits who minted it', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const created = payload<InviteResult>(await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } }));
+      const row = inviteRow(trip.id);
+      expect(row?.token).toBe(created.invite_link?.token);
+      expect(row?.created_by).toBe(user.id);
+      expect(row?.expires_at).toBeNull();
+
+      const audit = testDb.prepare("SELECT user_id, resource, details FROM audit_log WHERE action = 'trip.invite_link_create'").get() as
+        | { user_id: number; resource: string; details: string | null }
+        | undefined;
+      expect(audit?.user_id).toBe(user.id);
+      expect(audit?.resource).toBe(String(trip.id));
+    });
+  });
+
+  it('takes an expiry as a number or as the digits-only string the contract allows', async () => {
+    const { user } = createUser(testDb);
+    const numeric = createTrip(testDb, user.id);
+    const stringy = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: numeric.id, expires_in_days: 7 } });
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: stringy.id, expires_in_days: '7' } });
+    });
+    const expected = Date.now() + 7 * 86400000;
+    for (const trip of [numeric, stringy]) {
+      const at = inviteRow(trip.id)?.expires_at;
+      expect(at).toBeTruthy();
+      expect(Math.abs(new Date(at as string).getTime() - expected)).toBeLessThan(60_000);
+    }
+  });
+
+  it('reads a non-positive or empty expiry as no expiry at all', async () => {
+    const { user } = createUser(testDb);
+    const zero = createTrip(testDb, user.id);
+    const blank = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: zero.id, expires_in_days: 0 } });
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: blank.id, expires_in_days: '' } });
+    });
+    expect(inviteRow(zero.id)?.expires_at).toBeNull();
+    expect(inviteRow(blank.id)?.expires_at).toBeNull();
+  });
+
+  it('rejects an expiry the shared contract does not admit', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id, expires_in_days: '7 days' } });
+      expect(result.isError).toBe(true);
+      expect(inviteRow(trip.id)).toBeUndefined();
+    });
+  });
+
+  it('rotates in place: a second call replaces the token and keeps one row', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const first = payload<InviteResult>(await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } }));
+      const second = payload<InviteResult>(await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } }));
+      expect(second.invite_link?.token).not.toBe(first.invite_link?.token);
+      const count = testDb.prepare('SELECT COUNT(*) AS n FROM trip_invite_tokens WHERE trip_id = ?').get(trip.id) as { n: number };
+      expect(count.n).toBe(1);
+      expect(inviteRow(trip.id)?.token).toBe(second.invite_link?.token);
+    });
+  });
+});
+
+describe('Tool: delete_trip_invite_link', () => {
+  it('removes the link and audits the revocation', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } });
+      const result = payload<{ success: boolean }>(await h.client.callTool({ name: 'delete_trip_invite_link', arguments: { tripId: trip.id } }));
+      expect(result.success).toBe(true);
+      expect(inviteRow(trip.id)).toBeUndefined();
+      const audit = testDb.prepare("SELECT resource FROM audit_log WHERE action = 'trip.invite_link_delete'").get() as { resource: string } | undefined;
+      expect(audit?.resource).toBe(String(trip.id));
+    });
+  });
+});
+
+describe('trip invite link gates', () => {
+  const INVITE_TOOLS = ['get_trip_invite_link', 'create_trip_invite_link', 'delete_trip_invite_link'];
+
+  it.each(INVITE_TOOLS)('%s refuses a trip the user cannot reach', async (name) => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const foreign = createTrip(testDb, other.id);
+    await withHarness(other.id, async (h) => {
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: foreign.id } });
+    });
+    const existing = inviteRow(foreign.id)?.token;
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: foreign.id } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('Trip not found or access denied.');
+    });
+    expect(inviteRow(foreign.id)?.token).toBe(existing);
+  });
+
+  it.each(INVITE_TOOLS)('%s refuses a trip id that does not exist', async (name) => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: 987654 } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('Trip not found or access denied.');
+    });
+  });
+
+  it.each(INVITE_TOOLS)('%s refuses a member without share_manage', async (name) => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    await withHarness(owner.id, async (h) => {
+      await h.client.callTool({ name: 'create_trip_invite_link', arguments: { tripId: trip.id } });
+    });
+    const existing = inviteRow(trip.id)?.token;
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('You do not have permission to perform this action on this trip.');
+    });
+    expect(inviteRow(trip.id)?.token).toBe(existing);
+  });
+
+  it.each(['create_trip_invite_link', 'delete_trip_invite_link'])('%s refuses a demo account', async (name) => {
+    process.env.DEMO_MODE = 'true';
+    const { user: demo } = createUser(testDb, { email: 'demo@trek.app' });
+    const trip = createTrip(testDb, demo.id);
+    testDb.prepare('INSERT INTO trip_invite_tokens (trip_id, token, created_by) VALUES (?, ?, ?)').run(trip.id, 'seeded-token', demo.id);
+    await withHarness(demo.id, async (h) => {
+      const result = await h.client.callTool({ name, arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toBe('Write operations are disabled in demo mode.');
+    });
+    expect(inviteRow(trip.id)?.token).toBe('seeded-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope gating: the feed tools ride trips:share, the invite tools need
+// trips:share AND trips:write because the link grants membership.
+// ---------------------------------------------------------------------------
+
+describe('scope gating', () => {
+  const FEED_TOOLS = [
+    'get_trip_calendar_feed', 'enable_trip_calendar_feed', 'rotate_trip_calendar_feed', 'disable_trip_calendar_feed',
+    'get_all_trips_calendar_feed', 'enable_all_trips_calendar_feed', 'rotate_all_trips_calendar_feed', 'disable_all_trips_calendar_feed',
+  ];
+  const INVITE_TOOLS = ['get_trip_invite_link', 'create_trip_invite_link', 'delete_trip_invite_link'];
+
+  async function toolNames(scopes: string[] | null): Promise<string[]> {
+    const h = await createMcpHarness({ userId: 1, withResources: false, scopes });
+    try {
+      const { tools } = await h.client.listTools();
+      return tools.map((t) => t.name);
+    } finally {
+      await h.cleanup();
+    }
+  }
+
+  it('a static token (null scopes) sees all eleven', async () => {
+    const names = await toolNames(null);
+    for (const tool of [...FEED_TOOLS, ...INVITE_TOOLS]) expect(names).toContain(tool);
+  });
+
+  it('trips:read alone sees none of them', async () => {
+    const names = await toolNames(['trips:read']);
+    for (const tool of [...FEED_TOOLS, ...INVITE_TOOLS]) expect(names).not.toContain(tool);
+  });
+
+  it('trips:share carries the feed tools but not the membership-granting invite link', async () => {
+    const names = await toolNames(['trips:share']);
+    for (const tool of FEED_TOOLS) expect(names).toContain(tool);
+    for (const tool of INVITE_TOOLS) expect(names).not.toContain(tool);
+  });
+
+  it('trips:write alone carries neither', async () => {
+    const names = await toolNames(['trips:write']);
+    for (const tool of [...FEED_TOOLS, ...INVITE_TOOLS]) expect(names).not.toContain(tool);
+  });
+
+  it('trips:share plus trips:write unlocks the invite link', async () => {
+    const names = await toolNames(['trips:share', 'trips:write']);
+    for (const tool of INVITE_TOOLS) expect(names).toContain(tool);
+  });
+});

--- a/server/tests/unit/mcp/tools-files.test.ts
+++ b/server/tests/unit/mcp/tools-files.test.ts
@@ -1,0 +1,870 @@
+/**
+ * The trip-file MCP surface (FilesMcp): listing a trip's documents, reading one
+ * document's contents under its own scope, and the attach/describe writes.
+ *
+ * The gates are what this file is really about. Every tool has to answer exactly
+ * what its REST route answers: trip access before anything else, file_edit on
+ * the writes, and a file id that is only resolvable inside its own trip. And
+ * read_trip_file has to stay behind files:content while list_trip_files answers
+ * on files:read alone.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import fs from 'node:fs';
+import nodePath from 'node:path';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
+
+const { fixture } = vi.hoisted(() => ({ fixture: {} as { root: string } }));
+// Each createMcpHarness() builds a fresh registry, and the helper hands every one
+// of those its own mkdtemp root, so bytes written by a test would land in a
+// directory the next registry never looks at. Pin one shared fixture instead,
+// which is what lets read_trip_file return a file this suite wrote.
+vi.mock('../../helpers/storage-fixture', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helpers/storage-fixture')>();
+  const shared = actual.makeStorageFixture('');
+  fixture.root = shared.root;
+  return { makeStorageFixture: () => shared };
+});
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb } from '../../helpers/test-db';
+import { invalidatePermissionsCache } from '../../../src/nest/permissions/permissions-cache';
+import { createUser, createTrip, createDay, createPlace, createDayAssignment, createReservation, addTripMember } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { expectRegisteredProvider } from '../../helpers/module-providers';
+import { FilesModule } from '../../../src/nest/files/files.module';
+import { FilesMcp } from '../../../src/nest/files/files.mcp';
+import { FILE_CONTENT_MAX } from '../../../src/nest/files/files.service';
+import { StorageService } from '../../../src/nest/storage/storage.service';
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  broadcastMock.mockClear();
+  delete process.env.DEMO_MODE;
+  // resetTestDb truncates app_settings, but the permission cache is module-scoped
+  // and would keep serving whatever the previous case configured.
+  invalidatePermissionsCache();
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
+  const h = await createMcpHarness({ userId, withResources: false });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+/** Lower a configurable action the way the admin permission panel does. */
+function setPermission(action: string, level: string) {
+  testDb.prepare('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)').run(`perm_${action}`, level);
+  invalidatePermissionsCache();
+}
+
+interface FileRowOverrides {
+  filename: string;
+  original_name: string;
+  file_size: number | null;
+  mime_type: string | null;
+  description: string | null;
+  uploaded_by: number | null;
+  place_id: number | null;
+  reservation_id: number | null;
+  starred: number;
+  deleted_at: string | null;
+}
+
+/** A trip_files row, straight in: there is no upload path through MCP to make one. */
+function insertFile(tripId: number, overrides: Partial<FileRowOverrides> = {}) {
+  const info = testDb.prepare(`
+    INSERT INTO trip_files (trip_id, filename, original_name, file_size, mime_type, description, uploaded_by, place_id, reservation_id, starred, deleted_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    tripId,
+    overrides.filename ?? 'stored-visa.pdf',
+    overrides.original_name ?? 'visa.pdf',
+    // `??` would swallow an explicit null here, and a row with no recorded size
+    // or type is exactly what the fallback cases need.
+    overrides.file_size === undefined ? 2 : overrides.file_size,
+    overrides.mime_type === undefined ? 'application/pdf' : overrides.mime_type,
+    overrides.description ?? null,
+    overrides.uploaded_by ?? null,
+    overrides.place_id ?? null,
+    overrides.reservation_id ?? null,
+    overrides.starred ?? 0,
+    overrides.deleted_at ?? null,
+  );
+  return testDb.prepare('SELECT * FROM trip_files WHERE id = ?').get(info.lastInsertRowid) as { id: number; description: string | null; place_id: number | null; reservation_id: number | null };
+}
+
+/** Put real bytes where the storage layer will look for `filename`. */
+function storeBytes(filename: string, body: Buffer | string) {
+  fs.writeFileSync(nodePath.join(fixture.root, filename), body);
+}
+
+function fileRow(id: number) {
+  return testDb.prepare('SELECT description, place_id, reservation_id FROM trip_files WHERE id = ?').get(id) as
+    { description: string | null; place_id: number | null; reservation_id: number | null };
+}
+
+function linkRows(fileId: number) {
+  return testDb.prepare('SELECT * FROM file_links WHERE file_id = ?').all(fileId) as
+    { id: number; reservation_id: number | null; assignment_id: number | null; place_id: number | null }[];
+}
+
+// ---------------------------------------------------------------------------
+// list_trip_files
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_trip_files', () => {
+  it('reports name, size, uploader, links and starred state', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id);
+    const reservation = createReservation(testDb, trip.id, { title: 'Hotel Ritz' });
+    const file = insertFile(trip.id, {
+      original_name: 'boarding-pass.pdf', file_size: 4242, uploaded_by: user.id,
+      place_id: place.id, reservation_id: reservation.id, starred: 1, description: 'AF1234',
+    });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_trip_files', arguments: { tripId: trip.id } });
+      const data = parseToolResult(result) as any;
+      expect(data.files).toHaveLength(1);
+      expect(data.files[0]).toMatchObject({
+        id: file.id,
+        original_name: 'boarding-pass.pdf',
+        file_size: 4242,
+        mime_type: 'application/pdf',
+        description: 'AF1234',
+        starred: 1,
+        deleted_at: null,
+        reservation_title: 'Hotel Ritz',
+        uploaded_by_name: user.username,
+      });
+    });
+  });
+
+  it('lists the trash only when asked for it', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    insertFile(trip.id, { original_name: 'live.pdf' });
+    insertFile(trip.id, { original_name: 'trashed.pdf', deleted_at: '2027-01-01 10:00:00' });
+
+    await withHarness(user.id, async (h) => {
+      const live = parseToolResult(await h.client.callTool({ name: 'list_trip_files', arguments: { tripId: trip.id } })) as any;
+      expect(live.files.map((f: any) => f.original_name)).toEqual(['live.pdf']);
+
+      const trashed = parseToolResult(await h.client.callTool({ name: 'list_trip_files', arguments: { tripId: trip.id, trash: true } })) as any;
+      expect(trashed.files.map((f: any) => f.original_name)).toEqual(['trashed.pdf']);
+    });
+  });
+
+  it('reports the bookings and places a file is linked to', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(file.id, reservation.id);
+    testDb.prepare('INSERT INTO file_links (file_id, place_id) VALUES (?, ?)').run(file.id, place.id);
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({ name: 'list_trip_files', arguments: { tripId: trip.id } })) as any;
+      expect(data.files[0].linked_reservation_ids).toEqual([reservation.id]);
+      expect(data.files[0].linked_place_ids).toEqual([place.id]);
+    });
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_trip_files', arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// read_trip_file
+// ---------------------------------------------------------------------------
+
+describe('Tool: read_trip_file', () => {
+  it('returns a text document as text', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id, { filename: 'notes.txt', original_name: 'packing-notes.txt', mime_type: 'text/plain', file_size: 11 });
+    storeBytes('notes.txt', 'Bring socks');
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id },
+      })) as any;
+      expect(data.file).toMatchObject({
+        id: file.id, name: 'packing-notes.txt', mimetype: 'text/plain', size: 11, encoding: 'utf8', content: 'Bring socks',
+      });
+    });
+  });
+
+  it('returns a binary document base64-encoded', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x00, 0xff]);
+    const file = insertFile(trip.id, { filename: 'stored.pdf', mime_type: 'application/pdf', file_size: bytes.length });
+    storeBytes('stored.pdf', bytes);
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id },
+      })) as any;
+      expect(data.file.encoding).toBe('base64');
+      expect(Buffer.from(data.file.content, 'base64').equals(bytes)).toBe(true);
+    });
+  });
+
+  it('falls back to a binary mimetype when the row has none', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id, { filename: 'unknown.bin', mime_type: null, file_size: null });
+    storeBytes('unknown.bin', 'hi');
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id },
+      })) as any;
+      expect(data.file.mimetype).toBe('application/octet-stream');
+      expect(data.file.encoding).toBe('base64');
+    });
+  });
+
+  it('refuses a file that belongs to another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreign = insertFile(otherTrip.id, { filename: 'foreign.txt', mime_type: 'text/plain' });
+    storeBytes('foreign.txt', 'secret');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: foreign.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+  });
+
+  it('refuses a trashed file', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id, { filename: 'trashed.txt', mime_type: 'text/plain', deleted_at: '2027-01-01 10:00:00' });
+    storeBytes('trashed.txt', 'gone');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+  });
+
+  it('refuses a file over the 10 MB cap without touching the bytes', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    // Recorded size only: the refusal happens before the storage layer is asked,
+    // which is the whole point of capping on the row.
+    const file = insertFile(trip.id, { filename: 'huge.mp4', mime_type: 'video/mp4', file_size: FILE_CONTENT_MAX + 1 });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('too large to read here (over 10 MB)');
+    });
+  });
+
+  it('reports a row whose bytes are gone as unavailable, not as a crash', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id, { filename: 'never-stored.pdf' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File contents are not available.');
+    });
+  });
+
+  it('lets an unexpected storage failure surface instead of calling the file missing', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id, { filename: 'flaky.txt', mime_type: 'text/plain' });
+    storeBytes('flaky.txt', 'hi');
+    // A backend outage is not one of the three refusals: reporting it as "not
+    // found" would send the caller off to fix a file that is perfectly fine.
+    const outage = vi.spyOn(StorageService.prototype, 'getStream').mockRejectedValueOnce(new Error('backend down'));
+
+    try {
+      await withHarness(user.id, async (h) => {
+        const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+        expect(result.isError).toBe(true);
+        const text = JSON.stringify(result.content);
+        expect(text).not.toContain('File not found.');
+        expect(text).not.toContain('File contents are not available.');
+      });
+    } finally {
+      outage.mockRestore();
+    }
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const file = insertFile(trip.id, { filename: 'members-only.txt', mime_type: 'text/plain' });
+    storeBytes('members-only.txt', 'secret');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'read_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_trip_file
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_trip_file', () => {
+  it('sets the description and attaches the file to a place', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, description: 'Museum ticket', place_id: place.id },
+      })) as any;
+      expect(data.file.description).toBe('Museum ticket');
+      expect(fileRow(file.id)).toMatchObject({ description: 'Museum ticket', place_id: place.id });
+    });
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'file:updated', expect.objectContaining({ _source: 'mcp' }));
+  });
+
+  it('leaves out fields the caller did not send', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id, { description: 'Keep me' });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: reservation.id },
+      });
+      expect(fileRow(file.id)).toMatchObject({ description: 'Keep me', reservation_id: reservation.id });
+    });
+  });
+
+  it('detaches a booking when reservation_id is null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id, { reservation_id: reservation.id });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: null },
+      });
+      expect(fileRow(file.id).reservation_id).toBeNull();
+    });
+  });
+
+  it('refuses a place that belongs to another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreignPlace = createPlace(testDb, otherTrip.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, place_id: foreignPlace.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('does not belong to this trip (place_id)');
+      expect(fileRow(file.id).place_id).toBeNull();
+    });
+  });
+
+  it('refuses a file id from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreign = insertFile(otherTrip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: foreign.id, description: 'x' },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+  });
+
+  it('refuses a member once file_edit is owner-only', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    const file = insertFile(trip.id);
+    setPermission('file_edit', 'trip_owner');
+
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, description: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+      expect(fileRow(file.id).description).toBeNull();
+    });
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, description: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+    });
+  });
+
+  it('blocks a demo user before it looks at the trip', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, description: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+      expect(fileRow(file.id).description).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// link_trip_file
+// ---------------------------------------------------------------------------
+
+describe('Tool: link_trip_file', () => {
+  it('attaches one file to a booking, a place and a day assignment', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const day = createDay(testDb, trip.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const first = parseToolResult(await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: reservation.id },
+      })) as any;
+      expect(first.success).toBe(true);
+      expect(first.links).toHaveLength(1);
+
+      await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, place_id: place.id, assignment_id: assignment.id },
+      });
+    });
+
+    const links = linkRows(file.id);
+    expect(links).toHaveLength(2);
+    expect(links[0].reservation_id).toBe(reservation.id);
+    expect(links[1]).toMatchObject({ place_id: place.id, assignment_id: assignment.id });
+  });
+
+  it('refuses a call with no target instead of storing an empty link', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'link_trip_file', arguments: { tripId: trip.id, fileId: file.id } });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('at least one of reservation_id');
+    });
+    expect(linkRows(file.id)).toHaveLength(0);
+  });
+
+  it('refuses a booking from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreignReservation = createReservation(testDb, otherTrip.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: foreignReservation.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('does not belong to this trip (reservation_id)');
+    });
+    expect(linkRows(file.id)).toHaveLength(0);
+  });
+
+  it('refuses a day assignment from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreignDay = createDay(testDb, otherTrip.id);
+    const foreignPlace = createPlace(testDb, otherTrip.id);
+    const foreignAssignment = createDayAssignment(testDb, foreignDay.id, foreignPlace.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, assignment_id: foreignAssignment.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('does not belong to this trip (assignment_id)');
+    });
+  });
+
+  it('refuses a file id from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreign = insertFile(otherTrip.id);
+    const reservation = createReservation(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: foreign.id, reservation_id: reservation.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+  });
+
+  it('refuses a member once file_edit is owner-only', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+    setPermission('file_edit', 'trip_owner');
+
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: reservation.id },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(linkRows(file.id)).toHaveLength(0);
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: reservation.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+    });
+  });
+
+  it('blocks a demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'link_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, reservation_id: reservation.id },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(linkRows(file.id)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unlink_trip_file
+// ---------------------------------------------------------------------------
+
+describe('Tool: unlink_trip_file', () => {
+  it('removes one link and leaves the others alone', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    const file = insertFile(trip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(file.id, reservation.id);
+    testDb.prepare('INSERT INTO file_links (file_id, place_id) VALUES (?, ?)').run(file.id, place.id);
+    const doomed = linkRows(file.id)[0].id;
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'unlink_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, linkId: doomed },
+      })) as any;
+      expect(data.success).toBe(true);
+    });
+    const left = linkRows(file.id);
+    expect(left).toHaveLength(1);
+    expect(left[0].place_id).toBe(place.id);
+  });
+
+  it('refuses a file id from another trip, so a foreign link survives', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreignFile = insertFile(otherTrip.id);
+    const foreignReservation = createReservation(testDb, otherTrip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(foreignFile.id, foreignReservation.id);
+    const linkId = linkRows(foreignFile.id)[0].id;
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'unlink_trip_file',
+        arguments: { tripId: trip.id, fileId: foreignFile.id, linkId },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+    expect(linkRows(foreignFile.id)).toHaveLength(1);
+  });
+
+  it('refuses a member once file_edit is owner-only', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(file.id, reservation.id);
+    const linkId = linkRows(file.id)[0].id;
+    setPermission('file_edit', 'trip_owner');
+
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'unlink_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, linkId },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(linkRows(file.id)).toHaveLength(1);
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'unlink_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, linkId: 1 },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+    });
+  });
+
+  it('blocks a demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id);
+    const file = insertFile(trip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(file.id, reservation.id);
+    const linkId = linkRows(file.id)[0].id;
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'unlink_trip_file',
+        arguments: { tripId: trip.id, fileId: file.id, linkId },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(linkRows(file.id)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_trip_file_links
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_trip_file_links', () => {
+  it('returns every link with its id and the booking title', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const reservation = createReservation(testDb, trip.id, { title: 'Nightjet 421' });
+    const file = insertFile(trip.id);
+    testDb.prepare('INSERT INTO file_links (file_id, reservation_id) VALUES (?, ?)').run(file.id, reservation.id);
+
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'list_trip_file_links', arguments: { tripId: trip.id, fileId: file.id },
+      })) as any;
+      expect(data.links).toHaveLength(1);
+      expect(data.links[0]).toMatchObject({ file_id: file.id, reservation_id: reservation.id, reservation_title: 'Nightjet 421' });
+      expect(typeof data.links[0].id).toBe('number');
+    });
+  });
+
+  it('refuses a file id from another trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const otherTrip = createTrip(testDb, user.id);
+    const foreign = insertFile(otherTrip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_trip_file_links', arguments: { tripId: trip.id, fileId: foreign.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('File not found.');
+    });
+  });
+
+  it('denies a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const file = insertFile(trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_trip_file_links', arguments: { tripId: trip.id, fileId: file.id },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope gating
+// ---------------------------------------------------------------------------
+
+describe('File tools: scope gating', () => {
+  const READ_TOOLS = ['list_trip_files', 'list_trip_file_links'];
+  const WRITE_TOOLS = ['update_trip_file', 'link_trip_file', 'unlink_trip_file'];
+
+  async function listToolNames(userId: number, scopes: string[] | null): Promise<string[]> {
+    const h = await createMcpHarness({ userId, withResources: false, scopes });
+    try {
+      return (await h.client.listTools()).tools.map((t) => t.name);
+    } finally {
+      await h.cleanup();
+    }
+  }
+
+  it('registers all six tools for a full-access session', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, null);
+    for (const tool of [...READ_TOOLS, ...WRITE_TOOLS, 'read_trip_file']) expect(names).toContain(tool);
+  });
+
+  it('files:read lists the documents but does not open them', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['files:read']);
+    for (const tool of READ_TOOLS) expect(names).toContain(tool);
+    for (const tool of [...WRITE_TOOLS, 'read_trip_file']) expect(names).not.toContain(tool);
+  });
+
+  it('files:content opens a document without granting the listing', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['files:content']);
+    expect(names).toContain('read_trip_file');
+    for (const tool of [...READ_TOOLS, ...WRITE_TOOLS]) expect(names).not.toContain(tool);
+  });
+
+  it('files:write carries the reads, and still not the contents', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['files:write']);
+    for (const tool of [...READ_TOOLS, ...WRITE_TOOLS]) expect(names).toContain(tool);
+    expect(names).not.toContain('read_trip_file');
+  });
+
+  it('a token without any files scope gets none of them', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['trips:read']);
+    for (const tool of [...READ_TOOLS, ...WRITE_TOOLS, 'read_trip_file']) expect(names).not.toContain(tool);
+  });
+});
+
+describe('FilesMcp wiring', () => {
+  it('is listed in its module providers', () => {
+    expectRegisteredProvider(FilesModule, FilesMcp);
+  });
+});

--- a/server/tests/unit/mcp/tools-help-addons.test.ts
+++ b/server/tests/unit/mcp/tools-help-addons.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Unit tests for the MCP help and addons tools:
+ * list_help_topics, get_help_page, list_addons.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
+
+// The wiki reader is stubbed at the module boundary, the way the weather tools
+// stub weather.impl: help.mcp.ts calls these functions directly, and the reader
+// has its own tests in tests/unit/nest/wiki.test.ts. Stubbing keeps these cases
+// off the 94 real pages in wiki/ and reaches the failure branches, which a
+// directory on disk cannot produce on demand.
+const { wiki } = vi.hoisted(() => {
+  class WikiNotFound extends Error {
+    status = 404;
+  }
+  return {
+    wiki: {
+      WikiNotFound,
+      isLocalWiki: vi.fn(() => true),
+      getWikiIndex: vi.fn(),
+      getWikiPage: vi.fn(),
+      getWikiAsset: vi.fn(),
+    },
+  };
+});
+vi.mock('../../../src/nest/help/wiki', () => wiki);
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb, setAddonEnabled } from '../../helpers/test-db';
+import { createUser } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { AddonsService } from '../../../src/nest/addons/addons.service';
+import { DatabaseService } from '../../../src/nest/database/database.service';
+import { ADDON_IDS } from '../../../src/addons';
+
+const SECTIONS = [
+  { title: 'Getting Started', pages: [{ title: 'Quick Start', slug: 'Quick-Start' }] },
+  { title: 'Planning', pages: [{ title: 'Currencies', slug: 'Currencies' }] },
+];
+
+// 40004 characters: four over the 40000-character cap, so the second chunk is
+// short enough to assert on in full.
+const LONG_MARKDOWN = 'a'.repeat(40_000) + 'TAIL';
+
+const PAGES: Record<string, { slug: string; title: string; markdown: string }> = {
+  'Quick-Start': {
+    slug: 'Quick-Start',
+    title: 'Quick Start',
+    markdown: '# Quick Start\n\nCreate a trip, then add days to it.',
+  },
+  'Plugin-Development': {
+    slug: 'Plugin-Development',
+    title: 'Plugin Development',
+    markdown: LONG_MARKDOWN,
+  },
+};
+
+interface HelpIndexPayload {
+  sections: { title: string; pages: { title: string; slug: string }[] }[];
+}
+interface HelpPagePayload {
+  slug: string;
+  title: string;
+  markdown: string;
+  truncated: boolean;
+  next_offset: number | null;
+}
+interface AddonEntry {
+  id: string;
+  name: string;
+  type: string;
+  enabled: boolean;
+}
+interface AddonsPayload {
+  addons: AddonEntry[];
+  collabFeatures: { chat: boolean; notes: boolean; polls: boolean; whatsnext: boolean };
+  bagTracking: boolean;
+}
+
+/** First text block of a tool result, for asserting on refusal wording. */
+function toolText(result: unknown): string {
+  const { content } = result as { content: { type: string; text?: string }[] };
+  return content.find((c) => c.type === 'text')?.text ?? '';
+}
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  broadcastMock.mockClear();
+  delete process.env.DEMO_MODE;
+  wiki.getWikiIndex.mockReset();
+  wiki.getWikiPage.mockReset();
+  wiki.getWikiIndex.mockResolvedValue({ sections: SECTIONS });
+  wiki.getWikiPage.mockImplementation(async (slug: string) => {
+    const page = PAGES[slug];
+    if (!page) throw new wiki.WikiNotFound(slug);
+    return page;
+  });
+  // resetTestDb leaves the addons table alone, so a case that flips a toggle
+  // would otherwise leak into the next one.
+  for (const id of [ADDON_IDS.BUDGET, ADDON_IDS.PACKING, ADDON_IDS.COLLAB]) {
+    setAddonEnabled(testDb, id, true);
+  }
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(
+  userId: number,
+  fn: (h: McpHarness) => Promise<void>,
+  scopes?: string[] | null,
+) {
+  const h = await createMcpHarness({ userId, withResources: false, scopes: scopes ?? null });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// list_help_topics
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_help_topics', () => {
+  it('returns the sections the wiki reader parsed out of the sidebar', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_help_topics', arguments: {} });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as HelpIndexPayload;
+      expect(data.sections).toEqual(SECTIONS);
+      expect(wiki.getWikiIndex).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('answers with a refusal instead of throwing when the reader fails', async () => {
+    wiki.getWikiIndex.mockRejectedValue(new Error('ENOENT'));
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_help_topics', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect(toolText(result)).toBe('Help contents unavailable.');
+    });
+  });
+
+  it('stays registered for a token holding an unrelated scope', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map((t) => t.name);
+      expect(names).toContain('list_help_topics');
+      expect(names).toContain('get_help_page');
+      const result = await h.client.callTool({ name: 'list_help_topics', arguments: {} });
+      expect(result.isError).toBeFalsy();
+    }, ['weather:read']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_help_page
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_help_page', () => {
+  it('returns a short page whole, with nothing left to fetch', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Quick-Start' },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as HelpPagePayload;
+      expect(data).toEqual({
+        slug: 'Quick-Start',
+        title: 'Quick Start',
+        markdown: PAGES['Quick-Start'].markdown,
+        truncated: false,
+        next_offset: null,
+      });
+      expect(wiki.getWikiPage).toHaveBeenCalledWith('Quick-Start');
+    });
+  });
+
+  it('refuses a slug this instance does not ship, and says where to look', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'No-Such-Page' },
+      });
+      expect(result.isError).toBe(true);
+      expect(toolText(result)).toContain('No help page named "No-Such-Page"');
+      expect(toolText(result)).toContain('list_help_topics');
+    });
+  });
+
+  it('separates an unavailable reader from a missing page', async () => {
+    wiki.getWikiPage.mockRejectedValue(new Error('socket hang up'));
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Quick-Start' },
+      });
+      expect(result.isError).toBe(true);
+      expect(toolText(result)).toBe('Help page unavailable.');
+    });
+  });
+
+  it('caps a long page and hands back the offset to resume from', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Plugin-Development' },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as HelpPagePayload;
+      expect(data.markdown).toHaveLength(40_000);
+      expect(data.markdown).toBe(LONG_MARKDOWN.slice(0, 40_000));
+      expect(data.truncated).toBe(true);
+      expect(data.next_offset).toBe(40_000);
+    });
+  });
+
+  it('resumes from the offset the previous chunk reported', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Plugin-Development', offset: 40_000 },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as HelpPagePayload;
+      expect(data.markdown).toBe('TAIL');
+      expect(data.truncated).toBe(false);
+      expect(data.next_offset).toBeNull();
+    });
+  });
+
+  it('refuses an offset past the end of the page', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Quick-Start', offset: 5000 },
+      });
+      expect(result.isError).toBe(true);
+      expect(toolText(result)).toContain('past the end of "Quick-Start"');
+    });
+  });
+
+  it('serves a demo account, the way the public REST route does', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_help_page',
+        arguments: { slug: 'Quick-Start' },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as HelpPagePayload;
+      expect(data.title).toBe('Quick Start');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_addons
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_addons', () => {
+  it('lists the enabled addons with the collab sub-features and bag tracking', async () => {
+    const { user } = createUser(testDb);
+    const row = testDb.prepare('SELECT name, type FROM addons WHERE id = ?').get('budget') as {
+      name: string;
+      type: string;
+    };
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as AddonsPayload;
+      // The whole entry, so the admin-panel chrome (icon, plus config and fields
+      // on a photo provider) has to be absent rather than merely unasserted.
+      expect(data.addons).toContainEqual({
+        id: 'budget',
+        name: row.name,
+        type: row.type,
+        enabled: true,
+      });
+      expect(data.collabFeatures).toEqual({ chat: true, notes: true, polls: true, whatsnext: true });
+      expect(data.bagTracking).toBe(false);
+    });
+  });
+
+  it('lists the enabled photo providers alongside the addons', async () => {
+    const { user } = createUser(testDb);
+    const row = testDb.prepare('SELECT name FROM photo_providers WHERE id = ?').get('immich') as {
+      name: string;
+    };
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      const data = parseToolResult(result) as AddonsPayload;
+      expect(data.addons).toContainEqual({
+        id: 'immich',
+        name: row.name,
+        type: 'photo_provider',
+        enabled: true,
+      });
+    });
+  });
+
+  it('drops an addon the admin switched off, so absence means disabled', async () => {
+    setAddonEnabled(testDb, ADDON_IDS.BUDGET, false);
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      const data = parseToolResult(result) as AddonsPayload;
+      const ids = data.addons.map((a) => a.id);
+      expect(ids).not.toContain(ADDON_IDS.BUDGET);
+      expect(ids).toContain(ADDON_IDS.PACKING);
+    });
+  });
+
+  it('follows a collab sub-feature the admin toggles, in both directions', async () => {
+    // Written through the same service the admin panel writes through rather
+    // than through a hand-rolled app_settings row, so the tool is checked
+    // against the real writer and not against a restatement of it.
+    const addonsService = new AddonsService(new DatabaseService(testDb));
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      addonsService.updateCollabFeatures({ polls: false });
+      const off = parseToolResult(
+        await h.client.callTool({ name: 'list_addons', arguments: {} }),
+      ) as AddonsPayload;
+      expect(off.collabFeatures.polls).toBe(false);
+      expect(off.collabFeatures.chat).toBe(true);
+
+      addonsService.updateCollabFeatures({ polls: true });
+      const on = parseToolResult(
+        await h.client.callTool({ name: 'list_addons', arguments: {} }),
+      ) as AddonsPayload;
+      expect(on.collabFeatures.polls).toBe(true);
+    });
+  });
+
+  it('reports bag tracking once it is switched on', async () => {
+    testDb
+      .prepare("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('bag_tracking_enabled', 'true')")
+      .run();
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      const data = parseToolResult(result) as AddonsPayload;
+      expect(data.bagTracking).toBe(true);
+    });
+  });
+
+  it('stays registered for a token holding an unrelated scope', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map((t) => t.name);
+      expect(names).toContain('list_addons');
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      expect(result.isError).toBeFalsy();
+    }, ['weather:read']);
+  });
+
+  it('serves a demo account, the way the authenticated REST route does', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_addons', arguments: {} });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as AddonsPayload;
+      expect(data.addons.map((a) => a.id)).toContain(ADDON_IDS.PACKING);
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-journey.test.ts
+++ b/server/tests/unit/mcp/tools-journey.test.ts
@@ -34,6 +34,23 @@ vi.mock('../../../src/config', () => ({
 const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
 vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock, broadcastToUser: broadcastMock }));
 
+/*
+ * get_journey_stats resolves a country per stop. The real lookup loads and
+ * indexes 4MB of gzipped admin-0 boundaries on first call, which is Atlas'
+ * work and has its own tests (journey-stats.service.test.ts stubs it for the
+ * same reason). Only this one export is replaced: AtlasService is constructed
+ * by the harness and imports the rest of the module for real.
+ */
+vi.mock('../../../src/nest/atlas/atlas-geo', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  // Rough boxes, enough to tell two countries apart in a fixture.
+  getCountryFromCoords: (lat: number, lng: number) => {
+    if (lat > 47 && lat < 55 && lng > 5 && lng < 15) return 'DE';
+    if (lat > 42 && lat < 51 && lng > -5 && lng < 8) return 'FR';
+    return null;
+  },
+}));
+
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
@@ -409,6 +426,277 @@ describe('journey write tools', () => {
         name: 'update_journey_preferences', arguments: { journeyId, hide_skeletons: true },
       });
       expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The entry columns the REST route has always accepted. The INSERT writes a
+// place, its coordinates, weather, tags, the verdict, the visibility and the
+// type; the UPDATE allow-list carries all of them plus sort_order. The tools
+// took a location_name at create and nothing at all after that, so an entry
+// written through MCP never landed on the journey map and a wrong place name
+// could not be corrected. Asserted against the row, not the tool's echo.
+// ---------------------------------------------------------------------------
+
+function entryRow(id: number) {
+  return testDb.prepare('SELECT * FROM journey_entries WHERE id = ?').get(id) as any;
+}
+
+async function seedEntry(h: McpHarness, journeyId: number, args: Record<string, unknown> = {}) {
+  return (parseToolResult(await h.client.callTool({
+    name: 'create_journey_entry',
+    arguments: { journeyId, entry_date: '2026-07-01', ...args },
+  })) as any).entry;
+}
+
+describe('journey entry fields', () => {
+  it('create_journey_entry persists the place, coordinates, weather, tags, verdict, visibility and type', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id, {
+        title: 'Reykjavik',
+        location_name: 'Hallgrimskirkja',
+        location_lat: 64.1418,
+        location_lng: -21.9266,
+        weather: 'overcast, 9C',
+        tags: ['church', 'view'],
+        pros_cons: { pros: ['the tower'], cons: ['the queue'] },
+        visibility: 'public',
+        type: 'checkin',
+      });
+
+      const row = entryRow(entry.id);
+      expect(row.location_name).toBe('Hallgrimskirkja');
+      expect(row.location_lat).toBeCloseTo(64.1418, 4);
+      expect(row.location_lng).toBeCloseTo(-21.9266, 4);
+      expect(row.weather).toBe('overcast, 9C');
+      expect(JSON.parse(row.tags)).toEqual(['church', 'view']);
+      expect(JSON.parse(row.pros_cons)).toEqual({ pros: ['the tower'], cons: ['the queue'] });
+      expect(row.visibility).toBe('public');
+      expect(row.type).toBe('checkin');
+    });
+  });
+
+  it('create_journey_entry accepts a one-sided verdict and fills the other side in', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id, { pros_cons: { pros: ['cheap'] } });
+      expect(JSON.parse(entryRow(entry.id).pros_cons)).toEqual({ pros: ['cheap'], cons: [] });
+    });
+  });
+
+  it('create_journey_entry defaults to a private entry when neither is given', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const row = entryRow((await seedEntry(h, journey.id)).id);
+      expect(row.visibility).toBe('private');
+      expect(row.type).toBe('entry');
+    });
+  });
+
+  it('create_journey_entry refuses coordinates off the globe and an unknown visibility', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      for (const bad of [{ location_lat: 91 }, { location_lng: -181 }, { visibility: 'friends' }]) {
+        expect((await h.client.callTool({
+          name: 'create_journey_entry',
+          arguments: { journeyId: journey.id, entry_date: '2026-07-01', ...bad },
+        })).isError).toBe(true);
+      }
+    });
+  });
+
+  it('update_journey_entry corrects the place and its coordinates', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id, {
+        location_name: 'Hallgrimskirja', location_lat: 64.0, location_lng: -21.0,
+      });
+
+      await h.client.callTool({
+        name: 'update_journey_entry',
+        arguments: {
+          entryId: entry.id,
+          location_name: 'Hallgrimskirkja',
+          location_lat: 64.1418,
+          location_lng: -21.9266,
+        },
+      });
+
+      const row = entryRow(entry.id);
+      expect(row.location_name).toBe('Hallgrimskirkja');
+      expect(row.location_lat).toBeCloseTo(64.1418, 4);
+      expect(row.location_lng).toBeCloseTo(-21.9266, 4);
+    });
+  });
+
+  it('update_journey_entry sets weather, tags, the verdict, visibility and sort_order', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id);
+
+      const data = parseToolResult(await h.client.callTool({
+        name: 'update_journey_entry',
+        arguments: {
+          entryId: entry.id,
+          weather: 'rain all day',
+          tags: ['museum'],
+          pros_cons: { pros: ['free on Sundays'], cons: ['packed'] },
+          visibility: 'shared',
+          sort_order: 3,
+        },
+      })) as any;
+
+      const row = entryRow(entry.id);
+      expect(row.weather).toBe('rain all day');
+      expect(JSON.parse(row.tags)).toEqual(['museum']);
+      expect(JSON.parse(row.pros_cons)).toEqual({ pros: ['free on Sundays'], cons: ['packed'] });
+      expect(row.visibility).toBe('shared');
+      expect(row.sort_order).toBe(3);
+      // The enrichment parses both back out, so the caller sees the objects.
+      expect(data.entry.tags).toEqual(['museum']);
+      expect(data.entry.pros_cons).toEqual({ pros: ['free on Sundays'], cons: ['packed'] });
+    });
+  });
+
+  it('update_journey_entry promotes a trip-derived skeleton to a real entry', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id, { type: 'skeleton', title: 'Blue Lagoon' });
+      expect(entryRow(entry.id).type).toBe('skeleton');
+
+      await h.client.callTool({ name: 'update_journey_entry', arguments: { entryId: entry.id, type: 'entry' } });
+      expect(entryRow(entry.id).type).toBe('entry');
+    });
+  });
+
+  it('update_journey_entry clears a field on null and leaves the omitted ones alone', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id, {
+        title: 'Vik',
+        entry_time: '14:30',
+        location_name: 'Reynisfjara',
+        location_lat: 63.4,
+        location_lng: -19.04,
+        weather: 'gale',
+        tags: ['beach'],
+        pros_cons: { pros: ['the stacks'], cons: ['sneaker waves'] },
+      });
+
+      await h.client.callTool({
+        name: 'update_journey_entry',
+        arguments: {
+          entryId: entry.id,
+          entry_time: null,
+          location_lat: null,
+          location_lng: null,
+          weather: null,
+          tags: null,
+          pros_cons: null,
+        },
+      });
+
+      const row = entryRow(entry.id);
+      expect(row.entry_time).toBeNull();
+      expect(row.location_lat).toBeNull();
+      expect(row.location_lng).toBeNull();
+      expect(row.weather).toBeNull();
+      expect(row.tags).toBeNull();
+      expect(row.pros_cons).toBeNull();
+      // Untouched: the service only writes the keys it was handed.
+      expect(row.title).toBe('Vik');
+      expect(row.location_name).toBe('Reynisfjara');
+    });
+  });
+
+  it('update_journey_entry refuses an unknown visibility and an out-of-range longitude', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await seedJourney(h);
+      const entry = await seedEntry(h, journey.id);
+      for (const bad of [{ visibility: 'friends' }, { location_lng: 181 }, { type: 'note' }]) {
+        expect((await h.client.callTool({
+          name: 'update_journey_entry', arguments: { entryId: entry.id, ...bad },
+        })).isError).toBe(true);
+      }
+      // And none of the refusals touched the row.
+      const row = entryRow(entry.id);
+      expect(row.visibility).toBe('private');
+      expect(row.location_lng).toBeNull();
+    });
+  });
+});
+
+describe('Tool: get_journey_stats', () => {
+  async function twoStopJourney(h: McpHarness) {
+    const journey = await seedJourney(h);
+    await seedEntry(h, journey.id, { title: 'Paris', entry_date: '2026-07-01', location_lat: 48.85, location_lng: 2.35 });
+    await seedEntry(h, journey.id, { title: 'Berlin', entry_date: '2026-07-04', location_lat: 52.52, location_lng: 13.4 });
+    return journey;
+  }
+
+  it('answers with the distance, days and countries get_journey does not carry', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await twoStopJourney(h);
+
+      const data = parseToolResult(await h.client.callTool({
+        name: 'get_journey_stats', arguments: { journeyId: journey.id },
+      })) as any;
+
+      // Paris to Berlin is about 880km great-circle, and the figure is metres.
+      expect(data.stats.distance).toBeGreaterThan(800_000);
+      expect(data.stats.distance).toBeLessThan(950_000);
+      expect(data.stats.days).toBe(4);
+      expect(data.stats.steps).toBe(2);
+      expect(data.stats.countries.map((c: any) => c.code)).toEqual(['FR', 'DE']);
+      expect(data.stats.start).toBe('2026-07-01');
+      expect(data.stats.end).toBe('2026-07-04');
+
+      // get_journey still answers with the three counts and nothing more.
+      const full = parseToolResult(await h.client.callTool({
+        name: 'get_journey', arguments: { journeyId: journey.id },
+      })) as any;
+      expect(Object.keys(full.journey.stats).sort()).toEqual(['entries', 'photos', 'places']);
+    });
+  });
+
+  it('leaves the route out unless include_route asks for it', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const journey = await twoStopJourney(h);
+
+      const lean = parseToolResult(await h.client.callTool({
+        name: 'get_journey_stats', arguments: { journeyId: journey.id },
+      })) as any;
+      expect(lean.stats.points).toBeUndefined();
+
+      const full = parseToolResult(await h.client.callTool({
+        name: 'get_journey_stats', arguments: { journeyId: journey.id, include_route: true },
+      })) as any;
+      expect(full.stats.points).toHaveLength(2);
+      expect(full.stats.points.map((p: any) => p.label)).toEqual(['Paris', 'Berlin']);
+      expect(full.stats.points[0].country).toBe('FR');
+    });
+  });
+
+  it('refuses a journey the caller cannot see', async () => {
+    const { user } = createUser(testDb);
+    const { journeyId } = foreignJourney();
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.callTool({
+        name: 'get_journey_stats', arguments: { journeyId },
+      })).isError).toBe(true);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-memories.test.ts
+++ b/server/tests/unit/mcp/tools-memories.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Unit tests for the memories (photo provider) MCP tools and the journey
+ * provider-photo attach they feed.
+ *
+ * The provider calls themselves are spied on the service prototypes: the real
+ * methods talk HTTP to an Immich or Synology box, and what these cases are about
+ * is the layer above that, the provider gate, the argument coercion each REST
+ * route performs, and what lands in the DB.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+const { broadcastMock } = vi.hoisted(() => ({ broadcastMock: vi.fn() }));
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock, broadcastToUser: broadcastMock }));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb, setAddonEnabled } from '../../helpers/test-db';
+import { createUser, createJourney, createJourneyEntry, addJourneyContributor } from '../../helpers/factories';
+import { ADDON_IDS } from '../../../src/addons';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { ImmichService } from '../../../src/nest/memories/immich.service';
+import { SynologyService } from '../../../src/nest/memories/synology.service';
+import { PhotoCaptureBackfillService } from '../../../src/nest/memories/photo-capture-backfill.service';
+
+const immichSearch = vi.spyOn(ImmichService.prototype, 'searchPhotos');
+const immichAlbums = vi.spyOn(ImmichService.prototype, 'listAlbums');
+const immichAlbumPhotos = vi.spyOn(ImmichService.prototype, 'getAlbumPhotos');
+const synologySearch = vi.spyOn(SynologyService.prototype, 'searchSynologyPhotos');
+const synologyAlbums = vi.spyOn(SynologyService.prototype, 'listSynologyAlbums');
+const synologyAlbumPhotos = vi.spyOn(SynologyService.prototype, 'getSynologyAlbumPhotos');
+// Detached in production; held still here so a case can assert what was queued
+// without the provider lookup it would otherwise fire.
+const backfillSchedule = vi.spyOn(PhotoCaptureBackfillService.prototype, 'schedule').mockImplementation(() => {});
+
+const IMMICH_ASSET = { id: 'a1', takenAt: '2026-07-01T10:00:00.000Z', city: 'Rome', country: 'IT', lat: 41.9, lng: 12.5, mediaType: 'image' };
+const SYNOLOGY_ASSET = { id: 's1', takenAt: '2026-07-02T10:00:00.000Z', lat: 48.1, lng: 11.6 };
+
+/**
+ * photo_providers is seed data, so resetTestDb leaves it alone and a toggle
+ * leaks into the next case. Every case states what it needs.
+ */
+function setProviderEnabled(id: string, enabled: boolean): void {
+  testDb.prepare(
+    'INSERT INTO photo_providers (id, name, enabled) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET enabled = excluded.enabled',
+  ).run(id, id, enabled ? 1 : 0);
+}
+
+function removeProvider(id: string): void {
+  testDb.prepare('DELETE FROM photo_providers WHERE id = ?').run(id);
+}
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  setAddonEnabled(testDb, ADDON_IDS.JOURNEY, true);
+  setProviderEnabled('immich', true);
+  setProviderEnabled('synologyphotos', true);
+  broadcastMock.mockClear();
+  delete process.env.DEMO_MODE;
+
+  immichSearch.mockReset().mockResolvedValue({ assets: [IMMICH_ASSET], hasMore: false });
+  immichAlbums.mockReset().mockResolvedValue({ albums: [{ id: 'alb-1', albumName: 'Rome', assetCount: 2 }] });
+  immichAlbumPhotos.mockReset().mockResolvedValue({ assets: [IMMICH_ASSET] });
+  synologySearch.mockReset().mockResolvedValue({ success: true, data: { assets: [SYNOLOGY_ASSET], total: 1, hasMore: false } });
+  synologyAlbums.mockReset().mockResolvedValue({ success: true, data: { albums: [{ id: '7', albumName: 'Munich', assetCount: 3, passphrase: 'pp' }] } });
+  synologyAlbumPhotos.mockReset().mockResolvedValue({ success: true, data: { assets: [SYNOLOGY_ASSET], total: 1, hasMore: false } });
+  backfillSchedule.mockClear();
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>, scopes?: string[] | null) {
+  const h = await createMcpHarness({ userId, withResources: false, scopes: scopes ?? null });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// search_provider_photos
+// ---------------------------------------------------------------------------
+
+describe('Tool: search_provider_photos', () => {
+  it('searches Immich with the page and size coercion the REST route applies', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'immich', from: '2026-07-01', to: '2026-07-31' },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect(data.provider).toBe('immich');
+      expect(data.assets).toEqual([IMMICH_ASSET]);
+      expect(data.hasMore).toBe(false);
+      expect(immichSearch).toHaveBeenCalledWith(user.id, '2026-07-01', '2026-07-31', 1, 50);
+    });
+  });
+
+  it('turns a 1-based page into the offset Synology paginates by', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'synologyphotos', page: 3, size: 20 },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect(data.assets).toEqual([SYNOLOGY_ASSET]);
+      expect(data.total).toBe(1);
+      expect(synologySearch).toHaveBeenCalledWith(user.id, undefined, undefined, 40, 20);
+    });
+  });
+
+  it('defaults Synology to its own page size, not Immich\'s', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'search_provider_photos', arguments: { provider: 'synologyphotos' } });
+      expect(synologySearch).toHaveBeenCalledWith(user.id, undefined, undefined, 0, 100);
+    });
+  });
+
+  it('refuses a provider the admin has switched off, without calling it', async () => {
+    const { user } = createUser(testDb);
+    setProviderEnabled('synologyphotos', false);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'synologyphotos' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toContain('is not enabled, contact server administrator');
+      expect(synologySearch).not.toHaveBeenCalled();
+    });
+  });
+
+  it('refuses a provider that is not in the provider table at all', async () => {
+    const { user } = createUser(testDb);
+    removeProvider('synologyphotos');
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'synologyphotos' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toContain('is not supported');
+      expect(synologySearch).not.toHaveBeenCalled();
+    });
+  });
+
+  it('passes the upstream refusal through verbatim', async () => {
+    const { user } = createUser(testDb);
+    immichSearch.mockResolvedValue({ error: 'Immich not configured', status: 400 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'search_provider_photos', arguments: { provider: 'immich' } });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Immich not configured');
+    });
+  });
+
+  it('rejects a page size past the cap instead of quietly clamping it', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'immich', size: 500 },
+      });
+      expect(result.isError).toBe(true);
+      expect(immichSearch).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects an unknown provider name at the schema', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_provider_photos',
+        arguments: { provider: 'google-photos' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('is not registered when every photo provider is switched off', async () => {
+    const { user } = createUser(testDb);
+    setProviderEnabled('immich', false);
+    setProviderEnabled('synologyphotos', false);
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).not.toContain('search_provider_photos');
+      expect(names).not.toContain('list_provider_albums');
+      expect(names).not.toContain('list_provider_album_photos');
+    });
+  });
+
+  it('is registered again as soon as one provider is on', async () => {
+    const { user } = createUser(testDb);
+    setProviderEnabled('immich', true);
+    setProviderEnabled('synologyphotos', false);
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).toContain('search_provider_photos');
+    });
+  });
+
+  it('is not registered for a token without journey read access', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).not.toContain('search_provider_photos');
+    }, ['trips:read']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_provider_albums
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_provider_albums', () => {
+  it('lists the Immich albums', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'list_provider_albums', arguments: { provider: 'immich' },
+      })) as any;
+      expect(data.albums).toEqual([{ id: 'alb-1', albumName: 'Rome', assetCount: 2 }]);
+      expect(immichAlbums).toHaveBeenCalledWith(user.id);
+    });
+  });
+
+  it('keeps the passphrase a shared Synology album needs to be opened again', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'list_provider_albums', arguments: { provider: 'synologyphotos' },
+      })) as any;
+      expect(data.albums[0].passphrase).toBe('pp');
+    });
+  });
+
+  it('refuses a disabled provider', async () => {
+    const { user } = createUser(testDb);
+    setProviderEnabled('immich', false);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_provider_albums', arguments: { provider: 'immich' } });
+      expect(result.isError).toBe(true);
+      expect(immichAlbums).not.toHaveBeenCalled();
+    });
+  });
+
+  it('passes the upstream refusal through', async () => {
+    const { user } = createUser(testDb);
+    synologyAlbums.mockResolvedValue({ success: false, error: { message: 'Synology not configured', status: 400 } });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_provider_albums', arguments: { provider: 'synologyphotos' } });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Synology not configured');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_provider_album_photos
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_provider_album_photos', () => {
+  it('reads one Immich album', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'list_provider_album_photos', arguments: { provider: 'immich', album_id: 'alb-1' },
+      })) as any;
+      expect(data.album_id).toBe('alb-1');
+      expect(data.assets).toEqual([IMMICH_ASSET]);
+      expect(immichAlbumPhotos).toHaveBeenCalledWith(user.id, 'alb-1');
+    });
+  });
+
+  it('forwards the passphrase to Synology', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'list_provider_album_photos',
+        arguments: { provider: 'synologyphotos', album_id: '7', passphrase: 'pp' },
+      });
+      expect(synologyAlbumPhotos).toHaveBeenCalledWith(user.id, '7', 'pp');
+    });
+  });
+
+  it('refuses a disabled provider', async () => {
+    const { user } = createUser(testDb);
+    setProviderEnabled('synologyphotos', false);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_provider_album_photos', arguments: { provider: 'synologyphotos', album_id: '7' },
+      });
+      expect(result.isError).toBe(true);
+      expect(synologyAlbumPhotos).not.toHaveBeenCalled();
+    });
+  });
+
+  it('passes an album that could not be fetched through as an error', async () => {
+    const { user } = createUser(testDb);
+    immichAlbumPhotos.mockResolvedValue({ error: 'Failed to fetch album', status: 404 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_provider_album_photos', arguments: { provider: 'immich', album_id: 'nope' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Failed to fetch album');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// add_journey_provider_photos
+// ---------------------------------------------------------------------------
+
+function entryPhotoRows(entryId: number) {
+  return testDb.prepare(`
+    SELECT tp.provider, tp.asset_id, tp.owner_id, tp.media_type, gp.journey_id, gp.caption
+    FROM journey_entry_photos jep
+    JOIN journey_photos gp ON gp.id = jep.journey_photo_id
+    JOIN trek_photos tp ON tp.id = gp.photo_id
+    WHERE jep.entry_id = ?
+    ORDER BY tp.asset_id
+  `).all(entryId) as Array<Record<string, unknown>>;
+}
+
+describe('Tool: add_journey_provider_photos', () => {
+  it('attaches provider assets to an entry and records them against the journey', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: {
+          journeyId: journey.id, entryId: entry.id, provider: 'immich',
+          asset_ids: ['a1', 'a2'], media_types: ['image', 'video'], caption: 'Rome day one',
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect(data.added).toBe(2);
+      expect(data.skipped).toBe(0);
+
+      const rows = entryPhotoRows(entry.id);
+      expect(rows).toHaveLength(2);
+      expect(rows.map(r => r.asset_id)).toEqual(['a1', 'a2']);
+      expect(rows.every(r => r.provider === 'immich' && r.owner_id === user.id)).toBe(true);
+      expect(rows.map(r => r.media_type)).toEqual(['image', 'video']);
+      expect(rows[0].caption).toBe('Rome day one');
+      expect(rows[0].journey_id).toBe(journey.id);
+    });
+  });
+
+  it('adds to the gallery alone when no entry is named', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const data = parseToolResult(await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: journey.id, provider: 'synologyphotos', asset_ids: ['g1'] },
+      })) as any;
+      expect(data.added).toBe(1);
+
+      const gallery = testDb.prepare(
+        'SELECT tp.asset_id, tp.provider FROM journey_photos gp JOIN trek_photos tp ON tp.id = gp.photo_id WHERE gp.journey_id = ?',
+      ).all(journey.id) as Array<Record<string, unknown>>;
+      expect(gallery).toEqual([{ asset_id: 'g1', provider: 'synologyphotos' }]);
+      expect(entryPhotoRows(entry.id)).toHaveLength(0);
+    });
+  });
+
+  it('skips an asset that is already on the entry rather than duplicating it', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const args = { journeyId: journey.id, entryId: entry.id, provider: 'immich', asset_ids: ['dup-1'] };
+      await h.client.callTool({ name: 'add_journey_provider_photos', arguments: args });
+      const second = parseToolResult(await h.client.callTool({ name: 'add_journey_provider_photos', arguments: args })) as any;
+      expect(second.added).toBe(0);
+      expect(second.skipped).toBe(1);
+      expect(entryPhotoRows(entry.id)).toHaveLength(1);
+    });
+  });
+
+  it('queues the capture backfill for what it actually attached', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: journey.id, entryId: entry.id, provider: 'immich', asset_ids: ['bf-1'] },
+      });
+      const photoId = (testDb.prepare('SELECT id FROM trek_photos WHERE asset_id = ? AND owner_id = ?').get('bf-1', user.id) as { id: number }).id;
+      expect(backfillSchedule).toHaveBeenCalledWith([photoId], user.id);
+    });
+  });
+
+  it('refuses a contributor who may only read the journey', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: viewer } = createUser(testDb);
+    const journey = createJourney(testDb, owner.id);
+    const entry = createJourneyEntry(testDb, journey.id, owner.id);
+    addJourneyContributor(testDb, journey.id, viewer.id, 'viewer');
+    await withHarness(viewer.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: journey.id, entryId: entry.id, provider: 'immich', asset_ids: ['x1'] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Journey not found or access denied.');
+      expect(entryPhotoRows(entry.id)).toHaveLength(0);
+    });
+  });
+
+  it('refuses a journey that does not exist', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: 999999, provider: 'immich', asset_ids: ['x1'] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Journey not found or access denied.');
+    });
+  });
+
+  it('refuses an entry that belongs to another journey', async () => {
+    const { user } = createUser(testDb);
+    const mine = createJourney(testDb, user.id);
+    const other = createJourney(testDb, user.id);
+    const foreignEntry = createJourneyEntry(testDb, other.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: mine.id, entryId: foreignEntry.id, provider: 'immich', asset_ids: ['x1'] },
+      });
+      expect(result.isError).toBe(true);
+      expect((result as any).content[0].text).toBe('Entry not found in this journey.');
+      expect(entryPhotoRows(foreignEntry.id)).toHaveLength(0);
+    });
+  });
+
+  it('blocks the demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: journey.id, entryId: entry.id, provider: 'immich', asset_ids: ['x1'] },
+      });
+      expect(result.isError).toBe(true);
+      expect(entryPhotoRows(entry.id)).toHaveLength(0);
+    });
+  });
+
+  it('refuses a batch past the per-call cap and writes nothing', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: {
+          journeyId: journey.id, entryId: entry.id, provider: 'immich',
+          asset_ids: Array.from({ length: 101 }, (_, i) => `cap-${i}`),
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(entryPhotoRows(entry.id)).toHaveLength(0);
+    });
+  });
+
+  it('rejects a provider the journey could never resolve', async () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_journey_provider_photos',
+        arguments: { journeyId: journey.id, provider: 'local', asset_ids: ['x1'] },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) c FROM journey_photos').get()).toEqual({ c: 0 });
+    });
+  });
+
+  it('is not registered while the journey addon is off', async () => {
+    const { user } = createUser(testDb);
+    setAddonEnabled(testDb, ADDON_IDS.JOURNEY, false);
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.listTools()).tools.map(t => t.name)).not.toContain('add_journey_provider_photos');
+    });
+  });
+
+  it('is not registered for a read-only journey token', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).not.toContain('add_journey_provider_photos');
+      expect(names).toContain('search_provider_photos');
+    }, ['journey:read']);
+  });
+});

--- a/server/tests/unit/mcp/tools-notes.test.ts
+++ b/server/tests/unit/mcp/tools-notes.test.ts
@@ -115,6 +115,52 @@ describe('Tool: create_day_note', () => {
     });
   });
 
+  it('persists a palette color and an explicit position', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, text: 'Ferry leaves early', color: '#dc2626', sort_order: 2 },
+      });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT color, sort_order FROM day_notes WHERE id = ?').get(data.note.id) as any;
+      expect(row.color).toBe('#dc2626');
+      expect(row.sort_order).toBe(2);
+    });
+  });
+
+  it('stores no color and appends at the bottom when neither is given', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, text: 'A note' },
+      });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT color, sort_order FROM day_notes WHERE id = ?').get(data.note.id) as any;
+      expect(row.color).toBeNull();
+      expect(row.sort_order).toBe(9999);
+    });
+  });
+
+  it('refuses a color outside the note palette and writes nothing', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, text: 'A note', color: '#ff0000' },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) AS n FROM day_notes WHERE day_id = ?').get(day.id)).toEqual({ n: 0 });
+    });
+  });
+
   it('returns error when day does not belong to trip', async () => {
     const { user } = createUser(testDb);
     const trip1 = createTrip(testDb, user.id);
@@ -172,6 +218,69 @@ describe('Tool: update_day_note', () => {
       });
       const data = parseToolResult(result) as any;
       expect(data.note.text).toBe('Trimmed');
+    });
+  });
+
+  it('sets color and moves the note within the day', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const note = createDayNote(testDb, day.id, trip.id, { sort_order: 9999 });
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, noteId: note.id, color: '#16a34a', sort_order: 1.5 },
+      });
+      const row = testDb.prepare('SELECT color, sort_order FROM day_notes WHERE id = ?').get(note.id) as any;
+      expect(row.color).toBe('#16a34a');
+      expect(row.sort_order).toBe(1.5);
+    });
+  });
+
+  it('clears the color with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const note = createDayNote(testDb, day.id, trip.id);
+    testDb.prepare('UPDATE day_notes SET color = ? WHERE id = ?').run('#2563eb', note.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, noteId: note.id, color: null },
+      });
+      expect((testDb.prepare('SELECT color FROM day_notes WHERE id = ?').get(note.id) as any).color).toBeNull();
+    });
+  });
+
+  it('keeps the stored color and position when neither is sent', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const note = createDayNote(testDb, day.id, trip.id, { sort_order: 3 });
+    testDb.prepare('UPDATE day_notes SET color = ? WHERE id = ?').run('#9333ea', note.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, noteId: note.id, text: 'Only the text changed' },
+      });
+      const row = testDb.prepare('SELECT color, sort_order FROM day_notes WHERE id = ?').get(note.id) as any;
+      expect(row.color).toBe('#9333ea');
+      expect(row.sort_order).toBe(3);
+    });
+  });
+
+  it('refuses a color outside the note palette', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const note = createDayNote(testDb, day.id, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_day_note',
+        arguments: { tripId: trip.id, dayId: day.id, noteId: note.id, color: 'red' },
+      });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT color FROM day_notes WHERE id = ?').get(note.id) as any).color).toBeNull();
     });
   });
 
@@ -371,6 +480,31 @@ describe('Tool: create_collab_note', () => {
     });
   });
 
+  it('persists the website link', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_collab_note',
+        arguments: { tripId: trip.id, title: 'Boat tour', website: 'https://example.com/tour' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.note.website).toBe('https://example.com/tour');
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(data.note.id) as any).website)
+        .toBe('https://example.com/tour');
+    });
+  });
+
+  it('stores no website when none is given', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_collab_note', arguments: { tripId: trip.id, title: 'Plain note' } });
+      const data = parseToolResult(result) as any;
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(data.note.id) as any).website).toBeNull();
+    });
+  });
+
   it('broadcasts collab:note:created event', async () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
@@ -409,6 +543,57 @@ describe('Tool: update_collab_note', () => {
       expect(data.note.title).toBe('New Title');
       expect(data.note.pinned).toBe(1);
       expect(data.note.color).toBe('#3b82f6');
+    });
+  });
+
+  it('sets the website link on an existing note', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const note = createCollabNote(testDb, trip.id, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_collab_note',
+        arguments: { tripId: trip.id, noteId: note.id, website: 'https://example.com/museum' },
+      });
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(note.id) as any).website)
+        .toBe('https://example.com/museum');
+    });
+  });
+
+  it('clears the website with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const note = createCollabNote(testDb, trip.id, user.id);
+    testDb.prepare('UPDATE collab_notes SET website = ? WHERE id = ?').run('https://example.com/old', note.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_collab_note', arguments: { tripId: trip.id, noteId: note.id, website: null } });
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(note.id) as any).website).toBeNull();
+    });
+  });
+
+  it('keeps the stored website when the field is not sent', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const note = createCollabNote(testDb, trip.id, user.id);
+    testDb.prepare('UPDATE collab_notes SET website = ? WHERE id = ?').run('https://example.com/keep', note.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_collab_note', arguments: { tripId: trip.id, noteId: note.id, title: 'Renamed' } });
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(note.id) as any).website)
+        .toBe('https://example.com/keep');
+    });
+  });
+
+  it('refuses a website past the tool cap, the way the sibling text fields are capped', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const note = createCollabNote(testDb, trip.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_collab_note',
+        arguments: { tripId: trip.id, noteId: note.id, website: `https://example.com/${'x'.repeat(600)}` },
+      });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT website FROM collab_notes WHERE id = ?').get(note.id) as any).website).toBeNull();
     });
   });
 

--- a/server/tests/unit/mcp/tools-packing.test.ts
+++ b/server/tests/unit/mcp/tools-packing.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unit tests for the packing MCP surface (PackingMcp, DI-discovered):
  * create_packing_item, update_packing_item, toggle_packing_item,
- * delete_packing_item, plus the registration-time scope/addon gating and the
+ * delete_packing_item, set_packing_item_sharing, plus the two bag fields that
+ * drive the fill bar, the registration-time scope/addon gating and the
  * trek://trips/{tripId}/packing + .../packing/bags resources (moved from the
  * legacy registerResources — see resources.test.ts). The advanced tools live
  * in tools-packing-advanced.test.ts.
@@ -44,7 +45,7 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createPackingItem } from '../../helpers/factories';
+import { createUser, createTrip, createPackingItem, addTripMember } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 import { ADDON_IDS } from '../../../src/addons';
 
@@ -67,6 +68,11 @@ async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>)
   const h = await createMcpHarness({ userId, withResources: false });
   try { await fn(h); } finally { await h.cleanup(); }
 }
+
+/** The text of a failed call, including the SDK's own schema-validation refusals
+ *  (which come back as an error result, not a rejection). */
+const errorText = (result: unknown) =>
+  ((result as { content?: { text?: string }[] }).content ?? []).map((c) => c.text ?? '').join(' ');
 
 // ---------------------------------------------------------------------------
 // create_packing_item
@@ -132,6 +138,109 @@ describe('Tool: create_packing_item', () => {
 });
 
 // ---------------------------------------------------------------------------
+// create_packing_item: the sharing tiers and the pre-checked flag (#858)
+//
+// A tool-made item used to land on the Common list whatever was asked for:
+// there was no way to say "this is mine" or "I'm bringing it for these two",
+// which is the whole three-tier model the REST route has taken since #858.
+// ---------------------------------------------------------------------------
+
+const itemRow = (id: number) =>
+  testDb.prepare('SELECT * FROM packing_items WHERE id = ?').get(id) as
+    { id: number; checked: number; is_private: number; owner_id: number | null; bag_id: number | null; quantity: number; weight_grams: number | null };
+
+/** The id of the item a create call just made, typed rather than cast wide open. */
+const createdItemId = (result: Parameters<typeof parseToolResult>[0]) =>
+  (parseToolResult(result) as { item: { id: number } }).item.id;
+
+const recipientIds = (itemId: number) =>
+  (testDb.prepare('SELECT user_id FROM packing_item_recipients WHERE item_id = ? ORDER BY user_id').all(itemId) as { user_id: number }[])
+    .map((r) => r.user_id);
+
+describe('Tool: create_packing_item sharing', () => {
+  it('puts a personal item on the caller\'s own list', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'Insulin pens', visibility: 'personal' },
+      });
+      const row = itemRow(createdItemId(result));
+      expect(row.is_private).toBe(1);
+      expect(row.owner_id).toBe(user.id);
+    });
+  });
+
+  it('records the recipients of a shared item and drops ids off the trip roster', async () => {
+    const { user } = createUser(testDb);
+    const { user: mate } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    addTripMember(testDb, trip.id, mate.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'Sunscreen', visibility: 'shared', recipient_ids: [mate.id, stranger.id] },
+      });
+      const itemId = createdItemId(result);
+      expect(itemRow(itemId).is_private).toBe(1);
+      expect(recipientIds(itemId)).toEqual([mate.id]);
+    });
+  });
+
+  it('honours the legacy is_private flag', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'Gift', is_private: true },
+      });
+      expect(itemRow(createdItemId(result)).is_private).toBe(1);
+    });
+  });
+
+  it('creates an already-checked item', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'Charger', checked: true },
+      });
+      expect(itemRow(createdItemId(result)).checked).toBe(1);
+    });
+  });
+
+  it('keeps a personal item off the rest of the room', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'Insulin pens', visibility: 'personal' },
+      });
+    });
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:created', expect.any(Object), undefined, user.id);
+    expect(broadcastMock).not.toHaveBeenCalledWith(trip.id, 'packing:created', expect.any(Object));
+  });
+
+  it('refuses a visibility tier that does not exist', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_packing_item',
+        arguments: { tripId: trip.id, name: 'X', visibility: 'secret' },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('visibility');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // update_packing_item
 // ---------------------------------------------------------------------------
 
@@ -178,6 +287,383 @@ describe('Tool: update_packing_item', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'update_packing_item', arguments: { tripId: trip.id, itemId: item.id, name: 'X' } });
       expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_packing_item: bag, quantity, weight and privacy
+//
+// The tool could only rename and recategorise, so an assistant could not put an
+// item in a bag at all once it existed: bag assignment was reachable only at
+// bulk_import_packing time, by bag name.
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_packing_item bag, quantity, weight, privacy', () => {
+  const makeBag = (tripId: number, name = 'Carry-On') =>
+    Number(testDb.prepare('INSERT INTO packing_bags (trip_id, name) VALUES (?, ?)').run(tripId, name).lastInsertRowid);
+
+  it('moves an item into a bag', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    const bagId = makeBag(trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, bag_id: bagId },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(itemRow(item.id).bag_id).toBe(bagId);
+    });
+  });
+
+  it('takes an item out of its bag with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    const bagId = makeBag(trip.id);
+    testDb.prepare('UPDATE packing_items SET bag_id = ? WHERE id = ?').run(bagId, item.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, bag_id: null },
+      });
+      expect(itemRow(item.id).bag_id).toBeNull();
+    });
+  });
+
+  it('sets the quantity', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, quantity: 3 },
+      });
+      expect(itemRow(item.id).quantity).toBe(3);
+    });
+  });
+
+  it('sets and clears the weight', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, weight_grams: 850 },
+      });
+      expect(itemRow(item.id).weight_grams).toBe(850);
+
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, weight_grams: null },
+      });
+      expect(itemRow(item.id).weight_grams).toBeNull();
+    });
+  });
+
+  it('leaves the bag alone when the key is omitted', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    const bagId = makeBag(trip.id);
+    testDb.prepare('UPDATE packing_items SET bag_id = ? WHERE id = ?').run(bagId, item.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, name: 'Renamed' },
+      });
+      expect(itemRow(item.id).bag_id).toBe(bagId);
+    });
+  });
+
+  it('takes a common item onto the caller\'s own list, and off everyone else\'s screen', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, is_private: true },
+      });
+    });
+    const row = itemRow(item.id);
+    expect(row.is_private).toBe(1);
+    // An unowned item is claimed by whoever privatizes it, or the visibility
+    // filter would have nobody to match.
+    expect(row.owner_id).toBe(user.id);
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:deleted', expect.any(Object));
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:created', expect.any(Object), undefined, user.id);
+  });
+
+  it('hands a private item back to the room when it goes common again', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    testDb.prepare('UPDATE packing_items SET is_private = 1, owner_id = ? WHERE id = ?').run(user.id, item.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, is_private: false },
+      });
+    });
+    expect(itemRow(item.id).is_private).toBe(0);
+    // Created first: the members who never had the row cannot apply an update to it.
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:created', expect.any(Object));
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:updated', expect.any(Object));
+  });
+
+  it('refuses a bag id that is not a number', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_packing_item',
+        arguments: { tripId: trip.id, itemId: item.id, bag_id: 'carry-on' },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('bag_id');
+      expect(itemRow(item.id).bag_id).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_packing_item_sharing (#858): the tool the surface never had
+// ---------------------------------------------------------------------------
+
+describe('Tool: set_packing_item_sharing', () => {
+  it('moves a common item onto the caller\'s own list', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'personal' },
+      });
+      expect(result.isError).toBeFalsy();
+    });
+    const row = itemRow(item.id);
+    expect(row.is_private).toBe(1);
+    expect(row.owner_id).toBe(user.id);
+  });
+
+  it('shares an item with named members and drops ids off the trip roster', async () => {
+    const { user } = createUser(testDb);
+    const { user: mate } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    addTripMember(testDb, trip.id, mate.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'shared', recipient_ids: [mate.id, stranger.id] },
+      });
+    });
+    expect(itemRow(item.id).is_private).toBe(1);
+    expect(recipientIds(item.id)).toEqual([mate.id]);
+  });
+
+  it('returns an item to the common list and forgets its recipients', async () => {
+    const { user } = createUser(testDb);
+    const { user: mate } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    addTripMember(testDb, trip.id, mate.id);
+    const item = createPackingItem(testDb, trip.id);
+    testDb.prepare('UPDATE packing_items SET is_private = 1, owner_id = ? WHERE id = ?').run(user.id, item.id);
+    testDb.prepare('INSERT INTO packing_item_recipients (item_id, user_id) VALUES (?, ?)').run(item.id, mate.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'common' },
+      });
+    });
+    expect(itemRow(item.id).is_private).toBe(0);
+    expect(recipientIds(item.id)).toEqual([]);
+  });
+
+  it('rebuilds the room\'s view: gone for everyone, back for the people who may see it', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'personal' },
+      });
+    });
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:deleted', expect.any(Object));
+    expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'packing:created', expect.any(Object), undefined, user.id);
+  });
+
+  it('lets only the owner change sharing', async () => {
+    const { user } = createUser(testDb);
+    const { user: mate } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    addTripMember(testDb, trip.id, mate.id);
+    const item = createPackingItem(testDb, trip.id);
+    testDb.prepare('UPDATE packing_items SET owner_id = ? WHERE id = ?').run(mate.id, item.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'personal' },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(itemRow(item.id).is_private).toBe(0);
+  });
+
+  it('returns error for item not found', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: 99999, visibility: 'personal' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns access denied for non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'personal' },
+      });
+      expect(result.isError).toBe(true);
+    });
+    expect(itemRow(item.id).is_private).toBe(0);
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'personal' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('refuses a visibility tier that does not exist', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const item = createPackingItem(testDb, trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_packing_item_sharing',
+        arguments: { tripId: trip.id, itemId: item.id, visibility: 'nobody' },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('visibility');
+      expect(itemRow(item.id).is_private).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_packing_bag: weight limit and owner (the values behind the fill bar)
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_packing_bag limit and owner', () => {
+  const bagRow = (id: number) =>
+    testDb.prepare('SELECT * FROM packing_bags WHERE id = ?').get(id) as
+      { id: number; name: string; weight_limit_grams: number | null; user_id: number | null };
+
+  const makeBag = (tripId: number) =>
+    Number(testDb.prepare('INSERT INTO packing_bags (trip_id, name) VALUES (?, ?)').run(tripId, 'Carry-On').lastInsertRowid);
+
+  it('sets a weight limit', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bagId = makeBag(trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_packing_bag',
+        arguments: { tripId: trip.id, bagId, weight_limit_grams: 8000 },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(bagRow(bagId).weight_limit_grams).toBe(8000);
+    });
+  });
+
+  it('lifts the limit with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bagId = makeBag(trip.id);
+    testDb.prepare('UPDATE packing_bags SET weight_limit_grams = 8000 WHERE id = ?').run(bagId);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_packing_bag',
+        arguments: { tripId: trip.id, bagId, weight_limit_grams: null },
+      });
+      expect(bagRow(bagId).weight_limit_grams).toBeNull();
+    });
+  });
+
+  it('leaves the limit alone when the key is omitted', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bagId = makeBag(trip.id);
+    testDb.prepare('UPDATE packing_bags SET weight_limit_grams = 8000 WHERE id = ?').run(bagId);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_packing_bag', arguments: { tripId: trip.id, bagId, name: 'Backpack' } });
+      const row = bagRow(bagId);
+      expect(row.name).toBe('Backpack');
+      expect(row.weight_limit_grams).toBe(8000);
+    });
+  });
+
+  it('assigns the bag to a trip member', async () => {
+    const { user } = createUser(testDb);
+    const { user: mate } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    addTripMember(testDb, trip.id, mate.id);
+    const bagId = makeBag(trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_packing_bag', arguments: { tripId: trip.id, bagId, user_id: mate.id } });
+      expect(bagRow(bagId).user_id).toBe(mate.id);
+    });
+  });
+
+  it('leaves the bag unassigned for an id off the trip roster', async () => {
+    const { user } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bagId = makeBag(trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_packing_bag', arguments: { tripId: trip.id, bagId, user_id: stranger.id } });
+      expect(bagRow(bagId).user_id).toBeNull();
+    });
+  });
+
+  it('refuses a weight limit that is not a number', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const bagId = makeBag(trip.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_packing_bag',
+        arguments: { tripId: trip.id, bagId, weight_limit_grams: '8kg' },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('weight_limit_grams');
+      expect(bagRow(bagId).weight_limit_grams).toBeNull();
     });
   });
 });
@@ -306,6 +792,7 @@ describe('Packing tools — scope gating', () => {
     'reorder_packing_items', 'create_packing_bag', 'update_packing_bag', 'delete_packing_bag',
     'set_bag_members', 'set_packing_category_assignees', 'apply_packing_template',
     'save_packing_template', 'delete_packing_template', 'bulk_import_packing',
+    'set_packing_item_sharing',
   ];
 
   async function listToolNames(userId: number, scopes: string[] | null): Promise<string[]> {
@@ -317,7 +804,7 @@ describe('Packing tools — scope gating', () => {
     }
   }
 
-  it('registers all seventeen tools with null scopes (full access)', async () => {
+  it('registers all eighteen tools with null scopes (full access)', async () => {
     const { user } = createUser(testDb);
     const names = await listToolNames(user.id, null);
     for (const tool of [...READ_TOOLS, ...WRITE_TOOLS]) expect(names).toContain(tool);

--- a/server/tests/unit/mcp/tools-places.test.ts
+++ b/server/tests/unit/mcp/tools-places.test.ts
@@ -63,6 +63,10 @@ function linkJourney(journeyId: number, tripId: number) {
 function skeletonFor(journeyId: number, placeId: number) {
   return testDb.prepare('SELECT * FROM journey_entries WHERE journey_id = ? AND source_place_id = ?').get(journeyId, placeId) as any;
 }
+/** The stored thumbnail, read off the row rather than out of the tool's echo. */
+function imageOf(placeId: number): string | null {
+  return (testDb.prepare('SELECT image_url FROM places WHERE id = ?').get(placeId) as { image_url: string | null }).image_url;
+}
 
 beforeAll(() => {
   createTables(testDb);
@@ -133,6 +137,54 @@ describe('Tool: create_place', () => {
     });
   });
 
+  it('persists image_url on the row (#37)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'create_place',
+        arguments: { tripId: trip.id, name: 'Pictured', image_url: 'https://cdn.example.com/spot.jpg' },
+      });
+    });
+
+    const row = testDb.prepare('SELECT image_url FROM places WHERE trip_id = ? AND name = ?').get(trip.id, 'Pictured') as { image_url: string };
+    expect(row.image_url).toBe('https://cdn.example.com/spot.jpg');
+  });
+
+  it('accepts the photo-proxy path the place picker hands out', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'create_place',
+        arguments: { tripId: trip.id, name: 'Proxied', image_url: '/api/maps/place-photo/ChIJabc~p0/bytes' },
+      });
+    });
+
+    const row = testDb.prepare('SELECT image_url FROM places WHERE trip_id = ? AND name = ?').get(trip.id, 'Proxied') as { image_url: string };
+    expect(row.image_url).toBe('/api/maps/place-photo/ChIJabc~p0/bytes');
+  });
+
+  // The marker builders assemble their HTML as a string, so the scheme pin is the
+  // thing standing between a stored value and the DOM. Same contract as REST.
+  it('refuses an image_url outside the four allowed shapes', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_place',
+        arguments: { tripId: trip.id, name: 'Hostile', image_url: 'javascript:alert(1)' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toMatch(/Invalid arguments/);
+    });
+
+    expect(testDb.prepare('SELECT COUNT(*) AS n FROM places WHERE trip_id = ?').get(trip.id)).toEqual({ n: 0 });
+  });
+
   it('broadcasts place:created event', async () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
@@ -195,6 +247,61 @@ describe('Tool: update_place', () => {
     });
   });
 
+  it('sets image_url on an existing place (#37)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Unpictured' });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'update_place',
+        arguments: { tripId: trip.id, placeId: place.id, image_url: 'https://cdn.example.com/new.jpg' },
+      });
+    });
+
+    expect(imageOf(place.id)).toBe('https://cdn.example.com/new.jpg');
+  });
+
+  // The service reads image_url through a `!== undefined` sentinel, so null is the
+  // only way to say "remove the picture" - an omitted field keeps the old one.
+  it('clears image_url when null is passed, and leaves it alone when omitted', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Pictured' });
+    testDb.prepare('UPDATE places SET image_url = ? WHERE id = ?').run('/uploads/places/old.jpg', place.id);
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_place', arguments: { tripId: trip.id, placeId: place.id, name: 'Renamed' } });
+      expect(imageOf(place.id)).toBe('/uploads/places/old.jpg');
+
+      const result = await h.client.callTool({
+        name: 'update_place',
+        arguments: { tripId: trip.id, placeId: place.id, image_url: null },
+      });
+      expect((parseToolResult(result) as any).place.image_url).toBeNull();
+    });
+
+    expect(imageOf(place.id)).toBeNull();
+  });
+
+  it('refuses an image_url outside the four allowed shapes', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Pictured' });
+    testDb.prepare('UPDATE places SET image_url = ? WHERE id = ?').run('https://cdn.example.com/keep.jpg', place.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_place',
+        arguments: { tripId: trip.id, placeId: place.id, image_url: 'http://insecure.example.com/x.jpg' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toMatch(/Invalid arguments/);
+    });
+
+    expect(imageOf(place.id)).toBe('https://cdn.example.com/keep.jpg');
+  });
+
   it('returns error for place not found in trip', async () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
@@ -250,6 +357,45 @@ describe('Tool: bulk_update_places', () => {
       const updates = broadcastMock.mock.calls.filter((c) => c[1] === 'place:updated');
       expect(updates).toHaveLength(2);
     });
+  });
+
+  it('sets the same image_url on every listed place (#37)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const a = createPlace(testDb, trip.id, { name: 'A' });
+    const b = createPlace(testDb, trip.id, { name: 'B' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'bulk_update_places',
+        arguments: { tripId: trip.id, placeIds: [a.id, b.id], image_url: 'https://cdn.example.com/batch.jpg' },
+      });
+      expect((parseToolResult(result) as any).count).toBe(2);
+    });
+
+    expect(imageOf(a.id)).toBe('https://cdn.example.com/batch.jpg');
+    expect(imageOf(b.id)).toBe('https://cdn.example.com/batch.jpg');
+  });
+
+  // A lone null still counts as a field, which is what makes "strip the pictures
+  // off these eighty places" reachable in one call.
+  it('strips the pictures off a batch when image_url is null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const a = createPlace(testDb, trip.id, { name: 'A' });
+    const b = createPlace(testDb, trip.id, { name: 'B' });
+    testDb.prepare('UPDATE places SET image_url = ? WHERE id IN (?, ?)').run('https://cdn.example.com/old.jpg', a.id, b.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'bulk_update_places',
+        arguments: { tripId: trip.id, placeIds: [a.id, b.id], image_url: null },
+      });
+      expect((parseToolResult(result) as any).count).toBe(2);
+    });
+
+    expect(imageOf(a.id)).toBeNull();
+    expect(imageOf(b.id)).toBeNull();
   });
 
   it('errors when no update fields are provided', async () => {
@@ -380,6 +526,20 @@ describe('Tool: create_and_assign_place', () => {
       expect(skeleton.title).toBe('Fresh POI');
     });
   });
+
+  it('persists image_url on the place it creates (#37)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = parseToolResult(await h.client.callTool({
+        name: 'create_and_assign_place',
+        arguments: { tripId: trip.id, dayId: day.id, name: 'Pictured', image_url: 'https://cdn.example.com/day.jpg' },
+      })) as any;
+      expect(imageOf(result.place.id)).toBe('https://cdn.example.com/day.jpg');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -399,7 +559,7 @@ describe('Tool: search_place', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'search_place', arguments: { query: 'Eiffel Tower' } });
       const data = parseToolResult(result) as any;
-      expect(searchPlacesMock).toHaveBeenCalledWith(user.id, 'Eiffel Tower');
+      expect(searchPlacesMock).toHaveBeenCalledWith(user.id, 'Eiffel Tower', undefined, undefined);
       expect(data.places).toHaveLength(1);
       expect(data.places[0].osm_id).toBe('node:12345');
       expect(data.places[0].name).toBe('Eiffel Tower');
@@ -419,7 +579,7 @@ describe('Tool: search_place', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'search_place', arguments: { query: 'Eiffel Tower' } });
       const data = parseToolResult(result) as any;
-      expect(searchPlacesMock).toHaveBeenCalledWith(user.id, 'Eiffel Tower');
+      expect(searchPlacesMock).toHaveBeenCalledWith(user.id, 'Eiffel Tower', undefined, undefined);
       expect(data.places).toHaveLength(1);
       expect(data.places[0].google_place_id).toBe('ChIJD3uTd9hx5kcR1IQvGfr8dbk');
       expect(data.places[0].name).toBe('Eiffel Tower');
@@ -434,6 +594,57 @@ describe('Tool: search_place', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'search_place', arguments: { query: 'something' } });
       expect(result.isError).toBe(true);
+    });
+  });
+
+  // Without the bias a bare name resolves wherever the provider guesses, which is
+  // how "Central Station" used to come back from the wrong continent (#32).
+  it('forwards locationBias and lang to the provider', async () => {
+    const { user } = createUser(testDb);
+    searchPlacesMock.mockResolvedValue({ source: 'google', places: [] });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'search_place',
+        arguments: {
+          query: 'Central Station',
+          locationBias: { lat: 35.6812, lng: 139.7671, radius: 8000 },
+          lang: 'ja',
+        },
+      });
+      expect(searchPlacesMock).toHaveBeenCalledWith(
+        user.id,
+        'Central Station',
+        'ja',
+        { lat: 35.6812, lng: 139.7671, radius: 8000 },
+      );
+    });
+  });
+
+  it('accepts a bias without an explicit radius', async () => {
+    const { user } = createUser(testDb);
+    searchPlacesMock.mockResolvedValue({ source: 'google', places: [] });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'search_place',
+        arguments: { query: 'Museum of Modern Art', locationBias: { lat: 40.7614, lng: -73.9776 } },
+      });
+      expect(searchPlacesMock).toHaveBeenCalledWith(user.id, 'Museum of Modern Art', undefined, { lat: 40.7614, lng: -73.9776 });
+    });
+  });
+
+  it('refuses a locationBias that is missing a coordinate', async () => {
+    const { user } = createUser(testDb);
+    searchPlacesMock.mockResolvedValue({ source: 'google', places: [] });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_place',
+        arguments: { query: 'Anywhere', locationBias: { lat: 48.8584 } },
+      });
+      expect(result.isError).toBe(true);
+      expect(searchPlacesMock).not.toHaveBeenCalled();
     });
   });
 });
@@ -679,7 +890,7 @@ describe('Tool: import_places_from_url', () => {
       });
       const data = parseToolResult(result) as any;
       expect(data).toMatchObject({ count: 2, listName: 'Weekend', skipped: 3 });
-      expect(spy).toHaveBeenCalledWith(String(trip.id), 'https://maps.app.goo.gl/x');
+      expect(spy).toHaveBeenCalledWith(String(trip.id), 'https://maps.app.goo.gl/x', { enrich: false, userId: user.id });
       expect(broadcastMock).toHaveBeenCalledTimes(2);
     });
     spy.mockRestore();
@@ -701,6 +912,58 @@ describe('Tool: import_places_from_url', () => {
     spy.mockRestore();
   });
 
+  // enrichImportedList guards on `opts?.enrich && opts.userId`, so without the
+  // third argument the enrichment branch was structurally unreachable (#38).
+  it('passes enrich and the calling user through to the google importer', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const spy = vi.spyOn(PlacesService.prototype, 'importGoogleList').mockResolvedValue({
+      places: [], listName: 'Weekend', skipped: 0,
+    });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'import_places_from_url',
+        arguments: { tripId: trip.id, url: 'https://maps.app.goo.gl/x', source: 'google-list', enrich: true },
+      });
+      expect(spy).toHaveBeenCalledWith(String(trip.id), 'https://maps.app.goo.gl/x', { enrich: true, userId: user.id });
+    });
+    spy.mockRestore();
+  });
+
+  it('passes enrich through to the naver importer too', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const spy = vi.spyOn(PlacesService.prototype, 'importNaverList').mockResolvedValue({
+      places: [], listName: 'Seoul', skipped: 0,
+    });
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'import_places_from_url',
+        arguments: { tripId: trip.id, url: 'https://naver.me/x', source: 'naver-list', enrich: true },
+      });
+      expect(spy).toHaveBeenCalledWith(String(trip.id), 'https://naver.me/x', { enrich: true, userId: user.id });
+    });
+    spy.mockRestore();
+  });
+
+  it('refuses a non-boolean enrich', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const spy = vi.spyOn(PlacesService.prototype, 'importGoogleList');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'import_places_from_url',
+        arguments: { tripId: trip.id, url: 'https://maps.app.goo.gl/x', source: 'google-list', enrich: 'yes' },
+      });
+      expect(result.isError).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    });
+    spy.mockRestore();
+  });
+
   it('returns access denied for non-member', async () => {
     const { user } = createUser(testDb);
     const { user: other } = createUser(testDb);
@@ -710,6 +973,103 @@ describe('Tool: import_places_from_url', () => {
         name: 'import_places_from_url',
         arguments: { tripId: trip.id, url: 'https://maps.app.goo.gl/x', source: 'google-list' },
       });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// export_trip_gpx (#39)
+// ---------------------------------------------------------------------------
+
+describe('Tool: export_trip_gpx', () => {
+  it('writes the trip places as waypoints and names the file after the trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris Weekend' });
+    createPlace(testDb, trip.id, { name: 'Eiffel Tower', lat: 48.8584, lng: 2.2945 });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'export_trip_gpx', arguments: { tripId: trip.id } });
+      const data = parseToolResult(result) as { gpx: string; filename: string };
+      expect(data.filename).toBe('Paris-Weekend.gpx');
+      expect(data.gpx).toContain('<wpt');
+      expect(data.gpx).toContain('Eiffel Tower');
+      expect(data.gpx).toContain('48.8584');
+    });
+  });
+
+  it('writes each planned day as a route through its stops in order', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris Weekend' });
+    const first = createPlace(testDb, trip.id, { name: 'Louvre', lat: 48.8606, lng: 2.3376 });
+    const second = createPlace(testDb, trip.id, { name: 'Notre Dame', lat: 48.8530, lng: 2.3499 });
+    const day = createDay(testDb, trip.id);
+    createDayAssignment(testDb, day.id, first.id);
+    createDayAssignment(testDb, day.id, second.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'export_trip_gpx', arguments: { tripId: trip.id } });
+      const data = parseToolResult(result) as { gpx: string };
+      expect(data.gpx).toContain('<rte>');
+      expect(data.gpx.indexOf('Louvre')).toBeLessThan(data.gpx.indexOf('Notre Dame'));
+    });
+  });
+
+  it('honours the three selection flags', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris Weekend' });
+    const first = createPlace(testDb, trip.id, { name: 'Louvre', lat: 48.8606, lng: 2.3376 });
+    const second = createPlace(testDb, trip.id, { name: 'Notre Dame', lat: 48.8530, lng: 2.3499 });
+    const day = createDay(testDb, trip.id);
+    createDayAssignment(testDb, day.id, first.id);
+    createDayAssignment(testDb, day.id, second.id);
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'export_trip_gpx',
+        arguments: { tripId: trip.id, waypoints: false, tracks: false },
+      });
+      const data = parseToolResult(result) as { gpx: string };
+      expect(data.gpx).not.toContain('<wpt');
+      expect(data.gpx).toContain('<rte>');
+    });
+  });
+
+  it('errors when every export type is switched off', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris Weekend' });
+    createPlace(testDb, trip.id, { name: 'Eiffel Tower' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'export_trip_gpx',
+        arguments: { tripId: trip.id, waypoints: false, tracks: false, dayRoutes: false },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toBe('No export types selected.');
+    });
+  });
+
+  // An empty document imports as nothing on the other end, so say so instead.
+  it('errors when the trip has nothing to write', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Empty' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'export_trip_gpx', arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toBe('Nothing to export.');
+    });
+  });
+
+  it('returns access denied for a non-member', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, other.id);
+    createPlace(testDb, trip.id, { name: 'Theirs' });
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'export_trip_gpx', arguments: { tripId: trip.id } });
       expect(result.isError).toBe(true);
     });
   });

--- a/server/tests/unit/mcp/tools-reservations.test.ts
+++ b/server/tests/unit/mcp/tools-reservations.test.ts
@@ -592,6 +592,23 @@ describe('Tool: set_reservation_travelers', () => {
       });
       const data = parseToolResult(result) as any;
       expect(data.travelers.map((t: any) => t.user_id)).toEqual([owner.id]);
+      // A caller that guessed an id for a name it could not resolve is told so
+      // rather than getting a plain success with a shorter list.
+      expect(data.ignored_user_ids).toEqual([outsider.id]);
+    });
+  });
+
+  it('says nothing about ignored ids when every id was on the trip', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.ignored_user_ids).toBeUndefined();
     });
   });
 

--- a/server/tests/unit/mcp/tools-reservations.test.ts
+++ b/server/tests/unit/mcp/tools-reservations.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createDay, createPlace, createReservation, createDayAssignment, addTripMember } from '../../helpers/factories';
+import { createUser, createTrip, createDay, createPlace, createReservation, createDayAssignment, createDayAccommodation, createCategory, addTripMember } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 
 beforeAll(() => {
@@ -489,8 +489,8 @@ describe('Resource: trek://trips/{tripId}/reservations', () => {
 // Reads already hydrate a booking's travellers; there was no way to write them,
 // so an imported booking could not record who was on it. The roster filter lives
 // in the service, so the cases below pin that an off-trip id is dropped rather
-// than attached, and that a guest — the only representation of a companion
-// without an account — is assignable like any member.
+// than attached, and that a guest, the only representation of a companion
+// without an account, is assignable like any member.
 // ---------------------------------------------------------------------------
 
 describe('Tool: set_reservation_travelers', () => {
@@ -785,6 +785,111 @@ describe('Reservation tools: url and reservation_end_time', () => {
         arguments: { tripId: trip.id, reservationId: reservation.id, url: 'https://flix.example/booking/8892' },
       });
       expect(testDb.prepare('SELECT url FROM reservations WHERE id = ?').get(reservation.id)).toEqual({ url: 'https://flix.example/booking/8892' });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_upcoming_reservations
+//
+// The one cross-trip read here. GET /api/reservations/upcoming scopes itself in
+// SQL (owned or joined, not archived) rather than through verifyTripAccess, so
+// the visibility cases below are the access test for this tool. The hotel arm is
+// the part no per-trip list can stand in for: a stay contributes a check-in and
+// a check-out moment that exist in day_accommodations, not in reservations.
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_upcoming_reservations', () => {
+  function dateInDays(days: number): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + days);
+    return d.toISOString().slice(0, 10);
+  }
+
+  function seedBooking(
+    tripId: number,
+    title: string,
+    time: string | null,
+    extra: Partial<{ type: string; status: string }> = {},
+  ): number {
+    return Number(testDb.prepare(
+      'INSERT INTO reservations (trip_id, title, type, status, reservation_time) VALUES (?, ?, ?, ?, ?)',
+    ).run(tripId, title, extra.type ?? 'restaurant', extra.status ?? 'pending', time).lastInsertRowid);
+  }
+
+  async function upcoming(userId: number, args: Record<string, unknown> = {}) {
+    let out: { title: string; type: string; trip_id: number }[] = [];
+    await withHarness(userId, async (h) => {
+      const data = parseToolResult(await h.client.callTool({ name: 'list_upcoming_reservations', arguments: args })) as {
+        reservations: { title: string; type: string; trip_id: number }[];
+      };
+      out = data.reservations;
+    });
+    return out;
+  }
+
+  it('spans every trip the user can see, soonest first, and stops at the trips they cannot', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const owned = createTrip(testDb, user.id);
+    const joined = createTrip(testDb, other.id);
+    const stranger = createTrip(testDb, other.id);
+    addTripMember(testDb, joined.id, user.id);
+
+    seedBooking(owned.id, 'Flight to Paris', `${dateInDays(4)}T08:00:00`, { type: 'flight' });
+    seedBooking(joined.id, 'Group dinner', `${dateInDays(2)}T19:00:00`);
+    seedBooking(stranger.id, 'Not mine', `${dateInDays(1)}T07:00:00`);
+
+    const rows = await upcoming(user.id);
+    expect(rows.map((r) => r.title)).toEqual(['Group dinner', 'Flight to Paris']);
+  });
+
+  it('reports a hotel stay as its check-in and check-out moments', async () => {
+    const { user } = createUser(testDb);
+    createCategory(testDb);
+    const trip = createTrip(testDb, user.id);
+    const arrival = createDay(testDb, trip.id, { date: dateInDays(3) });
+    const departure = createDay(testDb, trip.id, { date: dateInDays(6) });
+    const hotel = createPlace(testDb, trip.id, { name: 'Hotel Astoria' });
+    createDayAccommodation(testDb, trip.id, hotel.id, arrival.id, departure.id, { check_in: '15:00', check_out: '11:00' });
+
+    const rows = await upcoming(user.id);
+    expect(rows.map((r) => [r.type, r.title])).toEqual([
+      ['checkin', 'Hotel Astoria'],
+      ['checkout', 'Hotel Astoria'],
+    ]);
+  });
+
+  it('leaves out cancelled bookings and archived trips', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const archived = createTrip(testDb, user.id);
+    testDb.prepare('UPDATE trips SET is_archived = 1 WHERE id = ?').run(archived.id);
+
+    seedBooking(trip.id, 'Still on', `${dateInDays(2)}T12:00:00`);
+    seedBooking(trip.id, 'Called off', `${dateInDays(1)}T12:00:00`, { status: 'cancelled' });
+    seedBooking(archived.id, 'Last year', `${dateInDays(3)}T12:00:00`);
+
+    const rows = await upcoming(user.id);
+    expect(rows.map((r) => r.title)).toEqual(['Still on']);
+  });
+
+  it('returns the dashboard six by default and honours a limit', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    for (let i = 1; i <= 8; i++) seedBooking(trip.id, `Booking ${i}`, `${dateInDays(i)}T09:00:00`);
+
+    expect((await upcoming(user.id)).map((r) => r.title)).toEqual([
+      'Booking 1', 'Booking 2', 'Booking 3', 'Booking 4', 'Booking 5', 'Booking 6',
+    ]);
+    expect((await upcoming(user.id, { limit: 2 })).map((r) => r.title)).toEqual(['Booking 1', 'Booking 2']);
+  });
+
+  it('refuses a limit outside the allowed range', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_upcoming_reservations', arguments: { limit: 0 } });
+      expect(result.isError).toBe(true);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-reservations.test.ts
+++ b/server/tests/unit/mcp/tools-reservations.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, createDay, createPlace, createReservation, createDayAssignment } from '../../helpers/factories';
+import { createUser, createTrip, createDay, createPlace, createReservation, createDayAssignment, addTripMember } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 
 beforeAll(() => {
@@ -479,6 +479,179 @@ describe('Resource: trek://trips/{tripId}/reservations', () => {
       const result = await h.client.readResource({ uri: `trek://trips/${trip.id}/reservations` });
       const data = parseResourceResult(result) as { error?: string };
       expect(data.error).toBeTruthy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_reservation_travelers (#1517)
+//
+// Reads already hydrate a booking's travellers; there was no way to write them,
+// so an imported booking could not record who was on it. The roster filter lives
+// in the service, so the cases below pin that an off-trip id is dropped rather
+// than attached, and that a guest — the only representation of a companion
+// without an account — is assignable like any member.
+// ---------------------------------------------------------------------------
+
+describe('Tool: set_reservation_travelers', () => {
+  async function makeBooking(h: McpHarness, tripId: number): Promise<number> {
+    const created = await h.client.callTool({
+      name: 'create_reservation',
+      arguments: { tripId, type: 'event', title: 'Concert' },
+    });
+    return (parseToolResult(created) as any).reservation.id;
+  }
+
+  it('sets the travellers on a booking', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: friend } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id, friend.id] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.travelers.map((t: any) => t.user_id).sort()).toEqual([owner.id, friend.id].sort());
+      const rows = testDb.prepare('SELECT user_id FROM reservation_travelers WHERE reservation_id = ?').all(reservationId) as any[];
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  it('assigns a guest, who has no account to look up', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestResult = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: 'Anna' },
+      });
+      const guestId = (parseToolResult(guestResult) as any).member.id;
+      const reservationId = await makeBooking(h, trip.id);
+
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [guestId] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.travelers).toHaveLength(1);
+      expect(data.travelers[0].username).toBe('Anna');
+      expect(data.travelers[0].is_guest).toBeTruthy();
+    });
+  });
+
+  it('replaces the previous list rather than adding to it', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: friend } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, friend.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id, friend.id] },
+      });
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [friend.id] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.travelers.map((t: any) => t.user_id)).toEqual([friend.id]);
+    });
+  });
+
+  it('clears the list on an empty array', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id] },
+      });
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [] },
+      });
+      expect((parseToolResult(result) as any).travelers).toEqual([]);
+      expect(testDb.prepare('SELECT user_id FROM reservation_travelers WHERE reservation_id = ?').all(reservationId)).toEqual([]);
+    });
+  });
+
+  it('drops a user who is not on the trip instead of attaching them', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id, outsider.id] },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.travelers.map((t: any) => t.user_id)).toEqual([owner.id]);
+    });
+  });
+
+  it('broadcasts reservation:travelers-updated', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, trip.id);
+      broadcastMock.mockClear();
+      await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [owner.id] },
+      });
+      expect(broadcastMock).toHaveBeenCalledWith(
+        trip.id,
+        'reservation:travelers-updated',
+        expect.objectContaining({ reservationId }),
+      );
+    });
+  });
+
+  it('404s a booking of another trip', async () => {
+    const { user: owner } = createUser(testDb);
+    const ownTrip = createTrip(testDb, owner.id);
+    const otherTrip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const reservationId = await makeBooking(h, otherTrip.id);
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: ownTrip.id, reservationId, user_ids: [owner.id] },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns access denied for a non-member', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    let reservationId = 0;
+    await withHarness(owner.id, async (h) => { reservationId = await makeBooking(h, trip.id); });
+    await withHarness(outsider.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId, user_ids: [outsider.id] },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'set_reservation_travelers',
+        arguments: { tripId: trip.id, reservationId: 1, user_ids: [] },
+      });
+      expect(result.isError).toBe(true);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-reservations.test.ts
+++ b/server/tests/unit/mcp/tools-reservations.test.ts
@@ -672,3 +672,119 @@ describe('Tool: set_reservation_travelers', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// The booking link and the end time
+//
+// Both are persisted on create and update and rendered by the planner; neither
+// was in any tool schema, so an imported booking arrived without its
+// confirmation link and a dinner could only carry a start.
+// ---------------------------------------------------------------------------
+
+describe('Reservation tools: url and reservation_end_time', () => {
+  it('stores the booking link on create', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_reservation',
+        arguments: {
+          tripId: trip.id, type: 'restaurant', title: 'Dinner',
+          url: 'https://example.com/booking/abc123',
+        },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.reservation.url).toBe('https://example.com/booking/abc123');
+      const row = testDb.prepare('SELECT url FROM reservations WHERE id = ?').get(data.reservation.id) as any;
+      expect(row.url).toBe('https://example.com/booking/abc123');
+    });
+  });
+
+  it('stores an end time on a non-transport booking', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_reservation',
+        arguments: {
+          tripId: trip.id, type: 'restaurant', title: 'Dinner',
+          reservation_time: '2025-06-01T19:00:00', reservation_end_time: '2025-06-01T21:30:00',
+        },
+      });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT reservation_time, reservation_end_time FROM reservations WHERE id = ?').get(data.reservation.id) as any;
+      expect(row.reservation_time).toBe('2025-06-01T19:00:00');
+      expect(row.reservation_end_time).toBe('2025-06-01T21:30:00');
+    });
+  });
+
+  it('updates the link and the end time on an existing booking', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_reservation',
+        arguments: { tripId: trip.id, type: 'tour', title: 'Walking tour' },
+      });
+      const { reservation } = parseToolResult(created) as { reservation: { id: number } };
+
+      await h.client.callTool({
+        name: 'update_reservation',
+        arguments: {
+          tripId: trip.id, reservationId: reservation.id,
+          url: 'https://tours.example/booking/9', reservation_end_time: '2025-06-02T16:00:00',
+        },
+      });
+      const row = testDb.prepare('SELECT url, reservation_end_time FROM reservations WHERE id = ?').get(reservation.id) as any;
+      expect(row.url).toBe('https://tours.example/booking/9');
+      expect(row.reservation_end_time).toBe('2025-06-02T16:00:00');
+    });
+  });
+
+  it('refuses a javascript: link, like the REST contract does', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_reservation',
+        arguments: { tripId: trip.id, type: 'other', title: 'Nope', url: 'javascript:alert(1)' },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) AS n FROM reservations').get()).toEqual({ n: 0 });
+    });
+  });
+
+  it('refuses a javascript: link split by a control character', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_reservation',
+        arguments: { tripId: trip.id, type: 'other', title: 'Nope', url: 'java\tscript:alert(1)' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('stores the booking link on a transport booking too', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_transport',
+        arguments: {
+          tripId: trip.id, type: 'bus', title: 'Zurich → Milan',
+          url: 'https://flix.example/booking/8891',
+        },
+      });
+      const { reservation } = parseToolResult(created) as { reservation: { id: number } };
+      expect(testDb.prepare('SELECT url FROM reservations WHERE id = ?').get(reservation.id)).toEqual({ url: 'https://flix.example/booking/8891' });
+
+      await h.client.callTool({
+        name: 'update_transport',
+        arguments: { tripId: trip.id, reservationId: reservation.id, url: 'https://flix.example/booking/8892' },
+      });
+      expect(testDb.prepare('SELECT url FROM reservations WHERE id = ?').get(reservation.id)).toEqual({ url: 'https://flix.example/booking/8892' });
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-settings.test.ts
+++ b/server/tests/unit/mcp/tools-settings.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Unit tests for the settings MCP surface (SettingsMcp):
+ * get_display_settings and update_display_settings.
+ *
+ * The security half carries the weight here. `settings` is one flat key/value
+ * table that holds display preferences next to encrypted credentials, and
+ * SettingsService.getUserSettings hands several of those back decrypted, so
+ * these tests pin that the allow-list is the only thing either tool can see or
+ * touch: a stored mapbox_access_token must not appear in a read, and neither
+ * that key nor llm_api_key nor an unknown name may be written.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA busy_timeout = 5000');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: any, userId: number) =>
+      db.prepare(`SELECT t.id, t.user_id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)`).get(userId, tripId, userId),
+    isOwner: (tripId: any, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+
+vi.mock('../../../src/websocket', () => ({ broadcast: vi.fn() }));
+
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+import { resetTestDb } from '../../helpers/test-db';
+import { createUser } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { encrypt_api_key } from '../../../src/nest/common/crypto/apiKeyCrypto';
+import { MASKED_SETTING_VALUE } from '@trek/shared';
+import { DISPLAY_PREFERENCE_KEYS } from '../../../src/nest/settings/settings.mcp';
+import { MANAGED_LOCKED_SETTING_KEYS } from '../../../src/nest/common/managed';
+import { isAdminOnlyLlmSetting, ENCRYPTED_SETTING_KEYS, MASKED_SETTING_KEYS } from '../../../src/nest/settings/settings.service';
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  delete process.env.DEMO_MODE;
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setSetting(userId: number, key: string, value: string): void {
+  testDb.prepare(
+    'INSERT INTO settings (user_id, key, value) VALUES (?, ?, ?) ' +
+      'ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value',
+  ).run(userId, key, value);
+}
+
+function readSetting(userId: number, key: string): string | undefined {
+  const row = testDb.prepare('SELECT value FROM settings WHERE user_id = ? AND key = ?').get(userId, key) as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}
+
+function countSettings(userId: number): number {
+  return (testDb.prepare('SELECT COUNT(*) as c FROM settings WHERE user_id = ?').get(userId) as { c: number }).c;
+}
+
+async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
+  const h = await createMcpHarness({ userId, withResources: false });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+async function withScopedHarness(userId: number, scopes: string[] | null, fn: (h: McpHarness) => Promise<void>) {
+  const h = await createMcpHarness({ userId, withResources: false, scopes });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+async function update(h: McpHarness, settings: Record<string, unknown>) {
+  return h.client.callTool({ name: 'update_display_settings', arguments: { settings } });
+}
+
+/** The message of an isError result, for asserting the wording a model reads. */
+function errorText(result: any): string {
+  return String(result.content?.[0]?.text ?? '');
+}
+
+// ---------------------------------------------------------------------------
+// get_display_settings
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_display_settings', () => {
+  it('returns an empty object for a user who has set nothing', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings).toEqual({});
+    });
+  });
+
+  it('returns the display preferences the user has stored', async () => {
+    const { user } = createUser(testDb);
+    setSetting(user.id, 'temperature_unit', '"fahrenheit"');
+    setSetting(user.id, 'distance_unit', '"imperial"');
+    setSetting(user.id, 'time_format', '"12h"');
+    setSetting(user.id, 'language', '"de"');
+    setSetting(user.id, 'default_currency', '"USD"');
+    setSetting(user.id, 'start_page', '"active_trip"');
+    setSetting(user.id, 'blur_booking_codes', 'true');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings).toEqual({
+        start_page: 'active_trip',
+        default_currency: 'USD',
+        language: 'de',
+        temperature_unit: 'fahrenheit',
+        distance_unit: 'imperial',
+        time_format: '12h',
+        blur_booking_codes: true,
+      });
+    });
+  });
+
+  it('falls back to the admin-set instance default for a key the user has not set', async () => {
+    const { user } = createUser(testDb);
+    testDb.prepare('INSERT INTO app_settings (key, value) VALUES (?, ?)')
+      .run('default_user_setting_temperature_unit', '"fahrenheit"');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.temperature_unit).toBe('fahrenheit');
+    });
+  });
+
+  it('does not return stored credentials, not even to a settings:read token', async () => {
+    const { user } = createUser(testDb);
+    // mapbox_access_token and carto_api_key are encrypted-but-NOT-masked, so
+    // getUserSettings hands them back in cleartext. That is the leak this
+    // surface must not have: store them the way the real write path does and
+    // assert they are nowhere in the result.
+    setSetting(user.id, 'mapbox_access_token', String(encrypt_api_key('pk.super-secret-token')));
+    setSetting(user.id, 'carto_api_key', String(encrypt_api_key('carto-secret')));
+    setSetting(user.id, 'llm_api_key', String(encrypt_api_key('sk-secret')));
+    setSetting(user.id, 'ntfy_token', String(encrypt_api_key('ntfy-secret')));
+    setSetting(user.id, 'webhook_url', String(encrypt_api_key('https://hook.example/secret')));
+    setSetting(user.id, 'temperature_unit', '"celsius"');
+
+    await withScopedHarness(user.id, ['settings:read'], async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings).toEqual({ temperature_unit: 'celsius' });
+      const serialized = JSON.stringify(data);
+      expect(serialized).not.toContain('pk.super-secret-token');
+      expect(serialized).not.toContain('carto-secret');
+      expect(serialized).not.toContain('sk-secret');
+      expect(serialized).not.toContain('ntfy-secret');
+      expect(serialized).not.toContain('hook.example');
+      for (const key of ['mapbox_access_token', 'carto_api_key', 'llm_api_key', 'ntfy_token', 'webhook_url']) {
+        expect(Object.keys(data.settings)).not.toContain(key);
+      }
+    });
+  });
+
+  it('leaves out settings that are neither display preferences nor credentials', async () => {
+    const { user } = createUser(testDb);
+    setSetting(user.id, 'map_tile_url', '"https://tiles.example/{z}/{x}/{y}.png"');
+    setSetting(user.id, 'dashboard_fx_from', '"EUR"');
+    setSetting(user.id, 'time_format', '"24h"');
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings).toEqual({ time_format: '24h' });
+    });
+  });
+
+  it('does not leak another user\'s preferences', async () => {
+    const { user: mine } = createUser(testDb);
+    const { user: theirs } = createUser(testDb);
+    setSetting(theirs.id, 'temperature_unit', '"fahrenheit"');
+
+    await withHarness(mine.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings).toEqual({});
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_display_settings: happy paths
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_display_settings', () => {
+  it('writes several preferences at once and reports what changed', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'fahrenheit', distance_unit: 'imperial' });
+      const data = parseToolResult(result) as any;
+      expect(data.success).toBe(true);
+      expect(data.updated).toBe(2);
+      expect(data.settings).toEqual({ temperature_unit: 'fahrenheit', distance_unit: 'imperial' });
+      expect(readSetting(user.id, 'temperature_unit')).toBe('fahrenheit');
+      expect(readSetting(user.id, 'distance_unit')).toBe('imperial');
+    });
+  });
+
+  it('leaves untouched keys alone', async () => {
+    const { user } = createUser(testDb);
+    setSetting(user.id, 'time_format', '"12h"');
+    await withHarness(user.id, async (h) => {
+      await update(h, { temperature_unit: 'celsius' });
+      expect(readSetting(user.id, 'time_format')).toBe('"12h"');
+    });
+  });
+
+  it('accepts every non-boolean display preference in one call', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, {
+        start_page: 'active_trip',
+        start_trip_tab: 'finanzplan',
+        default_currency: 'JPY',
+        language: 'ja',
+        temperature_unit: 'celsius',
+        distance_unit: 'metric',
+        time_format: '24h',
+        dark_mode: 'auto',
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.updated).toBe(8);
+      expect(data.settings.start_trip_tab).toBe('finanzplan');
+      expect(data.settings.dark_mode).toBe('auto');
+      expect(data.settings.language).toBe('ja');
+    });
+  });
+
+  it('accepts every boolean display preference', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, {
+        map_booking_labels: true,
+        map_always_show_routes: false,
+        map_poi_pill_enabled: true,
+        blur_booking_codes: false,
+        optimize_from_accommodation: true,
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.updated).toBe(5);
+      expect(data.settings).toEqual({
+        map_booking_labels: true,
+        map_always_show_routes: false,
+        map_poi_pill_enabled: true,
+        blur_booking_codes: false,
+        optimize_from_accommodation: true,
+      });
+    });
+  });
+
+  it('accepts a boolean dark_mode, the pre-auto form still sitting in older rows', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { dark_mode: false });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.dark_mode).toBe(false);
+      expect(readSetting(user.id, 'dark_mode')).toBe('false');
+    });
+  });
+
+  it('accepts an empty default_currency, which falls back to each trip\'s own', async () => {
+    const { user } = createUser(testDb);
+    setSetting(user.id, 'default_currency', '"USD"');
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { default_currency: '' });
+      const data = parseToolResult(result) as any;
+      expect(data.success).toBe(true);
+      expect(readSetting(user.id, 'default_currency')).toBe('');
+    });
+  });
+
+  it('reads back the admin default rather than echoing the input', async () => {
+    const { user } = createUser(testDb);
+    testDb.prepare('INSERT INTO app_settings (key, value) VALUES (?, ?)')
+      .run('default_user_setting_distance_unit', '"imperial"');
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'celsius' });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.distance_unit).toBe('imperial');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_display_settings: refusals
+// ---------------------------------------------------------------------------
+
+describe('Tool: update_display_settings, refusals', () => {
+  it('refuses a credential key and stores nothing', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { mapbox_access_token: 'pk.attacker-token' });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('mapbox_access_token');
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses llm_api_key and stores nothing, even for a settings:write token', async () => {
+    const { user } = createUser(testDb);
+    await withScopedHarness(user.id, ['settings:write'], async (h) => {
+      const result = await update(h, { llm_api_key: 'sk-attacker' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses the two admin-only LLM endpoint keys the REST route answers 403 for', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      for (const settings of [{ llm_base_url: 'http://127.0.0.1:11434' }, { llm_provider: 'local' }]) {
+        const result = await update(h, settings);
+        expect(result.isError).toBe(true);
+      }
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses a key nobody has heard of rather than storing it', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { made_up_preference: 'whatever' });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('made_up_preference');
+      expect(countSettings(user.id)).toBe(0);
+      expect(readSetting(user.id, 'made_up_preference')).toBeUndefined();
+    });
+  });
+
+  it('refuses an inherited Object property name, which a plain `in` check would wave through', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { toString: 'gotcha' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('writes nothing at all when one key of a multi-key call is refused', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'fahrenheit', llm_api_key: 'sk-attacker' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('writes nothing when one value of a multi-key call is invalid', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'fahrenheit', time_format: '36h' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses a value outside the allowed set and names the key', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'kelvin' });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('temperature_unit');
+      expect(readSetting(user.id, 'temperature_unit')).toBeUndefined();
+    });
+  });
+
+  it('refuses an unsupported language code', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const bad = await update(h, { language: 'xx' });
+      expect(bad.isError).toBe(true);
+      const good = await update(h, { language: 'fr' });
+      expect(good.isError).toBeFalsy();
+      expect(readSetting(user.id, 'language')).toBe('fr');
+    });
+  });
+
+  it('refuses a currency that is not a three-letter uppercase code', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      for (const value of ['eur', 'EUROS', 'E']) {
+        const result = await update(h, { default_currency: value });
+        expect(result.isError).toBe(true);
+      }
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses a non-boolean for a boolean preference', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { blur_booking_codes: 'yes' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses a start_trip_tab that is empty or absurdly long', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      expect((await update(h, { start_trip_tab: '' })).isError).toBe(true);
+      expect((await update(h, { start_trip_tab: 'x'.repeat(65) })).isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses the redaction placeholder instead of silently skipping it', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { start_trip_tab: MASKED_SETTING_VALUE });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('start_trip_tab');
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('refuses an empty settings object and says what it takes', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, {});
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toContain('temperature_unit');
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('blocks the demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    await withHarness(user.id, async (h) => {
+      const result = await update(h, { temperature_unit: 'fahrenheit' });
+      expect(result.isError).toBe(true);
+      expect(countSettings(user.id)).toBe(0);
+    });
+  });
+
+  it('lets the demo user read', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@trek.app' });
+    setSetting(user.id, 'temperature_unit', '"celsius"');
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_display_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.temperature_unit).toBe('celsius');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The allow-list itself
+// ---------------------------------------------------------------------------
+
+describe('Display-preference allow-list', () => {
+  it('holds no key the operator owns on a managed install', () => {
+    // The REST route needs isManagedLockedKey because it takes any key at all.
+    // Here the two lists must simply not overlap, which is what makes the
+    // managed lock unreachable rather than merely duplicated.
+    const overlap = DISPLAY_PREFERENCE_KEYS.filter((key) =>
+      (MANAGED_LOCKED_SETTING_KEYS as readonly string[]).includes(key));
+    expect(overlap).toEqual([]);
+  });
+
+  it('holds no key assertMayWriteLlmEndpoint would have to refuse', () => {
+    // isAdminOnlyLlmSetting is value-dependent, so probe it with the values
+    // that trip it rather than matching on the key name.
+    const offenders = DISPLAY_PREFERENCE_KEYS.filter((key) =>
+      isAdminOnlyLlmSetting(key, 'http://127.0.0.1:11434') || isAdminOnlyLlmSetting(key, 'local'));
+    expect(offenders).toEqual([]);
+  });
+
+  // Against the live sets, not a copy of them: a sixth encrypted key added to
+  // the service has to fail here, which is the whole point of the allow-list.
+  it('holds no key that is encrypted at rest', () => {
+    const overlap = [...ENCRYPTED_SETTING_KEYS].filter(key => (DISPLAY_PREFERENCE_KEYS as readonly string[]).includes(key));
+    expect(overlap).toEqual([]);
+  });
+
+  it('holds no key that is masked on the way out', () => {
+    const overlap = [...MASKED_SETTING_KEYS].filter(key => (DISPLAY_PREFERENCE_KEYS as readonly string[]).includes(key));
+    expect(overlap).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope gating
+// ---------------------------------------------------------------------------
+
+describe('Settings tools, scope gating', () => {
+  async function listToolNames(userId: number, scopes: string[] | null): Promise<string[]> {
+    const h = await createMcpHarness({ userId, withResources: false, scopes });
+    try {
+      return (await h.client.listTools()).tools.map((t) => t.name);
+    } finally {
+      await h.cleanup();
+    }
+  }
+
+  it('registers both tools with null scopes (full access)', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, null);
+    expect(names).toContain('get_display_settings');
+    expect(names).toContain('update_display_settings');
+  });
+
+  it('registers only the read tool with settings:read', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['settings:read']);
+    expect(names).toContain('get_display_settings');
+    expect(names).not.toContain('update_display_settings');
+  });
+
+  it('registers both with settings:write, since write implies read', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['settings:write']);
+    expect(names).toContain('get_display_settings');
+    expect(names).toContain('update_display_settings');
+  });
+
+  it('registers neither for a token without a settings scope', async () => {
+    const { user } = createUser(testDb);
+    const names = await listToolNames(user.id, ['trips:read']);
+    expect(names).not.toContain('get_display_settings');
+    expect(names).not.toContain('update_display_settings');
+  });
+});

--- a/server/tests/unit/mcp/tools-tags-maps-weather.test.ts
+++ b/server/tests/unit/mcp/tools-tags-maps-weather.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit tests for MCP tag, maps extras, and weather tools:
  * list_tags, create_tag, update_tag, delete_tag,
- * get_place_details, reverse_geocode, resolve_maps_url,
+ * get_place_details, search_pois, reverse_geocode, resolve_maps_url,
  * get_weather, get_detailed_weather.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 const { testDb, dbMock } = vi.hoisted(() => {
   const Database = require('better-sqlite3');
@@ -56,6 +56,21 @@ vi.spyOn(MapsService.prototype, 'getPlaceDetails').mockResolvedValue({
   name: 'Eiffel Tower',
   address: 'Paris',
 } as never);
+vi.spyOn(MapsService.prototype, 'getPlaceDetailsExpanded').mockResolvedValue({
+  name: 'Eiffel Tower',
+  summary: 'Wrought-iron lattice tower.',
+  reviews: [{ author: 'Someone', rating: 5, text: 'Tall.', time: 'a month ago', photo: null }],
+} as never);
+// Overpass is stubbed one level below the facade so MapsService.pois() itself
+// still runs, the way the geo tools reach it.
+vi.spyOn(MapsService.prototype, 'searchOverpassPois').mockResolvedValue({
+  pois: [{ osm_id: 'node:1', name: 'Chez Nous', lat: 48.86, lng: 2.34, category: 'restaurant' }],
+  source: 'openstreetmap',
+  truncated: false,
+  clamped: false,
+} as never);
+// Off by default, so the existing cases exercise the lookup rather than the gate.
+vi.spyOn(MapsService.prototype, 'detailsDisabled').mockReturnValue(false);
 vi.spyOn(MapsService.prototype, 'reverseGeocode').mockResolvedValue({ name: 'Paris', address: 'France' });
 vi.spyOn(MapsService.prototype, 'resolveGoogleMapsUrl').mockResolvedValue({
   lat: 48.8566,
@@ -316,6 +331,155 @@ describe('Tool: get_place_details', () => {
   // The former "isError when service returns null" case pinned a dead branch —
   // MapsService.getPlaceDetails throws or returns an object, never null — and
   // died with the guard in the fix(maps) quirk pass.
+
+  // The expanded field mask bills as a Google Enterprise SKU, so the default has
+  // to stay on the lean lookup: nothing an existing caller does may start costing
+  // more (#31).
+  it('takes the lean path when expand is not asked for', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.getPlaceDetails).mockClear();
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'get_place_details', arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ' } });
+      expect(MapsService.prototype.getPlaceDetails).toHaveBeenCalledWith(user.id, 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', 'en');
+      expect(MapsService.prototype.getPlaceDetailsExpanded).not.toHaveBeenCalled();
+    });
+  });
+
+  it('explicitly passing expand: false also stays on the lean path', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', expand: false, refresh: true },
+      });
+      expect(MapsService.prototype.getPlaceDetailsExpanded).not.toHaveBeenCalled();
+    });
+  });
+
+  it('expand routes to the expanded lookup and returns reviews and the summary', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.getPlaceDetails).mockClear();
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', expand: true, lang: 'de' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.details.summary).toBe('Wrought-iron lattice tower.');
+      expect(data.details.reviews).toHaveLength(1);
+      expect(MapsService.prototype.getPlaceDetailsExpanded).toHaveBeenCalledWith(user.id, 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', 'de', false);
+      expect(MapsService.prototype.getPlaceDetails).not.toHaveBeenCalled();
+    });
+  });
+
+  it('forwards refresh so a stale expanded payload can be re-fetched', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', expand: true, refresh: true },
+      });
+      expect(MapsService.prototype.getPlaceDetailsExpanded).toHaveBeenCalledWith(user.id, 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', 'en', true);
+    });
+  });
+
+  it('refuses a non-boolean expand', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', expand: 'yes' },
+      });
+      expect(result.isError).toBe(true);
+      expect(MapsService.prototype.getPlaceDetailsExpanded).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search_pois (#30)
+// ---------------------------------------------------------------------------
+
+describe('Tool: search_pois', () => {
+  const BBOX = { south: 48.85, west: 2.33, north: 48.87, east: 2.36 };
+
+  it('returns the POIs of a category inside the bbox', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.searchOverpassPois).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_pois',
+        arguments: { category: 'restaurant', bbox: BBOX, lang: 'fr' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.pois).toHaveLength(1);
+      expect(data.pois[0].name).toBe('Chez Nous');
+      expect(data.source).toBe('openstreetmap');
+      expect(MapsService.prototype.searchOverpassPois).toHaveBeenCalledWith('restaurant', BBOX, 'fr');
+    });
+  });
+
+  it('passes no language through when none is given', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.searchOverpassPois).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'search_pois', arguments: { category: 'museum', bbox: BBOX } });
+      expect(MapsService.prototype.searchOverpassPois).toHaveBeenCalledWith('museum', BBOX, undefined);
+    });
+  });
+
+  // The enum is built from CATEGORY_OSM_FILTERS, so a category with no OSM tag
+  // mapping never reaches Overpass in the first place.
+  it('refuses a category that has no OSM mapping', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.searchOverpassPois).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_pois',
+        arguments: { category: 'dentist', bbox: BBOX },
+      });
+      expect(result.isError).toBe(true);
+      expect(MapsService.prototype.searchOverpassPois).not.toHaveBeenCalled();
+    });
+  });
+
+  it('refuses a bbox edge outside the coordinate range', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.searchOverpassPois).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'search_pois',
+        arguments: { category: 'cafe', bbox: { ...BBOX, north: 118 } },
+      });
+      expect(result.isError).toBe(true);
+      expect(MapsService.prototype.searchOverpassPois).not.toHaveBeenCalled();
+    });
+  });
+
+  it('answers isError when every Overpass mirror is unreachable', async () => {
+    const { user } = createUser(testDb);
+    vi.mocked(MapsService.prototype.searchOverpassPois).mockRejectedValueOnce(new Error('all mirrors failed'));
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'search_pois', arguments: { category: 'bar', bbox: BBOX } });
+      expect(result.isError).toBe(true);
+      expect((result as { content: { text: string }[] }).content[0].text).toBe('POI search failed.');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -504,6 +668,70 @@ describe('Tool: get_airport', () => {
       const result = await h.client.callTool({ name: 'get_airport', arguments: { iata: 'QQQ' } });
       expect((result as { isError?: boolean }).isError).toBe(true);
       expect((result as { content: { text: string }[] }).content[0].text).toBe('Airport not found.');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The admin kill switch
+//
+// An instance owner turns Place Details off to stop Google billing them. REST
+// checks detailsDisabled() before it can reach either lookup; a tool that did
+// not would bill them from the one surface the switch does not cover, and the
+// expanded mask would do it at Enterprise-SKU rates.
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_place_details (admin kill switch)', () => {
+  afterEach(() => {
+    vi.mocked(MapsService.prototype.detailsDisabled).mockReturnValue(false);
+  });
+
+  it('fetches nothing when an admin has turned Place Details off', async () => {
+    const { user } = createUser(testDb);
+    vi.spyOn(MapsService.prototype, 'detailsDisabled').mockReturnValue(true);
+    vi.mocked(MapsService.prototype.getPlaceDetails).mockClear();
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.disabled).toBe(true);
+      expect(data.details).toBeNull();
+      expect(MapsService.prototype.getPlaceDetails).not.toHaveBeenCalled();
+      expect(MapsService.prototype.getPlaceDetailsExpanded).not.toHaveBeenCalled();
+    });
+  });
+
+  it('the switch also stops the expensive expanded path', async () => {
+    const { user } = createUser(testDb);
+    vi.spyOn(MapsService.prototype, 'detailsDisabled').mockReturnValue(true);
+    vi.mocked(MapsService.prototype.getPlaceDetailsExpanded).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ', expand: true },
+      });
+      expect((parseToolResult(result) as any).disabled).toBe(true);
+      expect(MapsService.prototype.getPlaceDetailsExpanded).not.toHaveBeenCalled();
+    });
+  });
+
+  it('leaves the lookup alone while the switch is on', async () => {
+    const { user } = createUser(testDb);
+    vi.spyOn(MapsService.prototype, 'detailsDisabled').mockReturnValue(false);
+    vi.mocked(MapsService.prototype.getPlaceDetails).mockClear();
+
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'get_place_details',
+        arguments: { placeId: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ' },
+      });
+      expect((parseToolResult(result) as any).details.name).toBe('Eiffel Tower');
+      expect(MapsService.prototype.getPlaceDetails).toHaveBeenCalled();
     });
   });
 });

--- a/server/tests/unit/mcp/tools-transports.test.ts
+++ b/server/tests/unit/mcp/tools-transports.test.ts
@@ -1052,11 +1052,11 @@ describe('Tool: update_transport (multi-leg)', () => {
 
 /** client/src/components/Planner/TransportModal.tsx, in the picker's order. */
 const PICKER_TRANSPORT_TYPES = [
-  'flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transit', 'transport_other',
+  'flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transport_other',
 ] as const;
 
-/** The six the tools used to reject outright. */
-const NEWLY_ACCEPTED = ['bus', 'taxi', 'bicycle', 'ferry', 'transit', 'transport_other'] as const;
+/** The five the tools used to reject outright. */
+const NEWLY_ACCEPTED = ['bus', 'taxi', 'bicycle', 'ferry', 'transport_other'] as const;
 
 describe('Transport tools: the full type list', () => {
   it.each(PICKER_TRANSPORT_TYPES)('create_transport accepts %s', async (type) => {
@@ -1169,6 +1169,36 @@ describe('Transport tools: the full type list', () => {
         arguments: { tripId: trip.id, type: 'teleport', title: 'Nope' },
       });
       expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+  });
+
+  it('refuses to hand-make a transit booking, which create_transit_journey owns', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: { tripId: trip.id, type: 'transit', title: 'Tram 4' },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+  });
+
+  it('still lets update_transport reach a stored transit booking', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    // As create_transit_journey leaves it: a transport row carrying an itinerary.
+    const reservationId = Number(testDb.prepare(
+      "INSERT INTO reservations (trip_id, title, type, status) VALUES (?, 'Tram 4', 'transit', 'pending')"
+    ).run(trip.id).lastInsertRowid);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_transport',
+        arguments: { tripId: trip.id, reservationId, status: 'confirmed' },
+      });
+      expect((result as { isError?: boolean }).isError).toBeFalsy();
+      const row = testDb.prepare('SELECT status, type FROM reservations WHERE id = ?').get(reservationId) as any;
+      expect(row).toMatchObject({ status: 'confirmed', type: 'transit' });
     });
   });
 

--- a/server/tests/unit/mcp/tools-transports.test.ts
+++ b/server/tests/unit/mcp/tools-transports.test.ts
@@ -1040,3 +1040,160 @@ describe('Tool: update_transport (multi-leg)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// The full type list
+//
+// The planner's transport picker offers ten modes; these tools accepted four, so
+// a bus or a ferry could be planned in the UI and not through an assistant. The
+// cases below pin the whole picker list, and pin that widening it did not also
+// hand legs[] to a mode whose form never writes them.
+// ---------------------------------------------------------------------------
+
+/** client/src/components/Planner/TransportModal.tsx, in the picker's order. */
+const PICKER_TRANSPORT_TYPES = [
+  'flight', 'train', 'bus', 'car', 'taxi', 'bicycle', 'cruise', 'ferry', 'transit', 'transport_other',
+] as const;
+
+/** The six the tools used to reject outright. */
+const NEWLY_ACCEPTED = ['bus', 'taxi', 'bicycle', 'ferry', 'transit', 'transport_other'] as const;
+
+describe('Transport tools: the full type list', () => {
+  it.each(PICKER_TRANSPORT_TYPES)('create_transport accepts %s', async (type) => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: { tripId: trip.id, type, title: `A ${type} booking` },
+      });
+      expect((result as { isError?: boolean }).isError).toBeFalsy();
+      const data = parseToolResult(result) as any;
+      expect(data.reservation.type).toBe(type);
+      const row = testDb.prepare('SELECT type FROM reservations WHERE id = ?').get(data.reservation.id) as any;
+      expect(row.type).toBe(type);
+    });
+  });
+
+  it('stores a bus booking with its stops, times and booking reference', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const depDay = createDay(testDb, trip.id, { day_number: 1 });
+    const arrDay = createDay(testDb, trip.id, { day_number: 2 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: {
+          tripId: trip.id, type: 'bus', title: 'Zurich → Milan',
+          start_day_id: depDay.id, end_day_id: arrDay.id,
+          reservation_time: '22:30', reservation_end_time: '06:15',
+          confirmation_number: 'FLIX-8891',
+          endpoints: [
+            { role: 'from', sequence: 0, name: 'Zurich Sihlquai', lat: 47.3846, lng: 8.5324 },
+            { role: 'to', sequence: 1, name: 'Milano Lampugnano', lat: 45.4936, lng: 9.1177 },
+          ],
+        },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.reservation.type).toBe('bus');
+      expect(data.reservation.confirmation_number).toBe('FLIX-8891');
+      expect(data.reservation.endpoints).toHaveLength(2);
+      const row = testDb.prepare('SELECT day_id, end_day_id FROM reservations WHERE id = ?').get(data.reservation.id) as any;
+      expect(row.day_id).toBe(depDay.id);
+      expect(row.end_day_id).toBe(arrDay.id);
+    });
+  });
+
+  it('reports a missing coordinate on a non-flight endpoint rather than failing the insert', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: {
+          tripId: trip.id, type: 'ferry', title: 'Piraeus → Santorini',
+          endpoints: [{ role: 'from', sequence: 0, name: 'Piraeus' }],
+        },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(errorText(result)).toContain('missing coordinates');
+    });
+  });
+
+  it.each(NEWLY_ACCEPTED)('update_transport accepts %s as the new type', async (type) => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_transport',
+        arguments: { tripId: trip.id, type: 'car', title: 'Rental' },
+      });
+      const { reservation } = parseToolResult(created) as { reservation: { id: number } };
+
+      const result = await h.client.callTool({
+        name: 'update_transport',
+        arguments: { tripId: trip.id, reservationId: reservation.id, type },
+      });
+      expect((result as { isError?: boolean }).isError).toBeFalsy();
+      const row = testDb.prepare('SELECT type FROM reservations WHERE id = ?').get(reservation.id) as any;
+      expect(row.type).toBe(type);
+    });
+  });
+
+  it('update_transport reaches a booking created as a bus', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const created = await h.client.callTool({
+        name: 'create_transport',
+        arguments: { tripId: trip.id, type: 'bus', title: 'Night bus' },
+      });
+      const { reservation } = parseToolResult(created) as { reservation: { id: number } };
+
+      const result = await h.client.callTool({
+        name: 'update_transport',
+        arguments: { tripId: trip.id, reservationId: reservation.id, status: 'confirmed' },
+      });
+      expect((result as { isError?: boolean }).isError).toBeFalsy();
+      const row = testDb.prepare('SELECT status FROM reservations WHERE id = ?').get(reservation.id) as any;
+      expect(row.status).toBe('confirmed');
+    });
+  });
+
+  it('still refuses a type the picker does not offer', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: { tripId: trip.id, type: 'teleport', title: 'Nope' },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+  });
+
+  it('still refuses legs on a mode whose form never writes them', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id, { day_number: 1 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_transport',
+        arguments: {
+          tripId: trip.id, type: 'bus', title: 'Zurich → Milan via Lugano',
+          endpoints: [
+            { role: 'from', sequence: 0, name: 'Zurich', lat: 47.38, lng: 8.53 },
+            { role: 'stop', sequence: 1, name: 'Lugano', lat: 46.01, lng: 8.96 },
+            { role: 'to', sequence: 2, name: 'Milan', lat: 45.49, lng: 9.11 },
+          ],
+          legs: [
+            { dep_day_id: day.id, dep_time: '22:30', arr_day_id: day.id, arr_time: '00:40' },
+            { dep_day_id: day.id, dep_time: '00:50', arr_day_id: day.id, arr_time: '06:15' },
+          ],
+        },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(errorText(result)).toContain('only supported for flight and train');
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-trip-members.test.ts
+++ b/server/tests/unit/mcp/tools-trip-members.test.ts
@@ -38,7 +38,8 @@ vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
 import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
-import { createUser, createTrip, addTripMember } from '../../helpers/factories';
+import { invalidatePermissionsCache } from '../../../src/nest/permissions/permissions-cache';
+import { createUser, createAdmin, createTrip, addTripMember } from '../../helpers/factories';
 import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
 
 beforeAll(() => {
@@ -50,6 +51,9 @@ beforeEach(() => {
   resetTestDb(testDb);
   broadcastMock.mockClear();
   delete process.env.DEMO_MODE;
+  // resetTestDb truncates app_settings, but the permission cache is module-scoped
+  // and would keep serving whatever the previous case configured.
+  invalidatePermissionsCache();
 });
 
 afterAll(() => {
@@ -59,6 +63,12 @@ afterAll(() => {
 async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
   const h = await createMcpHarness({ userId, withResources: false });
   try { await fn(h); } finally { await h.cleanup(); }
+}
+
+/** Lower a configurable action the way the admin permission panel does. */
+function setPermission(action: string, level: string) {
+  testDb.prepare('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)').run(`perm_${action}`, level);
+  invalidatePermissionsCache();
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +171,57 @@ describe('Tool: add_trip_member', () => {
       expect(result.isError).toBe(true);
     });
   });
+
+  it('lets a collaborator add when member_manage sits at trip_member', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    setPermission('member_manage', 'trip_member');
+    await withHarness(collaborator.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_trip_member',
+        arguments: { tripId: trip.id, identifier: outsider.username },
+      });
+      expect(result.isError).toBeFalsy();
+      const row = testDb.prepare('SELECT invited_by FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, outsider.id) as any;
+      expect(row).toBeTruthy();
+      expect(row.invited_by).toBe(collaborator.id);
+    });
+  });
+
+  it('lets a site admin on the trip add a member without owning it', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: admin } = createAdmin(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, admin.id);
+    await withHarness(admin.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_trip_member',
+        arguments: { tripId: trip.id, identifier: outsider.username },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, outsider.id)).toBeTruthy();
+    });
+  });
+
+  it('still refuses a collaborator while member_manage sits at its trip_owner default', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const { user: outsider } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    await withHarness(collaborator.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_trip_member',
+        arguments: { tripId: trip.id, identifier: outsider.username },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, outsider.id)).toBeUndefined();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -207,6 +268,150 @@ describe('Tool: remove_trip_member', () => {
         arguments: { tripId: trip.id, memberId: owner.id },
       });
       expect(result.isError).toBe(true);
+    });
+  });
+
+  it('leaves another member in place when a collaborator has no member_manage', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    addTripMember(testDb, trip.id, other.id);
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'remove_trip_member',
+        arguments: { tripId: trip.id, memberId: other.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, other.id)).toBeTruthy();
+    });
+  });
+
+  it('lets a collaborator remove another member when member_manage sits at trip_member', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    addTripMember(testDb, trip.id, other.id);
+    setPermission('member_manage', 'trip_member');
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'remove_trip_member',
+        arguments: { tripId: trip.id, memberId: other.id },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, other.id)).toBeUndefined();
+    });
+  });
+
+  it('lets a site admin on the trip remove a member without owning it', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: admin } = createAdmin(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, admin.id);
+    addTripMember(testDb, trip.id, other.id);
+    await withHarness(admin.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'remove_trip_member',
+        arguments: { tripId: trip.id, memberId: other.id },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, other.id)).toBeUndefined();
+    });
+  });
+
+  it('lets a member remove themselves without member_manage', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'remove_trip_member',
+        arguments: { tripId: trip.id, memberId: member.id },
+      });
+      expect((parseToolResult(result) as any).success).toBe(true);
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, member.id)).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// leave_trip
+// ---------------------------------------------------------------------------
+
+describe('Tool: leave_trip', () => {
+  it('drops the caller from the roster', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    await withHarness(member.id, async (h) => {
+      const result = await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect((parseToolResult(result) as any).success).toBe(true);
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, member.id)).toBeUndefined();
+      expect(testDb.prepare('SELECT id FROM trips WHERE id = ?').get(trip.id)).toBeTruthy();
+    });
+  });
+
+  it('broadcasts member:removed for the leaving user', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    await withHarness(member.id, async (h) => {
+      await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'member:removed', expect.objectContaining({ userId: member.id }));
+    });
+  });
+
+  it('leaves the other members alone', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    addTripMember(testDb, trip.id, other.id);
+    await withHarness(member.id, async (h) => {
+      await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, other.id)).toBeTruthy();
+    });
+  });
+
+  it('refuses the owner and keeps the trip theirs', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      const row = testDb.prepare('SELECT user_id FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.user_id).toBe(owner.id);
+    });
+  });
+
+  it('returns access denied for a non-member', async () => {
+    const { user: outsider } = createUser(testDb);
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(outsider.id, async (h) => {
+      const result = await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user: owner } = createUser(testDb);
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'leave_trip', arguments: { tripId: trip.id } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE trip_id = ? AND user_id = ?').get(trip.id, user.id)).toBeTruthy();
     });
   });
 });
@@ -411,7 +616,7 @@ describe('Tool: create_trip_guest', () => {
       expect(row.is_guest).toBe(1);
       expect(row.password_hash).toBe('');
       expect(row.display_name).toBe('Anna');
-      // A synthetic address on an undeliverable domain — a guest is never emailed.
+      // A synthetic address on an undeliverable domain: a guest is never emailed.
       expect(row.email).toMatch(/@guests\.invalid$/);
     });
   });
@@ -652,5 +857,40 @@ describe('Tool: delete_trip_guest', () => {
       });
       expect(result.isError).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The guest routes carry TripOwnerGuard, which deliberately does NOT consult the
+// permission matrix: handing a trip over and creating or deleting guests are the
+// things a collaborator must never do, however generously the trip is configured.
+// Lowering member_manage moves add/remove_trip_member and must move nothing here.
+// ---------------------------------------------------------------------------
+
+describe('Guest tools stay owner-only', () => {
+  it('refuses a collaborator all three guest tools even with member_manage at trip_member', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    let guestId = 0;
+    await withHarness(owner.id, async (h) => { guestId = await makeGuest(h, trip.id, 'Anna'); });
+
+    setPermission('member_manage', 'trip_member');
+    await withHarness(collaborator.id, async (h) => {
+      expect((await h.client.callTool({
+        name: 'create_trip_guest', arguments: { tripId: trip.id, name: 'Bea' },
+      })).isError).toBe(true);
+      expect((await h.client.callTool({
+        name: 'rename_trip_guest', arguments: { tripId: trip.id, guestId, name: 'Renamed' },
+      })).isError).toBe(true);
+      expect((await h.client.callTool({
+        name: 'delete_trip_guest', arguments: { tripId: trip.id, guestId },
+      })).isError).toBe(true);
+    });
+
+    const row = testDb.prepare('SELECT display_name FROM users WHERE id = ?').get(guestId) as any;
+    expect(row.display_name).toBe('Anna');
+    expect(testDb.prepare('SELECT COUNT(*) AS n FROM users WHERE is_guest = 1').get()).toEqual({ n: 1 });
   });
 });

--- a/server/tests/unit/mcp/tools-trip-members.test.ts
+++ b/server/tests/unit/mcp/tools-trip-members.test.ts
@@ -1,6 +1,7 @@
 /**
- * Unit tests for MCP trip member, copy, ICS, and share-link tools:
+ * Unit tests for MCP trip member, guest, copy, ICS, and share-link tools:
  * list_trip_members, add_trip_member, remove_trip_member,
+ * create_trip_guest, rename_trip_guest, delete_trip_guest,
  * copy_trip, export_trip_ics, get_share_link, create_share_link, delete_share_link.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
@@ -373,6 +374,283 @@ describe('Tool: delete_share_link', () => {
       expect(data.success).toBe(true);
       const row = testDb.prepare('SELECT token FROM share_tokens WHERE trip_id = ?').get(trip.id);
       expect(row).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guests (#1362)
+//
+// add_trip_member resolves an existing account, so these cover the companion who
+// has none: created, renamed and deleted through the assistant, owner-gated the
+// same way the /guests routes are, and trip-scoped so one trip's owner cannot
+// reach another trip's guest.
+// ---------------------------------------------------------------------------
+
+/** The guest id the tool reports back, for the rename/delete cases. */
+async function makeGuest(h: McpHarness, tripId: number, name: string): Promise<number> {
+  const result = await h.client.callTool({ name: 'create_trip_guest', arguments: { tripId, name } });
+  return (parseToolResult(result) as any).member.id;
+}
+
+describe('Tool: create_trip_guest', () => {
+  it('creates a credential-less guest and returns the display name', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: 'Anna' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.member.username).toBe('Anna');
+      expect(data.member.role).toBe('member');
+      expect(data.member.is_guest).toBe(true);
+
+      const row = testDb.prepare('SELECT is_guest, password_hash, display_name, email FROM users WHERE id = ?').get(data.member.id) as any;
+      expect(row.is_guest).toBe(1);
+      expect(row.password_hash).toBe('');
+      expect(row.display_name).toBe('Anna');
+      // A synthetic address on an undeliverable domain — a guest is never emailed.
+      expect(row.email).toMatch(/@guests\.invalid$/);
+    });
+  });
+
+  it('joins the guest into the trip roster', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      await makeGuest(h, trip.id, 'Jake');
+      const listed = await h.client.callTool({ name: 'list_trip_members', arguments: { tripId: trip.id } });
+      const data = parseToolResult(listed) as any;
+      expect(data.members.map((m: any) => m.username)).toContain('Jake');
+    });
+  });
+
+  it('broadcasts member:added event', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      await makeGuest(h, trip.id, 'Anna');
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'member:added', expect.any(Object));
+    });
+  });
+
+  it('rejects a whitespace-only name', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: '   ' },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) AS n FROM users WHERE is_guest = 1').get()).toEqual({ n: 0 });
+    });
+  });
+
+  it('returns error when a member who is not the owner tries to add a guest', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    await withHarness(collaborator.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: 'Anna' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('returns access denied for a non-member', async () => {
+    const { user: outsider } = createUser(testDb);
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(outsider.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: 'Anna' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'create_trip_guest',
+        arguments: { tripId: trip.id, name: 'Anna' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+describe('Tool: rename_trip_guest', () => {
+  it('renames the guest', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, trip.id, 'Anna');
+      const result = await h.client.callTool({
+        name: 'rename_trip_guest',
+        arguments: { tripId: trip.id, guestId, name: 'Anna B.' },
+      });
+      expect((parseToolResult(result) as any).success).toBe(true);
+      const row = testDb.prepare('SELECT display_name FROM users WHERE id = ?').get(guestId) as any;
+      expect(row.display_name).toBe('Anna B.');
+    });
+  });
+
+  it('rejects a whitespace-only name', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, trip.id, 'Anna');
+      const result = await h.client.callTool({
+        name: 'rename_trip_guest',
+        arguments: { tripId: trip.id, guestId, name: '  ' },
+      });
+      expect(result.isError).toBe(true);
+      const row = testDb.prepare('SELECT display_name FROM users WHERE id = ?').get(guestId) as any;
+      expect(row.display_name).toBe('Anna');
+    });
+  });
+
+  it('will not rename a guest of another trip', async () => {
+    const { user: owner } = createUser(testDb);
+    const ownTrip = createTrip(testDb, owner.id);
+    const otherTrip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, otherTrip.id, 'Anna');
+      const result = await h.client.callTool({
+        name: 'rename_trip_guest',
+        arguments: { tripId: ownTrip.id, guestId, name: 'Renamed' },
+      });
+      expect(result.isError).toBe(true);
+      const row = testDb.prepare('SELECT display_name FROM users WHERE id = ?').get(guestId) as any;
+      expect(row.display_name).toBe('Anna');
+    });
+  });
+
+  it('returns error when a member who is not the owner tries to rename', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    let guestId = 0;
+    await withHarness(owner.id, async (h) => { guestId = await makeGuest(h, trip.id, 'Anna'); });
+    await withHarness(collaborator.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'rename_trip_guest',
+        arguments: { tripId: trip.id, guestId, name: 'Renamed' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'rename_trip_guest',
+        arguments: { tripId: trip.id, guestId: 1, name: 'Anna' },
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+describe('Tool: delete_trip_guest', () => {
+  it('deletes the guest outright', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, trip.id, 'Anna');
+      const result = await h.client.callTool({
+        name: 'delete_trip_guest',
+        arguments: { tripId: trip.id, guestId },
+      });
+      expect((parseToolResult(result) as any).success).toBe(true);
+      expect(testDb.prepare('SELECT id FROM users WHERE id = ?').get(guestId)).toBeUndefined();
+      expect(testDb.prepare('SELECT user_id FROM trip_members WHERE user_id = ?').get(guestId)).toBeUndefined();
+    });
+  });
+
+  it('broadcasts member:removed event', async () => {
+    const { user: owner } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, trip.id, 'Anna');
+      broadcastMock.mockClear();
+      await h.client.callTool({ name: 'delete_trip_guest', arguments: { tripId: trip.id, guestId } });
+      expect(broadcastMock).toHaveBeenCalledWith(trip.id, 'member:removed', expect.objectContaining({ userId: guestId }));
+    });
+  });
+
+  it('will not delete a guest of another trip', async () => {
+    const { user: owner } = createUser(testDb);
+    const ownTrip = createTrip(testDb, owner.id);
+    const otherTrip = createTrip(testDb, owner.id);
+    await withHarness(owner.id, async (h) => {
+      const guestId = await makeGuest(h, otherTrip.id, 'Anna');
+      const result = await h.client.callTool({
+        name: 'delete_trip_guest',
+        arguments: { tripId: ownTrip.id, guestId },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM users WHERE id = ?').get(guestId)).toBeDefined();
+    });
+  });
+
+  it('will not delete a real member through the guest route', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'delete_trip_guest',
+        arguments: { tripId: trip.id, guestId: collaborator.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM users WHERE id = ?').get(collaborator.id)).toBeDefined();
+    });
+  });
+
+  it('returns error when a member who is not the owner tries to delete', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: collaborator } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, collaborator.id);
+    let guestId = 0;
+    await withHarness(owner.id, async (h) => { guestId = await makeGuest(h, trip.id, 'Anna'); });
+    await withHarness(collaborator.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'delete_trip_guest',
+        arguments: { tripId: trip.id, guestId },
+      });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM users WHERE id = ?').get(guestId)).toBeDefined();
+    });
+  });
+
+  it('blocks demo user', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { user } = createUser(testDb, { email: 'demo@nomad.app' });
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'delete_trip_guest',
+        arguments: { tripId: trip.id, guestId: 1 },
+      });
+      expect(result.isError).toBe(true);
     });
   });
 });

--- a/server/tests/unit/mcp/tools-trip-warnings.test.ts
+++ b/server/tests/unit/mcp/tools-trip-warnings.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for the get_trip_warnings MCP tool (src/nest/plugins/contributions/
+ * trip-warnings.mcp.ts), the MCP counterpart of GET /api/trip-warnings/:tripId.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { testDb, dbMock } = vi.hoisted(() => {
+  const Database = require('better-sqlite3');
+  const db = new Database(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  const mock = {
+    db,
+    closeDb: () => {},
+    reinitialize: () => {},
+    getPlaceWithTags: () => null,
+    canAccessTrip: (tripId: number, userId: number) =>
+      db
+        .prepare(
+          'SELECT t.id FROM trips t LEFT JOIN trip_members m ON m.trip_id = t.id AND m.user_id = ? WHERE t.id = ? AND (t.user_id = ? OR m.user_id IS NOT NULL)',
+        )
+        .get(userId, tripId, userId),
+    isOwner: (tripId: number, userId: number) =>
+      !!db.prepare('SELECT id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  };
+  return { testDb: db, dbMock: mock };
+});
+
+const { broadcastMock, pluginsEnabled } = vi.hoisted(() => ({
+  broadcastMock: vi.fn(),
+  pluginsEnabled: vi.fn(() => true),
+}));
+
+vi.mock('../../../src/db/database', () => dbMock);
+vi.mock('../../../src/websocket', () => ({ broadcast: broadcastMock }));
+vi.mock('../../../src/config', () => ({
+  JWT_SECRET: 'test-jwt-secret-for-trek-testing-only',
+  ENCRYPTION_KEY: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2',
+  updateJwtSecret: () => {},
+}));
+// The admin kill switch reads live env; drive it from the test instead of the process.
+vi.mock('../../../src/nest/plugins/kill-switch', () => ({ pluginsEnabled }));
+
+import { runMigrations } from '../../../src/db/migrations';
+import { createTables } from '../../../src/db/schema';
+import { addTripMember, createTrip, createUser } from '../../helpers/factories';
+import { createMcpHarness, parseToolResult, type McpHarness } from '../../helpers/mcp-harness';
+import { resetTestDb } from '../../helpers/test-db';
+import { PluginHooks } from '../../../src/nest/plugins/plugin-hooks.service';
+
+// The harness builds the registry itself, so the fan-out is played on the prototype
+// (the tools-transit.test.ts pattern). vitest is not configured to auto-restore, so
+// every case restates what it wants in beforeEach.
+const providersOfMock = vi.spyOn(PluginHooks.prototype, 'providersOf');
+const tripWarningsMock = vi.spyOn(PluginHooks.prototype, 'tripWarnings');
+
+beforeAll(() => {
+  createTables(testDb);
+  runMigrations(testDb);
+});
+
+beforeEach(() => {
+  resetTestDb(testDb);
+  broadcastMock.mockClear();
+  pluginsEnabled.mockReturnValue(true);
+  providersOfMock.mockReset().mockReturnValue([]);
+  tripWarningsMock.mockReset().mockResolvedValue([]);
+});
+
+afterAll(() => {
+  testDb.close();
+});
+
+async function withHarness(
+  userId: number,
+  fn: (h: McpHarness) => Promise<void>,
+  scopes?: string[] | null,
+) {
+  const h = await createMcpHarness({ userId, withResources: false, scopes: scopes ?? null });
+  try { await fn(h); } finally { await h.cleanup(); }
+}
+
+interface WarningsPayload {
+  warnings: { pluginId: string; level: string; message: string; dayId?: number; placeId?: number }[];
+}
+
+const call = async (h: McpHarness, tripId: number) =>
+  h.client.callTool({ name: 'get_trip_warnings', arguments: { tripId } });
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_trip_warnings', () => {
+  it('merges every provider, tags each warning with the plugin that raised it', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Kyoto' });
+    providersOfMock.mockReturnValue(['seasons', 'logistics']);
+    tripWarningsMock.mockImplementation(async (pluginId: string) =>
+      pluginId === 'seasons'
+        ? [{ level: 'info', message: 'Rainy week ahead' }]
+        : [{ level: 'error', message: 'Day 3 has no way back', dayId: 31 }],
+    );
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toEqual([
+        { pluginId: 'seasons', level: 'info', message: 'Rainy week ahead' },
+        { pluginId: 'logistics', level: 'error', message: 'Day 3 has no way back', dayId: 31 },
+      ]);
+      expect(providersOfMock).toHaveBeenCalledWith('warningProvider');
+      expect(tripWarningsMock).toHaveBeenCalledWith('seasons', trip.id, user.id);
+    });
+  });
+
+  it('carries the place link through and defaults an unknown level to warning', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['opening-hours']);
+    tripWarningsMock.mockResolvedValue([{ level: 'catastrophe', message: 'Museum closed Mondays', placeId: 7 }]);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toEqual([
+        { pluginId: 'opening-hours', level: 'warning', message: 'Museum closed Mondays', placeId: 7 },
+      ]);
+    });
+  });
+
+  it('answers with an empty list when no plugin provides warnings', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload).toEqual({ warnings: [] });
+      expect(tripWarningsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('is readable by a collaborator, not just the owner', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    addTripMember(testDb, trip.id, member.id);
+    providersOfMock.mockReturnValue(['logistics']);
+    tripWarningsMock.mockResolvedValue([{ level: 'warning', message: 'Tight connection' }]);
+
+    await withHarness(member.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toHaveLength(1);
+      expect(tripWarningsMock).toHaveBeenCalledWith('logistics', trip.id, member.id);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Access
+// ---------------------------------------------------------------------------
+
+describe('get_trip_warnings access', () => {
+  it('refuses a trip the caller is not on, without asking any provider', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    providersOfMock.mockReturnValue(['logistics']);
+
+    await withHarness(stranger.id, async (h) => {
+      const result = await call(h, trip.id);
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+      expect(tripWarningsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('refuses a trip that does not exist', async () => {
+    const { user } = createUser(testDb);
+
+    await withHarness(user.id, async (h) => {
+      const result = await call(h, 999999);
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Trip not found or access denied.');
+    });
+  });
+
+  it('checks trip access before the kill switch, so a stranger never learns the switch is off', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    const trip = createTrip(testDb, owner.id);
+    pluginsEnabled.mockReturnValue(false);
+
+    await withHarness(stranger.id, async (h) => {
+      const result = await call(h, trip.id);
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it('rides trips:read: present with it, absent without it', async () => {
+    const { user } = createUser(testDb);
+
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).toContain('get_trip_warnings');
+    }, ['trips:read']);
+
+    await withHarness(user.id, async (h) => {
+      const names = (await h.client.listTools()).tools.map(t => t.name);
+      expect(names).not.toContain('get_trip_warnings');
+    }, ['places:read']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Degrading rather than failing
+// ---------------------------------------------------------------------------
+
+describe('get_trip_warnings resilience', () => {
+  it('answers empty when an admin has the plugin system switched off', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    pluginsEnabled.mockReturnValue(false);
+    providersOfMock.mockReturnValue(['logistics']);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload).toEqual({ warnings: [] });
+      expect(providersOfMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('drops a provider that throws or times out and keeps the rest', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['broken', 'healthy']);
+    tripWarningsMock.mockImplementation(async (pluginId: string) => {
+      if (pluginId === 'broken') throw new Error('hook timed out after 5000ms');
+      return [{ level: 'warning', message: 'Still here' }];
+    });
+
+    await withHarness(user.id, async (h) => {
+      const result = await call(h, trip.id);
+      expect(result.isError).toBeFalsy();
+      const payload = parseToolResult(result) as WarningsPayload;
+      expect(payload.warnings).toEqual([{ pluginId: 'healthy', level: 'warning', message: 'Still here' }]);
+    });
+  });
+
+  it('ignores a provider that answers with something other than an array', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['confused']);
+    tripWarningsMock.mockResolvedValue({ warnings: 'lots' });
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload).toEqual({ warnings: [] });
+    });
+  });
+
+  it('skips null entries instead of losing the whole provider to them', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['sloppy']);
+    tripWarningsMock.mockResolvedValue([null, { level: 'info', message: 'Survives' }, 'nope']);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toEqual([{ pluginId: 'sloppy', level: 'info', message: 'Survives' }]);
+    });
+  });
+
+  it('drops a warning with no message rather than emitting a blank line', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['sloppy']);
+    tripWarningsMock.mockResolvedValue([{ level: 'error' }, { level: 'error', message: '' }]);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload).toEqual({ warnings: [] });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caps
+// ---------------------------------------------------------------------------
+
+describe('get_trip_warnings caps', () => {
+  it('caps a flooding provider at 20 warnings and truncates an oversized message', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['flood']);
+    tripWarningsMock.mockResolvedValue([
+      { level: 'warning', message: 'z'.repeat(1000) },
+      ...Array.from({ length: 50 }, (_v, i) => ({ level: 'info', message: `w${i}` })),
+    ]);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toHaveLength(20);
+      expect(payload.warnings[0].message).toHaveLength(300);
+    });
+  });
+
+  it('caps each provider separately, so two providers can contribute 40', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['a', 'b']);
+    tripWarningsMock.mockResolvedValue(
+      Array.from({ length: 50 }, (_v, i) => ({ level: 'info', message: `w${i}` })),
+    );
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings).toHaveLength(40);
+    });
+  });
+
+  it('strips emojis, because the assistant relays this text as TREK chrome', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    providersOfMock.mockReturnValue(['loud']);
+    tripWarningsMock.mockResolvedValue([{ level: 'error', message: '🔥 Overbooked!' }]);
+
+    await withHarness(user.id, async (h) => {
+      const payload = parseToolResult(await call(h, trip.id)) as WarningsPayload;
+      expect(payload.warnings[0].message).toBe('Overbooked!');
+    });
+  });
+});

--- a/server/tests/unit/mcp/tools-trips.test.ts
+++ b/server/tests/unit/mcp/tools-trips.test.ts
@@ -7,7 +7,7 @@
  * notice riding the attach ctx, and the scope gating (declarative
  * trips:write markers + the canReadTrips/canDeleteTrips predicates).
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 const { testDb, dbMock } = vi.hoisted(() => {
   const Database = require('better-sqlite3');
@@ -53,6 +53,11 @@ beforeEach(() => {
   resetTestDb(testDb);
   broadcastMock.mockClear();
   delete process.env.DEMO_MODE;
+});
+
+// Only search_cover_images stubs fetch, and it stubs a different response per case.
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 afterAll(() => {
@@ -132,6 +137,57 @@ describe('Tool: create_trip', () => {
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'create_trip', arguments: { title: 'Demo Trip' } });
       expect(result.isError).toBe(true);
+    });
+  });
+
+  it('gives a dateless trip the requested day_count instead of the default 7', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_trip', arguments: { title: 'Open Ended', day_count: 12 } });
+      const data = parseToolResult(result) as any;
+      const days = testDb.prepare('SELECT COUNT(*) as c FROM days WHERE trip_id = ?').get(data.trip.id) as { c: number };
+      expect(days.c).toBe(12);
+      const row = testDb.prepare('SELECT start_date, end_date FROM trips WHERE id = ?').get(data.trip.id) as any;
+      expect(row.start_date).toBeNull();
+      expect(row.end_date).toBeNull();
+    });
+  });
+
+  it('refuses a day_count outside 1..365', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.callTool({ name: 'create_trip', arguments: { title: 'Zero', day_count: 0 } })).isError).toBe(true);
+      expect((await h.client.callTool({ name: 'create_trip', arguments: { title: 'Huge', day_count: 400 } })).isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) as c FROM trips').get()).toEqual({ c: 0 });
+    });
+  });
+
+  it('stores the requested reminder_days', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_trip', arguments: { title: 'Reminded', reminder_days: 14 } });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT reminder_days FROM trips WHERE id = ?').get(data.trip.id) as any;
+      expect(row.reminder_days).toBe(14);
+    });
+  });
+
+  it('turns the reminder off with reminder_days 0 rather than falling back to 3', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'create_trip', arguments: { title: 'Quiet', reminder_days: 0 } });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT reminder_days FROM trips WHERE id = ?').get(data.trip.id) as any;
+      expect(row.reminder_days).toBe(0);
+    });
+  });
+
+  it('refuses a reminder_days outside 0..30', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.callTool({ name: 'create_trip', arguments: { title: 'Early', reminder_days: 31 } })).isError).toBe(true);
+      expect((await h.client.callTool({ name: 'create_trip', arguments: { title: 'Negative', reminder_days: -1 } })).isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) as c FROM trips').get()).toEqual({ c: 0 });
     });
   });
 });
@@ -271,6 +327,173 @@ describe('Tool: update_trip', () => {
         "SELECT date FROM vacay_entries WHERE plan_id = ? AND user_id = ? AND date BETWEEN '2026-09-08' AND '2026-09-14' ORDER BY date"
     ).all(ownPlanId, user.id) as { date: string }[];
     expect(shifted.map(r => r.date)).toEqual(['2026-09-09', '2026-09-10']);
+  });
+
+  it('clear_dates turns a dated trip back into a dateless one and un-dates its days', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-07-01', end_date: '2026-07-05' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, clear_dates: true } });
+      expect(result.isError).toBeFalsy();
+      const row = testDb.prepare('SELECT start_date, end_date FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.start_date).toBeNull();
+      expect(row.end_date).toBeNull();
+      const dated = testDb.prepare('SELECT COUNT(*) as c FROM days WHERE trip_id = ? AND date IS NOT NULL').get(trip.id) as { c: number };
+      expect(dated.c).toBe(0);
+    });
+  });
+
+  it('clear_dates with a day_count resizes the now dateless trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-07-01', end_date: '2026-07-05' });
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, clear_dates: true, day_count: 3 } });
+      const days = testDb.prepare('SELECT COUNT(*) as c FROM days WHERE trip_id = ?').get(trip.id) as { c: number };
+      expect(days.c).toBe(3);
+    });
+  });
+
+  it('refuses clear_dates alongside a start_date and leaves the trip untouched', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-07-01', end_date: '2026-07-05' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_trip',
+        arguments: { tripId: trip.id, clear_dates: true, start_date: '2026-08-01' },
+      });
+      expect(result.isError).toBe(true);
+      const row = testDb.prepare('SELECT start_date FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.start_date).toBe('2026-07-01');
+    });
+  });
+
+  it('resizes a dateless trip with day_count', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, 1, NULL), (?, 2, NULL)').run(trip.id, trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, day_count: 6 } });
+      const days = testDb.prepare('SELECT COUNT(*) as c FROM days WHERE trip_id = ?').get(trip.id) as { c: number };
+      expect(days.c).toBe(6);
+    });
+  });
+
+  it('refuses a day_count outside 1..365', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Untouched' });
+    await withHarness(user.id, async (h) => {
+      expect((await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, day_count: 0 } })).isError).toBe(true);
+      expect((await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, day_count: 400 } })).isError).toBe(true);
+      expect(testDb.prepare('SELECT COUNT(*) as c FROM days WHERE trip_id = ?').get(trip.id)).toEqual({ c: 0 });
+    });
+  });
+
+  it('changes reminder_days and can turn the reminder off', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, reminder_days: 10 } });
+      expect((testDb.prepare('SELECT reminder_days FROM trips WHERE id = ?').get(trip.id) as any).reminder_days).toBe(10);
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, reminder_days: 0 } });
+      expect((testDb.prepare('SELECT reminder_days FROM trips WHERE id = ?').get(trip.id) as any).reminder_days).toBe(0);
+    });
+  });
+
+  it('refuses a reminder_days outside 0..30 and keeps the stored value', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, reminder_days: 31 } });
+      expect(result.isError).toBe(true);
+      expect((testDb.prepare('SELECT reminder_days FROM trips WHERE id = ?').get(trip.id) as any).reminder_days).toBe(3);
+    });
+  });
+
+  it('clears the description with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { description: 'A great trip' });
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, description: null } });
+      const row = testDb.prepare('SELECT description FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.description).toBeNull();
+    });
+  });
+
+  it('clears the cover image with an explicit null', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    testDb.prepare('UPDATE trips SET cover_image = ? WHERE id = ?').run('/uploads/covers/old.jpg', trip.id);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_trip', arguments: { tripId: trip.id, cover_image: null } });
+      const row = testDb.prepare('SELECT cover_image FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.cover_image).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search_cover_images
+// ---------------------------------------------------------------------------
+
+describe('Tool: search_cover_images', () => {
+  function stubUnsplash(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+    })));
+  }
+
+  it('returns the photo candidates for a query', async () => {
+    const { user } = createUser(testDb);
+    stubUnsplash({
+      results: [{
+        id: 'p1',
+        urls: { regular: 'https://images.unsplash.com/photo-1.jpg', small: 'https://images.unsplash.com/thumb-1.jpg' },
+        alt_description: 'Rooftops at sunset',
+        user: { name: 'Ada L.' },
+        links: { html: 'https://unsplash.com/photos/p1' },
+      }],
+    });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'search_cover_images', arguments: { query: 'Lisbon rooftops' } });
+      const data = parseToolResult(result) as any;
+      expect(data.photos).toHaveLength(1);
+      expect(data.photos[0].url).toBe('https://images.unsplash.com/photo-1.jpg');
+      expect(data.photos[0].photographer).toBe('Ada L.');
+    });
+  });
+
+  it('reports an upstream failure as a tool error', async () => {
+    const { user } = createUser(testDb);
+    stubUnsplash({ errors: ['Rate Limit Exceeded'] }, { ok: false, status: 429 });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'search_cover_images', arguments: { query: 'Lisbon' } });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toBe('Rate Limit Exceeded');
+    });
+  });
+
+  it('refuses an empty query without reaching Unsplash', async () => {
+    const { user } = createUser(testDb);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'search_cover_images', arguments: { query: '' } });
+      expect(result.isError).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('saves nothing on the trip', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    stubUnsplash({ results: [] });
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'search_cover_images', arguments: { query: 'Lisbon' } });
+      const row = testDb.prepare('SELECT cover_image FROM trips WHERE id = ?').get(trip.id) as any;
+      expect(row.cover_image).toBeNull();
+    });
   });
 });
 
@@ -674,8 +897,8 @@ describe('scope gating', () => {
     }
   }
 
-  const WRITE_TOOLS = ['create_trip', 'update_trip', 'add_trip_member', 'remove_trip_member', 'copy_trip'];
-  const READ_TOOLS = ['list_trip_members', 'export_trip_ics'];
+  const WRITE_TOOLS = ['create_trip', 'update_trip', 'add_trip_member', 'remove_trip_member', 'leave_trip', 'copy_trip'];
+  const READ_TOOLS = ['list_trip_members', 'export_trip_ics', 'search_cover_images'];
   const NAV_TOOLS = ['list_trips', 'get_trip_summary'];
   const SHARE_TOOLS = ['get_share_link', 'create_share_link', 'delete_share_link'];
 

--- a/server/tests/unit/mcp/tools-vacay.test.ts
+++ b/server/tests/unit/mcp/tools-vacay.test.ts
@@ -1,17 +1,19 @@
 /**
  * Unit tests for MCP vacay tools (vacay addon-gated, VacayMcp — DI-discovered
  * via the hand-built test registry in tests/helpers/mcp-test-controllers.ts):
- * get_vacay_plan, update_vacay_plan, set_vacay_color,
+ * get_vacay_plan, get_vacay_year_settings, update_vacay_plan, set_vacay_color,
  * list_vacay_years, add_vacay_year, delete_vacay_year,
  * get_vacay_entries, toggle_vacay_entry, toggle_company_holiday,
  * get_vacay_stats, update_vacay_stats,
  * add_holiday_calendar, update_holiday_calendar, delete_holiday_calendar,
- * list_holiday_countries, list_holidays.
+ * list_holiday_countries, list_holidays,
+ * list_school_holiday_regions, list_school_holidays,
+ * get_shareable_vacay_users.
  * Resources: trek://vacay/plan, trek://vacay/entries/{year},
  * trek://vacay/holidays/{year} — these ride the registry too (attached inside
  * registerTools), so `withTools` must stay on even for resource reads.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 const { testDb, dbMock } = vi.hoisted(() => {
   const Database = require('better-sqlite3');
@@ -53,14 +55,24 @@ import { ADDON_IDS } from '../../../src/addons';
 import { createMcpHarness, parseToolResult, parseResourceResult, type McpHarness } from '../../helpers/mcp-harness';
 import { VacayService } from '../../../src/nest/vacay/vacay.service';
 
+// The plan-settings tests below need the real SQL write, so keep the
+// implementation the blanket stub replaces and delegate to it for one call.
+const realUpdatePlan = VacayService.prototype.updatePlan;
+
 // Stub the async methods that make external calls (VacayService is DI-native;
 // the registry constructs a real instance, so spy on the prototype — the
 // successor of the legacy path-level partial mock of services/vacayService).
-vi.spyOn(VacayService.prototype, 'updatePlan').mockResolvedValue({
+const updatePlanSpy = vi.spyOn(VacayService.prototype, 'updatePlan').mockResolvedValue({
   plan: { id: 1, block_weekends: true, holidays_enabled: false, company_holidays_enabled: false, carry_over_enabled: false, holiday_calendars: [] },
 } as never);
 vi.spyOn(VacayService.prototype, 'getCountries').mockResolvedValue({ data: [{ code: 'US', name: 'United States' }] });
 vi.spyOn(VacayService.prototype, 'getHolidays').mockResolvedValue({ data: [{ date: '2025-01-01', name: 'New Year' }] });
+const schoolRegionsSpy = vi.spyOn(VacayService.prototype, 'getSchoolHolidayRegions').mockResolvedValue({
+  data: { groups: [{ code: 'DE-BY-1', name: 'Bayern' }], subdivisions: [{ code: 'DE-BY', name: 'Bayern' }] },
+});
+const schoolHolidaysSpy = vi.spyOn(VacayService.prototype, 'getSchoolHolidays').mockResolvedValue({
+  data: [{ name: 'Sommerferien', startDate: '2025-07-28', endDate: '2025-09-08' }],
+});
 
 beforeAll(() => {
   createTables(testDb);
@@ -73,6 +85,9 @@ beforeEach(() => {
   // the admin panel writes — and this addon ships disabled by default.
   setAddonEnabled(testDb, ADDON_IDS.VACAY, true);
   broadcastMock.mockClear();
+  updatePlanSpy.mockClear();
+  schoolRegionsSpy.mockClear();
+  schoolHolidaysSpy.mockClear();
   delete process.env.DEMO_MODE;
 });
 
@@ -88,6 +103,23 @@ async function withHarness(userId: number, fn: (h: McpHarness) => Promise<void>)
 async function withResourceHarness(userId: number, fn: (h: McpHarness) => Promise<void>) {
   const h = await createMcpHarness({ userId, withResources: true });
   try { await fn(h); } finally { await h.cleanup(); }
+}
+
+function errorText(result: Awaited<ReturnType<McpHarness['client']['callTool']>>): string {
+  const text = (result.content as { type: string; text?: string }[]).find((c) => c.type === 'text');
+  return text?.text ?? '';
+}
+
+/** Fuse two users into one plan through the invite tools, as a member would. */
+async function fusePlan(ownerId: number, memberId: number): Promise<number> {
+  await withHarness(ownerId, async (h) => {
+    await h.client.callTool({ name: 'send_vacay_invite', arguments: { targetUserId: memberId } });
+  });
+  const planId = (testDb.prepare('SELECT plan_id FROM vacay_plan_members WHERE user_id = ?').get(memberId) as { plan_id: number }).plan_id;
+  await withHarness(memberId, async (h) => {
+    await h.client.callTool({ name: 'accept_vacay_invite', arguments: { planId } });
+  });
+  return planId;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,12 +158,82 @@ describe('Tool: update_vacay_plan', () => {
     });
   });
 
+  it('persists school holidays, the weekend weekdays and the week start', async () => {
+    const { user } = createUser(testDb);
+    updatePlanSpy.mockImplementationOnce(realUpdatePlan);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'update_vacay_plan',
+        arguments: { school_holidays_enabled: true, weekend_days: '5,6', week_start: 0 },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.plan.school_holidays_enabled).toBe(true);
+
+      const row = testDb.prepare('SELECT school_holidays_enabled, weekend_days, week_start FROM vacay_plans WHERE owner_id = ?').get(user.id) as any;
+      expect(row.school_holidays_enabled).toBe(1);
+      expect(row.weekend_days).toBe('5,6');
+      expect(row.week_start).toBe(0);
+    });
+  });
+
+  it('leaves the untouched settings alone', async () => {
+    const { user } = createUser(testDb);
+    updatePlanSpy.mockImplementationOnce(realUpdatePlan);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'update_vacay_plan', arguments: { weekend_days: '1,2' } });
+      const row = testDb.prepare('SELECT weekend_days, week_start, school_holidays_enabled FROM vacay_plans WHERE owner_id = ?').get(user.id) as any;
+      expect(row.weekend_days).toBe('1,2');
+      // Column defaults, not values this call wrote.
+      expect(row.week_start).toBe(1);
+      expect(row.school_holidays_enabled).toBe(0);
+    });
+  });
+
+  it('refuses a non-numeric week_start', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'update_vacay_plan', arguments: { week_start: 'monday' } });
+      expect(result.isError).toBe(true);
+      expect(updatePlanSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('blocks demo user', async () => {
     process.env.DEMO_MODE = 'true';
     const { user } = createUser(testDb, { email: 'demo@nomad.app' });
     await withHarness(user.id, async (h) => {
       const result = await h.client.callTool({ name: 'update_vacay_plan', arguments: { block_weekends: true } });
       expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_vacay_year_settings
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_vacay_year_settings', () => {
+  it('falls back to the calendar year when nothing is stored', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_vacay_year_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.year_type).toBe('calendar');
+      expect(data.settings.year_start_month).toBe(1);
+      expect(data.settings.year_start_day).toBe(1);
+    });
+  });
+
+  it('returns a stored fiscal window', async () => {
+    const { user } = createUser(testDb);
+    testDb.prepare('INSERT INTO vacay_user_settings (user_id, year_type, year_start_month, year_start_day, hire_date) VALUES (?, ?, ?, ?, ?)')
+      .run(user.id, 'fiscal', 4, 6, null);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'get_vacay_year_settings', arguments: {} });
+      const data = parseToolResult(result) as any;
+      expect(data.settings.year_type).toBe('fiscal');
+      expect(data.settings.year_start_month).toBe(4);
+      expect(data.settings.year_start_day).toBe(6);
     });
   });
 });
@@ -258,6 +360,97 @@ describe('Tool: toggle_vacay_entry', () => {
     });
   });
 
+  it('logs a half day', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-16', fraction: 0.5 } });
+      const data = parseToolResult(result) as any;
+      expect(data.action).toBe('added');
+
+      const row = testDb.prepare('SELECT fraction, kind FROM vacay_entries WHERE user_id = ? AND date = ?').get(user.id, '2025-06-16') as any;
+      expect(row.fraction).toBe(0.5);
+      expect(row.kind).toBe('vacation');
+    });
+  });
+
+  it('logs a comp day', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-17', kind: 'comp' } });
+      const row = testDb.prepare('SELECT fraction, kind FROM vacay_entries WHERE user_id = ? AND date = ?').get(user.id, '2025-06-17') as any;
+      expect(row.kind).toBe('comp');
+      expect(row.fraction).toBe(1);
+    });
+  });
+
+  it('converts the day in place on a different fraction and clears it on a repeat', async () => {
+    const { user } = createUser(testDb);
+    const row = () => testDb.prepare('SELECT fraction, kind FROM vacay_entries WHERE user_id = ? AND date = ?').get(user.id, '2025-06-18') as any;
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-18', fraction: 0.5, kind: 'comp' } });
+      expect(row().fraction).toBe(0.5);
+
+      const converted = await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-18', fraction: 1, kind: 'comp' } });
+      expect((parseToolResult(converted) as any).action).toBe('updated');
+      expect(row().fraction).toBe(1);
+      expect(row().kind).toBe('comp');
+
+      const cleared = await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-18', fraction: 1, kind: 'comp' } });
+      expect((parseToolResult(cleared) as any).action).toBe('removed');
+      expect(row()).toBeUndefined();
+    });
+  });
+
+  it('logs the day for another member of the plan', async () => {
+    const { user: owner } = createUser(testDb);
+    const { user: member } = createUser(testDb);
+    await fusePlan(owner.id, member.id);
+
+    await withHarness(owner.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'toggle_vacay_entry',
+        arguments: { date: '2025-06-19', fraction: 0.5, targetUserId: member.id },
+      });
+      expect((parseToolResult(result) as any).action).toBe('added');
+
+      const row = testDb.prepare('SELECT user_id, fraction FROM vacay_entries WHERE date = ?').get('2025-06-19') as any;
+      expect(row.user_id).toBe(member.id);
+      expect(row.fraction).toBe(0.5);
+    });
+  });
+
+  it('refuses a target user outside the plan, the way POST /entries/toggle does', async () => {
+    const { user } = createUser(testDb);
+    const { user: stranger } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'toggle_vacay_entry',
+        arguments: { date: '2025-06-20', targetUserId: stranger.id },
+      });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('User not in plan');
+      expect(testDb.prepare('SELECT id FROM vacay_entries WHERE user_id = ?').get(stranger.id)).toBeUndefined();
+    });
+  });
+
+  it('refuses a fraction the contract does not allow', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-21', fraction: 0.25 } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM vacay_entries WHERE date = ?').get('2025-06-21')).toBeUndefined();
+    });
+  });
+
+  it('refuses a leave kind the contract does not allow', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'toggle_vacay_entry', arguments: { date: '2025-06-22', kind: 'sabbatical' } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM vacay_entries WHERE date = ?').get('2025-06-22')).toBeUndefined();
+    });
+  });
+
   it('blocks demo user', async () => {
     process.env.DEMO_MODE = 'true';
     const { user } = createUser(testDb, { email: 'demo@nomad.app' });
@@ -349,6 +542,41 @@ describe('Tool: add_holiday_calendar', () => {
       const data = parseToolResult(result) as any;
       expect(data.calendar).toBeDefined();
       expect(data.calendar.region).toBe('US');
+    });
+  });
+
+  it('stores a school-holiday calendar with the colour that goes with the type', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'add_holiday_calendar',
+        arguments: { region: 'DE-BY', type: 'school_holiday' },
+      });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT type, region, color FROM vacay_holiday_calendars WHERE id = ?').get(data.calendar.id) as any;
+      expect(row.type).toBe('school_holiday');
+      expect(row.region).toBe('DE-BY');
+      expect(row.color).toBe('#a5f3fc');
+    });
+  });
+
+  it('still writes a public-holiday calendar when the type is omitted', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'add_holiday_calendar', arguments: { region: 'GB' } });
+      const data = parseToolResult(result) as any;
+      const row = testDb.prepare('SELECT type, color FROM vacay_holiday_calendars WHERE id = ?').get(data.calendar.id) as any;
+      expect(row.type).toBe('public_holiday');
+      expect(row.color).toBe('#fecaca');
+    });
+  });
+
+  it('refuses a calendar type outside the contract', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'add_holiday_calendar', arguments: { region: 'DE', type: 'bank_holiday' } });
+      expect(result.isError).toBe(true);
+      expect(testDb.prepare('SELECT id FROM vacay_holiday_calendars WHERE region = ?').get('DE')).toBeUndefined();
     });
   });
 
@@ -460,6 +688,86 @@ describe('Tool: list_holidays', () => {
 });
 
 // ---------------------------------------------------------------------------
+// list_school_holiday_regions
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_school_holiday_regions', () => {
+  it('returns the group and subdivision codes, asking in the country language like the route does', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_school_holiday_regions', arguments: { country: 'de' } });
+      const data = parseToolResult(result) as any;
+      expect(data.regions.subdivisions[0].code).toBe('DE-BY');
+      expect(schoolRegionsSpy).toHaveBeenCalledWith('de', 'DE');
+    });
+  });
+
+  it('asks in English for every other country', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'list_school_holiday_regions', arguments: { country: 'NL' } });
+      expect(schoolRegionsSpy).toHaveBeenCalledWith('NL', 'EN');
+    });
+  });
+
+  it('surfaces the upstream failure', async () => {
+    const { user } = createUser(testDb);
+    schoolRegionsSpy.mockResolvedValueOnce({ error: 'Failed to fetch school holiday regions' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_school_holiday_regions', arguments: { country: 'DE' } });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('Failed to fetch school holiday regions');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_school_holidays
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_school_holidays', () => {
+  it('forwards the subdivision and group filters', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_school_holidays',
+        arguments: { country: 'DE', year: 2025, subdivision: 'DE-BY', group: 'DE-BY-1' },
+      });
+      const data = parseToolResult(result) as any;
+      expect(data.holidays[0].name).toBe('Sommerferien');
+      expect(schoolHolidaysSpy).toHaveBeenCalledWith('2025', 'DE', 'DE-BY', 'DE', 'DE-BY-1');
+    });
+  });
+
+  it('leaves both filters unset when they are omitted', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({ name: 'list_school_holidays', arguments: { country: 'AT', year: 2026 } });
+      expect(schoolHolidaysSpy).toHaveBeenCalledWith('2026', 'AT', undefined, 'EN', undefined);
+    });
+  });
+
+  it('surfaces the upstream failure', async () => {
+    const { user } = createUser(testDb);
+    schoolHolidaysSpy.mockResolvedValueOnce({ error: 'Failed to fetch school holidays' });
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_school_holidays', arguments: { country: 'DE', year: 2025 } });
+      expect(result.isError).toBe(true);
+      expect(errorText(result)).toBe('Failed to fetch school holidays');
+    });
+  });
+
+  it('refuses a non-numeric year', async () => {
+    const { user } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const result = await h.client.callTool({ name: 'list_school_holidays', arguments: { country: 'DE', year: '2025' } });
+      expect(result.isError).toBe(true);
+      expect(schoolHolidaysSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // list_vacay_shares
 // ---------------------------------------------------------------------------
 
@@ -475,6 +783,47 @@ describe('Tool: list_vacay_shares', () => {
       expect(Array.isArray(data.incoming)).toBe(true);
       expect(data.outgoing).toHaveLength(1);
       expect(data.outgoing[0].user_id).toBe(other.id);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_shareable_vacay_users
+// ---------------------------------------------------------------------------
+
+describe('Tool: get_shareable_vacay_users', () => {
+  it('offers users the fusion picker leaves out because they already sit in a plan', async () => {
+    const { user } = createUser(testDb);
+    const { user: fusedOwner } = createUser(testDb);
+    const { user: fusedMember } = createUser(testDb);
+    await fusePlan(fusedOwner.id, fusedMember.id);
+
+    await withHarness(user.id, async (h) => {
+      const shareable = parseToolResult(await h.client.callTool({ name: 'get_shareable_vacay_users', arguments: {} })) as any;
+      const fusable = parseToolResult(await h.client.callTool({ name: 'get_available_vacay_users', arguments: {} })) as any;
+
+      const shareableIds = shareable.users.map((u: any) => u.id);
+      expect(shareableIds).toContain(fusedOwner.id);
+      expect(shareableIds).toContain(fusedMember.id);
+      expect(fusable.users.map((u: any) => u.id)).not.toContain(fusedOwner.id);
+
+      // The share picker reaches across plans, so it deliberately answers with
+      // usernames only rather than widening the instance directory.
+      expect(shareable.users[0].email).toBeUndefined();
+    });
+  });
+
+  it('drops a user the caller already shares with, and never the caller', async () => {
+    const { user } = createUser(testDb);
+    const { user: other } = createUser(testDb);
+    await withHarness(user.id, async (h) => {
+      const before = parseToolResult(await h.client.callTool({ name: 'get_shareable_vacay_users', arguments: {} })) as any;
+      expect(before.users.map((u: any) => u.id)).toEqual([other.id]);
+
+      await h.client.callTool({ name: 'share_vacay_calendar', arguments: { targetUserId: other.id } });
+
+      const after = parseToolResult(await h.client.callTool({ name: 'get_shareable_vacay_users', arguments: {} })) as any;
+      expect(after.users).toEqual([]);
     });
   });
 });
@@ -639,5 +988,58 @@ describe('Tool: decline_vacay_invite', () => {
       const result = await h.client.callTool({ name: 'decline_vacay_invite', arguments: { planId: 1 } });
       expect(result.isError).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The region code add_holiday_calendar actually needs
+//
+// A group is stored as COUNTRY|group:CODE and the client's parseCalendarRegion
+// reads a bare code as a subdivision, so handing a model the provider's raw
+// group code produces a calendar that queries nothing. Belgium and the
+// Netherlands are the two countries this hits.
+// ---------------------------------------------------------------------------
+
+describe('Tool: list_school_holiday_regions (the codes a calendar can be built from)', () => {
+  async function regionsFor(userId: number, country: string): Promise<any> {
+    let data: any;
+    await withHarness(userId, async (h) => {
+      const result = await h.client.callTool({
+        name: 'list_school_holiday_regions',
+        arguments: { country },
+      });
+      data = parseToolResult(result);
+    });
+    return data;
+  }
+
+  it('prefixes a group code with the country, the way the calendar reader expects', async () => {
+    const { user } = createUser(testDb);
+    schoolRegionsSpy.mockResolvedValueOnce({ data: { groups: [{ code: 'NO', name: 'Noord' }], subdivisions: [] } });
+    const data = await regionsFor(user.id, 'NL');
+    expect(data.calendar_regions).toEqual([{ region: 'NL|group:NO', kind: 'group' }]);
+  });
+
+  it('leaves a subdivision code alone', async () => {
+    const { user } = createUser(testDb);
+    schoolRegionsSpy.mockResolvedValueOnce({ data: { groups: [], subdivisions: [{ code: 'DE-BY', name: 'Bayern' }] } });
+    const data = await regionsFor(user.id, 'DE');
+    expect(data.calendar_regions).toEqual([{ region: 'DE-BY', kind: 'subdivision' }]);
+  });
+
+  it('walks nested children, which the provider uses for sub-regions', async () => {
+    const { user } = createUser(testDb);
+    schoolRegionsSpy.mockResolvedValueOnce({
+      data: { groups: [], subdivisions: [{ code: 'CH-BE', children: [{ code: 'CH-BE-1' }, { code: 'CH-BE-2', children: null }] }] },
+    });
+    const data = await regionsFor(user.id, 'CH');
+    expect(data.calendar_regions.map((r: any) => r.region)).toEqual(['CH-BE', 'CH-BE-1', 'CH-BE-2']);
+  });
+
+  it('still returns the raw provider payload alongside it', async () => {
+    const { user } = createUser(testDb);
+    schoolRegionsSpy.mockResolvedValueOnce({ data: { groups: [], subdivisions: [{ code: 'AT-9' }] } });
+    const data = await regionsFor(user.id, 'AT');
+    expect(data.regions.subdivisions).toEqual([{ code: 'AT-9' }]);
   });
 });

--- a/shared/src/i18n/ar/oauth.ts
+++ b/shared/src/i18n/ar/oauth.ts
@@ -93,5 +93,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'الملفات',
+  'oauth.scope.group.settings': 'الإعدادات',
+  'oauth.scope.files:read.label': 'عرض ملفات الرحلة',
+  'oauth.scope.files:read.description': 'سرد مستندات الرحلة: الأسماء والأحجام ومن رفعها وبماذا ترتبط',
+  'oauth.scope.files:write.label': 'إدارة ملفات الرحلة',
+  'oauth.scope.files:write.description': 'إعادة تسمية الملفات ووصفها وربطها بالحجوزات والأماكن وتمييزها ونقلها إلى سلة المهملات',
+  'oauth.scope.files:content.label': 'قراءة محتوى الملفات',
+  'oauth.scope.files:content.description': 'قراءة محتوى مستند مرفوع، مثل ملف PDF لحجز أو تذكرة',
+  'oauth.scope.settings:read.label': 'عرض تفضيلاتك',
+  'oauth.scope.settings:read.description': 'قراءة الوحدات وتنسيق الوقت واللغة والعملة الافتراضية وصفحة البداية',
+  'oauth.scope.settings:write.label': 'تغيير تفضيلاتك',
+  'oauth.scope.settings:write.description': 'تغيير الوحدات وتنسيق الوقت واللغة والعملة الافتراضية وصفحة البداية. لا مفاتيح API المخزنة أبدًا',
 };
 export default oauth;

--- a/shared/src/i18n/br/oauth.ts
+++ b/shared/src/i18n/br/oauth.ts
@@ -95,5 +95,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Arquivos',
+  'oauth.scope.group.settings': 'Configurações',
+  'oauth.scope.files:read.label': 'Ver arquivos da viagem',
+  'oauth.scope.files:read.description': 'Listar os documentos de uma viagem: nomes, tamanhos, quem enviou e a que estão vinculados',
+  'oauth.scope.files:write.label': 'Gerenciar arquivos da viagem',
+  'oauth.scope.files:write.description': 'Renomear e descrever arquivos, vinculá-los a reservas e lugares, favoritá-los e movê-los para a lixeira',
+  'oauth.scope.files:content.label': 'Ler o conteúdo dos arquivos',
+  'oauth.scope.files:content.description': 'Ler o conteúdo de um documento enviado, como um PDF de reserva ou um bilhete',
+  'oauth.scope.settings:read.label': 'Ver suas preferências',
+  'oauth.scope.settings:read.description': 'Ler unidades, formato de hora, idioma, moeda padrão e página inicial',
+  'oauth.scope.settings:write.label': 'Alterar suas preferências',
+  'oauth.scope.settings:write.description': 'Alterar unidades, formato de hora, idioma, moeda padrão e página inicial. Nunca as chaves de API salvas',
 };
 export default oauth;

--- a/shared/src/i18n/ca/oauth.ts
+++ b/shared/src/i18n/ca/oauth.ts
@@ -97,5 +97,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysTool.listTrips': 'Llista els teus viatges perquè la IA pugui descobrir els IDs dels viatges',
   'oauth.authorize.alwaysTool.getTripSummary':
     'Llegeix una visió general del viatge necessària per utilitzar qualsevol altra eina',
+  'oauth.scope.group.files': 'Fitxers',
+  'oauth.scope.group.settings': 'Configuració',
+  'oauth.scope.files:read.label': 'Veure els fitxers del viatge',
+  'oauth.scope.files:read.description': 'Llistar els documents d’un viatge: noms, mides, qui els ha pujat i a què estan vinculats',
+  'oauth.scope.files:write.label': 'Gestionar els fitxers del viatge',
+  'oauth.scope.files:write.description': 'Reanomenar i descriure fitxers, vincular-los a reserves i llocs, destacar-los i enviar-los a la paperera',
+  'oauth.scope.files:content.label': 'Llegir el contingut dels fitxers',
+  'oauth.scope.files:content.description': 'Llegir el contingut d’un document pujat, com un PDF de reserva o un bitllet',
+  'oauth.scope.settings:read.label': 'Veure les teves preferències',
+  'oauth.scope.settings:read.description': 'Llegir unitats, format d’hora, idioma, moneda per defecte i pàgina d’inici',
+  'oauth.scope.settings:write.label': 'Canviar les teves preferències',
+  'oauth.scope.settings:write.description': 'Canviar unitats, format d’hora, idioma, moneda per defecte i pàgina d’inici. Mai les claus API desades',
 };
 export default oauth;

--- a/shared/src/i18n/cs/oauth.ts
+++ b/shared/src/i18n/cs/oauth.ts
@@ -93,5 +93,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Soubory',
+  'oauth.scope.group.settings': 'Nastavení',
+  'oauth.scope.files:read.label': 'Zobrazit soubory cesty',
+  'oauth.scope.files:read.description': 'Vypsat dokumenty cesty: názvy, velikosti, kdo je nahrál a k čemu jsou připojené',
+  'oauth.scope.files:write.label': 'Spravovat soubory cesty',
+  'oauth.scope.files:write.description': 'Přejmenovat a popsat soubory, připojit je k rezervacím a místům, označit hvězdičkou a přesunout do koše',
+  'oauth.scope.files:content.label': 'Číst obsah souborů',
+  'oauth.scope.files:content.description': 'Přečíst obsah nahraného dokumentu, například PDF rezervace nebo jízdenku',
+  'oauth.scope.settings:read.label': 'Zobrazit vaše předvolby',
+  'oauth.scope.settings:read.description': 'Číst jednotky, formát času, jazyk, výchozí měnu a úvodní stránku',
+  'oauth.scope.settings:write.label': 'Změnit vaše předvolby',
+  'oauth.scope.settings:write.description': 'Změnit jednotky, formát času, jazyk, výchozí měnu a úvodní stránku. Nikdy uložené API klíče',
 };
 export default oauth;

--- a/shared/src/i18n/de/oauth.ts
+++ b/shared/src/i18n/de/oauth.ts
@@ -97,5 +97,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Dateien',
+  'oauth.scope.group.settings': 'Einstellungen',
+  'oauth.scope.files:read.label': 'Reisedateien ansehen',
+  'oauth.scope.files:read.description': 'Dokumente einer Reise auflisten: Namen, Größen, wer sie hochgeladen hat und woran sie hängen',
+  'oauth.scope.files:write.label': 'Reisedateien verwalten',
+  'oauth.scope.files:write.description': 'Dateien umbenennen und beschreiben, mit Buchungen und Orten verknüpfen, markieren und in den Papierkorb legen',
+  'oauth.scope.files:content.label': 'Dateiinhalte lesen',
+  'oauth.scope.files:content.description': 'Den Inhalt eines hochgeladenen Dokuments lesen, etwa ein Buchungs-PDF oder ein Ticket',
+  'oauth.scope.settings:read.label': 'Einstellungen ansehen',
+  'oauth.scope.settings:read.description': 'Einheiten, Zeitformat, Sprache, Standardwährung und Startseite lesen',
+  'oauth.scope.settings:write.label': 'Einstellungen ändern',
+  'oauth.scope.settings:write.description': 'Einheiten, Zeitformat, Sprache, Standardwährung und Startseite ändern. Niemals gespeicherte API-Schlüssel',
 };
 export default oauth;

--- a/shared/src/i18n/en/oauth.ts
+++ b/shared/src/i18n/en/oauth.ts
@@ -94,5 +94,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included',
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs',
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool',
+  'oauth.scope.group.files': 'Files',
+  'oauth.scope.group.settings': 'Settings',
+  'oauth.scope.files:read.label': 'View trip files',
+  'oauth.scope.files:read.description': 'List the documents on a trip: names, sizes, who uploaded them, what they link to',
+  'oauth.scope.files:write.label': 'Organise trip files',
+  'oauth.scope.files:write.description': 'Rename and describe files, link them to bookings and places, star and trash them',
+  'oauth.scope.files:content.label': 'Read file contents',
+  'oauth.scope.files:content.description': 'Read what is inside an uploaded document, such as a booking PDF or a ticket',
+  'oauth.scope.settings:read.label': 'View your preferences',
+  'oauth.scope.settings:read.description': 'Read units, time format, language, default currency, and start page',
+  'oauth.scope.settings:write.label': 'Change your preferences',
+  'oauth.scope.settings:write.description': 'Change units, time format, language, default currency, and start page. Never stored API keys',
 };
 export default oauth;

--- a/shared/src/i18n/es/oauth.ts
+++ b/shared/src/i18n/es/oauth.ts
@@ -94,5 +94,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Archivos',
+  'oauth.scope.group.settings': 'Configuración',
+  'oauth.scope.files:read.label': 'Ver archivos del viaje',
+  'oauth.scope.files:read.description': 'Listar los documentos de un viaje: nombres, tamaños, quién los subió y a qué están vinculados',
+  'oauth.scope.files:write.label': 'Gestionar archivos del viaje',
+  'oauth.scope.files:write.description': 'Renombrar y describir archivos, vincularlos a reservas y lugares, destacarlos y enviarlos a la papelera',
+  'oauth.scope.files:content.label': 'Leer el contenido de archivos',
+  'oauth.scope.files:content.description': 'Leer el contenido de un documento subido, como un PDF de reserva o un billete',
+  'oauth.scope.settings:read.label': 'Ver tus preferencias',
+  'oauth.scope.settings:read.description': 'Leer unidades, formato de hora, idioma, moneda predeterminada y página de inicio',
+  'oauth.scope.settings:write.label': 'Cambiar tus preferencias',
+  'oauth.scope.settings:write.description': 'Cambiar unidades, formato de hora, idioma, moneda predeterminada y página de inicio. Nunca las claves API guardadas',
 };
 export default oauth;

--- a/shared/src/i18n/fr/oauth.ts
+++ b/shared/src/i18n/fr/oauth.ts
@@ -97,5 +97,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Fichiers',
+  'oauth.scope.group.settings': 'Paramètres',
+  'oauth.scope.files:read.label': 'Voir les fichiers du voyage',
+  'oauth.scope.files:read.description': 'Lister les documents d’un voyage : noms, tailles, qui les a envoyés et ce à quoi ils sont liés',
+  'oauth.scope.files:write.label': 'Gérer les fichiers du voyage',
+  'oauth.scope.files:write.description': 'Renommer et décrire les fichiers, les lier aux réservations et aux lieux, les épingler et les mettre à la corbeille',
+  'oauth.scope.files:content.label': 'Lire le contenu des fichiers',
+  'oauth.scope.files:content.description': 'Lire le contenu d’un document envoyé, par exemple un PDF de réservation ou un billet',
+  'oauth.scope.settings:read.label': 'Voir vos préférences',
+  'oauth.scope.settings:read.description': 'Lire les unités, le format horaire, la langue, la devise par défaut et la page d’accueil',
+  'oauth.scope.settings:write.label': 'Modifier vos préférences',
+  'oauth.scope.settings:write.description': 'Modifier les unités, le format horaire, la langue, la devise par défaut et la page d’accueil. Jamais les clés API enregistrées',
 };
 export default oauth;

--- a/shared/src/i18n/gr/oauth.ts
+++ b/shared/src/i18n/gr/oauth.ts
@@ -99,5 +99,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Αρχεία',
+  'oauth.scope.group.settings': 'Ρυθμίσεις',
+  'oauth.scope.files:read.label': 'Προβολή αρχείων ταξιδιού',
+  'oauth.scope.files:read.description': 'Λίστα των εγγράφων ενός ταξιδιού: ονόματα, μεγέθη, ποιος τα ανέβασε και με τι συνδέονται',
+  'oauth.scope.files:write.label': 'Διαχείριση αρχείων ταξιδιού',
+  'oauth.scope.files:write.description': 'Μετονομασία και περιγραφή αρχείων, σύνδεσή τους με κρατήσεις και τοποθεσίες, επισήμανση και διαγραφή',
+  'oauth.scope.files:content.label': 'Ανάγνωση περιεχομένου αρχείων',
+  'oauth.scope.files:content.description': 'Ανάγνωση του περιεχομένου ενός ανεβασμένου εγγράφου, όπως ένα PDF κράτησης ή ένα εισιτήριο',
+  'oauth.scope.settings:read.label': 'Προβολή προτιμήσεων',
+  'oauth.scope.settings:read.description': 'Ανάγνωση μονάδων, μορφής ώρας, γλώσσας, προεπιλεγμένου νομίσματος και αρχικής σελίδας',
+  'oauth.scope.settings:write.label': 'Αλλαγή προτιμήσεων',
+  'oauth.scope.settings:write.description': 'Αλλαγή μονάδων, μορφής ώρας, γλώσσας, προεπιλεγμένου νομίσματος και αρχικής σελίδας. Ποτέ αποθηκευμένων κλειδιών API',
 };
 export default oauth;

--- a/shared/src/i18n/hu/oauth.ts
+++ b/shared/src/i18n/hu/oauth.ts
@@ -97,5 +97,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Fájlok',
+  'oauth.scope.group.settings': 'Beállítások',
+  'oauth.scope.files:read.label': 'Az utazás fájljainak megtekintése',
+  'oauth.scope.files:read.description': 'Az utazás dokumentumainak listázása: nevek, méretek, ki töltötte fel és mihez kapcsolódnak',
+  'oauth.scope.files:write.label': 'Az utazás fájljainak kezelése',
+  'oauth.scope.files:write.description': 'Fájlok átnevezése és leírása, foglalásokhoz és helyekhez kapcsolása, megjelölése és kukába helyezése',
+  'oauth.scope.files:content.label': 'Fájltartalom olvasása',
+  'oauth.scope.files:content.description': 'Feltöltött dokumentum tartalmának olvasása, például egy foglalási PDF vagy jegy',
+  'oauth.scope.settings:read.label': 'Beállítások megtekintése',
+  'oauth.scope.settings:read.description': 'Mértékegységek, időformátum, nyelv, alapértelmezett pénznem és kezdőoldal olvasása',
+  'oauth.scope.settings:write.label': 'Beállítások módosítása',
+  'oauth.scope.settings:write.description': 'Mértékegységek, időformátum, nyelv, alapértelmezett pénznem és kezdőoldal módosítása. Soha nem a tárolt API-kulcsok',
 };
 export default oauth;

--- a/shared/src/i18n/id/oauth.ts
+++ b/shared/src/i18n/id/oauth.ts
@@ -94,5 +94,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Berkas',
+  'oauth.scope.group.settings': 'Pengaturan',
+  'oauth.scope.files:read.label': 'Lihat berkas perjalanan',
+  'oauth.scope.files:read.description': 'Menampilkan dokumen perjalanan: nama, ukuran, siapa yang mengunggah, dan tautannya',
+  'oauth.scope.files:write.label': 'Kelola berkas perjalanan',
+  'oauth.scope.files:write.description': 'Ganti nama dan deskripsi berkas, tautkan ke pemesanan dan tempat, beri bintang dan buang ke sampah',
+  'oauth.scope.files:content.label': 'Baca isi berkas',
+  'oauth.scope.files:content.description': 'Membaca isi dokumen yang diunggah, misalnya PDF pemesanan atau tiket',
+  'oauth.scope.settings:read.label': 'Lihat preferensi Anda',
+  'oauth.scope.settings:read.description': 'Membaca satuan, format waktu, bahasa, mata uang bawaan, dan halaman awal',
+  'oauth.scope.settings:write.label': 'Ubah preferensi Anda',
+  'oauth.scope.settings:write.description': 'Mengubah satuan, format waktu, bahasa, mata uang bawaan, dan halaman awal. Tidak pernah kunci API tersimpan',
 };
 export default oauth;

--- a/shared/src/i18n/it/oauth.ts
+++ b/shared/src/i18n/it/oauth.ts
@@ -95,5 +95,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'File',
+  'oauth.scope.group.settings': 'Impostazioni',
+  'oauth.scope.files:read.label': 'Vedere i file del viaggio',
+  'oauth.scope.files:read.description': 'Elencare i documenti di un viaggio: nomi, dimensioni, chi li ha caricati e a cosa sono collegati',
+  'oauth.scope.files:write.label': 'Gestire i file del viaggio',
+  'oauth.scope.files:write.description': 'Rinominare e descrivere i file, collegarli a prenotazioni e luoghi, contrassegnarli e cestinarli',
+  'oauth.scope.files:content.label': 'Leggere il contenuto dei file',
+  'oauth.scope.files:content.description': 'Leggere il contenuto di un documento caricato, come un PDF di prenotazione o un biglietto',
+  'oauth.scope.settings:read.label': 'Vedere le tue preferenze',
+  'oauth.scope.settings:read.description': 'Leggere unità, formato orario, lingua, valuta predefinita e pagina iniziale',
+  'oauth.scope.settings:write.label': 'Modificare le tue preferenze',
+  'oauth.scope.settings:write.description': 'Modificare unità, formato orario, lingua, valuta predefinita e pagina iniziale. Mai le chiavi API salvate',
 };
 export default oauth;

--- a/shared/src/i18n/ja/oauth.ts
+++ b/shared/src/i18n/ja/oauth.ts
@@ -94,5 +94,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'ファイル',
+  'oauth.scope.group.settings': '設定',
+  'oauth.scope.files:read.label': '旅行のファイルを表示',
+  'oauth.scope.files:read.description': '旅行の書類を一覧表示します。名前、サイズ、アップロードした人、リンク先',
+  'oauth.scope.files:write.label': '旅行のファイルを管理',
+  'oauth.scope.files:write.description': 'ファイルの名前と説明の変更、予約や場所への紐付け、スターとゴミ箱への移動',
+  'oauth.scope.files:content.label': 'ファイルの中身を読む',
+  'oauth.scope.files:content.description': 'アップロードされた書類の中身を読みます。予約PDFやチケットなど',
+  'oauth.scope.settings:read.label': '環境設定を表示',
+  'oauth.scope.settings:read.description': '単位、時刻表示、言語、既定通貨、開始ページの読み取り',
+  'oauth.scope.settings:write.label': '環境設定を変更',
+  'oauth.scope.settings:write.description': '単位、時刻表示、言語、既定通貨、開始ページの変更。保存されたAPIキーは対象外',
 };
 export default oauth;

--- a/shared/src/i18n/ko/oauth.ts
+++ b/shared/src/i18n/ko/oauth.ts
@@ -92,5 +92,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': '파일',
+  'oauth.scope.group.settings': '설정',
+  'oauth.scope.files:read.label': '여행 파일 보기',
+  'oauth.scope.files:read.description': '여행의 문서를 나열합니다. 이름, 크기, 업로드한 사람, 연결된 항목',
+  'oauth.scope.files:write.label': '여행 파일 관리',
+  'oauth.scope.files:write.description': '파일 이름과 설명 변경, 예약 및 장소에 연결, 즐겨찾기 및 휴지통 이동',
+  'oauth.scope.files:content.label': '파일 내용 읽기',
+  'oauth.scope.files:content.description': '업로드된 문서의 내용을 읽습니다. 예약 PDF나 티켓 등',
+  'oauth.scope.settings:read.label': '환경설정 보기',
+  'oauth.scope.settings:read.description': '단위, 시간 형식, 언어, 기본 통화, 시작 페이지 읽기',
+  'oauth.scope.settings:write.label': '환경설정 변경',
+  'oauth.scope.settings:write.description': '단위, 시간 형식, 언어, 기본 통화, 시작 페이지 변경. 저장된 API 키는 제외',
 };
 export default oauth;

--- a/shared/src/i18n/nl/oauth.ts
+++ b/shared/src/i18n/nl/oauth.ts
@@ -96,5 +96,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Bestanden',
+  'oauth.scope.group.settings': 'Instellingen',
+  'oauth.scope.files:read.label': 'Reisbestanden bekijken',
+  'oauth.scope.files:read.description': 'De documenten van een reis tonen: namen, groottes, wie ze heeft geüpload en waaraan ze gekoppeld zijn',
+  'oauth.scope.files:write.label': 'Reisbestanden beheren',
+  'oauth.scope.files:write.description': 'Bestanden hernoemen en beschrijven, koppelen aan boekingen en plaatsen, markeren en naar de prullenbak verplaatsen',
+  'oauth.scope.files:content.label': 'Bestandsinhoud lezen',
+  'oauth.scope.files:content.description': 'De inhoud van een geüpload document lezen, zoals een boekings-PDF of een ticket',
+  'oauth.scope.settings:read.label': 'Je voorkeuren bekijken',
+  'oauth.scope.settings:read.description': 'Eenheden, tijdnotatie, taal, standaardvaluta en startpagina lezen',
+  'oauth.scope.settings:write.label': 'Je voorkeuren wijzigen',
+  'oauth.scope.settings:write.description': 'Eenheden, tijdnotatie, taal, standaardvaluta en startpagina wijzigen. Nooit opgeslagen API-sleutels',
 };
 export default oauth;

--- a/shared/src/i18n/pl/oauth.ts
+++ b/shared/src/i18n/pl/oauth.ts
@@ -95,5 +95,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Pliki',
+  'oauth.scope.group.settings': 'Ustawienia',
+  'oauth.scope.files:read.label': 'Przeglądanie plików podróży',
+  'oauth.scope.files:read.description': 'Wyświetlanie dokumentów podróży: nazw, rozmiarów, kto je przesłał i z czym są powiązane',
+  'oauth.scope.files:write.label': 'Zarządzanie plikami podróży',
+  'oauth.scope.files:write.description': 'Zmiana nazw i opisów plików, wiązanie ich z rezerwacjami i miejscami, oznaczanie i przenoszenie do kosza',
+  'oauth.scope.files:content.label': 'Odczyt zawartości plików',
+  'oauth.scope.files:content.description': 'Odczyt zawartości przesłanego dokumentu, na przykład PDF-u rezerwacji lub biletu',
+  'oauth.scope.settings:read.label': 'Przeglądanie preferencji',
+  'oauth.scope.settings:read.description': 'Odczyt jednostek, formatu czasu, języka, waluty domyślnej i strony startowej',
+  'oauth.scope.settings:write.label': 'Zmiana preferencji',
+  'oauth.scope.settings:write.description': 'Zmiana jednostek, formatu czasu, języka, waluty domyślnej i strony startowej. Nigdy zapisanych kluczy API',
 };
 export default oauth;

--- a/shared/src/i18n/ru/oauth.ts
+++ b/shared/src/i18n/ru/oauth.ts
@@ -95,5 +95,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Файлы',
+  'oauth.scope.group.settings': 'Настройки',
+  'oauth.scope.files:read.label': 'Просмотр файлов поездки',
+  'oauth.scope.files:read.description': 'Список документов поездки: названия, размеры, кто их загрузил и с чем они связаны',
+  'oauth.scope.files:write.label': 'Управление файлами поездки',
+  'oauth.scope.files:write.description': 'Переименование и описание файлов, привязка к бронированиям и местам, отметка и удаление в корзину',
+  'oauth.scope.files:content.label': 'Чтение содержимого файлов',
+  'oauth.scope.files:content.description': 'Чтение содержимого загруженного документа, например PDF бронирования или билета',
+  'oauth.scope.settings:read.label': 'Просмотр ваших настроек',
+  'oauth.scope.settings:read.description': 'Чтение единиц измерения, формата времени, языка, валюты по умолчанию и стартовой страницы',
+  'oauth.scope.settings:write.label': 'Изменение ваших настроек',
+  'oauth.scope.settings:write.description': 'Изменение единиц измерения, формата времени, языка, валюты по умолчанию и стартовой страницы. Никогда сохранённых ключей API',
 };
 export default oauth;

--- a/shared/src/i18n/sv/oauth.ts
+++ b/shared/src/i18n/sv/oauth.ts
@@ -100,5 +100,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysTool.listTrips': 'Lista dina resor så att AI:n kan identifiera resenummer',
   'oauth.authorize.alwaysTool.getTripSummary':
     'Läs en översikt över resan som krävs för att kunna använda något annat verktyg',
+  'oauth.scope.group.files': 'Filer',
+  'oauth.scope.group.settings': 'Inställningar',
+  'oauth.scope.files:read.label': 'Visa resans filer',
+  'oauth.scope.files:read.description': 'Lista dokumenten på en resa: namn, storlek, vem som laddade upp dem och vad de är kopplade till',
+  'oauth.scope.files:write.label': 'Hantera resans filer',
+  'oauth.scope.files:write.description': 'Byt namn på och beskriv filer, koppla dem till bokningar och platser, stjärnmärk och släng dem',
+  'oauth.scope.files:content.label': 'Läsa filinnehåll',
+  'oauth.scope.files:content.description': 'Läsa innehållet i ett uppladdat dokument, till exempel en boknings-PDF eller en biljett',
+  'oauth.scope.settings:read.label': 'Visa dina inställningar',
+  'oauth.scope.settings:read.description': 'Läsa enheter, tidsformat, språk, standardvaluta och startsida',
+  'oauth.scope.settings:write.label': 'Ändra dina inställningar',
+  'oauth.scope.settings:write.description': 'Ändra enheter, tidsformat, språk, standardvaluta och startsida. Aldrig sparade API-nycklar',
 };
 export default oauth;

--- a/shared/src/i18n/tr/oauth.ts
+++ b/shared/src/i18n/tr/oauth.ts
@@ -98,5 +98,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Dosyalar',
+  'oauth.scope.group.settings': 'Ayarlar',
+  'oauth.scope.files:read.label': 'Gezi dosyalarını görüntüle',
+  'oauth.scope.files:read.description': 'Bir gezinin belgelerini listele: adlar, boyutlar, kimin yüklediği ve neye bağlı oldukları',
+  'oauth.scope.files:write.label': 'Gezi dosyalarını yönet',
+  'oauth.scope.files:write.description': 'Dosyaları yeniden adlandır ve açıkla, rezervasyonlara ve yerlere bağla, yıldızla ve çöpe taşı',
+  'oauth.scope.files:content.label': 'Dosya içeriğini oku',
+  'oauth.scope.files:content.description': 'Yüklenmiş bir belgenin içeriğini oku, örneğin bir rezervasyon PDF’i veya bir bilet',
+  'oauth.scope.settings:read.label': 'Tercihlerini görüntüle',
+  'oauth.scope.settings:read.description': 'Birimleri, saat biçimini, dili, varsayılan para birimini ve başlangıç sayfasını oku',
+  'oauth.scope.settings:write.label': 'Tercihlerini değiştir',
+  'oauth.scope.settings:write.description': 'Birimleri, saat biçimini, dili, varsayılan para birimini ve başlangıç sayfasını değiştir. Kayıtlı API anahtarlarını asla',
 };
 export default oauth;

--- a/shared/src/i18n/uk/oauth.ts
+++ b/shared/src/i18n/uk/oauth.ts
@@ -94,5 +94,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': 'Файли',
+  'oauth.scope.group.settings': 'Налаштування',
+  'oauth.scope.files:read.label': 'Перегляд файлів подорожі',
+  'oauth.scope.files:read.description': 'Список документів подорожі: назви, розміри, хто їх завантажив і з чим вони пов’язані',
+  'oauth.scope.files:write.label': 'Керування файлами подорожі',
+  'oauth.scope.files:write.description': 'Перейменування та опис файлів, прив’язка до бронювань і місць, позначення та переміщення в кошик',
+  'oauth.scope.files:content.label': 'Читання вмісту файлів',
+  'oauth.scope.files:content.description': 'Читання вмісту завантаженого документа, наприклад PDF бронювання або квитка',
+  'oauth.scope.settings:read.label': 'Перегляд ваших налаштувань',
+  'oauth.scope.settings:read.description': 'Читання одиниць вимірювання, формату часу, мови, валюти за умовчанням і стартової сторінки',
+  'oauth.scope.settings:write.label': 'Зміна ваших налаштувань',
+  'oauth.scope.settings:write.description': 'Зміна одиниць вимірювання, формату часу, мови, валюти за умовчанням і стартової сторінки. Ніколи збережених ключів API',
 };
 export default oauth;

--- a/shared/src/i18n/vi/oauth.ts
+++ b/shared/src/i18n/vi/oauth.ts
@@ -97,5 +97,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysTool.listTrips': 'Liệt kê các chuyến đi của bạn để AI có thể khám phá ID chuyến đi',
   'oauth.authorize.alwaysTool.getTripSummary':
     'Đọc tổng quan về chuyến đi cần thiết để sử dụng bất kỳ công cụ nào khác',
+  'oauth.scope.group.files': 'Tệp',
+  'oauth.scope.group.settings': 'Cài đặt',
+  'oauth.scope.files:read.label': 'Xem tệp của chuyến đi',
+  'oauth.scope.files:read.description': 'Liệt kê tài liệu của chuyến đi: tên, kích thước, ai đã tải lên và chúng liên kết với gì',
+  'oauth.scope.files:write.label': 'Quản lý tệp của chuyến đi',
+  'oauth.scope.files:write.description': 'Đổi tên và mô tả tệp, liên kết với đặt chỗ và địa điểm, gắn sao và chuyển vào thùng rác',
+  'oauth.scope.files:content.label': 'Đọc nội dung tệp',
+  'oauth.scope.files:content.description': 'Đọc nội dung của tài liệu đã tải lên, chẳng hạn PDF đặt chỗ hoặc vé',
+  'oauth.scope.settings:read.label': 'Xem tuỳ chọn của bạn',
+  'oauth.scope.settings:read.description': 'Đọc đơn vị, định dạng giờ, ngôn ngữ, tiền tệ mặc định và trang khởi đầu',
+  'oauth.scope.settings:write.label': 'Thay đổi tuỳ chọn của bạn',
+  'oauth.scope.settings:write.description': 'Thay đổi đơn vị, định dạng giờ, ngôn ngữ, tiền tệ mặc định và trang khởi đầu. Không bao giờ khoá API đã lưu',
 };
 export default oauth;

--- a/shared/src/i18n/zh-TW/oauth.ts
+++ b/shared/src/i18n/zh-TW/oauth.ts
@@ -92,5 +92,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': 'Always included', // en-fallback
   'oauth.authorize.alwaysTool.listTrips': 'List your trips so the AI can discover trip IDs', // en-fallback
   'oauth.authorize.alwaysTool.getTripSummary': 'Read a trip overview needed to use any other tool', // en-fallback
+  'oauth.scope.group.files': '檔案',
+  'oauth.scope.group.settings': '設定',
+  'oauth.scope.files:read.label': '檢視行程檔案',
+  'oauth.scope.files:read.description': '列出行程的文件：名稱、大小、上傳者以及關聯的對象',
+  'oauth.scope.files:write.label': '管理行程檔案',
+  'oauth.scope.files:write.description': '重新命名與描述檔案，關聯至訂位和地點，加上星號並移至垃圾桶',
+  'oauth.scope.files:content.label': '讀取檔案內容',
+  'oauth.scope.files:content.description': '讀取已上傳文件的內容，例如訂位 PDF 或票券',
+  'oauth.scope.settings:read.label': '檢視你的偏好設定',
+  'oauth.scope.settings:read.description': '讀取單位、時間格式、語言、預設貨幣和起始頁',
+  'oauth.scope.settings:write.label': '更改你的偏好設定',
+  'oauth.scope.settings:write.description': '更改單位、時間格式、語言、預設貨幣和起始頁。絕不涉及已儲存的 API 金鑰',
 };
 export default oauth;

--- a/shared/src/i18n/zh/oauth.ts
+++ b/shared/src/i18n/zh/oauth.ts
@@ -92,5 +92,17 @@ const oauth: TranslationStrings = {
   'oauth.authorize.alwaysIncluded': '始终包含',
   'oauth.authorize.alwaysTool.listTrips': '列出你的行程，以使 AI 找到行程 ID',
   'oauth.authorize.alwaysTool.getTripSummary': '读取行程概览，这是使用其他工具所需的信息',
+  'oauth.scope.group.files': '文件',
+  'oauth.scope.group.settings': '设置',
+  'oauth.scope.files:read.label': '查看行程文件',
+  'oauth.scope.files:read.description': '列出行程的文档：名称、大小、上传者以及关联的对象',
+  'oauth.scope.files:write.label': '管理行程文件',
+  'oauth.scope.files:write.description': '重命名和描述文件，关联到预订和地点，标记星标并移入回收站',
+  'oauth.scope.files:content.label': '读取文件内容',
+  'oauth.scope.files:content.description': '读取已上传文档的内容，例如预订 PDF 或票据',
+  'oauth.scope.settings:read.label': '查看你的偏好设置',
+  'oauth.scope.settings:read.description': '读取单位、时间格式、语言、默认货币和起始页',
+  'oauth.scope.settings:write.label': '更改你的偏好设置',
+  'oauth.scope.settings:write.description': '更改单位、时间格式、语言、默认货币和起始页。绝不涉及已保存的 API 密钥',
 };
 export default oauth;

--- a/wiki/MCP-Scopes.md
+++ b/wiki/MCP-Scopes.md
@@ -6,7 +6,7 @@ OAuth scopes control exactly which data your AI client can read or write in TREK
 
 ## All scopes
 
-TREK defines 29 scopes across 14 groups.
+TREK defines 34 scopes across 16 groups.
 
 | Group | Scope | Permission |
 |---|---|---|
@@ -39,12 +39,19 @@ TREK defines 29 scopes across 14 groups.
 | **Journey** | `journey:read` | Read journeys, entries, and contributor list |
 | | `journey:write` | Create, update, and delete journeys and their entries |
 | | `journey:share` | Create, update, and revoke public share links for journeys |
+| **Files** | `files:read` | List the documents on a trip: names, sizes, who uploaded them, what they link to |
+| | `files:write` | Rename and describe files, link them to bookings and places, star and trash them |
+| | `files:content` | Read what is inside an uploaded document, such as a booking PDF or a ticket |
+| **Settings** | `settings:read` | Read units, time format, language, default currency, and start page |
+| | `settings:write` | Change units, time format, language, default currency, and start page |
 
 ## Scope rules
 
 - A `:write` scope implies `:read` access for the same group (e.g. `budget:write` also grants read access to budget data).
 - Any `trips:*` scope (`trips:read`, `trips:write`, `trips:delete`, or `trips:share`) grants trip read access.
-- `journey:read` or `journey:write` grants journey read access. `journey:share` alone does **not** grant read access — it only enables managing public share links.
+- `journey:read` or `journey:write` grants journey read access. `journey:share` alone does **not** grant read access, it only enables managing public share links.
+- `files:content` is a **separate** scope from `files:read` and is not implied by `files:write`. A token can list a trip's documents without being allowed to read what is inside them. Content reads are capped at 10 MB per file.
+- `settings:write` never reaches a stored credential. The API keys, tokens and webhook URLs kept in settings are refused by the same allow-list the REST route uses, so an assistant can switch you to Fahrenheit but cannot read or replace your Mapbox key.
 - `list_trips` and `get_trip_summary` are always available regardless of scope — they are navigation tools.
 - Static tokens and web session JWTs have full access equivalent to all scopes.
 - Addon-gated tools (Packing, To-dos, Budget, Collections, Atlas, Collab, Vacay, Journey) require both the relevant scope **and** the corresponding addon to be enabled by an admin. The to-do tools ride the **Packing** addon, not an addon of their own.

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -108,7 +108,7 @@ Requires `reservations:write` scope.
 
 | Tool | Description |
 |---|---|
-| `create_transport` | Create a transport booking — the nine types the transport form offers (`flight`, `train`, `bus`, `car`, `taxi`, `bicycle`, `cruise`, `ferry`, `transport_other`) — with optional multi-stop endpoints, departure/arrival times, and confirmation details. Scheduled public transit goes through `create_transit_journey` instead. |
+| `create_transport` | Create a transport booking in any of the nine types the transport form offers (`flight`, `train`, `bus`, `car`, `taxi`, `bicycle`, `cruise`, `ferry`, `transport_other`), with optional multi-stop endpoints, departure/arrival times, and confirmation details. Scheduled public transit goes through `create_transit_journey` instead. |
 | `update_transport` | Update an existing transport booking. Pass `endpoints[]` to replace all stops. |
 | `delete_transport` | Delete a transport booking from a trip. |
 
@@ -128,7 +128,7 @@ Requires `reservations:read` or `reservations:write` scope.
 
 | Tool | Description |
 |---|---|
-| `create_reservation` | Create a pending reservation — hotels, restaurants, events, tours, activities, and other types. Carries the booking link (`url`) and an end time. |
+| `create_reservation` | Create a pending reservation: hotels, restaurants, events, tours, activities, and other types. Carries the booking link (`url`) and an end time. |
 | `update_reservation` | Update any field including status (`pending` / `confirmed` / `cancelled`). |
 | `delete_reservation` | Delete a reservation and its linked accommodation record if applicable. |
 | `reorder_reservations` | Reorder reservations within a day. |

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -37,6 +37,9 @@ Requires `trips:read` or `trips:write` scope.
 | `list_trip_members` | List the owner and all collaborators of a trip. |
 | `add_trip_member` | Add a user to a trip by username or email. Owner only. |
 | `remove_trip_member` | Remove a collaborator from a trip. Owner only. |
+| `create_trip_guest` | Add a travelling companion who has no TREK account. Assignable to budget splits, packing and day participants; never signs in, never emailed. Owner only. |
+| `rename_trip_guest` | Rename a guest on a trip. Owner only. |
+| `delete_trip_guest` | Delete a guest and re-split the expenses they were part of. Owner only. |
 | `copy_trip` | Duplicate a trip (days, places, itinerary, packing, budget, reservations). Packing items reset to unchecked. |
 | `export_trip_ics` | Export the trip itinerary and reservations as iCalendar (`.ics`) text. |
 | `get_share_link` | Get the current public share link for a trip and its permission flags. Requires `trips:share`. |
@@ -105,7 +108,7 @@ Requires `reservations:write` scope.
 
 | Tool | Description |
 |---|---|
-| `create_transport` | Create a transport booking (`flight`, `train`, `car`, `cruise`) with optional multi-stop endpoints, departure/arrival times, and confirmation details. |
+| `create_transport` | Create a transport booking (`flight`, `train`, `bus`, `car`, `taxi`, `bicycle`, `cruise`, `ferry`, `transit`, `transport_other`) with optional multi-stop endpoints, departure/arrival times, and confirmation details. |
 | `update_transport` | Update an existing transport booking. Pass `endpoints[]` to replace all stops. |
 | `delete_transport` | Delete a transport booking from a trip. |
 

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -108,7 +108,7 @@ Requires `reservations:write` scope.
 
 | Tool | Description |
 |---|---|
-| `create_transport` | Create a transport booking (`flight`, `train`, `bus`, `car`, `taxi`, `bicycle`, `cruise`, `ferry`, `transit`, `transport_other`) with optional multi-stop endpoints, departure/arrival times, and confirmation details. |
+| `create_transport` | Create a transport booking — the nine types the transport form offers (`flight`, `train`, `bus`, `car`, `taxi`, `bicycle`, `cruise`, `ferry`, `transport_other`) — with optional multi-stop endpoints, departure/arrival times, and confirmation details. Scheduled public transit goes through `create_transit_journey` instead. |
 | `update_transport` | Update an existing transport booking. Pass `endpoints[]` to replace all stops. |
 | `delete_transport` | Delete a transport booking from a trip. |
 
@@ -132,7 +132,7 @@ Requires `reservations:read` or `reservations:write` scope.
 | `update_reservation` | Update any field including status (`pending` / `confirmed` / `cancelled`). |
 | `delete_reservation` | Delete a reservation and its linked accommodation record if applicable. |
 | `reorder_reservations` | Reorder reservations within a day. |
-| `set_reservation_travelers` | Set who is travelling on a booking, from the trip roster (members and guests). Replaces the list; an empty array clears it. |
+| `set_reservation_travelers` | Set who is travelling on a booking, from the trip roster (members and guests). Replaces the list; an empty array clears it. Ids that are not on the trip come back under `ignored_user_ids` rather than being attached. |
 | `link_hotel_accommodation` | Set or update a hotel reservation's check-in/out day links and place. |
 
 ### Budget

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -132,6 +132,7 @@ Requires `reservations:read` or `reservations:write` scope.
 | `update_reservation` | Update any field including status (`pending` / `confirmed` / `cancelled`). |
 | `delete_reservation` | Delete a reservation and its linked accommodation record if applicable. |
 | `reorder_reservations` | Reorder reservations within a day. |
+| `set_reservation_travelers` | Set who is travelling on a booking, from the trip roster (members and guests). Replaces the list; an empty array clears it. |
 | `link_hotel_accommodation` | Set or update a hotel reservation's check-in/out day links and place. |
 
 ### Budget

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -187,6 +187,83 @@ Requires `notifications:read` or `notifications:write` scope.
 | `mark_notification_unread` | Mark a notification as unread. |
 | `mark_all_notifications_read` | Mark all notifications as read. |
 
+### Files
+
+Requires `files:read` or `files:write`. Reading what is inside a document needs `files:content`, which is a **separate** scope and is not implied by `files:write`.
+
+| Tool | Description |
+|---|---|
+| `list_trip_files` | List a trip's documents: name, type, size, uploader, description, what they are linked to, starred and trash state. Pass `trash` to list the trash instead. |
+| `read_trip_file` | Read one document's contents. Text comes back as text, anything else base64, with an `encoding` field saying which. Files over 10 MB are refused; use the download link in the app. |
+| `update_trip_file` | Set a file's description and the booking or place it belongs to. Pass null to detach. |
+| `link_trip_file` | Link a file to one more booking, place or day assignment. |
+| `unlink_trip_file` | Remove one link. The file stays. |
+| `list_trip_file_links` | List everything a file is linked to. |
+
+### Settings
+
+Requires `settings:read` or `settings:write`.
+
+| Tool | Description |
+|---|---|
+| `get_display_settings` | Read the user's units, time format, language, default currency and start page. Read this before rendering a temperature, a distance or a clock time. |
+| `update_display_settings` | Change one or more of those preferences. Only display preferences: API keys, map tokens and LLM settings are refused, whatever is passed. |
+
+### Calendar feeds
+
+Requires `trips:share`, the same scope that manages public share links.
+
+| Tool | Description |
+|---|---|
+| `get_trip_calendar_feed` | Read the subscribable feed URL for one trip, and whether it is on. |
+| `enable_trip_calendar_feed` | Turn the trip feed on and mint its token. |
+| `rotate_trip_calendar_feed` | Issue a new token. Every existing subscription to that trip stops working. |
+| `disable_trip_calendar_feed` | Turn it off and revoke the token. |
+| `get_all_trips_calendar_feed` | The same, for the feed that carries every trip the user can see. |
+| `enable_all_trips_calendar_feed` | |
+| `rotate_all_trips_calendar_feed` | |
+| `disable_all_trips_calendar_feed` | |
+
+### Invite links
+
+Requires `trips:share`. This is the link that grants **membership**, not the read-only public view link that `create_share_link` makes.
+
+| Tool | Description |
+|---|---|
+| `get_trip_invite_link` | Read the current invite link and when it expires. |
+| `create_trip_invite_link` | Mint an invite link, optionally with an expiry. Rotating replaces the old one, which stops working. |
+| `delete_trip_invite_link` | Revoke it. |
+
+Accepting an invite has no tool on purpose: joining somebody's trip is a human act.
+
+### Imports
+
+| Tool | Description |
+|---|---|
+| `list_airtrail_flights` | List the flights available to import from a connected AirTrail account. Requires the AirTrail addon. |
+| `import_airtrail_flights` | Import chosen flights into a trip as transport bookings. |
+
+### Photos
+
+Requires `journey:read`, or `journey:write` to attach. Needs a configured Immich or Synology Photos provider.
+
+| Tool | Description |
+|---|---|
+| `search_provider_photos` | Search the connected photo library. |
+| `list_provider_albums` | List its albums. |
+| `list_provider_album_photos` | List one album's photos. |
+
+Photo bytes are never returned: those are image URLs the app renders.
+
+### Help and instance
+
+| Tool | Description |
+|---|---|
+| `list_help_topics` | List the bundled help pages. Answers "how do I do X in TREK?" without guessing. |
+| `get_help_page` | Read one help page. |
+| `list_addons` | Which addons and collaboration features this instance has enabled. Worth calling when a tool you expected is not in the list: an addon that is off removes its tools exactly the way a missing scope does. |
+| `get_trip_warnings` | Warnings plugins have raised about a trip. A plugin raising one is telling the user something is wrong, so it is worth reading before reviewing an itinerary. |
+
 ---
 
 ## Resources

--- a/wiki/MCP-Tools-and-Resources.md
+++ b/wiki/MCP-Tools-and-Resources.md
@@ -128,7 +128,7 @@ Requires `reservations:read` or `reservations:write` scope.
 
 | Tool | Description |
 |---|---|
-| `create_reservation` | Create a pending reservation — hotels, restaurants, events, tours, activities, and other types. |
+| `create_reservation` | Create a pending reservation — hotels, restaurants, events, tours, activities, and other types. Carries the booking link (`url`) and an end time. |
 | `update_reservation` | Update any field including status (`pending` / `confirmed` / `cancelled`). |
 | `delete_reservation` | Delete a reservation and its linked accommodation record if applicable. |
 | `reorder_reservations` | Reorder reservations within a day. |

--- a/wiki/Reservations-and-Bookings.md
+++ b/wiki/Reservations-and-Bookings.md
@@ -39,6 +39,10 @@ Reservations are grouped into two collapsible sections: **Pending** and **Confir
 
 On desktop, a type filter bar lets you show only specific types. Filter selections are kept for the current browser session.
 
+Travelers are set per booking from the trip roster, guests included.
+
+> **AI / MCP:** `set_reservation_travelers` writes that list; it replaces it wholesale and ignores anybody who is not on the trip. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
+
 A traveler filter sits next to it — on desktop and mobile — once the trip has more than one member and at least one booking has travelers assigned. Click an avatar to show only that person's bookings; several can be active at once. On desktop the selection is kept for the browser session like the type filter; on mobile it resets when you leave the tab.
 
 ## Reservation card contents

--- a/wiki/Transport-Flights-Trains-Cars.md
+++ b/wiki/Transport-Flights-Trains-Cars.md
@@ -27,7 +27,7 @@ Self-hosters can point the `TRANSIT_API_URL` environment variable at their own M
 
 Nine types are available: **Flight**, **Train**, **Bus**, **Car**, **Taxi**, **Bicycle**, **Cruise**, **Ferry**, and **Other**.
 
-> **AI / MCP:** `create_transport` accepts the same nine. Scheduled public transit is its own thing — `create_transit_journey` attaches the provider itinerary. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
+> **AI / MCP:** `create_transport` accepts the same nine. Scheduled public transit is its own thing: `create_transit_journey` attaches the provider itinerary. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
 
 ## Common fields
 

--- a/wiki/Transport-Flights-Trains-Cars.md
+++ b/wiki/Transport-Flights-Trains-Cars.md
@@ -27,6 +27,8 @@ Self-hosters can point the `TRANSIT_API_URL` environment variable at their own M
 
 Nine types are available: **Flight**, **Train**, **Bus**, **Car**, **Taxi**, **Bicycle**, **Cruise**, **Ferry**, and **Other**.
 
+> **AI / MCP:** `create_transport` accepts the same nine. Scheduled public transit is its own thing — `create_transit_journey` attaches the provider itinerary. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
+
 ## Common fields
 
 All transport types share these fields:

--- a/wiki/Trip-Members-and-Sharing.md
+++ b/wiki/Trip-Members-and-Sharing.md
@@ -79,7 +79,7 @@ In the owner's Guests section, each guest row has a **Rename** (pencil) and a **
 
 There is no limit on the number of guests per trip.
 
-> **AI / MCP:** an assistant can do all three — `create_trip_guest`, `rename_trip_guest`, `delete_trip_guest` — and is held to the same owner-only rule. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
+> **AI / MCP:** an assistant can do all three (`create_trip_guest`, `rename_trip_guest`, `delete_trip_guest`) and is held to the same owner-only rule. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
 
 ## Public Share Link
 

--- a/wiki/Trip-Members-and-Sharing.md
+++ b/wiki/Trip-Members-and-Sharing.md
@@ -79,6 +79,8 @@ In the owner's Guests section, each guest row has a **Rename** (pencil) and a **
 
 There is no limit on the number of guests per trip.
 
+> **AI / MCP:** an assistant can do all three — `create_trip_guest`, `rename_trip_guest`, `delete_trip_guest` — and is held to the same owner-only rule. See [MCP-Tools-and-Resources](MCP-Tools-and-Resources).
+
 ## Public Share Link
 
 The right column is only visible to users with the `share_manage` permission (default: trip owner).


### PR DESCRIPTION
A community member tried to import their TripIt history with an assistant and hit two walls: a bus booking could not be created over MCP, and a travelling companion could not be added to a trip at all.

Both are fixed. Auditing why they were broken turned up the same shape everywhere else, so this closes that too.

## What was actually wrong

Not missing features. In almost every case the tool exists, the service method exists, the REST route accepts the field and the UI writes it, and only the zod `inputSchema` does not carry it. The handler then destructures a fixed key list and rebuilds an object literal, so the field cannot leak through even if a client sends it.

Two patterns ran through the whole surface:

- **Create is systematically richer than update.** `location_name` could be set when writing a journey entry and never when correcting one. `expense_date` and `currency` were on `create_budget_item` and not on its update. These tools were written against a "can the assistant create X?" checklist and never a "can the assistant *fix* X?" one, which is exactly the difference between a demo and an import.
- **Nullability was dropped almost everywhere.** `trips.mcp.ts` had zero `.nullable()` against four nullable fields in the REST contract. Since every update service decides whether to write with `!== undefined`, an omitted key preserves and `null` is the only way to clear, so "remove the check-in time" and "drop the dates" were unreachable.

## Bookings

`create_transport` and `update_transport` accepted `flight`, `train`, `car`, `cruise`. The picker in `TransportModal.tsx` offers nine, so `bus`, `taxi`, `bicycle`, `ferry` and `transport_other` could be planned in the UI and refused through an assistant. The REST route never rejected them; the write contract is an open record, so this was the MCP schema alone.

Two constants now, because they answer different questions:

- `CREATABLE_TRANSPORT_TYPES` is what a caller may ask for: exactly the transport form's picker, in its order.
- `TRANSPORT_TYPES` is what counts as a transport booking, for the `update_transport` gate: everything `ReservationsPanel` draws with a transport icon.

They differ by `transit`, deliberately. The picker does not offer it either: a transit booking carries a provider itinerary in `metadata.transit` and `create_transit_journey` is what writes one, so a hand-made `transit` row would be a shape the transit UI does not expect. A *stored* transit booking stays editable through `update_transport`.

`legs[]` stays on flight and train. The form writes `metadata.legs` for those two and nothing else.

Two fields every imported booking carries were in no tool schema: **`url`**, the confirmation link, persisted on both verbs and rendered as an href; and **`reservation_end_time`** on a non-transport booking, so a dinner could only ever carry a start. `url` validates through `reservationUrlSchema` from `@trek/shared`, the same refinement REST applies, so a `javascript:` link is refused here too, including one split by a control character.

## People

`add_trip_member` resolves an existing account by username or email. Someone's partner who never signed up has no account to resolve, so they could be added in the planner and not through an assistant, and a trip imported without them silently loses who was on it.

| Tool | Route it mirrors |
| --- | --- |
| `create_trip_guest` | `POST /api/trips/:id/guests` |
| `rename_trip_guest` | `PUT /api/trips/:id/guests/:userId` |
| `delete_trip_guest` | `DELETE /api/trips/:id/guests/:userId` |
| `set_reservation_travelers` | `PUT /api/trips/:tripId/reservations/:id/travelers` |

Guest tools are owner-only like their routes, and `guestOfTrip` keeps every guest mutation trip-scoped, so one trip's owner cannot rename another trip's guest and `delete_trip_guest` cannot reach a real member's user row. No invite notification: a guest has no inbox.

`set_reservation_travelers` completes the pair, since creating a guest is only half an answer if the guest cannot be attached to the flight they were on. The roster filter stays in the service, so an off-trip id is dropped rather than attached; the dropped ids come back as `ignored_user_ids` instead of vanishing, because silently succeeding with a shorter list reads as "done" to a caller that guessed an id for a name it could not resolve.

**One permission change.** `add_trip_member` and `remove_trip_member` hardcoded an owner check while REST consults the configurable permission matrix, and so does the plugin RPC: three surfaces, two behaviours. They now use the same `hasTripPermission('member_manage', ...)` call `update_trip` already made, so an instance that lowered that permission behaves consistently. The guest tools stay owner-only, because their REST routes are owner-only by design and `trip-owner.guard.ts` documents it.

## The rest of the sweep

| Domain | What was unreachable |
| --- | --- |
| days | reordering days at all, and inserting one mid-trip |
| budget | uneven splits, and currency, date and place link on the tools that already existed |
| packing | bags, quantity, weight, and the whole three-tier sharing model |
| vacay | half days, comp days, logging for another member, school-holiday setup |
| journey | correcting an entry's place, coordinates, weather, tags or verdict |
| places | giving a place a picture, POI search, GPX export, a region-biased search |
| atlas | resolving a coordinate to a region code, and the derived visited list |
| day notes | colour and position |
| collab notes | the website the card renders |
| categories | creating one at all |
| collections | membership lookup, and marking a trip's places visited across lists |
| reservations | the cross-trip upcoming view |
| trips | day count, reminder days, cover image search |

Three of these needed care beyond adding a field:

- **Money.** A custom split has to reconcile before it is persisted, so the tool refuses one whose shares do not add up in whole cents. Two routes around that check had to close with it: the write path drops a payer who is not on the trip and then derives the total from what survived, and an empty payer list means a total of zero rather than the previous one. Either would have certified a split the stored row does not satisfy.
- **Cost.** `get_place_details` gained `expand` for reviews and the editorial summary. It defaults to off, because that field mask bills as a Google Enterprise SKU, and it now honours `detailsDisabled()`, the admin kill switch REST checks. An owner who turns Place Details off to stop the billing was still billable through this one surface, expanded mask included.
- **A composite key.** A vacay group region is stored as `COUNTRY|group:CODE` and the calendar reader treats a bare code as a subdivision, so returning the provider's raw group code produced a calendar that queries nothing. `list_school_holiday_regions` now returns the string `add_holiday_calendar` actually wants. Belgium and the Netherlands are the two countries this affects.

## Seven domains that had no tools at all

| Domain | What an assistant can now do |
| --- | --- |
| files | list a trip's documents, read one, set its description, link it to a booking or place |
| settings | read the user's units, time format and default currency, and change them |
| feeds | read, mint, rotate and revoke both calendar feed tokens |
| trip-invite | read, mint and revoke the link that grants membership |
| integrations | list AirTrail flights and import them into a trip |
| memories | search the connected photo library and attach photos to a journal entry |
| help / addons | read the bundled help pages, and see which addons this instance has on |

Three of these needed a decision rather than a port:

- **The file content read is not a second copy.** `files.rpc.ts` already served bytes to plugins under a stricter grant, with the size cap checked before the read, the bytes from the storage layer so remote backends work, and the decode off the event loop. That moved into `FilesService` and both callers use it, rather than the tool growing its own version to drift from.
- **`update_display_settings` works off an allow-list, not off the settings row.** That row also holds the webhook URL, the ntfy token and the Mapbox, Carto and LLM keys, and `getUserSettings` returns some of them in cleartext. Everything outside the list is refused, including a key nobody has added yet, and the guard test asserts against the service's own encrypted and masked sets rather than a copy, so a sixth key added there fails it.
- **`list_addons` exists because the gate is invisible.** 131 of 201 tools carry an addon gate, and the registry drops an entry when either that gate or the scope gate fails: one filter, one outcome. The session instructions tell the model to check what is available before assuming a tool exists while giving it nothing to check with.

What deliberately has no tool: uploading a file, streaming photo or thumbnail bytes, accepting an invite, and the two `.ics` consumer URLs. The first two have no transport, and the last two are human acts or the thing being subscribed to.

## Scopes

Two new groups, taking the table from 29 scopes across 14 groups to 34 across 16, translated into all 23 languages.

`files:content` is a **third mode** rather than a second group. Listing the documents on a trip and reading the bytes inside a booking PDF are different privileges, and the plugin host already draws that line between `db:read:files` and `db:read:files:content`. It is not implied by `files:write`, the same way `journey:share` is not implied by `journey:write`.

`settings:write` is scoped to display preferences. Settings also holds the webhook URL, the ntfy token and the Mapbox, Carto and LLM keys, some of which `getUserSettings` returns in cleartext, so the tools that ride this scope work off an allow-list rather than off the settings row.

One line went into the MCP session instructions: read the display settings before rendering a temperature, a distance or a clock time. Without it nothing tells an assistant that the user has already picked units, and the tool would sit unused.

## Method

Every gap in here was found by auditing all 25 `*.mcp.ts` files against their REST controllers and the client, then handed to a second reviewer whose only instruction was to disprove it. Nine claims did not survive and are not in this PR. The same shape was used on the implementation: each domain's diff was reviewed by an agent that had not written it, which is where the two money holes, the missing cost switch and the composite region key came from.

Read the code, not the audit: two negative claims in the corpus were wrong because they were read off a working copy that was being edited underneath them.
