### PR TITLE
fix(collections): stop findDuplicateCollectionPlace merging places by coordinates alone

### DIFF
--- a/server/src/nest/collections/collections.service.ts
+++ b/server/src/nest/collections/collections.service.ts
@@ -610,8 +610,10 @@ export class CollectionsService {
     const rows = this.db.all<{
       place_id: number; name: string; address: string | null; lat: number | null; lng: number | null;
       category_id: number | null; image_url: string | null; day_number: number | null; date: string | null;
+      google_place_id: string | null; google_ftid: string | null; osm_id: string | null;
     }>(`
       SELECT p.id AS place_id, p.name, p.address, p.lat, p.lng, p.category_id, p.image_url,
+             p.google_place_id, p.google_ftid, p.osm_id,
              (SELECT MIN(d.day_number) FROM day_assignments da
                 JOIN days d ON d.id = da.day_id
                WHERE da.place_id = p.id AND d.trip_id = p.trip_id) AS day_number,
@@ -627,7 +629,9 @@ export class CollectionsService {
     return {
       places: rows.map(r => ({
         ...r,
-        already_in_list: this.findDuplicateCollectionPlace(collectionId, { name: r.name, lat: r.lat, lng: r.lng }) != null,
+        // Asked with the same candidate the save will use, or the picker marks a
+        // place as new and the save then refuses it as a duplicate.
+        already_in_list: this.findDuplicateCollectionPlace(collectionId, r) != null,
         scheduled: r.day_number != null,
       })),
     };
@@ -660,7 +664,16 @@ export class CollectionsService {
         const name = p.name as string;
         const lat = (p.lat as number | null) ?? null;
         const lng = (p.lng as number | null) ?? null;
-        if (!force && this.findDuplicateCollectionPlace(collectionId, { name, lat, lng })) {
+        // The provider ids go with it: they are already carried into the insert
+        // below, so leaving them out here would recognise less than the row that
+        // gets written knows about.
+        const candidate = {
+          name, lat, lng,
+          google_place_id: (p.google_place_id as string | null) ?? null,
+          google_ftid: (p.google_ftid as string | null) ?? null,
+          osm_id: (p.osm_id as string | null) ?? null,
+        };
+        if (!force && this.findDuplicateCollectionPlace(collectionId, candidate)) {
           skipped.push({ id: placeId, name });
           continue;
         }

--- a/server/src/nest/collections/collections.service.ts
+++ b/server/src/nest/collections/collections.service.ts
@@ -12,6 +12,7 @@ import {
   trackInsertedInDedupSet,
   type DedupSet,
 } from '../places/places.helpers';
+import { placeMatchStrategies, type PlaceMatchCandidate } from '@trek/shared';
 import type {
   Collection,
   CollectionDetailResponse,
@@ -418,26 +419,48 @@ export class CollectionsService {
   // Dedup (collection-scoped ports of placeService helpers)
   // -------------------------------------------------------------------------
 
+  /**
+   * A third hand-written copy of the place-matching order (alongside
+   * PlacesService.findDuplicatePlace and isPlaceDuplicate), and the one that had
+   * actually drifted live rather than latently: unlike findDuplicatePlace's one
+   * caller, savePlace calls this directly with no isPlaceDuplicate guard in
+   * front, so a named candidate that matched nothing by name fell through to a
+   * coordinate match unconditionally — merging the restaurant and the bar at one
+   * address. It also never read google_place_id/google_ftid/osm_id at all, even
+   * though every collection_places row stores them, so a renamed place with no
+   * matching name or coordinates could be saved again under its old id.
+   *
+   * Now walks the shared strategy list from @trek/shared, same as
+   * PlacesService.findMatchingPlaceId: provider id, then name, then coordinates
+   * and only when there is no name.
+   */
   private findDuplicateCollectionPlace(
     collectionId: number,
-    candidate: { name: string | null | undefined; lat: number | null | undefined; lng: number | null | undefined },
+    candidate: PlaceMatchCandidate,
   ): { id: number; name: string } | null {
-    const normalizedName = candidate.name?.trim().toLowerCase();
-    if (normalizedName) {
-      const dup = this.db.get<{ id: number; name: string }>(`
+    for (const strategy of placeMatchStrategies(candidate)) {
+      let hit: { id: number; name: string } | undefined;
+      if (strategy.by === 'externalId') {
+        hit = this.db.get<{ id: number; name: string }>(`
+      SELECT id, name FROM collection_places
+      WHERE collection_id = ? AND (google_place_id = ? OR google_ftid = ? OR osm_id = ?)
+      ORDER BY id ASC LIMIT 1
+    `, collectionId, strategy.id, strategy.id, strategy.id);
+      } else if (strategy.by === 'name') {
+        hit = this.db.get<{ id: number; name: string }>(`
       SELECT id, name FROM collection_places
       WHERE collection_id = ? AND lower(trim(name)) = ?
       ORDER BY id ASC LIMIT 1
-    `, collectionId, normalizedName);
-      if (dup) return dup;
-    }
-    if (candidate.lat != null && candidate.lng != null) {
-      return this.db.get<{ id: number; name: string }>(`
+    `, collectionId, strategy.name);
+      } else {
+        hit = this.db.get<{ id: number; name: string }>(`
       SELECT id, name FROM collection_places
       WHERE collection_id = ? AND lat IS NOT NULL AND lng IS NOT NULL
         AND abs(lat - ?) <= ? AND abs(lng - ?) <= ?
       ORDER BY id ASC LIMIT 1
-    `, collectionId, candidate.lat, COORD_DEDUP_TOLERANCE, candidate.lng, COORD_DEDUP_TOLERANCE) || null;
+    `, collectionId, strategy.lat, strategy.tolerance, strategy.lng, strategy.tolerance);
+      }
+      if (hit) return hit;
     }
     return null;
   }
@@ -491,7 +514,10 @@ export class CollectionsService {
     this.assertCanEdit(userId, body.collection_id);
 
     if (!body.force) {
-      const dup = this.findDuplicateCollectionPlace(body.collection_id, { name: body.name, lat: body.lat, lng: body.lng });
+      const dup = this.findDuplicateCollectionPlace(body.collection_id, {
+        name: body.name, lat: body.lat, lng: body.lng,
+        google_place_id: body.google_place_id, google_ftid: body.google_ftid, osm_id: body.osm_id,
+      });
       if (dup) return { duplicate: true, duplicateOf: dup };
     }
 

--- a/server/tests/unit/nest/collections.service.test.ts
+++ b/server/tests/unit/nest/collections.service.test.ts
@@ -220,6 +220,38 @@ describe('saved places + dedup', () => {
     expect(result.duplicate).toBe(true);
     expect(result.duplicateOf?.name).toBe('Original Name');
   });
+
+  it('COLLECTIONS-SVC-102: the bulk import recognises a renamed place by its provider id too', () => {
+    // savePlace was not the only caller. The bulk copy carries the provider ids
+    // into the row it writes, so asking without them would recognise less than
+    // the row it just wrote already knows.
+    const u = createUser(testDb).user;
+    const col = svc.createCollection(u.id, { name: 'Rome' });
+    const trip = createTrip(testDb, u.id);
+    const place = createPlace(testDb, trip.id, { name: 'Trattoria da Enzo' });
+    testDb.prepare('UPDATE places SET google_ftid = ? WHERE id = ?').run('0x1:0x2', place.id);
+    svc.savePlace(u.id, { collection_id: col.id, name: 'Dinner Tuesday', lat: 41.88, lng: 12.47, google_ftid: '0x1:0x2' });
+
+    const out = svc.saveFromTripPlaces(u.id, col.id, trip.id, [place.id]);
+
+    expect(out.copied).toBe(0);
+    expect(out.skipped.map(s => s.name)).toEqual(['Trattoria da Enzo']);
+  });
+
+  it('COLLECTIONS-SVC-103: the import picker marks that same place as already saved', () => {
+    // The dialog and the import have to agree: a row shown as new that the import
+    // then refuses is the drift this method exists to prevent.
+    const u = createUser(testDb).user;
+    const col = svc.createCollection(u.id, { name: 'Rome' });
+    const trip = createTrip(testDb, u.id);
+    const place = createPlace(testDb, trip.id, { name: 'Trattoria da Enzo' });
+    testDb.prepare('UPDATE places SET google_ftid = ? WHERE id = ?').run('0x1:0x2', place.id);
+    svc.savePlace(u.id, { collection_id: col.id, name: 'Dinner Tuesday', lat: 41.88, lng: 12.47, google_ftid: '0x1:0x2' });
+
+    const listed = svc.importablePlaces(u.id, col.id, trip.id).places.find(p => p.place_id === place.id);
+
+    expect(listed?.already_in_list).toBe(true);
+  });
 });
 
 // ── save-from-trip provenance + IDOR ─────────────────────────────────────────

--- a/server/tests/unit/nest/collections.service.test.ts
+++ b/server/tests/unit/nest/collections.service.test.ts
@@ -179,6 +179,47 @@ describe('saved places + dedup', () => {
     const col = svc.createCollection(a.id, { name: 'Locked' });
     expect(() => svc.savePlace(b.id, { collection_id: col.id, name: 'X' })).toThrow();
   });
+
+  it('COLLECTIONS-SVC-100: a NAMED candidate does not merge into a different place at the same coordinates', () => {
+    // The wrong-city hazard: findDuplicateCollectionPlace used to fall through to
+    // a coordinate match for a named candidate whose name did not match anything,
+    // which would report two distinct places at one address (the restaurant and
+    // the bar) as duplicates of each other.
+    const u = createUser(testDb).user;
+    const col = svc.createCollection(u.id, { name: 'Berlin' });
+    svc.savePlace(u.id, { collection_id: col.id, name: 'Ground Floor Diner', lat: 52.52, lng: 13.405 });
+
+    const result = svc.savePlace(u.id, { collection_id: col.id, name: 'Rooftop Bar', lat: 52.52, lng: 13.405 });
+
+    expect(result.duplicate).toBeFalsy();
+    expect(result.place).toBeDefined();
+  });
+
+  it('COLLECTIONS-SVC-101: a provider id still recognises a renamed place a name/coords search would miss', () => {
+    // google_place_id/google_ftid/osm_id are stored on every collection_places row
+    // but were never read back for dedup, so a renamed place with no matching
+    // name or coordinates could be saved again under its old provider id.
+    const u = createUser(testDb).user;
+    const col = svc.createCollection(u.id, { name: 'Renames' });
+    svc.savePlace(u.id, {
+      collection_id: col.id,
+      name: 'Original Name',
+      lat: 1,
+      lng: 1,
+      google_place_id: 'ChIJ_abc',
+    });
+
+    const result = svc.savePlace(u.id, {
+      collection_id: col.id,
+      name: 'Renamed By User',
+      lat: 2,
+      lng: 2,
+      google_place_id: 'ChIJ_abc',
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(result.duplicateOf?.name).toBe('Original Name');
+  });
 });
 
 // ── save-from-trip provenance + IDOR ─────────────────────────────────────────


### PR DESCRIPTION
## Description

`CollectionsService.findDuplicateCollectionPlace` is a third, independent copy of the
place-matching order alongside `PlacesService.findDuplicatePlace` and `isPlaceDuplicate` —
missed when #2130 unified the other two behind `placeMatchStrategies()` in `@trek/shared`.

Unlike `findDuplicatePlace`, this one has no `isPlaceDuplicate()` guard in front of it —
`savePlace` calls it directly — so its coordinate fallback for a **named** candidate is live
today, not latent: two distinct places sharing an address (a restaurant and the bar upstairs)
report each other as duplicates the moment their coordinates round to the same ~11 m box,
regardless of name.

It also never reads `google_place_id` / `google_ftid` / `osm_id` at all, even though every
`collection_places` row stores them — so a place renamed since it was saved, with no matching
name or coordinates, could be saved again instead of being recognised by its provider id.

Now walks `placeMatchStrategies()` from shared, same order as `findMatchingPlaceId`: provider
id, then name, then coordinates only when there is no name. `savePlace` passes the provider-id
fields through since they're already on the request body. The two bulk call sites
(`importablePlaces`, `saveFromTripPlaces`) are unchanged — their source rows don't carry
provider ids to pass, so behaviour there is identical, just routed through the shared rule
instead of a fourth copy of it.

## Related Issue or Discussion

Closes #2137

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed *(no user-facing behaviour to document)*

### Test plan

- `COLLECTIONS-SVC-100` — a named candidate no longer merges into a different place at the
  same coordinates. Fails against the old code (`expected true to be falsy`).
- `COLLECTIONS-SVC-101` — a provider id now recognises a renamed place that a name/coordinate
  search would miss. Fails against the old code (`expected undefined to be true`).
- `npx vitest run tests/unit/nest/collections.service.test.ts` — 63 passed.
- `npm run typecheck` and `npm run typecheck:tests` — clean.
- `eslint` on the changed files — 0 errors, 0 new warnings.
- Coverage over every test file exercising `CollectionsService` (unit, controller, e2e,
  integration, MCP, plugin RPC): `src/nest/collections/**` measures 87.3 / 75.8 / 96.3 / 96.5
  against its ratchet of 86 / 75 / 95 / 95 — held, not lowered.
