### PR TITLE
Fix stale OIDC avatars, the inflated Atlas country count and guests in Vacay pickers

### DIFF
--- a/server/src/nest/atlas/atlas-geo.ts
+++ b/server/src/nest/atlas/atlas-geo.ts
@@ -725,7 +725,17 @@ export function getCountryFromCoords(lat: number, lng: number): string | null {
   return looseBoxFallback ?? candidates[0].code;
 }
 
-export function getCountryFromAddress(address: string | null): string | null {
+/**
+ * `allowBareCode` decides whether a trailing two-letter uppercase segment counts as
+ * a country. It only does when the caller can sanity-check the answer against
+ * coordinates, because that segment is far more often a state or province than a
+ * country: "…, New York, NY", "…, Toronto, ON". Half of those abbreviations are
+ * real ISO codes as well (CA, DE, LA, IN, MD, GA, PA, VA), so a list of valid
+ * country codes does not separate them, and the other half are codes for nothing
+ * at all, which used to inflate the Atlas country count with places that could
+ * never appear on the map or in the continent bars (#2111).
+ */
+export function getCountryFromAddress(address: string | null, allowBareCode = true): string | null {
   if (!address) return null;
   const parts = address
     .split(',')
@@ -736,7 +746,7 @@ export function getCountryFromAddress(address: string | null): string | null {
   const normalized = last.toLowerCase();
   if (NAME_TO_CODE[normalized]) return NAME_TO_CODE[normalized];
   if (NAME_TO_CODE[last]) return NAME_TO_CODE[last];
-  if (last.length === 2 && last === last.toUpperCase()) return last;
+  if (allowBareCode && last.length === 2 && last === last.toUpperCase()) return last;
   return null;
 }
 
@@ -752,14 +762,16 @@ export function getCountryFromAddress(address: string | null): string | null {
 // to any country, the address result is sanity-gated against that country's own admin0
 // bounding box (isPointInCountryBox) before being trusted — the same guard the region-level
 // address fallback uses. A place with no coordinates at all has nothing to gate against, so
-// the address is trusted directly there, as before.
+// it does not get the bare-code branch at all (#2111): a spelled-out country name still
+// resolves there, a lone "NY" or "CA" no longer does. Guessing produced both phantom
+// countries that nothing downstream could draw and confidently wrong ones.
 async function resolveCountryCode(place: Place): Promise<string | null> {
   const hasCoords = !!(place.lat && place.lng);
   if (hasCoords) {
     const fromCoords = getCountryFromCoords(place.lat!, place.lng!);
     if (fromCoords) return fromCoords;
   }
-  const fromAddress = getCountryFromAddress(place.address);
+  const fromAddress = getCountryFromAddress(place.address, hasCoords);
   if (fromAddress && (!hasCoords || isPointInCountryBox(fromAddress, place.lat!, place.lng!))) {
     return fromAddress;
   }
@@ -775,7 +787,7 @@ export function resolveCountryCodeSync(place: Place): string | null {
     const fromCoords = getCountryFromCoords(place.lat!, place.lng!);
     if (fromCoords) return fromCoords;
   }
-  const fromAddress = getCountryFromAddress(place.address);
+  const fromAddress = getCountryFromAddress(place.address, hasCoords);
   if (fromAddress && (!hasCoords || isPointInCountryBox(fromAddress, place.lat!, place.lng!))) {
     return fromAddress;
   }

--- a/server/src/nest/oidc/oidc.service.ts
+++ b/server/src/nest/oidc/oidc.service.ts
@@ -525,6 +525,14 @@ export class OidcService implements OnModuleDestroy {
           return { error: 'email_not_verified' };
         }
         this.db.prepare('UPDATE users SET oidc_sub = ?, oidc_issuer = ? WHERE id = ?').run(sub, config.issuer, user.id);
+        user = { ...user, oidc_sub: sub, oidc_issuer: config.issuer } as User;
+      } else if (user.oidc_issuer !== config.issuer || user.oidc_sub !== sub) {
+        // The admin pointed the instance at a different IdP. We got here through the
+        // verified-email lookup, so this is the same person arriving from the new
+        // provider; leaving the old sub and issuer on the row would keep the account
+        // pinned to a provider that no longer exists (#2110).
+        this.db.prepare('UPDATE users SET oidc_sub = ?, oidc_issuer = ? WHERE id = ?').run(sub, config.issuer, user.id);
+        user = { ...user, oidc_sub: sub, oidc_issuer: config.issuer } as User;
       }
       // Update role based on OIDC claims on every login (if claim mapping is configured)
       if (readEnv().oidc.adminValue) {
@@ -547,10 +555,16 @@ export class OidcService implements OnModuleDestroy {
         }
       }
       // Keep the avatar in sync with the OIDC picture, but never clobber a custom
-      // upload: only fill it when empty or when the current value is itself an OIDC
+      // upload: only touch it when empty or when the current value is itself an OIDC
       // picture URL, so the picture refreshes on each login without overriding an
       // uploaded one. #1399
-      if (picture && picture !== user.avatar && (!user.avatar || /^https:\/\//i.test(user.avatar))) {
+      //
+      // "In sync" includes the provider having no picture for this user any more. That
+      // is what a provider switch looks like from here, and the old value points at a
+      // host this instance no longer talks to, so it renders as a broken image forever
+      // (#2110). An uploaded avatar is a bare filename and stays untouched either way.
+      const avatarIsOidc = !!user.avatar && /^https:\/\//i.test(user.avatar);
+      if (picture ? picture !== user.avatar && (!user.avatar || avatarIsOidc) : avatarIsOidc) {
         this.db.prepare('UPDATE users SET avatar = ? WHERE id = ?').run(picture, user.id);
         user = { ...user, avatar: picture } as User;
       }

--- a/server/src/nest/vacay/vacay.service.ts
+++ b/server/src/nest/vacay/vacay.service.ts
@@ -639,7 +639,9 @@ export class VacayService {
   sendInvite(planId: number, inviterId: number, inviterUsername: string, inviterEmail: string, targetUserId: number): { error?: string; status?: number } {
     if (targetUserId === inviterId) return { error: 'Cannot invite yourself', status: 400 };
 
-    const targetUser = this.db.get('SELECT id, username FROM users WHERE id = ?', targetUserId);
+    // The picker no longer offers guests, but the id arrives from the client, so the
+    // write path has to refuse them too rather than trust the list it handed out.
+    const targetUser = this.db.get('SELECT id, username FROM users WHERE id = ? AND COALESCE(is_guest, 0) = 0', targetUserId);
     if (!targetUser) return { error: 'User not found', status: 404 };
 
     const existing = this.db.get<{ id: number; status: string }>('SELECT id, status FROM vacay_plan_members WHERE plan_id = ? AND user_id = ?', planId, targetUserId);
@@ -785,6 +787,7 @@ export class VacayService {
     return this.db.all(`
     SELECT u.id, u.username, u.email FROM users u
     WHERE u.id != ?
+    AND COALESCE(u.is_guest, 0) = 0
     AND u.id NOT IN (SELECT user_id FROM vacay_plan_members WHERE plan_id = ?)
     AND u.id NOT IN (SELECT user_id FROM vacay_plan_members WHERE status = 'accepted')
     AND u.id NOT IN (SELECT owner_id FROM vacay_plans WHERE id IN (
@@ -877,7 +880,7 @@ export class VacayService {
   shareCalendar(ownerId: number, ownerEmail: string, targetUserId: number, socketId?: string): { error?: string; status?: number } {
     if (targetUserId === ownerId) return { error: 'Cannot share with yourself', status: 400 };
 
-    const targetUser = this.db.get('SELECT id FROM users WHERE id = ?', targetUserId);
+    const targetUser = this.db.get('SELECT id FROM users WHERE id = ? AND COALESCE(is_guest, 0) = 0', targetUserId);
     if (!targetUser) return { error: 'User not found', status: 404 };
 
     const existing = this.db.get('SELECT id FROM vacay_shares WHERE owner_id = ? AND user_id = ?', ownerId, targetUserId);
@@ -931,6 +934,7 @@ export class VacayService {
     return this.db.all(`
     SELECT u.id, u.username FROM users u
     WHERE u.id != ?
+    AND COALESCE(u.is_guest, 0) = 0
     AND u.id NOT IN (SELECT user_id FROM vacay_shares WHERE owner_id = ?)
     AND u.id NOT IN (
       SELECT owner_id FROM vacay_plans WHERE id = ?

--- a/server/tests/unit/nest/atlas.service.test.ts
+++ b/server/tests/unit/nest/atlas.service.test.ts
@@ -604,6 +604,20 @@ describe('getCountryFromAddress', () => {
   it('ATLAS-SVC-012: returns null for unrecognized country name', () => {
     expect(getCountryFromAddress('Unknown City, Unknown Country')).toBeNull();
   });
+
+  // #2111 — the bare-code branch is a guess, and it is only allowed where the caller
+  // can check it against coordinates.
+  it('ATLAS-SVC-046: a bare trailing code is refused when the caller cannot verify it', () => {
+    expect(getCountryFromAddress('11 W 53rd St, New York, NY', false)).toBeNull();
+    // Half of these abbreviations are real ISO codes, so a list of valid country
+    // codes would not have caught them: CA is California here, not Canada.
+    expect(getCountryFromAddress('1 Market St, San Francisco, CA', false)).toBeNull();
+    expect(getCountryFromAddress('100 King St, Toronto, ON', false)).toBeNull();
+  });
+
+  it('ATLAS-SVC-047: a spelled-out country still resolves without coordinates', () => {
+    expect(getCountryFromAddress('Eiffel Tower, Paris, France', false)).toBe('FR');
+  });
 });
 
 // ── reverseGeocodeCountry ───────────────────────────────────────────────────

--- a/server/tests/unit/nest/oidc.service.test.ts
+++ b/server/tests/unit/nest/oidc.service.test.ts
@@ -678,6 +678,54 @@ describe('findOrCreateUser', () => {
     expect(row.avatar).toBe('https://idp.example.com/u/new.png');
   });
 
+  // #2110 — the admin repoints the instance at a different IdP. The user still logs in,
+  // because the verified-email lookup finds the row, but everything the old provider put
+  // on it used to survive: an avatar URL on a host this instance no longer talks to, and
+  // a sub/issuer pair pinning the account to a provider that is gone.
+  it('OIDC-SVC-060: a provider without a picture claim clears the previous provider avatar', () => {
+    const { user } = createUser(testDb, { email: 'switch1@example.com' });
+    testDb.prepare('UPDATE users SET oidc_sub = ?, oidc_issuer = ?, avatar = ? WHERE id = ?')
+      .run('sub-old-1', 'https://old-idp.example.com', 'https://old-idp.example.com/u/me.png', user.id);
+
+    svc.findOrCreateUser(
+      { sub: 'sub-new-1', email: 'switch1@example.com', name: 'Switcher', email_verified: true },
+      { ...MOCK_CONFIG, issuer: 'https://new-idp.example.com' },
+    );
+
+    const row = testDb.prepare('SELECT avatar FROM users WHERE id = ?').get(user.id) as any;
+    expect(row.avatar).toBeNull();
+  });
+
+  it('OIDC-SVC-061: an uploaded avatar survives the same switch', () => {
+    const { user } = createUser(testDb, { email: 'switch2@example.com' });
+    // A local upload is a bare filename, not a URL, and belongs to the user.
+    testDb.prepare('UPDATE users SET oidc_sub = ?, oidc_issuer = ?, avatar = ? WHERE id = ?')
+      .run('sub-old-2', 'https://old-idp.example.com', 'uploaded-abc.jpg', user.id);
+
+    svc.findOrCreateUser(
+      { sub: 'sub-new-2', email: 'switch2@example.com', name: 'Switcher', email_verified: true },
+      { ...MOCK_CONFIG, issuer: 'https://new-idp.example.com' },
+    );
+
+    const row = testDb.prepare('SELECT avatar FROM users WHERE id = ?').get(user.id) as any;
+    expect(row.avatar).toBe('uploaded-abc.jpg');
+  });
+
+  it('OIDC-SVC-062: the account is relinked to the new provider sub and issuer', () => {
+    const { user } = createUser(testDb, { email: 'switch3@example.com' });
+    testDb.prepare('UPDATE users SET oidc_sub = ?, oidc_issuer = ? WHERE id = ?')
+      .run('sub-old-3', 'https://old-idp.example.com', user.id);
+
+    svc.findOrCreateUser(
+      { sub: 'sub-new-3', email: 'switch3@example.com', name: 'Switcher', email_verified: true },
+      { ...MOCK_CONFIG, issuer: 'https://new-idp.example.com' },
+    );
+
+    const row = testDb.prepare('SELECT oidc_sub, oidc_issuer FROM users WHERE id = ?').get(user.id) as any;
+    expect(row.oidc_sub).toBe('sub-new-3');
+    expect(row.oidc_issuer).toBe('https://new-idp.example.com');
+  });
+
   it('OIDC-SVC-053: returns no_email when the email claim is missing (no throw)', () => {
     const result = svc.findOrCreateUser({ sub: 'sub-no-email', name: 'No Email' }, MOCK_CONFIG);
     expect('error' in result).toBe(true);

--- a/server/tests/unit/nest/vacay.service.test.ts
+++ b/server/tests/unit/nest/vacay.service.test.ts
@@ -779,6 +779,42 @@ describe('getAvailableUsers', () => {
 
     expect(available.map(u => u.id)).not.toContain(alreadyFused.id);
   });
+
+  // #2112 — guests are trip-scoped accounts, and every other directory in the app
+  // already leaves them out. Vacay's two pickers did not, so a guest stayed
+  // selectable here even after being removed from the trip it was created for.
+  it('VACAY-SVC-073: guest accounts are not offered in the plan invite picker', () => {
+    const { user: owner, plan } = setupUserWithPlan();
+    const { user: guest } = createUser(testDb);
+    testDb.prepare('UPDATE users SET is_guest = 1 WHERE id = ?').run(guest.id);
+
+    const available = svc.getAvailableUsers(owner.id, plan.id) as { id: number }[];
+
+    expect(available.map(u => u.id)).not.toContain(guest.id);
+  });
+
+  it('VACAY-SVC-074: guest accounts are not offered in the shared-calendar picker', () => {
+    const { user: owner } = setupUserWithPlan();
+    const { user: guest } = createUser(testDb);
+    testDb.prepare('UPDATE users SET is_guest = 1 WHERE id = ?').run(guest.id);
+
+    const available = svc.getShareAvailableUsers(owner.id) as { id: number }[];
+
+    expect(available.map(u => u.id)).not.toContain(guest.id);
+  });
+
+  it('VACAY-SVC-075: a guest id sent straight to the write paths is refused', () => {
+    const { user: owner, plan } = setupUserWithPlan();
+    const { user: guest } = createUser(testDb);
+    testDb.prepare('UPDATE users SET is_guest = 1 WHERE id = ?').run(guest.id);
+
+    // The picker is only a list. The id comes back from the client, and the MCP
+    // tools reach the same two methods, so refusing has to happen here.
+    const invited = svc.sendInvite(plan.id, owner.id, 'owner', 'owner@example.test', guest.id);
+    expect(invited.error).toBe('User not found');
+    const shared = svc.shareCalendar(owner.id, 'owner@example.test', guest.id);
+    expect(shared.error).toBe('User not found');
+  });
 });
 
 // ── getStats ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Three unrelated reports, all server-side, all with the same shape: a rule that one part of the app applies and another forgot.

Fixes #2110
Fixes #2111
Fixes #2112

## The old provider's avatar and identity survive an IdP switch (#2110)

Repointing the instance at a different OIDC provider left two things from the old one on every account.

The avatar kept a URL on a host this instance no longer talks to. The sync only ran when the new provider sent a `picture` claim, and having no picture for a user is a perfectly ordinary answer, so the stale URL stayed and rendered as a broken image indefinitely.

The account also stayed pinned to the old provider. Login still worked, because the verified-email lookup finds the row, but the relink sat behind a check for a *missing* sub, so `oidc_sub` and `oidc_issuer` never moved. The SSO note under Settings went on naming a provider that no longer exists.

An uploaded avatar is a bare filename rather than a URL, and is left alone on both paths exactly as before.

## The Atlas counted more countries than it could show (#2111)

The hero number counted more than the continent bars drew, and more than the dashboard widget. The extras were invented: a place without coordinates falls back to parsing its address, and any two-letter uppercase segment at the end became a country code. `New York, NY` produced `NY`, `Toronto, ON` produced `ON`.

Those phantoms only ever appeared in that one number. The continent strip files an unknown code under `Other` and never draws it, the map skips codes it cannot resolve, and the dashboard builds its set from stored regions instead, which is why the reporter saw the right figure there.

**Filtering against a list of valid country codes would not have been enough**, and would have concealed the worse half of this: 26 US state abbreviations *are* real ISO country codes. `CA` is California far more often than Canada, `DE` is Delaware, `IN` is Indiana, `LA` is Louisiana. Those resolve to a wrong country rather than a phantom one, and no code list separates them.

The comment above `resolveCountryCode` already describes exactly this collision and solves it by trusting coordinates first and sanity-checking the address against the country's own bounding box. Its closing line names the remaining gap, and that gap is this bug: with no coordinates there is nothing to check against. So the bare-code branch is now only offered to callers that have coordinates. A spelled-out country name still resolves either way; a lone `NY` or `CA` resolves to nothing, which is the honest answer.

## Guest accounts stayed selectable in Vacay (#2112)

Guests are trip-scoped accounts. Trip Members excludes them from its picker *and* refuses them on the write path, and Collections does the same. Vacay's two directories did neither, so a guest stayed selectable in a plan's Invite User dialog and in the shared-calendar picker, including after being removed from the trip it was created for.

The queries are server-side, so the filter belongs there rather than in the client, which never received the flag to filter on. Both write paths get it too: the picker only hands out a list, the id comes back from the client, and the Vacay MCP tools reach the same two service methods, so they are covered by the same change.

## Verification

All eight new cases were run against the unfixed sources first: six fail, and the two that pass are the regression guards (an uploaded avatar survives the switch; a spelled-out country still resolves without coordinates). No client change, no migration, no new i18n keys, no contract change.
