### PR TITLE
feat(map): offer Esri's grey canvas as a keyless basemap

### DIFF
--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -19,7 +19,7 @@ import { escapeHtml } from '@trek/shared'
 import type { Day, Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { resolveTrackColor, hasManualTrackColor } from './trackColors'
-import { CARTO_LIGHT, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, SATELLITE_TILE_URL, SATELLITE_TILE_ATTRIBUTION, SATELLITE_TILE_MAXZOOM } from '../../constants/mapDefaults'
+import { CARTO_LIGHT, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, SATELLITE_TILE_URL, SATELLITE_TILE_ATTRIBUTION, SATELLITE_TILE_MAXZOOM, attributionForTile } from '../../constants/mapDefaults'
 import { useSettingsStore } from '../../store/settingsStore'
 import { MapLayerSwitcher } from './MapLayerSwitcher'
 import { computeMapViewport, TILE_SIZE_RASTER, type ViewportPadding } from '../../utils/mapViewport'
@@ -832,7 +832,7 @@ export const MapView = memo(function MapView({
       <TileLayer
         key={isSatellite ? 'satellite' : 'default'}
         url={isSatellite ? SATELLITE_TILE_URL : tileUrl}
-        attribution={isSatellite ? SATELLITE_TILE_ATTRIBUTION : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'}
+        attribution={isSatellite ? SATELLITE_TILE_ATTRIBUTION : attributionForTile(tileUrl)}
         maxZoom={isSatellite ? SATELLITE_TILE_MAXZOOM : 19}
         keepBuffer={8}
         updateWhenZooming={false}

--- a/client/src/components/Settings/MapSettingsTab.tsx
+++ b/client/src/components/Settings/MapSettingsTab.tsx
@@ -20,6 +20,7 @@ import {
   normalizeStyleForProvider,
   type GlMapProvider,
 } from '../Map/glProviders'
+import { ESRI_GRAY_DARK, ESRI_GRAY_LIGHT } from '../../constants/mapDefaults'
 import { useAuthStore } from '../../store/authStore'
 
 interface MapPreset {
@@ -33,6 +34,10 @@ const MAP_PRESETS: MapPreset[] = [
   { name: 'CartoDB Light', url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png' },
   { name: 'CartoDB Dark', url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' },
   { name: 'Stadia Smooth', url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png' },
+  // Keyless, and on the same host the satellite layer already uses. No place
+  // names: Esri serves those as a separate overlay a single tile url cannot carry.
+  { name: 'Esri Light Gray', url: ESRI_GRAY_LIGHT },
+  { name: 'Esri Dark Gray', url: ESRI_GRAY_DARK },
 ]
 
 // Tag → chip color mapping. Keeps the dropdown readable at a glance so a

--- a/client/src/constants/mapDefaults.test.ts
+++ b/client/src/constants/mapDefaults.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import {
+  attributionForTile,
+  ESRI_GRAY_ATTRIBUTION,
+  ESRI_GRAY_DARK,
+  ESRI_GRAY_LIGHT,
+  SATELLITE_TILE_ATTRIBUTION,
+  SATELLITE_TILE_URL,
+  CARTO_LIGHT,
+} from './mapDefaults'
+
+describe('attributionForTile', () => {
+  it('FE-CONST-MAPDEF-001: credits Esri under an Esri basemap', () => {
+    // Printing OpenStreetMap under Esri tiles is both wrong and a licence problem,
+    // which is why the host decides rather than a flag at the call site.
+    expect(attributionForTile(ESRI_GRAY_LIGHT)).toBe(ESRI_GRAY_ATTRIBUTION)
+    expect(attributionForTile(ESRI_GRAY_DARK)).toBe(ESRI_GRAY_ATTRIBUTION)
+  })
+
+  it('FE-CONST-MAPDEF-002: keeps the imagery credit for the satellite layer on the same host', () => {
+    expect(attributionForTile(SATELLITE_TILE_URL)).toBe(SATELLITE_TILE_ATTRIBUTION)
+  })
+
+  it('FE-CONST-MAPDEF-003: everything else stays OpenStreetMap, including no template at all', () => {
+    expect(attributionForTile(CARTO_LIGHT)).toMatch(/OpenStreetMap/)
+    expect(attributionForTile('https://tile.openstreetmap.org/{z}/{x}/{y}.png')).toMatch(/OpenStreetMap/)
+    expect(attributionForTile(null)).toMatch(/OpenStreetMap/)
+    expect(attributionForTile('')).toMatch(/OpenStreetMap/)
+  })
+
+  it('FE-CONST-MAPDEF-004: the Esri templates put the row before the column', () => {
+    // Esri is the one provider here that orders the path {z}/{y}/{x}. Getting it
+    // wrong yields tiles from the wrong place rather than an error.
+    for (const url of [ESRI_GRAY_LIGHT, ESRI_GRAY_DARK, SATELLITE_TILE_URL]) {
+      expect(url).toContain('/{z}/{y}/{x}')
+      expect(url).not.toContain('/{z}/{x}/{y}')
+    }
+  })
+})

--- a/client/src/constants/mapDefaults.ts
+++ b/client/src/constants/mapDefaults.ts
@@ -10,6 +10,37 @@ export const SATELLITE_TILE_ATTRIBUTION =
   'Imagery &copy; <a href="https://www.esri.com">Esri</a>, Maxar, Earthstar Geographics'
 export const SATELLITE_TILE_MAXZOOM = 19
 
+// Esri's grey canvas, on the same keyless legacy host the satellite layer already
+// uses. Offered as an alternative to CARTO, whose keyless tiles carry an
+// "API KEY REQUIRED" watermark since 26.08.2026 and now need a key the operator
+// has to request by mail.
+//
+// Note the {z}/{y}/{x} order: Esri puts the row before the column, unlike every
+// other template here. The base carries no place names; Esri serves those as a
+// separate transparent overlay, which a single tile-url setting cannot express,
+// so these read as label-free basemaps for now.
+export const ESRI_GRAY_LIGHT =
+  'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}'
+export const ESRI_GRAY_DARK =
+  'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}'
+export const ESRI_GRAY_ATTRIBUTION =
+  'Tiles &copy; <a href="https://www.esri.com">Esri</a> &mdash; Esri, DeLorme, NAVTEQ'
+
+const OSM_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+
+/**
+ * Attribution for whatever template a map ended up with. Esri asks for its own
+ * credit, and printing OpenStreetMap under an Esri basemap is both wrong and a
+ * licence problem, so the host decides rather than a flag at the call site.
+ */
+export function attributionForTile(url: string | null | undefined): string {
+  if (!url) return OSM_ATTRIBUTION
+  if (url.includes('arcgisonline.com')) {
+    return url.includes('World_Imagery') ? SATELLITE_TILE_ATTRIBUTION : ESRI_GRAY_ATTRIBUTION
+  }
+  return OSM_ATTRIBUTION
+}
+
 // CARTO basemaps. Keyless tiles carry an "API KEY REQUIRED" watermark since
 // 26.08.2026, so these are always passed through withTileApiKey() (#2054).
 export const CARTO_LIGHT = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'


### PR DESCRIPTION
## Description

CARTO burns an "API KEY REQUIRED" watermark into keyless tiles since 26.08.2026, and the key has to be requested **by mail**. That is a poor thing to ask of every self-hosted instance, so this adds a basemap that needs no key at all.

Esri's grey canvas sits on `server.arcgisonline.com`, the same keyless legacy host the satellite layer has always used, so it adds no new dependency and no new party to trust.

**Deliberately just an option.** Two entries in the basemap list. CARTO stays the default and stays selectable for anyone who has a key. Nothing about the default map changes, and nothing about `map_provider`.

## Attribution

The attribution was hardcoded to OpenStreetMap for everything except satellite. Printing that under Esri tiles is both wrong and a licence problem, so it is now picked from the template: Esri credit for the grey canvas, the imagery credit for the satellite layer on the same host, OpenStreetMap for everything else including an empty template.

## Two things worth knowing before this becomes a default anywhere

**No place names.** The grey canvas is a base layer; Esri serves labels as a separate transparent overlay (`Canvas/World_Light_Gray_Reference`). A single tile-url setting cannot express two layers, so these read as label-free basemaps. Making them the default for a map that shows city names would need the overlay wired in per map component.

**Row before column.** Esri templates order the path `{z}/{y}/{x}`, unlike every other entry in that list. Getting it the other way round yields tiles from the wrong place rather than an error, so there is a test pinning it.

## Context

This came out of asking what to do about CARTO now that it needs a key. OpenFreeMap Positron was the other candidate and is already wired up in this repo under `map_provider: 'maplibre-gl'`, but it is vector-only, so it cannot serve the Leaflet maps (atlas, collections, journey, shared trip) at all. That decision is separate from this PR.
