### PR TITLE
Fix the booking-import path before anything writes to it automatically

### DIFF
--- a/client/src/components/Planner/BookingImportModal.tsx
+++ b/client/src/components/Planner/BookingImportModal.tsx
@@ -10,6 +10,9 @@ interface BookingImportModalProps {
   isOpen: boolean
   onClose: () => void
   tripId: number
+  /** The tab this import was started from, carried into the job so the review
+   *  can pick the right form for an item whose type had to be guessed (#2076). */
+  kind?: 'transports' | 'bookings'
 }
 
 const ACCEPTED_EXTS = ['.eml', '.pdf', '.pkpass', '.html', '.htm', '.txt']
@@ -22,7 +25,7 @@ const MAX_FILES = 5
  * (progress over the WebSocket). When it finishes, the trip page opens the per-item
  * review flow — so the user can navigate and keep editing while it works.
  */
-export default function BookingImportModal({ isOpen, onClose, tripId }: BookingImportModalProps) {
+export default function BookingImportModal({ isOpen, onClose, tripId, kind }: BookingImportModalProps) {
   const { t } = useTranslation()
   const addTask = useBackgroundTasksStore((s) => s.addTask)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -100,7 +103,7 @@ export default function BookingImportModal({ isOpen, onClose, tripId }: BookingI
       // Keep the uploaded files so the review can attach each source document to its booking —
       // in memory for the immediate path, and in IndexedDB so it survives a reload mid-parse.
       await saveImportFiles(jobId, files)
-      addTask({ id: jobId, tripId: String(tripId), label: files.map((f) => f.name).join(', '), total: files.length, files, mode })
+      addTask({ id: jobId, tripId: String(tripId), label: files.map((f) => f.name).join(', '), total: files.length, files, mode, kind })
       handleClose()
     } catch (err: any) {
       setError(err?.response?.data?.error ?? t('reservations.import.error'))

--- a/client/src/components/Planner/parsedItemToDraft.ts
+++ b/client/src/components/Planner/parsedItemToDraft.ts
@@ -52,9 +52,16 @@ export function isTransportItem(item: BookingImportPreviewItem): boolean {
 }
 
 /**
- * Neither form can express this type, so neither is obviously right. The tab the
- * user started the import from breaks the tie (#2076).
+ * Neither form is obviously right, so the tab the user started the import from
+ * breaks the tie (#2076).
+ *
+ * Two cases. A type neither form can express, and a type the extractor filled in
+ * rather than read. The second is the one that actually occurs: the server can
+ * only ever emit its eight known types, so the first branch never fires on a real
+ * document, and a ferry voucher the model could not classify arrived as a
+ * placeholder 'hotel' with no way to tell it from a real one.
  */
 export function isUnplaceableItem(item: BookingImportPreviewItem): boolean {
+  if (item.type_guessed === true) return true
   return !TRANSPORT_TYPES.has(item.type) && !BOOKING_TYPES.has(item.type)
 }

--- a/client/src/mobile/screens/trip/sheets/MTripSheets.tsx
+++ b/client/src/mobile/screens/trip/sheets/MTripSheets.tsx
@@ -126,7 +126,7 @@ export default function MTripSheets({ planner, shell }: MTripSheetsProps) {
         />
       )}
 
-      <BookingImportModal isOpen={planner.showBookingImport} onClose={() => planner.setShowBookingImport(false)} tripId={tripId} />
+      <BookingImportModal isOpen={planner.showBookingImport} onClose={() => planner.setShowBookingImport(false)} tripId={tripId} kind={planner.bookingImportKind} />
       <AirTrailImportModal isOpen={planner.showAirTrailImport} onClose={() => planner.setShowAirTrailImport(false)} tripId={tripId} pushUndo={planner.pushUndo} />
 
       {/* Trip edit + share/members, opened from the Mehr sheet. */}

--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -252,7 +252,7 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
     prefillCoords, setPrefillCoords, editingAssignmentId, setEditingAssignmentId,
     showTripForm, setShowTripForm, showMembersModal, setShowMembersModal,
     showReservationModal, setShowReservationModal, editingReservation, setEditingReservation,
-    showBookingImport, setShowBookingImport, setBookingImportKind, bookingImportAvailable,
+    showBookingImport, setShowBookingImport, bookingImportKind, setBookingImportKind, bookingImportAvailable,
     airTrailAvailable, showAirTrailImport, setShowAirTrailImport,
     bookingForAssignmentId, setBookingForAssignmentId,
     showTransportModal, setShowTransportModal, editingTransport, setEditingTransport,
@@ -877,7 +877,7 @@ function TripPlannerPageDesktop(): React.ReactElement | null {
           </Suspense>
         </ErrorBoundary>
       )}
-      <BookingImportModal isOpen={showBookingImport} onClose={() => setShowBookingImport(false)} tripId={tripId} />
+      <BookingImportModal isOpen={showBookingImport} onClose={() => setShowBookingImport(false)} tripId={tripId} kind={bookingImportKind} />
       <AirTrailImportModal isOpen={showAirTrailImport} onClose={() => setShowAirTrailImport(false)} tripId={tripId} pushUndo={pushUndo} />
       <ConfirmDialog
         isOpen={!!deletePlaceId}

--- a/client/src/pages/tripPlanner/useTripPlanner.test.tsx
+++ b/client/src/pages/tripPlanner/useTripPlanner.test.tsx
@@ -1642,8 +1642,10 @@ describe('useTripPlanner — booking import review', () => {
     const { result } = await renderPlanner()
     const odd = { type: 'shuttle-voucher', title: 'Airport transfer' }
 
-    act(() => { result.current.setBookingImportKind('transports') })
-    act(() => { result.current.startImportReview([odd] as never) })
+    // The tab now travels with the review rather than living in component state:
+    // the parse outlives navigation and reload, and the review is triggered by the
+    // global widget, so by then the state has remounted back to its default.
+    act(() => { result.current.startImportReview([odd] as never, [], 'transports') })
 
     expect(result.current.showTransportModal).toBe(true)
     expect(result.current.showReservationModal).toBe(false)
@@ -1654,8 +1656,33 @@ describe('useTripPlanner — booking import review', () => {
     const { result } = await renderPlanner()
     const odd = { type: 'shuttle-voucher', title: 'Airport transfer' }
 
-    act(() => { result.current.setBookingImportKind('bookings') })
-    act(() => { result.current.startImportReview([odd] as never) })
+    act(() => { result.current.startImportReview([odd] as never, [], 'bookings') })
+
+    expect(result.current.showReservationModal).toBe(true)
+    expect(result.current.showTransportModal).toBe(false)
+  })
+
+  // The case that actually occurs. The server only ever emits its eight known
+  // types, so 'shuttle-voucher' above never reaches a real import: a document the
+  // model could not classify arrived as a placeholder 'hotel', which IS a booking
+  // type, so the tie-breaker never ran and the tab lost every time (#2076).
+  it('FE-TP-HOOK-112b: a guessed hotel opens the transport form when the import began there', async () => {
+    seedTrip()
+    const { result } = await renderPlanner()
+    const guessed = { type: 'hotel', title: 'Airport transfer', type_guessed: true }
+
+    act(() => { result.current.startImportReview([guessed] as never, [], 'transports') })
+
+    expect(result.current.showTransportModal).toBe(true)
+    expect(result.current.showReservationModal).toBe(false)
+  })
+
+  it('FE-TP-HOOK-112c: a real hotel from the same tab still opens the booking form', async () => {
+    seedTrip()
+    const { result } = await renderPlanner()
+    const real = { type: 'hotel', title: 'Ryokan' }
+
+    act(() => { result.current.startImportReview([real] as never, [], 'transports') })
 
     expect(result.current.showReservationModal).toBe(true)
     expect(result.current.showTransportModal).toBe(false)

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -274,6 +274,11 @@ export function useTripPlanner() {
   const importQueueRef = useRef<BookingImportPreviewItem[]>([])
   // The files this import was parsed from, so each reviewed booking can attach its source doc.
   const importSourceFilesRef = useRef<File[]>([])
+  // The tab the items under review came from. A ref, not the bookingImportKind
+  // state: the parse outlives navigation and reload, and the review is triggered
+  // by the global widget, so by then the state has remounted back to its default.
+  // The value comes off the persisted job (#2076).
+  const importKindRef = useRef<'transports' | 'bookings'>('bookings')
   // Manual route planning: off by default, toggled from the day-plan footer. Mode
   // is per-session and selects which travel time the connectors show — either a
   // built-in OSRM profile or a plugin route profile ('plugin:<id>/<profile>').
@@ -933,7 +938,7 @@ export function useTripPlanner() {
     const srcName = item.source?.fileName
     const srcFile = srcName ? importSourceFilesRef.current.find(f => f.name === srcName) : undefined
     if (srcFile) draft._sourceFiles = [srcFile]
-    if (isTransportItem(item) || (isUnplaceableItem(item) && bookingImportKind === 'transports')) {
+    if (isTransportItem(item) || (isUnplaceableItem(item) && importKindRef.current === 'transports')) {
       setShowReservationModal(false); setEditingReservation(null); setReservationPrefill(null)
       setEditingTransport(null); setTransportModalDayId(null)
       setTransportPrefill(draft); setShowTransportModal(true)
@@ -944,9 +949,14 @@ export function useTripPlanner() {
     }
   }
 
-  const startImportReview = (items: BookingImportPreviewItem[], sourceFiles: File[] = []) => {
+  const startImportReview = (
+    items: BookingImportPreviewItem[],
+    sourceFiles: File[] = [],
+    kind: 'transports' | 'bookings' = 'bookings',
+  ) => {
     if (!items.length) return
     importSourceFilesRef.current = sourceFiles
+    importKindRef.current = kind
     importQueueRef.current = items.slice(1)
     setImportReviewActive(true)
     openImportItem(items[0])
@@ -967,12 +977,13 @@ export function useTripPlanner() {
       const items = task.items
       const jobId = task.id
       const inMemory = task.sourceFiles
+      const kind = task.kind ?? 'bookings'
       dismissBgTask(jobId)
       // Prefer the in-memory files (immediate path); after a reload they live in IndexedDB.
       void (async () => {
         const files = inMemory && inMemory.length ? inMemory : await getImportFiles(jobId)
         deleteImportFiles(jobId)
-        startImportReview(items, files)
+        startImportReview(items, files, kind)
       })()
     }
   }, [bgTasks, tripId, startImportReview, dismissBgTask])

--- a/client/src/store/backgroundTasksStore.ts
+++ b/client/src/store/backgroundTasksStore.ts
@@ -32,11 +32,19 @@ export interface BackgroundImportTask {
   sourceFiles?: File[]
   /** Mode this run used — the widget only offers an AI retry if it wasn't already one. Not persisted. */
   mode?: BookingImportMode
+  /**
+   * Which tab the import was started from. It decides which form an item opens
+   * when its type is guessed (#2076), and unlike the other transient flags it IS
+   * persisted: the parse deliberately outlives navigation and reload, and the
+   * review is triggered by the global widget on any page, so a component-local
+   * value is gone by the time it is needed.
+   */
+  kind?: 'transports' | 'bookings'
 }
 
 interface BackgroundTasksState {
   tasks: BackgroundImportTask[]
-  addTask: (task: { id: string; tripId: string; label: string; total: number; files?: File[]; mode?: BookingImportMode }) => void
+  addTask: (task: { id: string; tripId: string; label: string; total: number; files?: File[]; mode?: BookingImportMode; kind?: 'transports' | 'bookings' }) => void
   setProgress: (id: string, tripId: string, done: number, total: number) => void
   setDone: (id: string, tripId: string, items: BookingImportPreviewItem[], warnings: string[]) => void
   setError: (id: string, tripId: string, error: string) => void
@@ -63,7 +71,7 @@ export const useBackgroundTasksStore = create<BackgroundTasksState>()(
 
       return {
         tasks: [],
-        addTask: ({ id, tripId, label, total, files, mode }) => upsert(id, tripId, { label, total, status: 'running', done: 0, sourceFiles: files, mode }),
+        addTask: ({ id, tripId, label, total, files, mode, kind }) => upsert(id, tripId, { label, total, status: 'running', done: 0, sourceFiles: files, mode, kind }),
         setProgress: (id, tripId, done, total) => upsert(id, tripId, { done, total, status: 'running' }),
         setDone: (id, tripId, items, warnings) => upsert(id, tripId, { status: 'done', items, warnings, done: items?.length ?? 0 }),
         setError: (id, tripId, error) => upsert(id, tripId, { status: 'error', error }),
@@ -81,7 +89,9 @@ export const useBackgroundTasksStore = create<BackgroundTasksState>()(
       partialize: (state) => ({
         tasks: state.tasks
           .filter((t) => !t.consumed && t.status !== 'error')
-          .map((t) => ({ id: t.id, tripId: t.tripId, label: t.label, status: t.status, done: t.done, total: t.total })),
+          // `kind` rides along: it is not a review flag but the context the review
+          // needs, and without it a reload silently falls back to 'bookings'.
+          .map((t) => ({ id: t.id, tripId: t.tripId, label: t.label, status: t.status, done: t.done, total: t.total, kind: t.kind })),
       }),
     },
   ),

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -4136,6 +4136,24 @@ function runMigrations(db: Database.Database): void {
         console.warn('[migrations] Non-fatal migration step failed:', err);
       }
     },
+
+    // Reservations an automated ingest parked for review are 'staged' and stay
+    // out of the two anonymous exports (ICS feed, shared trip) until a person
+    // confirms them. Nothing writes 'staged' yet; this is the gate the mail
+    // ingest writes through.
+    //
+    // 'live' as the default is what keeps this from being a breaking change:
+    // SQLite fills every existing row on the ALTER, and no current writer names
+    // the column, so every booking that is visible today stays visible.
+    // Appended LAST, the array is index-addressed against schema_version.
+    () => {
+      const hasColumn = db
+        .prepare("SELECT 1 FROM pragma_table_info('reservations') WHERE name = 'ingest_state'")
+        .get();
+      if (!hasColumn) {
+        db.exec("ALTER TABLE reservations ADD COLUMN ingest_state TEXT NOT NULL DEFAULT 'live'");
+      }
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/nest/booking-import/kitinerary-mapper.ts
+++ b/server/src/nest/booking-import/kitinerary-mapper.ts
@@ -1,3 +1,4 @@
+import { normalizeLocalDateTime, splitLocalDateTime } from '@trek/shared';
 import { findByIata } from '../airports/airports.data';
 import type {
   KiReservation, KiFlight, KiTrainTrip, KiBusTrip, KiBoatTrip,
@@ -9,17 +10,31 @@ import type {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Extract a plain ISO string from either a string or a KDE QDateTime object. */
+/**
+ * Extract a plain ISO string from either a string or a KDE QDateTime object.
+ *
+ * The value passes through normalizeLocalDateTime so a printed 12-hour clock
+ * ("2026-06-11T02:30 PM") becomes 24-hour before anything downstream reads it.
+ * These two functions are the mapper's only exits for a date, so this covers
+ * every type and every emitted field at once, and it keeps `sameConnection`
+ * from comparing a NaN timestamp (#2094).
+ */
 function toIsoString(dt: KiDateTimeish): string | null {
   if (!dt) return null;
-  if (typeof dt === 'string') return dt || null;
-  if (typeof dt === 'object' && dt['@type'] === 'QDateTime') return dt['@value'] || null;
+  if (typeof dt === 'string') return dt ? normalizeLocalDateTime(dt) : null;
+  if (typeof dt === 'object' && dt['@type'] === 'QDateTime') {
+    return dt['@value'] ? normalizeLocalDateTime(dt['@value']) : null;
+  }
   return null;
 }
 
 function splitIso(dt: KiDateTimeish): { date: string | null; time: string | null } {
   const iso = toIsoString(dt);
   if (!iso) return { date: null, time: null };
+  const split = splitLocalDateTime(iso);
+  // The slice is the fallback for anything the normalizer does not recognise,
+  // so a shape that works today cannot start returning null.
+  if (split.date) return split;
   return { date: iso.slice(0, 10) || null, time: iso.length > 10 ? iso.slice(11, 16) || null : null };
 }
 
@@ -261,6 +276,9 @@ function mapLodging(r: KiReservation, source: ParsedBookingItem['source']): Pars
 
   return {
     type: 'hotel',
+    // Only the lodging path can carry this: it is the shape the extractor falls
+    // back to when it could not read a type at all (#2076).
+    ...(r.trekTypeGuessed === true ? { type_guessed: true } : {}),
     title: l.name,
     confirmation_number: r.reservationNumber ?? null,
     location: formatAddress(l.address),

--- a/server/src/nest/booking-import/kitinerary.types.ts
+++ b/server/src/nest/booking-import/kitinerary.types.ts
@@ -127,6 +127,11 @@ export interface KiEvent {
 /** A single output node from kitinerary-extractor's JSON array */
 export interface KiReservation {
   '@type': string;
+  /**
+   * TREK's own marker, not schema.org: the extractor could not read a type and
+   * fell back to the lodging shape so the item would survive mapping (#2076).
+   */
+  trekTypeGuessed?: boolean;
   reservationNumber?: string;
   checkinTime?: KiDateTimeish;
   checkoutTime?: KiDateTimeish;
@@ -182,6 +187,8 @@ export interface ParsedAccommodation {
  */
 export interface ParsedBookingItem {
   type: string;
+  /** The type was filled in, not read from the document (#2076). */
+  type_guessed?: boolean;
   title: string;
   reservation_time?: string | null;
   reservation_end_time?: string | null;

--- a/server/src/nest/calendar/calendar.service.ts
+++ b/server/src/nest/calendar/calendar.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
 import { ReservationsService } from '../reservations/reservations.service';
+import { publicReservationSql, publicStaySql } from '../reservations/reservation-visibility';
 import { addDays } from '../days/days.service';
 import { resolveTimeZone } from '../common/timezoneService';
 import { NotFoundError } from '../common/domain-errors';
@@ -163,7 +164,7 @@ export class CalendarService {
          LEFT JOIN days ed ON a.end_day_id = ed.id
          LEFT JOIN days rd ON r.day_id = rd.id
          LEFT JOIN days red ON r.end_day_id = red.id
-         WHERE r.trip_id = ?`,
+         WHERE r.trip_id = ? AND ${publicReservationSql('r')}`,
       )
       .all(tripId) as any[];
 
@@ -569,13 +570,13 @@ export class CalendarService {
              sd.date AS start_date, ed.date AS end_date,
              p.name AS place_name, p.address AS place_address, p.lat AS place_lat, p.lng AS place_lng,
              (SELECT r.title FROM reservations r
-               WHERE r.accommodation_id = a.id
+               WHERE r.accommodation_id = a.id AND ${publicReservationSql('r')}
                ORDER BY r.id ASC LIMIT 1) AS reservation_title
       FROM day_accommodations a
       LEFT JOIN days sd ON a.start_day_id = sd.id
       LEFT JOIN days ed ON a.end_day_id = ed.id
       LEFT JOIN places p ON a.place_id = p.id
-      WHERE a.trip_id = ?
+      WHERE a.trip_id = ? AND ${publicStaySql('a')}
       ORDER BY a.id ASC
     `).all(tripId) as any[];
 

--- a/server/src/nest/llm-parse/clients/nuextract.ts
+++ b/server/src/nest/llm-parse/clients/nuextract.ts
@@ -170,6 +170,9 @@ function buildNode(x: Record<string, unknown>): Record<string, unknown> | undefi
 
   const node: Record<string, unknown> = {
     '@type': atType,
+    // Not a schema.org field: it says the router had to guess the type, so the
+    // importer can offer the form the user was importing into (#2076).
+    ...(x.type_guessed === true ? { trekTypeGuessed: true } : {}),
     reservationNumber: x.booking_reference,
     seat: x.seat,
     class: x.travel_class,

--- a/server/src/nest/llm-parse/router/extraction-router.ts
+++ b/server/src/nest/llm-parse/router/extraction-router.ts
@@ -18,7 +18,7 @@
  * existing `nuExtractToKiReservations` mapper, so nothing downstream changes.
  */
 
-import { normalizeLocalDateTime } from '@trek/shared';
+import { normalizeLocalDateTime, parseMeridiemClock } from '@trek/shared';
 import type { KiReservation } from '../../booking-import/kitinerary.types';
 import { nuExtractToKiReservations } from '../clients/nuextract';
 import { FLAT_SCHEMA_BY_TYPE, FLAT_TYPES, FLIGHTS_ARRAY_SCHEMA, UNION_SINGLE_SCHEMA, type FlatType, type FlatLike } from './flat-schemas';
@@ -151,17 +151,16 @@ export function extractTotalPrice(text: string): { price: string; currency?: str
  */
 export function fixArrivalDate(flat: FlatLike): FlatLike {
   if (!TRANSPORT_TYPES.includes(flat.type)) return flat;
-  // Both sides go through the 12-hour normalizer first. Reading the arrival
-  // with a bare /(\d{2}:\d{2})/ used to throw a trailing "PM" away, and the
-  // comparison below is lexicographic: "04:00" < "12:40" rolled a 13:11
-  // arrival onto the next day and turned a short hop into an overnight (#2094).
-  const depSource = normalizeLocalDateTime(String(flat.departure_time ?? ''));
-  const arrSource = normalizeLocalDateTime(String(flat.arrival_time ?? ''));
-  const dep = /(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(depSource);
-  const arr = /(\d{2}:\d{2})/.exec(arrSource.slice(10));
-  if (!dep || !arr) return flat;
+  const dep = /(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(normalizeLocalDateTime(String(flat.departure_time ?? '')));
+  // The arrival reaches us either as a bare clock ("13:00", "01:11 pm") or as a
+  // full date-time, so try the bare form first and fall back to the normalized
+  // string. Reading it with a plain /(\d{2}:\d{2})/ used to throw a trailing
+  // "PM" away, and the comparison below is lexicographic: "01:11" sorts before
+  // a 09:51 departure, so a short hop was rolled onto the next day (#2094).
+  const rawArr = String(flat.arrival_time ?? '').trim();
+  const arrTime = parseMeridiemClock(rawArr) ?? /(\d{2}:\d{2})/.exec(normalizeLocalDateTime(rawArr))?.[1];
+  if (!dep || !arrTime) return flat;
   const [, depDate, depTime] = dep;
-  const arrTime = arr[1];
   const d = new Date(`${depDate}T00:00:00Z`);
   if (arrTime < depTime) d.setUTCDate(d.getUTCDate() + 1);
   flat.arrival_time = `${d.toISOString().slice(0, 10)}T${arrTime}:00`;

--- a/server/src/nest/llm-parse/router/extraction-router.ts
+++ b/server/src/nest/llm-parse/router/extraction-router.ts
@@ -18,9 +18,10 @@
  * existing `nuExtractToKiReservations` mapper, so nothing downstream changes.
  */
 
+import { normalizeLocalDateTime } from '@trek/shared';
 import type { KiReservation } from '../../booking-import/kitinerary.types';
 import { nuExtractToKiReservations } from '../clients/nuextract';
-import { FLAT_SCHEMA_BY_TYPE, FLIGHTS_ARRAY_SCHEMA, UNION_SINGLE_SCHEMA, type FlatType, type FlatLike } from './flat-schemas';
+import { FLAT_SCHEMA_BY_TYPE, FLAT_TYPES, FLIGHTS_ARRAY_SCHEMA, UNION_SINGLE_SCHEMA, type FlatType, type FlatLike } from './flat-schemas';
 import { extractEnforced } from './ollama-format.client';
 
 export interface RouterContext {
@@ -38,9 +39,9 @@ const TYPE_HINT: Record<FlatType, string> = {
   train: 'train. from_name/to_name = stations, vehicle_number = train number, times = full ISO, price/currency = total fare.',
   bus: 'bus. from_name/to_name = stops, times = full ISO, price/currency = total fare.',
   ferry: 'ferry/cruise. from_name/to_name = terminals/ports, times = full ISO, price/currency = total fare.',
-  car: 'rental car. operator = the rental company, from_name = pick-up location, to_name = return location (may differ), departure_time = pick-up, arrival_time = return, price/currency = total rental cost.',
+  car: 'rental car. operator = the rental company, from_name = pick-up location, to_name = return location (may differ), departure_time = pick-up, arrival_time = return, times = full ISO (24-hour), price/currency = total rental cost.',
   hotel: 'hotel stay. name = hotel name, address = the hotel street address, checkin_time/checkout_time = full ISO date-time, price/currency = total paid.',
-  restaurant: 'restaurant booking. name = the restaurant, address = its street address, start_time = the reservation date-time, price/currency = total if shown.',
+  restaurant: 'restaurant booking. name = the restaurant, address = its street address, start_time = the reservation date-time as full ISO (24-hour), price/currency = total if shown.',
   event: 'event/attraction. name = the event/ticket, address = the venue, start_time/end_time = full ISO, price/currency = ticket price.',
 };
 
@@ -150,8 +151,14 @@ export function extractTotalPrice(text: string): { price: string; currency?: str
  */
 export function fixArrivalDate(flat: FlatLike): FlatLike {
   if (!TRANSPORT_TYPES.includes(flat.type)) return flat;
-  const dep = /(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(String(flat.departure_time ?? ''));
-  const arr = /(\d{2}:\d{2})/.exec(String(flat.arrival_time ?? ''));
+  // Both sides go through the 12-hour normalizer first. Reading the arrival
+  // with a bare /(\d{2}:\d{2})/ used to throw a trailing "PM" away, and the
+  // comparison below is lexicographic: "04:00" < "12:40" rolled a 13:11
+  // arrival onto the next day and turned a short hop into an overnight (#2094).
+  const depSource = normalizeLocalDateTime(String(flat.departure_time ?? ''));
+  const arrSource = normalizeLocalDateTime(String(flat.arrival_time ?? ''));
+  const dep = /(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(depSource);
+  const arr = /(\d{2}:\d{2})/.exec(arrSource.slice(10));
   if (!dep || !arr) return flat;
   const [, depDate, depTime] = dep;
   const arrTime = arr[1];
@@ -167,16 +174,25 @@ const DATE_FIELDS = ['departure_time', 'arrival_time', 'checkin_time', 'checkout
  * Coerce a date value to ISO 8601. Models occasionally ignore the format instruction and
  * emit a natural-language date ("Aug 23 2025 13:30"), which the downstream `splitIso` then
  * slices into garbage ("Aug 23 202"). Keep already-ISO values untouched; otherwise parse and
- * reformat. (The server runs in UTC, so the components line up.)
+ * reformat.
+ *
+ * These fields are naive local wall-clock strings everywhere else in TREK, so the components
+ * are read back locally. Reading with Date.parse and printing with getUTC* used to shift every
+ * such value by the container's UTC offset, which docker-compose sets from TZ and documents
+ * with Europe/Berlin. That is why a rental car came back off by the offset rather than by
+ * twelve hours: only `car` and `restaurant` lack the full-ISO instruction in TYPE_HINT, so
+ * only they reach this parse at all (#2094).
  */
 function toIso(value: unknown): unknown {
   if (typeof value !== 'string' || !value.trim()) return value;
-  if (/^\d{4}-\d{2}-\d{2}/.test(value)) return value;
+  // An ISO date with a printed meridiem behind it ("2026-06-11T02:30 PM") is not
+  // already ISO, it only looks like it. Resolve the clock, keep everything else.
+  if (/^\d{4}-\d{2}-\d{2}/.test(value)) return normalizeLocalDateTime(value);
   const t = Date.parse(value);
   if (Number.isNaN(t)) return value;
   const d = new Date(t);
   const p = (n: number) => String(n).padStart(2, '0');
-  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}T${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:00`;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}:00`;
 }
 
 /** Normalize every date-ish field on a flat reservation to ISO before mapping. */
@@ -213,8 +229,21 @@ async function extractSingle(text: string, ctx: RouterContext): Promise<FlatLike
     return fixArrivalDate(normalizeDates({ ...out, type: known }));
   }
   const out = (await call(UNION_SINGLE_SCHEMA, 'Pick the correct "type".')) ?? {};
-  const type = (typeof out.type === 'string' ? out.type : 'hotel') as FlatType;
-  return fixArrivalDate(normalizeDates({ ...out, type }));
+  // "I could not tell" used to be written down as "hotel", and a hotel is a
+  // booking, so a ferry voucher imported from the Transport tab opened the
+  // booking form with no transport type to pick and stayed 'other' (#2076).
+  // An unvalidated cast also let any string through, and the item then vanished
+  // silently in nuExtractToKiReservations, which drops an unmapped type.
+  const raw = typeof out.type === 'string' ? out.type.toLowerCase().trim() : '';
+  const picked = (FLAT_TYPES as string[]).includes(raw) ? (raw as FlatType) : null;
+  // Still extract with the hotel shape so the item survives the mapping, but say
+  // out loud that the type was guessed. Only here: a valid pick by the model is
+  // a real answer, and flagging it would push AI-parsed hotels into the
+  // transport form whenever the document never says the word "hotel".
+  const flat: FlatLike = picked
+    ? { ...out, type: picked }
+    : { ...out, type: 'hotel' as FlatType, type_guessed: true };
+  return fixArrivalDate(normalizeDates(flat));
 }
 
 /**

--- a/server/src/nest/llm-parse/router/flat-schemas.ts
+++ b/server/src/nest/llm-parse/router/flat-schemas.ts
@@ -23,6 +23,13 @@ export const FLAT_TYPES: FlatType[] = ['flight', 'train', 'bus', 'ferry', 'car',
  *  are the ones the router reads directly; the index signature carries the rest unchanged. */
 export interface FlatLike {
   type: FlatType;
+  /**
+   * The type was not read from the document, it was filled in because neither the
+   * keyword table nor the model produced a valid one. The extractor still uses the
+   * hotel shape so the item survives mapping, but the flag rides along so the
+   * importer opens the form the user was actually importing into (#2076).
+   */
+  type_guessed?: boolean;
   booking_reference?: string;
   vehicle_number?: string;
   from_code?: string;

--- a/server/src/nest/reservations/reservation-visibility.ts
+++ b/server/src/nest/reservations/reservation-visibility.ts
@@ -1,0 +1,34 @@
+/**
+ * Which reservation rows a viewer without a TREK session may see.
+ *
+ * `ingest_state` is 'live' for everything a person put on a trip, and 'staged'
+ * for a row an automated ingest parked for review. Only the two anonymous
+ * exports filter on it. The authenticated lists deliberately do not: the
+ * staging inbox has to see its own rows, or nobody can confirm them.
+ *
+ * These are SQL fragments rather than a service. calendar/ and share/ are
+ * separate modules and neither should have to import the other for a WHERE
+ * clause. They take the table alias because share.service.ts queries
+ * `reservations` without one while calendar.service.ts uses `r`.
+ *
+ * The COALESCE guards a NULL in the column, not a missing column: a table
+ * without `ingest_state` fails the query outright rather than returning NULL.
+ * The migration adds the column NOT NULL DEFAULT 'live', so a NULL should not
+ * occur; the COALESCE costs nothing and keeps a row that predates a botched
+ * ALTER visible rather than silently dropping it out of a live calendar feed.
+ */
+export const publicReservationSql = (alias = 'r'): string => `COALESCE(${alias}.ingest_state, 'live') <> 'staged'`;
+
+/**
+ * A stay is public when nothing points at it (somebody added it by hand), or
+ * when a live booking does. Both halves matter: a plain EXISTS would drop every
+ * hand-added hotel out of trips that are shared today.
+ *
+ * `accommodation_id` is a TEXT column that reads back as "14.0", hence the
+ * CAST. Same coercion as reservations.service.ts.
+ */
+export const publicStaySql = (alias = 'a'): string => `(
+      NOT EXISTS (SELECT 1 FROM reservations vr WHERE CAST(vr.accommodation_id AS INTEGER) = ${alias}.id)
+      OR EXISTS (SELECT 1 FROM reservations vr WHERE CAST(vr.accommodation_id AS INTEGER) = ${alias}.id
+                   AND ${publicReservationSql('vr')})
+    )`;

--- a/server/src/nest/share/share.service.ts
+++ b/server/src/nest/share/share.service.ts
@@ -5,6 +5,7 @@ import type { TripAccess } from '../database/database.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { QueryHelpersService } from '../query-helpers/query-helpers.service';
 import { PlacePhotoCacheService } from '../place-photos/place-photo-cache.service';
+import { publicReservationSql, publicStaySql } from '../reservations/reservation-visibility';
 import { SettingsService } from '../settings/settings.service';
 import type { User } from '../../types';
 
@@ -241,13 +242,18 @@ export class ShareService {
         if (!posMap.has(dp.reservation_id)) posMap.set(dp.reservation_id, {});
         posMap.get(dp.reservation_id)![dp.day_id] = dp.position;
       }
-      reservations = this.dbs.all<any>('SELECT * FROM reservations WHERE trip_id = ? ORDER BY reservation_time ASC', tripId)
+      // The alias is not cosmetic: the visibility predicate qualifies its column,
+      // and this query had no alias to qualify against.
+      reservations = this.dbs.all<any>(
+        `SELECT r.* FROM reservations r
+         WHERE r.trip_id = ? AND ${publicReservationSql('r')}
+         ORDER BY r.reservation_time ASC`, tripId)
         .map((r) => ({ ...r, day_positions: posMap.get(r.id) ?? null }));
 
       accommodations = this.dbs.all(`
         SELECT a.*, p.name as place_name, p.address as place_address, p.lat as place_lat, p.lng as place_lng
         FROM day_accommodations a JOIN places p ON a.place_id = p.id
-        WHERE a.trip_id = ?
+        WHERE a.trip_id = ? AND ${publicStaySql('a')}
       `, tripId);
     }
 

--- a/server/src/nest/trips/trips.service.ts
+++ b/server/src/nest/trips/trips.service.ts
@@ -625,8 +625,8 @@ export class TripsService {
       const reservationMap = new Map<number, number | bigint>();
       const insertReservation = this.db.prepare(`
         INSERT INTO reservations (trip_id, day_id, end_day_id, place_id, assignment_id, accommodation_id, title, reservation_time, reservation_end_time,
-          location, confirmation_number, notes, url, status, type, metadata, day_plan_position, needs_review)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          location, confirmation_number, notes, url, status, type, metadata, day_plan_position, needs_review, ingest_state)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       for (const r of oldReservations) {
         const rr = insertReservation.run(newTripId,
@@ -641,7 +641,10 @@ export class TripsService {
           r.accommodation_id != null ? (accomMap.get(Number(r.accommodation_id)) ?? null) : null,
           r.title, r.reservation_time, r.reservation_end_time,
           r.location, r.confirmation_number, r.notes, r.url, r.status, r.type,
-          r.metadata, r.day_plan_position, r.needs_review ?? 0);
+          // ingest_state travels with the copy: a staged booking must not turn
+          // 'live' just because the trip was duplicated, or it lands in the
+          // duplicate's public feed.
+          r.metadata, r.day_plan_position, r.needs_review ?? 0, r.ingest_state ?? 'live');
         reservationMap.set(r.id, rr.lastInsertRowid);
       }
 

--- a/server/tests/e2e/calendar-feed-visibility.e2e.test.ts
+++ b/server/tests/e2e/calendar-feed-visibility.e2e.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Calendar-feed visibility e2e — proves the staged-booking gate holds on the
+ * one path that needs no session at all: the public /api/feed/trip/:token.ics.
+ *
+ * tests/e2e/feeds.e2e.test.ts cannot cover this. It mocks buildTripCalendar and
+ * never creates a reservations table, so it owns the calendar parts and the SQL
+ * filter is invisible to it. This file runs the REAL CalendarService against a
+ * real migrated SQLite instead, and asserts on the bytes a calendar client
+ * would receive.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import type { Server } from 'http';
+import { Test } from '@nestjs/testing';
+
+const { db } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3');
+  const tmp = new Database(':memory:');
+  tmp.exec('PRAGMA journal_mode = WAL');
+  return { db: tmp };
+});
+
+vi.mock('../../src/db/database', () => ({
+  db,
+  canAccessTrip: (tripId: number | string, userId: number) =>
+    db.prepare('SELECT id, user_id FROM trips WHERE id = ? AND user_id = ?').get(tripId, userId),
+  isOwner: () => true,
+  getPlaceWithTags: () => null,
+  closeDb: () => {},
+  reinitialize: () => {},
+}));
+
+import { createTables } from '../../src/db/schema';
+import { runMigrations } from '../../src/db/migrations';
+import { DatabaseModule } from '../../src/nest/database/database.module';
+import { FeedsModule } from '../../src/nest/feeds/feeds.module';
+import { TrekExceptionFilter } from '../../src/nest/common/trek-exception.filter';
+
+describe('Calendar feed visibility e2e (real CalendarService over temp SQLite)', () => {
+  let server: Server;
+  let app: Awaited<ReturnType<typeof build>>;
+  let feedToken: string;
+
+  async function build() {
+    const moduleRef = await Test.createTestingModule({ imports: [DatabaseModule, FeedsModule] }).compile();
+    const nest = moduleRef.createNestApplication();
+    nest.useGlobalFilters(new TrekExceptionFilter());
+    await nest.init();
+    return nest;
+  }
+
+  beforeAll(async () => {
+    createTables(db);
+    runMigrations(db);
+    db.prepare(
+      "INSERT INTO users (id, username, email, password_hash, role) VALUES (1, 'e2e-user', 'e2e@example.test', 'x', 'user')",
+    ).run();
+    feedToken = 'feed-token-visibility';
+    db.prepare(
+      "INSERT INTO trips (id, user_id, title, start_date, end_date, feed_token) VALUES (1, 1, 'Kyoto', '2026-09-01', '2026-09-05', ?)",
+    ).run(feedToken);
+    db.prepare("INSERT INTO days (id, trip_id, day_number, date) VALUES (1, 1, 1, '2026-09-01')").run();
+    db.prepare(`INSERT INTO reservations (trip_id, day_id, title, type, status, reservation_time, confirmation_number, ingest_state)
+      VALUES (1, 1, 'Parked Flight', 'flight', 'confirmed', '2026-09-01T08:00', 'SECRET1', 'staged')`).run();
+    db.prepare(`INSERT INTO reservations (trip_id, day_id, title, type, status, reservation_time, confirmation_number)
+      VALUES (1, 1, 'Booked Flight', 'flight', 'confirmed', '2026-09-01T12:00', 'OPEN1')`).run();
+
+    app = await build();
+    server = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('the public feed serves the live booking and neither the staged one nor its confirmation number', async () => {
+    const res = await request(server).get(`/api/feed/trip/${feedToken}.ics`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/calendar');
+    expect(res.text).toContain('SUMMARY:Booked Flight');
+    expect(res.text).not.toContain('Parked Flight');
+    // The number rides in the DESCRIPTION, so search the whole document.
+    expect(res.text).not.toContain('SECRET1');
+    expect(res.text).toContain('OPEN1');
+  });
+});

--- a/server/tests/unit/db/reservation-ingest-state-migration.test.ts
+++ b/server/tests/unit/db/reservation-ingest-state-migration.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Boot migration: reservations.ingest_state.
+ *
+ * The column gates the two anonymous exports (ICS feed, shared trip) so an
+ * automated ingest can park a booking for review without publishing it. Every
+ * row that exists before the ALTER has to come out 'live', or the migration
+ * would empty a calendar subscription that works today.
+ */
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTables } from '../../../src/db/schema';
+import { runMigrations } from '../../../src/db/migrations';
+
+function dbWithReservations(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('PRAGMA foreign_keys = ON');
+  createTables(db);
+  db.prepare("INSERT INTO users (id, username, email, password_hash) VALUES (1, 'u', 'u@example.test', 'x')").run();
+  db.prepare("INSERT INTO trips (id, user_id, title) VALUES (1, 1, 'T')").run();
+  db.prepare("INSERT INTO reservations (id, trip_id, title, type) VALUES (1, 1, 'Old Flight', 'flight')").run();
+  return db;
+}
+
+describe('reservations ingest_state migration', () => {
+  it('MIGRATE-INGEST-001: every pre-existing row comes out live', () => {
+    const db = dbWithReservations();
+    try {
+      runMigrations(db);
+      const row = db.prepare('SELECT ingest_state FROM reservations WHERE id = 1').get() as { ingest_state: string };
+      expect(row.ingest_state).toBe('live');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('MIGRATE-INGEST-002: running the migration twice is a no-op', () => {
+    const db = dbWithReservations();
+    try {
+      runMigrations(db);
+      // Rewind the version so the step replays against a table that already has
+      // the column. Without the pragma_table_info guard the ALTER throws and
+      // runMigrations exits the process.
+      const version = (db.prepare('SELECT version FROM schema_version').get() as { version: number }).version;
+      db.prepare('UPDATE schema_version SET version = ?').run(version - 1);
+      runMigrations(db);
+
+      const cols = db.prepare("SELECT name FROM pragma_table_info('reservations') WHERE name = 'ingest_state'").all();
+      expect(cols).toHaveLength(1);
+      expect((db.prepare('SELECT version FROM schema_version').get() as { version: number }).version).toBe(version);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/tests/unit/nest/calendar.service.test.ts
+++ b/server/tests/unit/nest/calendar.service.test.ts
@@ -1243,6 +1243,98 @@ describe('car rentals', () => {
   });
 });
 
+describe('staged bookings', () => {
+  /** A stay plus, optionally, the bookings that point at it. */
+  const stayWith = (tripId: number, states: Array<{ state: string; title: string }>) => {
+    const place = createPlace(testDb, tripId, { name: 'Hotel Bellevue', lat: 48.8566, lng: 2.3522 });
+    const startDay = createDay(testDb, tripId, { date: '2026-09-01' });
+    const endDay = createDay(testDb, tripId, { date: '2026-09-04' });
+    const stayId = testDb.prepare(`
+      INSERT INTO day_accommodations (trip_id, place_id, start_day_id, end_day_id, check_in, check_out)
+      VALUES (?, ?, ?, ?, '15:00', '11:00')
+    `).run(tripId, place.id, startDay.id, endDay.id).lastInsertRowid as number;
+
+    for (const s of states) {
+      testDb.prepare(`
+        INSERT INTO reservations (trip_id, day_id, title, reservation_time, status, type, accommodation_id, ingest_state)
+        VALUES (?, ?, ?, '2026-09-01T15:00', 'confirmed', 'hotel', ?, ?)
+      `).run(tripId, startDay.id, s.title, String(stayId), s.state);
+    }
+    return { stayId, placeId: place.id };
+  };
+
+  it('CAL-055: a staged booking is left out of the calendar, confirmation number included', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Kyoto' });
+    const day = createDay(testDb, trip.id, { date: '2026-09-01' });
+    const staged = createReservation(testDb, trip.id, { title: 'Parked Flight', type: 'flight', day_id: day.id });
+    testDb.prepare(`UPDATE reservations SET ingest_state='staged', reservation_time='2026-09-01T08:00',
+      confirmation_number='ABC123' WHERE id=?`).run(staged.id);
+    const live = createReservation(testDb, trip.id, { title: 'Booked Flight', type: 'flight', day_id: day.id });
+    testDb.prepare("UPDATE reservations SET reservation_time='2026-09-01T12:00' WHERE id=?").run(live.id);
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics).toContain('SUMMARY:Booked Flight');
+    expect(ics).not.toContain('Parked Flight');
+    // The number rides in the DESCRIPTION, not the SUMMARY, so search the whole document.
+    expect(ics).not.toContain('ABC123');
+  });
+
+  it('CAL-056: a booking created before the column existed still exports', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Lisbon' });
+    const day = createDay(testDb, trip.id, { date: '2026-09-02' });
+    // No ingest_state named on the insert: exactly what every writer does today,
+    // and what the ALTER backfilled onto every pre-existing row.
+    const old = createReservation(testDb, trip.id, { title: 'Legacy Booking', type: 'flight', day_id: day.id });
+    testDb.prepare("UPDATE reservations SET reservation_time='2026-09-02T09:00' WHERE id=?").run(old.id);
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics).toContain('SUMMARY:Legacy Booking');
+  });
+
+  it('CAL-057: an accommodation whose only booking is staged emits no stay, check-in or check-out', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Osaka' });
+    stayWith(trip.id, [{ state: 'staged', title: 'Parked Hotel' }]);
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics).not.toContain('Parked Hotel');
+    expect(ics).not.toMatch(/UID:trek-checkin-\d+@trek/);
+    expect(ics).not.toMatch(/UID:trek-checkout-\d+@trek/);
+  });
+
+  it('CAL-058: an accommodation with no linked booking at all still emits its stay', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Nara' });
+    // The regression this pins: a plain EXISTS(live) instead of
+    // NOT EXISTS(any) OR EXISTS(live) would drop every hand-added hotel out of
+    // trips that are shared today.
+    stayWith(trip.id, []);
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics).toContain('Hotel Bellevue');
+    expect(ics).toMatch(/UID:trek-checkin-\d+@trek/);
+  });
+
+  it('CAL-059: a stay with both a staged and a live booking takes its title from the live one', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Kobe' });
+    // The staged row gets the lower id, so the subquery's ORDER BY r.id ASC
+    // would pick it without the predicate.
+    stayWith(trip.id, [{ state: 'staged', title: 'Parked Name' }, { state: 'live', title: 'Real Name' }]);
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics).toContain('Real Name');
+    expect(ics).not.toContain('Parked Name');
+  });
+});
+
 describe('folded quirk branches', () => {
   it('TRIP-SVC-048: exportICS renders untimed/notes all-day summaries, multi-leg routes, endpoint routes and train/location fields', () => {
     const { user } = createUser(testDb);

--- a/server/tests/unit/nest/llm-parse/extraction-router.test.ts
+++ b/server/tests/unit/nest/llm-parse/extraction-router.test.ts
@@ -114,7 +114,10 @@ describe('routeExtraction', () => {
     expect(res.kiItems).toEqual([{ '@type': 'Mock' }]);
     const flats = mapToKi.mock.calls[0][0];
     expect(flats).toHaveLength(2);
-    expect(flats[0].departure_time).toMatch(/^2025-08-23T\d{2}:\d{2}:00$/); // natural-language → ISO
+    // Exact now, not a pattern: toIso reads and prints local components, so a naive
+    // string is the same wall clock on every machine. It used to parse locally and
+    // print in UTC, which shifted the value by the container's offset (#2094).
+    expect(flats[0].departure_time).toBe('2025-08-23T10:00:00');
     expect(flats[1].arrival_time).toBe('2025-08-31T07:00:00'); // overnight roll (TZ-safe: derived from the ISO departure date)
   });
 
@@ -213,4 +216,44 @@ describe('routeExtraction', () => {
     expect(mapToKi.mock.calls[0][0][0].type).toBe('flight');
   });
 
+});
+
+describe('printed 12-hour clocks and unreadable types (#2094, #2076)', () => {
+  it('fixArrivalDate resolves both meridiems before deciding the day rolled over', () => {
+    // '01:11 pm' used to be read as '01:11', which sorts before the 09:51
+    // departure, so a three-hour hop was rolled onto the next day.
+    const out = fixArrivalDate({ type: 'flight', departure_time: '2026-06-11T09:51 am', arrival_time: '2026-06-11T01:11 pm' });
+    expect(out.arrival_time).toBe('2026-06-11T13:11:00');
+  });
+
+  it('fixArrivalDate still rolls a genuine overnight', () => {
+    const out = fixArrivalDate({ type: 'flight', departure_time: '2026-06-11T10:00 pm', arrival_time: '2026-06-12T06:00 am' });
+    expect(out.arrival_time).toBe('2026-06-12T06:00:00');
+  });
+
+  it('resolves a meridiem that sits behind an ISO date', async () => {
+    extractEnforced.mockResolvedValue({ name: 'B&B Hotel', address: 'Str 1', checkin_time: '2026-05-01T03:00 pm', checkout_time: '2026-05-02T11:00 am' });
+    await routeExtraction('Hotel booking — check-in 1 May', CTX);
+    const flats = mapToKi.mock.calls[0][0];
+    expect(flats[0].checkin_time).toBe('2026-05-01T15:00:00');
+    expect(flats[0].checkout_time).toBe('2026-05-02T11:00:00');
+  });
+
+  it('marks a type it could not read instead of writing it down as a hotel', async () => {
+    extractEnforced.mockResolvedValue({ type: 'shuttle voucher', name: 'Airport Transfer' });
+    await routeExtraction('A document with no obvious type keywords', CTX);
+    const flats = mapToKi.mock.calls[0][0];
+    // Still the hotel shape, so the item survives mapping, but the guess is
+    // declared so the importer can offer the form the user was importing into.
+    expect(flats[0].type).toBe('hotel');
+    expect(flats[0].type_guessed).toBe(true);
+  });
+
+  it('does not mark a type the model picked legitimately', async () => {
+    extractEnforced.mockResolvedValue({ type: 'event', name: 'Concert' });
+    await routeExtraction('A document with no obvious type keywords', CTX);
+    const flats = mapToKi.mock.calls[0][0];
+    expect(flats[0].type).toBe('event');
+    expect(flats[0].type_guessed).toBeUndefined();
+  });
 });

--- a/server/tests/unit/nest/reservations.service.test.ts
+++ b/server/tests/unit/nest/reservations.service.test.ts
@@ -877,6 +877,18 @@ describe('ReservationsService — legacy branch parity (coverage of the folded c
     svc.syncBudgetOnUpdate(String(trip.id), '999999', 'X', 'flight', 'X', 'flight', { total_price: 0 }, undefined);
     expect(budget.deleteBudgetItem).not.toHaveBeenCalled();
   });
+
+  it('RESV-SVC-031: list returns staged bookings, the staging inbox has to see its own rows', () => {
+    const { trip } = ownerTrip();
+    createReservation(testDb, trip.id, { title: 'Live One' });
+    const staged = createReservation(testDb, trip.id, { title: 'Parked One' });
+    testDb.prepare("UPDATE reservations SET ingest_state = 'staged' WHERE id = ?").run(staged.id);
+
+    // The visibility predicate belongs to the anonymous exports (ICS feed,
+    // shared trip) and must never be pulled into the authenticated list, or
+    // nobody can confirm what the ingest parked.
+    expect(svc.list(String(trip.id)).map((r: any) => r.title).sort()).toEqual(['Live One', 'Parked One']);
+  });
 });
 
 describe('ReservationsService — quirk fixes (post-fold)', () => {

--- a/server/tests/unit/nest/share.service.test.ts
+++ b/server/tests/unit/nest/share.service.test.ts
@@ -384,6 +384,48 @@ describe('getSharedTripData', () => {
     testDb.prepare("INSERT INTO settings (user_id, key, value) VALUES (?, 'carto_api_key', ' owner-key ')").run(user.id);
     expect(svc.getSharedTripData(token)!.cartoApiKey).toBe('owner-key');
   });
+
+  it('SHARE-SVC-029: staged bookings stay out of the public payload, confirmation number included', () => {
+    const { trip, token } = seedSharedTrip();
+    testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status, confirmation_number, ingest_state)
+      VALUES (?, 'Parked Flight', 'flight', 'confirmed', 'SECRET1', 'staged')`).run(trip.id);
+    testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status, confirmation_number)
+      VALUES (?, 'Booked Flight', 'flight', 'confirmed', 'OPEN1')`).run(trip.id);
+
+    const data = svc.getSharedTripData(token)!;
+
+    expect((data.reservations as any[]).map((r) => r.title)).toEqual(['Booked Flight']);
+    // SELECT * hands out notes, url and metadata too, so check the whole payload.
+    expect(JSON.stringify(data)).not.toContain('SECRET1');
+  });
+
+  it('SHARE-SVC-030: every booking that predates the column stays in the payload', () => {
+    const { trip, token } = seedSharedTrip();
+    for (let i = 0; i < 5; i++) {
+      testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status)
+        VALUES (?, ?, 'flight', 'confirmed')`).run(trip.id, `Booking ${i}`);
+    }
+
+    expect((svc.getSharedTripData(token)!.reservations as any[])).toHaveLength(5);
+  });
+
+  it('SHARE-SVC-031: accommodations backed only by a staged booking are withheld, unlinked ones are kept', () => {
+    const { trip, token } = seedSharedTrip();
+    const place = createPlace(testDb, trip.id, { name: 'Hotel Bellevue' });
+    const day = createDay(testDb, trip.id, { date: '2026-09-01' });
+    const stay = (): number => testDb.prepare(`
+      INSERT INTO day_accommodations (trip_id, place_id, start_day_id, end_day_id) VALUES (?, ?, ?, ?)
+    `).run(trip.id, place.id, day.id, day.id).lastInsertRowid as number;
+
+    const stagedStay = stay();
+    testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status, accommodation_id, ingest_state)
+      VALUES (?, 'Parked Hotel', 'hotel', 'confirmed', ?, 'staged')`).run(trip.id, String(stagedStay));
+    const unlinkedStay = stay();
+
+    const rows = svc.getSharedTripData(token)!.accommodations as any[];
+
+    expect(rows.map((a) => a.id)).toEqual([unlinkedStay]);
+  });
 });
 
 // ── getSharedPlacePhotoKey ───────────────────────────────────────────────────

--- a/server/tests/unit/nest/trips.service.test.ts
+++ b/server/tests/unit/nest/trips.service.test.ts
@@ -754,6 +754,26 @@ describe('folded trip CRUD', () => {
     expect((testDb.prepare('SELECT title FROM trips WHERE id = ?').get(secondCopy) as any).title).toBe('Origin');
   });
 
+  it('TRIP-SVC-060: copying a trip keeps a staged booking staged', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Origin', start_date: '2025-06-01', end_date: '2025-06-02' });
+    testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status, ingest_state)
+      VALUES (?, 'Parked', 'flight', 'confirmed', 'staged')`).run(trip.id);
+    testDb.prepare(`INSERT INTO reservations (trip_id, title, type, status)
+      VALUES (?, 'Booked', 'flight', 'confirmed')`).run(trip.id);
+
+    const newTripId = svc.copy(trip.id, user.id, 'Clone');
+
+    // Without ingest_state on the duplicate INSERT the staged row falls back to
+    // the column default and shows up in the copy's public feed.
+    const rows = testDb.prepare('SELECT title, ingest_state FROM reservations WHERE trip_id = ? ORDER BY title')
+      .all(newTripId) as any[];
+    expect(rows).toEqual([
+      { title: 'Booked', ingest_state: 'live' },
+      { title: 'Parked', ingest_state: 'staged' },
+    ]);
+  });
+
   /**
    * Copying a trip used to take every packing row and re-insert it without
    * is_private/owner_id, so both fell back to the column defaults and another

--- a/server/tests/unit/services/kitineraryMapper.test.ts
+++ b/server/tests/unit/services/kitineraryMapper.test.ts
@@ -68,3 +68,42 @@ describe('kitinerary mapper — multi-leg flight grouping', () => {
     expect((items[0].metadata as any).legs).toBeUndefined();
   });
 });
+
+describe('kitinerary mapper — printed 12-hour clocks (#2094)', () => {
+  it('reads a PM arrival as the afternoon instead of slicing the meridiem off', () => {
+    // Before the fix the endpoint carried '01:11', because splitIso sliced
+    // characters 11..16 out of '2026-06-11T01:11 PM'. The hour survived and the
+    // arrival landed twelve hours early.
+    const { items } = mapReservations([
+      flight('PM1', FRA, BER, '2026-06-11T09:51 am', '2026-06-11T01:11 pm', 'LH 300'),
+    ] as any, 'meridiem.json');
+
+    expect(items).toHaveLength(1);
+    const [dep, arr] = items[0].endpoints!;
+    expect(dep.local_time).toBe('09:51');
+    expect(arr.local_time).toBe('13:11');
+    expect(items[0].reservation_time).toBe('2026-06-11T09:51:00');
+    expect(items[0].reservation_end_time).toBe('2026-06-11T13:11:00');
+  });
+
+  it('leaves a 24-hour document byte for byte where it was', () => {
+    const { items } = mapReservations([
+      flight('H24', FRA, BER, '2026-06-11T10:00:00', '2026-06-11T12:00:00', 'LH 400'),
+    ] as any, 'plain.json');
+
+    expect(items[0].reservation_time).toBe('2026-06-11T10:00:00');
+    expect(items[0].endpoints![1].local_time).toBe('12:00');
+  });
+
+  it('keeps two legs apart that a NaN comparison used to merge', () => {
+    // sameConnection does `new Date(value).getTime()`, which is NaN for a
+    // printed meridiem, and both of its comparisons are false against NaN, so
+    // the guard fell through and merged unrelated legs into one booking.
+    const { items } = mapReservations([
+      flight('SAME', FRA, BER, '2026-06-11T09:00 am', '2026-06-11T10:00 am', 'LH 500'),
+      flight('SAME', HND, FRA, '2026-06-18T09:00 am', '2026-06-18T05:00 pm', 'LH 600'),
+    ] as any, 'two-legs.json');
+
+    expect(items).toHaveLength(2);
+  });
+});

--- a/shared/src/datetime/datetime-normalize.spec.ts
+++ b/shared/src/datetime/datetime-normalize.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseMeridiemClock, splitLocalDateTime, normalizeLocalDateTime } from './datetime-normalize';
+
+describe('parseMeridiemClock', () => {
+  it('resolves the half of the day', () => {
+    expect(parseMeridiemClock('01:11 pm')).toBe('13:11');
+    expect(parseMeridiemClock('09:51 am')).toBe('09:51');
+    expect(parseMeridiemClock('3 PM')).toBe('15:00');
+    expect(parseMeridiemClock('02:30:00 p.m.')).toBe('14:30');
+  });
+
+  it('keeps noon at 12 and midnight at 00', () => {
+    expect(parseMeridiemClock('12:05 pm')).toBe('12:05');
+    expect(parseMeridiemClock('12:05 am')).toBe('00:05');
+  });
+
+  it('returns null when there is no meridiem to resolve', () => {
+    expect(parseMeridiemClock('13:11')).toBeNull();
+    expect(parseMeridiemClock('')).toBeNull();
+    expect(parseMeridiemClock(null)).toBeNull();
+    // 13 with a meridiem is not a 12-hour clock, so it is not ours to rewrite.
+    expect(parseMeridiemClock('13:11 pm')).toBeNull();
+  });
+});
+
+describe('splitLocalDateTime', () => {
+  it('reads a printed 12-hour clock instead of slicing it', () => {
+    // The defect this pins: 'T02:30 PM'.slice(11, 16) is '02:30'. The hour
+    // survives and the booking lands twelve hours early (#2094).
+    expect(splitLocalDateTime('2026-06-11T02:30 PM')).toEqual({ date: '2026-06-11', time: '14:30' });
+  });
+
+  it('leaves a 24-hour value exactly as it is', () => {
+    expect(splitLocalDateTime('2026-06-11T13:11:00')).toEqual({ date: '2026-06-11', time: '13:11' });
+    expect(splitLocalDateTime('2026-06-11')).toEqual({ date: '2026-06-11', time: null });
+  });
+
+  it('has no date to give when the value does not start with one', () => {
+    expect(splitLocalDateTime('Aug 23 2025 10:00')).toEqual({ date: null, time: null });
+    expect(splitLocalDateTime(undefined)).toEqual({ date: null, time: null });
+  });
+});
+
+describe('normalizeLocalDateTime', () => {
+  it('rewrites only the clock, and keeps the seconds it was given', () => {
+    expect(normalizeLocalDateTime('2026-06-11T02:30 PM')).toBe('2026-06-11T14:30:00');
+    expect(normalizeLocalDateTime('2026-06-11T02:30:45 pm')).toBe('2026-06-11T14:30:45');
+  });
+
+  it('touches nothing that has no meridiem on it', () => {
+    // Strictly additive: a date-only value stays date-only (the calendar
+    // branches on whether the string contains a 'T' and would turn an all-day
+    // event into a midnight point), an offset survives, and an unreadable
+    // shape keeps whatever it meant before.
+    expect(normalizeLocalDateTime('2026-06-11')).toBe('2026-06-11');
+    expect(normalizeLocalDateTime('2026-06-11T13:11:00')).toBe('2026-06-11T13:11:00');
+    expect(normalizeLocalDateTime('2026-06-11T13:11:00+02:00')).toBe('2026-06-11T13:11:00+02:00');
+    expect(normalizeLocalDateTime('Aug 23 2025 10:00')).toBe('Aug 23 2025 10:00');
+    expect(normalizeLocalDateTime('')).toBe('');
+  });
+});

--- a/shared/src/datetime/datetime-normalize.ts
+++ b/shared/src/datetime/datetime-normalize.ts
@@ -1,0 +1,80 @@
+/**
+ * Twelve-hour clock handling for imported booking documents (#2094).
+ *
+ * A confirmation mail prints "01:11 pm". Every downstream consumer in TREK
+ * expects a naive 24-hour local string, and the mapper used to reach it by
+ * slicing: `'2026-06-11T02:30 PM'.slice(11, 16)` yields '02:30'. The hour
+ * survives, the half of the day does not, and the booking silently lands
+ * twelve hours early. Because the arrival then sorts before the departure, the
+ * router also rolls it onto the next day, so a three-hour domestic flight is
+ * rendered as an overnight.
+ *
+ * The client has carried the same fix since #1725 (client/src/utils/formatters.ts);
+ * this is the server half, which was never pulled across. The regex here is
+ * deliberately looser than the client's: the server also sees 'HH:MM:SS AM' and
+ * 'a.m.' straight out of a PDF.
+ *
+ * Everything here is total: a value that cannot be read comes back unchanged
+ * rather than becoming null, so no format that works today can start failing.
+ */
+
+const MERIDIEM_CLOCK = /^(\d{1,2})(?::(\d{2}))?(?::\d{2})?\s*([ap])\.?\s?m\.?$/i;
+
+/**
+ * '3:00 PM' / '02:30:00 pm' / '3 PM' → '15:00'.
+ * Returns null when there is no meridiem to resolve, so callers can tell
+ * "not my format" from "midnight".
+ */
+export function parseMeridiemClock(value: string | null | undefined): string | null {
+  const m = MERIDIEM_CLOCK.exec((value || '').trim());
+  if (!m) return null;
+  let hour = Number.parseInt(m[1], 10);
+  const minute = m[2] ? Number.parseInt(m[2], 10) : 0;
+  if (!Number.isFinite(hour) || hour > 12) return null;
+  const isPm = m[3].toLowerCase() === 'p';
+  // 12 AM is midnight and 12 PM is noon: the hour does not shift at 12.
+  if (hour === 12) hour = isPm ? 12 : 0;
+  else if (isPm) hour += 12;
+  return `${String(hour).padStart(2, '0')}:${String(Math.min(59, minute)).padStart(2, '0')}`;
+}
+
+/** Split a naive date-time string into its date and its 24-hour clock. */
+export function splitLocalDateTime(value: string | null | undefined): { date: string | null; time: string | null } {
+  const raw = (value || '').trim();
+  if (!raw) return { date: null, time: null };
+
+  const dateMatch = /^(\d{4}-\d{2}-\d{2})/.exec(raw);
+  if (!dateMatch) return { date: null, time: null };
+  const date = dateMatch[1];
+
+  const rest = raw.slice(10).replace(/^[T\s]/, '').trim();
+  if (!rest) return { date, time: null };
+
+  const meridiem = parseMeridiemClock(rest);
+  if (meridiem) return { date, time: meridiem };
+
+  const clock = /^(\d{2}:\d{2})/.exec(rest);
+  return { date, time: clock ? clock[1] : null };
+}
+
+/**
+ * Return the same naive date-time with a 24-hour clock. Anything the parser
+ * cannot read comes back byte for byte, which is what keeps this additive:
+ * a value that is already correct is never rewritten.
+ */
+export function normalizeLocalDateTime(value: string): string {
+  if (!value) return value;
+  const dateMatch = /^(\d{4}-\d{2}-\d{2})/.exec(value.trim());
+  if (!dateMatch) return value;
+
+  // Only a printed 12-hour clock is rewritten. Everything else comes back
+  // untouched, which is what makes this safe to drop into the middle of the
+  // mapper: a value carrying a UTC offset, a date-only value, or a shape this
+  // does not know keeps whatever it meant before.
+  const rest = value.trim().slice(10).replace(/^[T\s]/, '').trim();
+  const clock = parseMeridiemClock(rest);
+  if (!clock) return value;
+
+  const seconds = /^\d{1,2}:\d{2}:(\d{2})/.exec(rest);
+  return `${dateMatch[1]}T${clock}:${seconds ? seconds[1] : '00'}`;
+}

--- a/shared/src/datetime/datetime-normalize.ts
+++ b/shared/src/datetime/datetime-normalize.ts
@@ -19,6 +19,7 @@
  */
 
 const MERIDIEM_CLOCK = /^(\d{1,2})(?::(\d{2}))?(?::\d{2})?\s*([ap])\.?\s?m\.?$/i;
+const LEADING_DATE = /^(\d{4}-\d{2}-\d{2})/;
 
 /**
  * '3:00 PM' / '02:30:00 pm' / '3 PM' → '15:00'.
@@ -27,34 +28,40 @@ const MERIDIEM_CLOCK = /^(\d{1,2})(?::(\d{2}))?(?::\d{2})?\s*([ap])\.?\s?m\.?$/i
  */
 export function parseMeridiemClock(value: string | null | undefined): string | null {
   const m = MERIDIEM_CLOCK.exec((value || '').trim());
-  if (!m) return null;
-  let hour = Number.parseInt(m[1], 10);
-  const minute = m[2] ? Number.parseInt(m[2], 10) : 0;
+  const rawHour = m?.[1];
+  const half = m?.[3];
+  if (!rawHour || !half) return null;
+
+  let hour = Number.parseInt(rawHour, 10);
+  const minute = Number.parseInt(m?.[2] ?? '0', 10);
   if (!Number.isFinite(hour) || hour > 12) return null;
-  const isPm = m[3].toLowerCase() === 'p';
+
+  const isPm = half.toLowerCase() === 'p';
   // 12 AM is midnight and 12 PM is noon: the hour does not shift at 12.
   if (hour === 12) hour = isPm ? 12 : 0;
   else if (isPm) hour += 12;
+
   return `${String(hour).padStart(2, '0')}:${String(Math.min(59, minute)).padStart(2, '0')}`;
+}
+
+/** The part after a leading `YYYY-MM-DD`, with its `T` or space removed. */
+function clockPart(value: string): string {
+  return value.slice(10).replace(/^[T\s]/, '').trim();
 }
 
 /** Split a naive date-time string into its date and its 24-hour clock. */
 export function splitLocalDateTime(value: string | null | undefined): { date: string | null; time: string | null } {
   const raw = (value || '').trim();
-  if (!raw) return { date: null, time: null };
+  const date = LEADING_DATE.exec(raw)?.[1];
+  if (!date) return { date: null, time: null };
 
-  const dateMatch = /^(\d{4}-\d{2}-\d{2})/.exec(raw);
-  if (!dateMatch) return { date: null, time: null };
-  const date = dateMatch[1];
-
-  const rest = raw.slice(10).replace(/^[T\s]/, '').trim();
+  const rest = clockPart(raw);
   if (!rest) return { date, time: null };
 
   const meridiem = parseMeridiemClock(rest);
   if (meridiem) return { date, time: meridiem };
 
-  const clock = /^(\d{2}:\d{2})/.exec(rest);
-  return { date, time: clock ? clock[1] : null };
+  return { date, time: /^(\d{2}:\d{2})/.exec(rest)?.[1] ?? null };
 }
 
 /**
@@ -64,17 +71,18 @@ export function splitLocalDateTime(value: string | null | undefined): { date: st
  */
 export function normalizeLocalDateTime(value: string): string {
   if (!value) return value;
-  const dateMatch = /^(\d{4}-\d{2}-\d{2})/.exec(value.trim());
-  if (!dateMatch) return value;
+  const trimmed = value.trim();
+  const date = LEADING_DATE.exec(trimmed)?.[1];
+  if (!date) return value;
 
   // Only a printed 12-hour clock is rewritten. Everything else comes back
   // untouched, which is what makes this safe to drop into the middle of the
   // mapper: a value carrying a UTC offset, a date-only value, or a shape this
   // does not know keeps whatever it meant before.
-  const rest = value.trim().slice(10).replace(/^[T\s]/, '').trim();
+  const rest = clockPart(trimmed);
   const clock = parseMeridiemClock(rest);
   if (!clock) return value;
 
-  const seconds = /^\d{1,2}:\d{2}:(\d{2})/.exec(rest);
-  return `${dateMatch[1]}T${clock}:${seconds ? seconds[1] : '00'}`;
+  const seconds = /^\d{1,2}:\d{2}:(\d{2})/.exec(rest)?.[1] ?? '00';
+  return `${date}T${clock}:${seconds}`;
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -28,6 +28,7 @@ export * from './todo/todo.schema';
 export * from './budget/budget.schema';
 export * from './reservation/reservation.schema';
 export * from './reservation/ki-reservation.schema';
+export * from './datetime/datetime-normalize';
 export * from './airtrail/airtrail.schema';
 export * from './day/day.schema';
 export * from './day/note-colors';

--- a/shared/src/reservation/reservation.schema.ts
+++ b/shared/src/reservation/reservation.schema.ts
@@ -153,6 +153,9 @@ export const reservationSchema = z.object({
   accommodation_id: z.union([z.number(), z.string()]).nullable().optional(),
   metadata: z.string().nullable().optional(),
   needs_review: z.number().optional(),
+  // 'live' for anything a person put on the trip, 'staged' while an automated
+  // ingest waits for confirmation. Only the anonymous exports filter on it.
+  ingest_state: z.string().optional(),
   day_plan_position: z.number().nullable().optional(),
   created_at: z.string().optional(),
   // AirTrail (or future provider) linkage — drives the "synced" badge (#214).
@@ -309,6 +312,12 @@ const bookingImportAccommodationSchema = z.object({
 
 export const bookingImportPreviewItemSchema = z.object({
   type: z.string(),
+  /**
+   * The extractor could not read a type and filled one in, so the import UI
+   * should offer the form the user was importing into rather than trusting the
+   * placeholder (#2076).
+   */
+  type_guessed: z.boolean().optional(),
   title: z.string().min(1),
   reservation_time: z.string().nullable().optional(),
   reservation_end_time: z.string().nullable().optional(),


### PR DESCRIPTION
Three fixes on the booking-import path, ahead of any automated ingest. Two are reported bugs users hit today; the third closes a hole that only bites once something writes bookings without a person watching.

Closes #2094
Closes #2076

## The public feed and the shared trip publish everything

The ICS feed is `@Public` with a token that never expires and writes the confirmation number into the DESCRIPTION. The shared-trip payload does `SELECT *` over reservations, with `share_bookings` on by default. Neither filters anything, so whatever lands on a trip is published the moment it is written.

`reservations.ingest_state` is the gate: `'live'` by default, so SQLite backfills every existing row on the ALTER and every booking visible today stays visible. No current writer names the column, and nothing writes `'staged'` yet.

Two details worth reviewing. The predicate takes its table alias as an argument because `share.service.ts` queried `reservations` without one, and appending a qualified condition there would have 500-ed every share link that is already in circulation. And a stay is withheld only when bookings point at it and all of them are staged: a plain `EXISTS(live)` would have dropped every hand-added hotel out of trips that are shared right now.

Deliberately not filtered: `ReservationsService.list()` and everything else behind a session. A review inbox has to be able to see its own rows.

## PM times imported as AM (#2094)

`splitIso` reached the time by taking characters 11..16, so `"2026-06-11T01:11 PM"` became `01:11`. The hour survived and the half of the day did not, which is exactly why AM and 24-hour times in the same document came through correctly. The arrival then sorted before the departure, the router rolled it onto the next day, and a three-hour hop was rendered as an overnight.

The client has handled this since #1725; this is the server half, which was never pulled across. `normalizeLocalDateTime` rewrites a value only when it actually finds a meridiem, so a date-only value, a value carrying a UTC offset, and anything the parser does not recognise come back byte for byte.

The reporter's second symptom, a rental car off by the local UTC offset rather than by twelve hours, is a different cause in the same file: `toIso` parsed with `Date.parse` (local) and printed with `getUTC*`. These fields are naive local wall-clock strings everywhere else in TREK, so it reads local components now. It surfaced on rentals because only `car` and `restaurant` lacked the full-ISO instruction in `TYPE_HINT`; both have it now.

Side effect of the same root cause: `sameConnection` did `new Date(value).getTime()`, which is NaN for a printed meridiem, and both of its comparisons are false against NaN. The guard fell through and merged unrelated legs into one booking.

## Transport import always becomes a booking (#2076)

When neither the keyword table nor the model produced a type, the router wrote `'hotel'` and cast whatever string it received to `FlatType` without checking. A hotel is a booking type, so a ferry voucher imported from the Transport tab opened the booking form, which offers six chips and not one transport among them, and `'other'` was the only honest pick left. An unrecognised string got through the cast too, and then disappeared silently in `nuExtractToKiReservations`.

The type is validated against `FLAT_TYPES` now. When it cannot be read the item is still extracted with the lodging shape so it survives mapping, but it says so, and the tie-breaker added in #2080 finally has something to fire on: `isUnplaceableItem` only ever matched a type outside both forms' vocabularies, and the server can only emit its own eight, so on a real document it never matched at all.

The tab now travels with the job rather than living in component state. The parse deliberately outlives navigation and reload, and the review is triggered by the global background widget on any page, so by the time it ran the state had remounted back to its default and the context was gone.
