### PR TITLE
Fix the transit exit stop and same-day bookings without times

### DIFF
--- a/client/src/components/Planner/ReservationModal.test.tsx
+++ b/client/src/components/Planner/ReservationModal.test.tsx
@@ -1,4 +1,4 @@
-// FE-PLANNER-RESMODAL-001 to FE-PLANNER-RESMODAL-080
+// FE-PLANNER-RESMODAL-001 to FE-PLANNER-RESMODAL-093
 import { render, screen, waitFor, fireEvent, within } from '../../../tests/helpers/render';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -1435,6 +1435,96 @@ describe('ReservationModal', () => {
     expect(screen.getByDisplayValue('Grand Hotel')).toBeInTheDocument();
     const times = screen.getAllByTestId('time-picker') as HTMLInputElement[];
     expect(times.map(i => i.value)).toEqual(['', '', '']);
+  });
+
+  // #2107 — a booking that lasts a whole day has no clock to compare, and filling the
+  // missing one with midnight made the comparison read as inverted.
+  it('FE-PLANNER-RESMODAL-089: the same start and end date with no times is accepted', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<ReservationModal {...defaultProps} onSave={onSave} days={reviewDays()} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/e\.g\. Lufthansa/i), 'Park permit');
+    const datePickers = screen.getAllByTestId('date-picker');
+    fireEvent.change(datePickers[0], { target: { value: '2026-05-02' } });
+    fireEvent.change(datePickers[1], { target: { value: '2026-05-02' } });
+
+    expect(screen.queryByText(/End date\/time must be after start/i)).toBeNull();
+    fireEvent.submit(document.querySelector('form')!);
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+  });
+
+  it('FE-PLANNER-RESMODAL-090: an all-day booking is saved as bare dates on both ends', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<ReservationModal {...defaultProps} onSave={onSave} days={reviewDays()} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/e\.g\. Lufthansa/i), 'Park permit');
+    const datePickers = screen.getAllByTestId('date-picker');
+    fireEvent.change(datePickers[0], { target: { value: '2026-05-02' } });
+    fireEvent.change(datePickers[1], { target: { value: '2026-05-02' } });
+    fireEvent.submit(document.querySelector('form')!);
+
+    // The stored shape matters: the calendar export branches on whether the value
+    // carries a clock, and a bare date is what makes it an all-day event.
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ reservation_time: '2026-05-02', reservation_end_time: '2026-05-02' }),
+    ));
+  });
+
+  it('FE-PLANNER-RESMODAL-091: an end date before the start is still refused without times', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const addToast = vi.fn();
+    window.__addToast = addToast;
+    render(<ReservationModal {...defaultProps} onSave={onSave} days={reviewDays()} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/e\.g\. Lufthansa/i), 'Backwards');
+    const datePickers = screen.getAllByTestId('date-picker');
+    fireEvent.change(datePickers[0], { target: { value: '2026-05-02' } });
+    fireEvent.change(datePickers[1], { target: { value: '2026-05-01' } });
+    fireEvent.submit(document.querySelector('form')!);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(expect.stringMatching(/End date\/time must be after start/i), 'error', undefined);
+    delete window.__addToast;
+  });
+
+  it('FE-PLANNER-RESMODAL-092: a stored booking whose end is a bare date on the start day stays editable', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    // The shape the booking import and the mobile sheet both write. Nothing is typed
+    // here: the row alone used to leave the save button dead.
+    const res = buildReservation({
+      id: 21, type: 'event', title: 'Day permit',
+      reservation_time: '2026-05-02T10:00:00', reservation_end_time: '2026-05-02',
+    });
+    render(<ReservationModal {...defaultProps} reservation={res} onSave={onSave} days={reviewDays()} />);
+
+    expect(screen.queryByText(/End date\/time must be after start/i)).toBeNull();
+    fireEvent.submit(document.querySelector('form')!);
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+  });
+
+  it('FE-PLANNER-RESMODAL-093: switching to hotel clears a date error the hidden panel cannot explain', async () => {
+    render(<ReservationModal {...defaultProps} days={reviewDays()} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/e\.g\. Lufthansa/i), 'Switched');
+    const datePickers = screen.getAllByTestId('date-picker');
+    const timePickers = screen.getAllByTestId('time-picker');
+    fireEvent.change(datePickers[0], { target: { value: '2026-05-02' } });
+    fireEvent.change(timePickers[0], { target: { value: '19:00' } });
+    fireEvent.change(datePickers[1], { target: { value: '2026-05-01' } });
+    expect(screen.getByText(/End date\/time must be after start/i)).toBeTruthy();
+    // The footer button reads 'Add' while creating and 'Update' while editing.
+    const save = () => Array.from(document.querySelectorAll('button'))
+      .find(b => /^\s*(Add|Update)\s*$/.test(b.textContent || '')) as HTMLButtonElement;
+    expect(save().disabled).toBe(true);
+
+    // The date panel is hidden for hotels, and the message sits inside it, so
+    // asserting on the message proves nothing here. The save button is the part
+    // that stayed dead with no visible reason.
+    // The hotel type is labelled 'Accommodation' in the picker.
+    const hotelBtn = Array.from(document.querySelectorAll('button'))
+      .find(b => /^\s*Accommodation\s*$/.test(b.textContent || ''))!;
+    fireEvent.click(hotelBtn);
+    expect(save().disabled).toBe(false);
   });
 
   it('FE-PLANNER-RESMODAL-088: double-encoded metadata still fills the check-in times', () => {

--- a/client/src/components/Planner/ReservationModal.tsx
+++ b/client/src/components/Planner/ReservationModal.tsx
@@ -224,14 +224,25 @@ export function ReservationModal({ isOpen, onClose, onSave, reservation, days, p
     return next
   })
 
+  // Mirrors the mobile sheet, which has had this shape since 72a82b3c while the
+  // desktop copy was never pulled across (#2107). Filling a missing clock with '00:00' made a
+  // day-long booking compare as midnight against midnight, and the comparison is
+  // strict, so an all-day permit on a single date was refused. It also left every
+  // booking with a date-only end time uneditable here, which is the shape the booking
+  // import and the mobile sheet both write.
+  //
+  // The hotel guard matters for the same reason it does on mobile: the date panel is
+  // hidden for hotels, so a type switch after typing dates would leave the save button
+  // dead with its explanation inside the hidden block.
   const isEndBeforeStart = (() => {
-    if (!form.end_date || !form.reservation_time) return false
+    if (form.type === 'hotel' || !form.end_date || !form.reservation_time) return false
     const startDate = form.reservation_time.split('T')[0]
-    const startTime = form.reservation_time.split('T')[1] || '00:00'
-    const endTime = form.reservation_end_time || '00:00'
-    const startFull = `${startDate}T${startTime}`
-    const endFull = `${form.end_date}T${endTime}`
-    return endFull <= startFull
+    const startTime = form.reservation_time.split('T')[1] || ''
+    const endTime = form.reservation_end_time || ''
+    // Without a time on either side the booking is all-day, so an end on the
+    // start day is fine — only compare the dates there.
+    if (!startTime || !endTime) return form.end_date < startDate
+    return `${form.end_date}T${endTime}` <= `${startDate}T${startTime}`
   })()
 
   const handleSubmit = async (e?: { preventDefault?: () => void }) => {

--- a/client/src/components/Planner/TransitSearchPanel.test.tsx
+++ b/client/src/components/Planner/TransitSearchPanel.test.tsx
@@ -1,4 +1,4 @@
-// FE-PLANNER-TRANSIT-001 to FE-PLANNER-TRANSIT-027 — the transit search panel
+// FE-PLANNER-TRANSIT-001 to FE-PLANNER-TRANSIT-030 — the transit search panel
 // (embedded as the TransportModal's Automated mode).
 import { render, screen, fireEvent, waitFor } from '../../../tests/helpers/render'
 import userEvent from '@testing-library/user-event'
@@ -33,6 +33,27 @@ const ITINERARY = {
   legs: [
     { mode: 'WALK', from: { name: 'Start', lat: 52.52, lng: 13.4, time: '2025-06-01T06:30:00Z', scheduledTime: null, track: null }, to: { name: 'Alexanderplatz', lat: 52.521, lng: 13.41, time: '2025-06-01T06:34:00Z', scheduledTime: null, track: null }, duration: 240, distance: 300, headsign: null, line: null, lineColor: null, lineTextColor: null, agency: null, intermediateStops: 0 },
     { mode: 'SUBWAY', from: { name: 'Alexanderplatz', lat: 52.521, lng: 13.41, time: '2025-06-01T06:36:00Z', scheduledTime: null, track: '2' }, to: { name: 'Zoologischer Garten', lat: 52.507, lng: 13.332, time: '2025-06-01T07:00:00Z', scheduledTime: null, track: null }, duration: 1440, distance: null, headsign: 'Ruhleben', line: 'U2', lineColor: '#FF3300', lineTextColor: '#FFFFFF', agency: 'BVG', intermediateStops: 6 },
+  ],
+}
+
+const stop = (name: string, lat: number, lng: number, time: string, track: string | null = null) =>
+  ({ name, lat, lng, time, scheduledTime: null, track })
+
+// The shape MOTIS actually returns for the reported connection: every journey is
+// bracketed in walking legs, and a change between two stations adds one in the
+// middle (#2106).
+const WALK_BRACKETED = {
+  startTime: '2025-06-01T06:30:00Z',
+  endTime: '2025-06-01T09:10:00Z',
+  duration: 9600,
+  transfers: 1,
+  walkSeconds: 1080,
+  legs: [
+    { mode: 'WALK', from: stop('Aachen, Bushof', 50.777, 6.09, '2025-06-01T06:30:00Z'), to: stop('Aachen Hbf', 50.768, 6.091, '2025-06-01T06:34:00Z'), duration: 240, distance: 300, headsign: null, line: null, lineColor: null, lineTextColor: null, agency: null, intermediateStops: 0 },
+    { mode: 'HIGHSPEED_RAIL', from: stop('Aachen Hbf', 50.768, 6.091, '2025-06-01T06:40:00Z', '2'), to: stop('Koeln Hbf', 50.943, 6.959, '2025-06-01T07:30:00Z'), duration: 3000, distance: null, headsign: 'Koeln', line: 'ICE 10', lineColor: null, lineTextColor: null, agency: 'DB', intermediateStops: 1 },
+    { mode: 'WALK', from: stop('Koeln Hbf', 50.943, 6.959, '2025-06-01T07:32:00Z'), to: stop('Koeln Messe/Deutz', 50.941, 6.974, '2025-06-01T07:40:00Z'), duration: 480, distance: 600, headsign: null, line: null, lineColor: null, lineTextColor: null, agency: null, intermediateStops: 0 },
+    { mode: 'HIGHSPEED_RAIL', from: stop('Koeln Messe/Deutz', 50.941, 6.974, '2025-06-01T07:50:00Z', '11'), to: stop('Frankfurt(Main)Hbf', 50.107, 8.663, '2025-06-01T08:57:00Z'), duration: 4020, distance: null, headsign: 'Frankfurt', line: 'ICE 610', lineColor: null, lineTextColor: null, agency: 'DB', intermediateStops: 2 },
+    { mode: 'WALK', from: stop('Frankfurt(Main)Hbf', 50.107, 8.663, '2025-06-01T09:00:00Z'), to: stop('Frankfurt Flughafen Fernbf', 50.053, 8.57, '2025-06-01T09:10:00Z'), duration: 600, distance: 800, headsign: null, line: null, lineColor: null, lineTextColor: null, agency: null, intermediateStops: 0 },
   ],
 }
 
@@ -517,8 +538,59 @@ describe('TransitSearchPanel', () => {
     await user.click(await screen.findByText(/08:30 – 09:00/))
     expect(await screen.findByText('BVG')).toBeInTheDocument()
     expect(screen.getByText(/Platform 2/)).toBeInTheDocument()
-    expect(screen.getByText('Walk to Alexanderplatz')).toBeInTheDocument()
+    // Rows are anchored at the leg's start, so the access walk carries the picked
+    // origin and not the station the next row already names (#2106).
+    expect(screen.getByText('Start')).toBeInTheDocument()
+    expect(screen.queryByText('Walk to Alexanderplatz')).not.toBeInTheDocument()
     expect(screen.getByText('300 m')).toBeInTheDocument()
     expect(screen.getByText('6 stops')).toBeInTheDocument()
+  })
+
+  // #2106 — the walking legs printed their DESTINATION as the row heading, which is
+  // the stop the next row already names. The stop you actually get off at is a
+  // walking leg's origin, so it had no row at all and disappeared from the card.
+  it('FE-PLANNER-TRANSIT-028: the stop you get off at is listed, with the arrival time', async () => {
+    const user = userEvent.setup()
+    transitApiMock.plan.mockResolvedValueOnce({ itineraries: [WALK_BRACKETED] })
+    render(<TransitSearchPanel {...makeProps()} />)
+    await pickFromAndTo(user)
+    await user.click(screen.getByRole('button', { name: /^Search$/ }))
+    await user.click(await screen.findByText(/08:30 – 11:10/))
+
+    // The final train's arrival station, which is where the closing walk begins.
+    expect(await screen.findByText(/Frankfurt\(Main\)Hbf/)).toBeInTheDocument()
+    // Its arrival time, which the old WALK branch blanked. Not a time the card
+    // header already prints, or this would pass without the fix.
+    expect(screen.getByText('11:00')).toBeInTheDocument()
+  })
+
+  it('FE-PLANNER-TRANSIT-029: a walk between two stations names the station it starts from', async () => {
+    const user = userEvent.setup()
+    transitApiMock.plan.mockResolvedValueOnce({ itineraries: [WALK_BRACKETED] })
+    render(<TransitSearchPanel {...makeProps()} />)
+    await pickFromAndTo(user)
+    await user.click(screen.getByRole('button', { name: /^Search$/ }))
+    await user.click(await screen.findByText(/08:30 – 11:10/))
+
+    // The change happens on foot between two different stations: the one you leave
+    // is its own row now, at the time the first train gets in.
+    expect(await screen.findByText('Koeln Hbf')).toBeInTheDocument()
+    expect(screen.getByText('09:32')).toBeInTheDocument()
+    // And the walk is still marked as one, in the badge row rather than the heading.
+    expect(screen.getAllByText('Walking').length).toBe(3)
+  })
+
+  it('FE-PLANNER-TRANSIT-030: no row is headed with the destination of its own walk', async () => {
+    const user = userEvent.setup()
+    transitApiMock.plan.mockResolvedValueOnce({ itineraries: [WALK_BRACKETED] })
+    render(<TransitSearchPanel {...makeProps()} />)
+    await pickFromAndTo(user)
+    await user.click(screen.getByRole('button', { name: /^Search$/ }))
+    await user.click(await screen.findByText(/08:30 – 11:10/))
+
+    await screen.findByText(/Frankfurt\(Main\)Hbf/)
+    expect(screen.queryByText(/^Walk to /)).not.toBeInTheDocument()
+    // The picked origin survives instead of being replaced by the first station.
+    expect(screen.getByText('Aachen, Bushof')).toBeInTheDocument()
   })
 })

--- a/client/src/components/Planner/TransitSearchPanel.tsx
+++ b/client/src/components/Planner/TransitSearchPanel.tsx
@@ -234,12 +234,28 @@ function ItineraryCard({ it, tzFrom, tzTo, is12h, expanded, onToggle, onAdd, add
       {expanded && (
         <div style={{ borderTop: '1px solid var(--border-faint)', padding: '10px 14px 12px' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+            {/*
+              Every row is anchored at the leg's START: its time, its stop name and its
+              platform. A leg's arrival shows up as the next row's heading, and the last
+              arrival gets the closing row below.
+
+              The walking legs used to break that and print leg.to.name, which is the stop
+              the NEXT row already names. The stop where you actually get off is a walking
+              leg's from.name, so it had no row of its own and vanished from the card
+              entirely, along with the train's arrival time, which the same branch blanked
+              (#2106). MOTIS brackets every journey in walking legs, so this hit the exit
+              of any real connection.
+
+              The time falls back to scheduledTime for the same reason the save path does
+              (see stopTime below): a feed without realtime data carries only the schedule,
+              and this row is now the one that shows the arrival.
+            */}
             {it.legs.map((leg, i) => {
               const color = leg.mode === 'WALK' ? 'var(--border-primary)' : (leg.lineColor || 'var(--text-muted)')
               return (
                 <div key={i} style={{ display: 'grid', gridTemplateColumns: '44px 18px 1fr', gap: 8, alignItems: 'stretch' }}>
                   <div className="text-content-muted" style={{ fontSize: 'calc(11.5px * var(--fs-scale-caption, 1))', fontWeight: 600, paddingTop: 2, textAlign: 'right' }}>
-                    {leg.mode === 'WALK' ? '' : fmtTimeInTz(leg.from.time, tzAt(leg.from.lat, leg.from.lng), is12h)}
+                    {fmtTimeInTz(leg.from.time ?? leg.from.scheduledTime, tzAt(leg.from.lat, leg.from.lng), is12h)}
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                     <span style={{ width: 10, height: 10, borderRadius: '50%', border: `2.5px solid ${color}`, background: 'var(--bg-card)', flexShrink: 0, marginTop: 4 }} />
@@ -247,13 +263,14 @@ function ItineraryCard({ it, tzFrom, tzTo, is12h, expanded, onToggle, onAdd, add
                   </div>
                   <div style={{ paddingBottom: 14, minWidth: 0 }}>
                     <div className="text-content" style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {leg.mode === 'WALK' ? t('transit.walkTo', { name: leg.to.name }) : leg.from.name}
-                      {leg.from.track && leg.mode !== 'WALK' && <span className="text-content-faint" style={{ fontWeight: 500 }}> · {t('transit.platform', { track: leg.from.track })}</span>}
+                      {leg.from.name}
+                      {leg.from.track && <span className="text-content-faint" style={{ fontWeight: 500 }}> · {t('transit.platform', { track: leg.from.track })}</span>}
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' }}>
                       {leg.mode === 'WALK' ? (
                         <TransitMetaBadges size="sm" items={[
-                          { icon: Footprints, text: fmtDuration(leg.duration, t) },
+                          { icon: Footprints, text: t('transit.walkLabel') },
+                          { text: fmtDuration(leg.duration, t) },
                           { text: leg.distance ? (leg.distance >= 1000 ? `${(leg.distance / 1000).toFixed(1)} km` : `${leg.distance} m`) : '' },
                         ]} />
                       ) : (


### PR DESCRIPTION
Two bugs from the same reporter, both in the planner's booking surfaces, both client-only.

Fixes #2106
Fixes #2107

## The stop you get off at was replaced by the walk that follows (#2106)

Every row of an expanded transit result is anchored at its leg's **start**: the time cell, the stop name, the platform. A leg's arrival shows up as the next row's heading, and the final arrival gets the closing row. The walking legs broke that pattern and printed their `to.name`, which is the stop the next row already names.

MOTIS brackets every journey in walking legs, so the last leg of any real connection is the walk from the arrival station to wherever you were headed. Its `from` is the station you get off at, and since that row printed the destination instead, the station had no row anywhere in the card and disappeared. The same branch blanked the time cell, so the train's arrival time went with it. At the other end, the access walk swallowed the origin the user had just picked.

Rows now read `from.name` for every mode, and a walking leg says so in its badge row instead of in the heading. The platform tags along, which gives the exit row the arrival platform it was already carrying. The time falls back to `scheduledTime` the same way the save path does, because a schedule-only feed would otherwise leave exactly the row this issue is about without a clock.

Reproduced against the reported connection before and after: with an itinerary of walk / train / walk / train / walk, `Frankfurt(Main)Hbf` and `Köln Hbf` were both absent from the DOM, as was the picked origin.

## A booking could not start and end on the same day without times (#2107)

`isEndBeforeStart` filled a missing clock with `'00:00'` on both sides and then compared strictly, so a day-long permit came out as end equal to start and was refused: inline error, disabled save button, toast on submit.

It also made existing rows uneditable, which the issue does not mention. A booking whose end is a bare date on the start day is exactly what the booking import writes, and what the mobile sheet has been allowed to save since 72a82b3c. Opening one of those on the desktop left the save button dead with nothing the user could change to revive it. That case is covered by its own test.

With a time missing on either side the booking is all-day, so only the dates are compared. An end date before the start is still refused with or without times, and two explicit clocks still have to be in order, which matches mobile and leaves today's behaviour alone.

The hotel guard rides along for the same reason mobile carries it: the date panel is hidden for hotels while the save button is not, so switching type after typing dates left the button disabled with its explanation inside the hidden block. Two clicks to reach, no way to see why.

## Scope

Both fixes are client-only, and both are the desktop half of something mobile already had right. `MReservationSheet` is untouched and served as the reference; `TransitSearchPanel` has no mobile twin, `MTransportFormSheet` embeds the same component. No server, MCP or plugin-RPC parallel exists for either rule, so nothing else moves. No new i18n keys.

All eight new or changed test cases were verified red against the unfixed sources and green after.
