### PR TITLE
fix(mobile): the phone admin map preview needs the CARTO key too

### DIFF
--- a/client/src/mobile/screens/admin/MAdminDefaultUserSettings.tsx
+++ b/client/src/mobile/screens/admin/MAdminDefaultUserSettings.tsx
@@ -6,7 +6,7 @@ import { useToast } from '../../../components/shared/Toast'
 import { MapView } from '../../../components/Map/MapView'
 import { SYMBOLS, currenciesWith } from '../../../components/Budget/BudgetPanel.constants'
 import { getApiErrorMessage, type DistanceUnit, type Place } from '../../../types'
-import { normalizeTileUrl } from '../../../utils/tileUrl'
+import { normalizeTileUrl, withTileApiKey } from '../../../utils/tileUrl'
 import {
   MAPBOX_DEFAULT_STYLE,
   defaultStyleForProvider,
@@ -331,7 +331,9 @@ export default function MAdminDefaultUserSettings(): React.ReactElement {
               onMapContextMenu: null,
               center: [48.8566, 2.3522],
               zoom: 10,
-              tileUrl: mapTileUrl,
+              // As on the other three previews: the field holds what is being
+              // edited, so the key goes back on before the template resolves.
+              tileUrl: withTileApiKey(mapTileUrl, cartoKey),
               fitKey: null,
               dayOrderMap: [],
               leftWidth: 0,


### PR DESCRIPTION
Follow-up to #2139, which fixed three of the four map previews. The phone admin page is the fourth and was missed.

Same shape as the others: the field holds the template being edited rather than the one `useTileUrl` resolved, so the preview received it with no key on it, read it as keyless CARTO and drew the app default instead of the basemap being set. The zoom-ceiling fix already stops it crashing; this stops it showing the wrong map.

Sonar is what pointed at it: the desktop and phone admin pages are near-identical, so its duplication report named the file the change had not reached.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update