### PR TITLE
fix(map): a vector basemap left the Leaflet map with no zoom ceiling

### DIFF
--- a/client/src/components/Admin/DefaultUserSettingsTab.tsx
+++ b/client/src/components/Admin/DefaultUserSettingsTab.tsx
@@ -8,7 +8,7 @@ import CustomSelect from '../shared/CustomSelect'
 import { MapView } from '../Map/MapView'
 import { SYMBOLS, currenciesWith } from '../Budget/BudgetPanel.constants'
 import type { DistanceUnit, Place } from '../../types'
-import { normalizeTileUrl } from '../../utils/tileUrl'
+import { normalizeTileUrl, withTileApiKey } from '../../utils/tileUrl'
 import {
   MAPBOX_DEFAULT_STYLE,
   defaultStyleForProvider,
@@ -378,7 +378,9 @@ export default function DefaultUserSettingsTab(): React.ReactElement {
             onMapContextMenu: null,
             center: [48.8566, 2.3522],
             zoom: 10,
-            tileUrl: mapTileUrl,
+            // Same as the user-facing map tab: the field holds what is being
+            // edited, so the key goes back on before the preview resolves it.
+            tileUrl: withTileApiKey(mapTileUrl, cartoKey),
             fitKey: null,
             dayOrderMap: [],
             leftWidth: 0,

--- a/client/src/components/Map/MapView.test.tsx
+++ b/client/src/components/Map/MapView.test.tsx
@@ -5,6 +5,7 @@ import { act, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { resetAllStores } from '../../../tests/helpers/store'
 import { buildPlace, buildReservation } from '../../../tests/helpers/factories'
+import { MAP_MAX_ZOOM } from '../../constants/mapDefaults'
 import { useAuthStore } from '../../store/authStore'
 import { CATEGORY_ICON_MAP } from '../shared/categoryIcons'
 import * as photoService from '../../services/photoService'
@@ -48,9 +49,10 @@ vi.mock('../../hooks/useGeolocation', () => ({
 const thumbCallbacks = vi.hoisted(() => new Map<string, (thumb: string) => void>())
 
 vi.mock('react-leaflet', () => ({
-  // center/zoom are surfaced so tests can assert the camera the map is built with.
-  MapContainer: ({ children, center, zoom }: any) => (
-    <div data-testid="map-container" data-center={JSON.stringify(center)} data-zoom={zoom}>{children}</div>
+  // center/zoom are surfaced so tests can assert the camera the map is built
+  // with; maxZoom because a cluster refuses to attach to a map without one.
+  MapContainer: ({ children, center, zoom, maxZoom }: any) => (
+    <div data-testid="map-container" data-center={JSON.stringify(center)} data-zoom={zoom} data-maxzoom={maxZoom}>{children}</div>
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
   Marker: ({ children, eventHandlers, position, icon, zIndexOffset }: any) => (
@@ -243,6 +245,14 @@ describe('MapView', () => {
     const places = [buildMapPlace({ lat: 48.8584, lng: 2.2945 })]
     render(<MapView places={places} />)
     expect(screen.getByTestId('cluster-group')).toBeTruthy()
+  })
+
+  it('FE-COMP-MAPVIEW-010b: the map carries a zoom ceiling of its own, whatever the basemap is', () => {
+    // Without it, a vector basemap leaves the map with none and the cluster
+    // above throws on attach, taking the planner to the error boundary. The
+    // ceiling has to sit on the map because only a GridLayer can contribute one.
+    render(<MapView places={[buildMapPlace({ lat: 48.8584, lng: 2.2945 })]} />)
+    expect(screen.getByTestId('map-container').getAttribute('data-maxzoom')).toBe(String(MAP_MAX_ZOOM))
   })
 
   it('FE-COMP-MAPVIEW-011: renders the route polyline; travel times are no longer drawn on the map', () => {

--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -19,7 +19,7 @@ import { escapeHtml } from '@trek/shared'
 import type { Day, Reservation, RouteVia } from '../../types'
 import { POI_CATEGORY_BY_KEY, type Poi } from './poiCategories'
 import { resolveTrackColor, hasManualTrackColor } from './trackColors'
-import { OFM_POSITRON, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, SATELLITE_TILE_URL, SATELLITE_TILE_ATTRIBUTION, SATELLITE_TILE_MAXZOOM, attributionForTile } from '../../constants/mapDefaults'
+import { OFM_POSITRON, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, MAP_MAX_ZOOM, SATELLITE_TILE_URL, SATELLITE_TILE_ATTRIBUTION, SATELLITE_TILE_MAXZOOM, attributionForTile } from '../../constants/mapDefaults'
 import { resolveBasemap } from '../../utils/tileUrl'
 import VectorBasemap from './VectorBasemap'
 import { useSettingsStore } from '../../store/settingsStore'
@@ -832,6 +832,12 @@ export const MapView = memo(function MapView({
       center={initialView.center}
       zoom={initialView.zoom}
       zoomControl={false}
+      // On the map itself, not left to the base layer. Leaflet reads its zoom
+      // ceiling from the map options or, failing that, from a GridLayer that
+      // brought one; a vector basemap is neither, so a map drawn by
+      // VectorBasemap had no ceiling at all. MarkerClusterGroup.onAdd throws
+      // outright on an infinite one, which took the whole planner down.
+      maxZoom={MAP_MAX_ZOOM}
       className="w-full h-full bg-[#e5e7eb]"
     >
       {/* The basemap is a vector style by default and a raster template when the

--- a/client/src/components/Map/mapZoomCeiling.test.ts
+++ b/client/src/components/Map/mapZoomCeiling.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The zoom ceiling a Leaflet map needs before a marker cluster will attach.
+ *
+ * This is a test about Leaflet's own semantics rather than about our components,
+ * because that semantic is what a basemap change quietly broke: switching the
+ * default basemap to a vector style replaced the TileLayer with a GL canvas, the
+ * ceiling went with it, and MarkerClusterGroup.onAdd threw on the way in. The
+ * planner and the map settings preview both went to the error boundary, which
+ * left no screen from which to pick a different basemap.
+ *
+ * Nothing is mocked here on purpose. A mocked react-leaflet would have kept
+ * passing throughout.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import L from 'leaflet'
+import 'leaflet.markercluster'
+import { MAP_MAX_ZOOM } from '../../constants/mapDefaults'
+
+/**
+ * A layer that is not a GridLayer, which is what a vector basemap amounts to:
+ * maplibre-gl-leaflet hands back an L.Layer holding a canvas, so it has no
+ * beforeAdd and never reaches Leaflet's _addZoomLimit.
+ */
+const GlCanvasLayer = L.Layer.extend({ onAdd: () => undefined, onRemove: () => undefined })
+function glCanvasLayer(): L.Layer {
+  return new GlCanvasLayer() as L.Layer
+}
+
+/**
+ * `leaflet.markercluster` ships no types and we do not depend on
+ * `@types/leaflet.markercluster`, so the one factory this file needs is named
+ * here rather than pulling a package in for a single call.
+ */
+const markerClusterGroup = (L as unknown as { markerClusterGroup: () => L.Layer }).markerClusterGroup
+
+const containers: HTMLElement[] = []
+
+function mapOn(options: L.MapOptions): L.Map {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'clientWidth', { value: 800 })
+  Object.defineProperty(el, 'clientHeight', { value: 600 })
+  document.body.appendChild(el)
+  containers.push(el)
+  return L.map(el, { center: [48.85, 2.35], zoom: 12, ...options })
+}
+
+afterEach(() => {
+  for (const el of containers.splice(0)) el.remove()
+})
+
+describe('the zoom ceiling of a Leaflet map', () => {
+  it('MAPZOOM-001: a vector basemap contributes none, so the map has none', () => {
+    const map = mapOn({})
+    glCanvasLayer().addTo(map)
+    // Only a GridLayer feeds Leaflet's _layersMaxZoom, via its beforeAdd hook.
+    expect(map.getMaxZoom()).toBe(Infinity)
+  })
+
+  it('MAPZOOM-002: a raster basemap contributes one, which is why raster maps never broke', () => {
+    const map = mapOn({})
+    L.tileLayer('https://example.test/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map)
+    expect(map.getMaxZoom()).toBe(19)
+  })
+
+  it('MAPZOOM-003: a cluster refuses to attach to a map with no ceiling', () => {
+    const map = mapOn({})
+    glCanvasLayer().addTo(map)
+    // The throw is in onAdd, before any clustering, so an empty trip hits it too.
+    expect(() => markerClusterGroup().addTo(map)).toThrow(/maxZoom/)
+  })
+
+  it('MAPZOOM-004: the ceiling on the map itself carries every basemap kind', () => {
+    const map = mapOn({ maxZoom: MAP_MAX_ZOOM })
+    glCanvasLayer().addTo(map)
+    expect(map.getMaxZoom()).toBe(MAP_MAX_ZOOM)
+    expect(() => markerClusterGroup().addTo(map)).not.toThrow()
+  })
+
+  it('MAPZOOM-005: it does not lower the raster and satellite layers, which already sat at 19', () => {
+    const map = mapOn({ maxZoom: MAP_MAX_ZOOM })
+    L.tileLayer('https://example.test/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map)
+    expect(map.getMaxZoom()).toBe(19)
+  })
+})

--- a/client/src/components/Settings/MapSettingsTab.test.tsx
+++ b/client/src/components/Settings/MapSettingsTab.test.tsx
@@ -8,10 +8,11 @@ import { buildUser, buildSettings } from '../../../tests/helpers/factories';
 import { ToastContainer } from '../shared/Toast';
 import MapSettingsTab from './MapSettingsTab';
 
-// Mock MapView to avoid Leaflet DOM issues in jsdom
+// Mock MapView to avoid Leaflet DOM issues in jsdom. tileUrl is surfaced because
+// the preview has to draw the basemap being configured, key included.
 vi.mock('../Map/MapView', () => ({
-  MapView: ({ onMapClick }: { onMapClick?: (info: { latlng: { lat: number; lng: number } }) => void }) => (
-    <div data-testid="map-view" onClick={() => onMapClick?.({ latlng: { lat: 51.5, lng: -0.1 } })} />
+  MapView: ({ onMapClick, tileUrl }: { onMapClick?: (info: { latlng: { lat: number; lng: number } }) => void; tileUrl?: string }) => (
+    <div data-testid="map-view" data-tile-url={tileUrl} onClick={() => onMapClick?.({ latlng: { lat: 51.5, lng: -0.1 } })} />
   ),
 }));
 
@@ -392,6 +393,27 @@ describe('MapSettingsTab – CARTO key', () => {
     await user.click(screen.getByText('Save Map'));
 
     expect(updateSettings).toHaveBeenCalledWith(expect.objectContaining({ carto_api_key: 'demo-key' }));
+  });
+
+  it('FE-COMP-MAP-033b: the preview draws the CARTO basemap being configured, not the app default', async () => {
+    // The fields hold what the user is editing, not what useTileUrl resolved, so
+    // the key has to be put back on before the preview reads the template.
+    // Without it the preview resolves a keyless CARTO url, silently falls back to
+    // the default vector style, and shows a basemap nobody chose.
+    const user = userEvent.setup();
+    seedStore(useSettingsStore, {
+      settings: buildSettings({ map_tile_url: CARTO_DARK_TILES, carto_api_key: 'demo-key' }),
+    });
+    render(<MapSettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-view').getAttribute('data-tile-url')).toContain('key=demo-key');
+    });
+
+    await user.clear(cartoInput());
+    await waitFor(() => {
+      expect(screen.getByTestId('map-view').getAttribute('data-tile-url')).not.toContain('key=');
+    });
   });
 
   it('FE-COMP-MAP-034: a CARTO template without a key explains the watermark until one is typed', async () => {

--- a/client/src/components/Settings/MapSettingsTab.tsx
+++ b/client/src/components/Settings/MapSettingsTab.tsx
@@ -11,6 +11,7 @@ import ErrorBoundary from '../shared/ErrorBoundary'
 import { GlMapPreviewMapbox, GlMapPreviewMaplibre } from '../Map/glLazy'
 import Section from './Section'
 import ToggleSwitch from './ToggleSwitch'
+import { withTileApiKey } from '../../utils/tileUrl'
 import type { Place } from '../../types'
 import {
   MAPBOX_DEFAULT_STYLE,
@@ -473,7 +474,12 @@ export default function MapSettingsTab(): React.ReactElement {
               onMarkerClick: null,
               onMapClick: null,
               onMapContextMenu: null,
-              tileUrl: mapTileUrl,
+              // With the key on it, or the preview resolves the template as a
+              // keyless CARTO one and quietly shows the app default instead of
+              // the basemap being configured. The fields hold what the user is
+              // editing rather than what useTileUrl already resolved, so the key
+              // has to be put back on here.
+              tileUrl: withTileApiKey(mapTileUrl, cartoKey),
               fitKey: null,
               dayOrderMap: [],
               leftWidth: 0,

--- a/client/src/constants/mapDefaults.ts
+++ b/client/src/constants/mapDefaults.ts
@@ -3,6 +3,18 @@ export const DEFAULT_MAP_LNG = 0
 export const DEFAULT_MAP_ZOOM = 2
 export const DEFAULT_MAP_CENTER: [number, number] = [DEFAULT_MAP_LAT, DEFAULT_MAP_LNG]
 
+/**
+ * Zoom ceiling for a Leaflet map, set on the map rather than on its base layer.
+ *
+ * Leaflet answers `getMaxZoom()` from the map options first and only then from a
+ * layer that carried one, and only a GridLayer ever contributes: a vector
+ * basemap is a GL canvas, so a map drawn by one has no ceiling from anywhere.
+ * `MarkerClusterGroup.onAdd` refuses an infinite ceiling by throwing, which is
+ * how a basemap choice could take down the whole planner. Matches the raster and
+ * satellite layers so nothing changes for the maps that already had one.
+ */
+export const MAP_MAX_ZOOM = 19
+
 // Tokenless satellite base layer (ESRI World Imagery) — works without an API key.
 export const SATELLITE_TILE_URL =
   'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'

--- a/client/src/mobile/screens/settings/MSettingsMap.tsx
+++ b/client/src/mobile/screens/settings/MSettingsMap.tsx
@@ -17,6 +17,7 @@ import {
   normalizeStyleForProvider,
   type GlMapProvider,
 } from '../../../components/Map/glProviders'
+import { withTileApiKey } from '../../../utils/tileUrl'
 import MToggle from '../../components/MToggle'
 import { MSetCard, MSetEyebrow, MSetSelectRow, MSetInput, MSetButton, MSetHint, MSetRow } from './MSettingsUi'
 import MSetPickerSheet from './MSetPickerSheet'
@@ -318,7 +319,9 @@ export default function MSettingsMap() {
             onMarkerClick: null,
             onMapClick: null,
             onMapContextMenu: null,
-            tileUrl: mapTileUrl,
+            // As on the desktop tab: the field holds what is being edited, so the
+            // key goes back on before the preview resolves the template.
+            tileUrl: withTileApiKey(mapTileUrl, cartoKey),
             fitKey: null,
             dayOrderMap: [],
             leftWidth: 0,

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -19,7 +19,7 @@ import { createElement, useEffect, useRef } from 'react';
 import { renderIconMarkup } from '../utils/iconMarkup';
 import { MapContainer, Marker, Polyline, TileLayer, Tooltip, useMap } from 'react-leaflet';
 import { getCategoryIcon } from '../components/shared/categoryIcons';
-import { OFM_POSITRON, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, attributionForTile } from '../constants/mapDefaults';
+import { OFM_POSITRON, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, MAP_MAX_ZOOM, attributionForTile } from '../constants/mapDefaults';
 import VectorBasemap from '../components/Map/VectorBasemap';
 import { SUPPORTED_LANGUAGES, useTranslation } from '../i18n';
 import { useSettingsStore } from '../store/settingsStore';
@@ -489,6 +489,9 @@ export default function SharedTripPage() {
                 center={initialView.center}
                 zoom={initialView.zoom}
                 zoomControl={false}
+                // Same reason as the planner map: a vector basemap contributes
+                // no zoom ceiling, and fitBounds below asks for one.
+                maxZoom={MAP_MAX_ZOOM}
                 style={{ width: '100%', height: '100%' }}
               >
                 {basemap.kind === 'vector' ? (


### PR DESCRIPTION
Closes #2135

Opening a trip on 4.1.0 lands on the error boundary with `Map has no maxZoom specified`, and so does Settings > Map and the admin default-settings page. Four reports on the issue so far, on fresh installs and on upgrades alike.

## Why the map has no ceiling

Leaflet answers `getMaxZoom()` from the map options first and otherwise from a layer that brought one, and only a `GridLayer` ever contributes, through its `beforeAdd` hook. A vector basemap is a GL canvas on a plain `L.Layer`, so it contributes nothing, and `MapContainer` set nothing of its own. `MarkerClusterGroup.onAdd` refuses an infinite ceiling by throwing, and it does that before any clustering, so an empty trip hits it too.

That is why the Atlas is fine and the planner is not: `useAtlas` builds its map with `maxZoom: 10`, and the journey map with 18.

## Why it reaches almost everyone

The path opens whenever the basemap is a style rather than a tile template, which is now the default. It is not limited to operators who picked OpenFreeMap on purpose:

- A fresh install has no `map_tile_url`, so `resolveBasemap` falls through to `OFM_POSITRON`.
- An instance carrying a CARTO template from before 4.1.0 hits `resolveTileUrl`'s keyless-CARTO rule, which sends it to the app default. That default used to be a raster template and is a vector style now, so the rule that was meant to spare people the watermark drops them into the crash instead.

`exxamalte` found the shape of it from the outside on the issue: picking OpenStreetMap in the map settings fixes it, because a raster template restores the ceiling.

## Why a saved CARTO key did not help

The map settings tab and the admin default-settings page keep the tile template in local state, since that is what the fields are editing, and hand that raw value to the preview. `useTileUrl` never sees it, so the key is not on the template, `resolveTileUrl` reads it as keyless CARTO, and the preview quietly draws the app default. Two consequences: the preview shows a basemap nobody chose, and the tab crashes through the same path as the planner. That is the loop, because the key is entered on the page the fallback has taken down.

## The fix

`maxZoom` goes on the map rather than on the base layer, because it has to hold whichever of the three branches renders. 19 is what the raster and satellite layers already carried, so nothing changes for the maps that worked. `SharedTripPage` gets it too: it has no cluster to throw, but it draws the same vector basemap and its `fitBounds` asks for a ceiling.

Both previews put the key back on the template before handing it over.

`mapZoomCeiling.test.ts` pins Leaflet's own semantics against the real library rather than a mock, because a mocked `react-leaflet` kept passing through all of this: a non-GridLayer contributes no ceiling, a cluster refuses to attach without one, the map option carries every basemap kind, and raster layers keep the 19 they had.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
