### PR TITLE
fix: boot in the account's language when offline

### DIFF
--- a/client/src/store/settingsStore.test.ts
+++ b/client/src/store/settingsStore.test.ts
@@ -90,3 +90,42 @@ describe('settings tile template hygiene', () => {
     expect(clearTileCache).not.toHaveBeenCalled()
   })
 })
+
+// The account's language lives on the server; the store boots from localStorage. Without a
+// mirror of the server value, a cold start with no network (PWA in airplane mode) booted in
+// English even though every online session ran in the user's language — the same stranding
+// #1618 fixed for currency and units. 'app_language' stays reserved for an explicit in-app
+// choice (the login page's detection chain keys off it), so the mirror gets its own key.
+describe('offline language fallback', () => {
+  beforeEach(() => {
+    localStorage.removeItem('app_language')
+    localStorage.removeItem('app_language_server')
+  })
+
+  it('SETTINGS-LANG-001: loadSettings mirrors the account language for the next launch', async () => {
+    vi.mocked(settingsApi.get).mockResolvedValue({ settings: { language: 'fr' } } as never)
+    await useSettingsStore.getState().loadSettings()
+    expect(localStorage.getItem('app_language_server')).toBe('fr')
+  })
+
+  it('SETTINGS-LANG-002: the mirror never claims to be an explicit choice', async () => {
+    vi.mocked(settingsApi.get).mockResolvedValue({ settings: { language: 'fr' } } as never)
+    await useSettingsStore.getState().loadSettings()
+    expect(localStorage.getItem('app_language')).toBeNull()
+  })
+
+  it('SETTINGS-LANG-003: a cold start with no explicit choice boots in the mirrored language', async () => {
+    localStorage.setItem('app_language_server', 'fr')
+    vi.resetModules()
+    const fresh = await import('./settingsStore')
+    expect(fresh.DEFAULT_SETTINGS.language).toBe('fr')
+  })
+
+  it('SETTINGS-LANG-004: an explicit in-app choice outranks the mirror', async () => {
+    localStorage.setItem('app_language', 'de')
+    localStorage.setItem('app_language_server', 'fr')
+    vi.resetModules()
+    const fresh = await import('./settingsStore')
+    expect(fresh.DEFAULT_SETTINGS.language).toBe('de')
+  })
+})

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -35,7 +35,11 @@ export const DEFAULT_SETTINGS: Settings = {
   dark_mode: false,
   // Empty = no personal display currency, so Costs falls back to the trip's own.
   default_currency: '',
-  language: localStorage.getItem('app_language') || 'en',
+  // Explicit in-app choice first, then the mirror of the account's server-side
+  // language (written by loadSettings below), then English. Without the mirror
+  // an offline cold start boots in English: the account's language lives on the
+  // server, and the fetch that would apply it cannot happen.
+  language: localStorage.getItem('app_language') || localStorage.getItem('app_language_server') || 'en',
   temperature_unit: 'celsius',
   distance_unit: 'metric',
   time_format: '24h',
@@ -99,6 +103,16 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         // The startup redirect runs before this ever resolves, so keep a mirror
         // it can read synchronously on the next launch.
         rememberStartDestination(incoming)
+        // Same trick for the language: mirror the account's value so the next
+        // launch — including an offline one, where this fetch fails — boots in
+        // it instead of English (#1618 fixed the same stranding for currency
+        // and units, but the language never made it into that fix). Its own
+        // key rather than 'app_language': that one means an explicit in-app
+        // choice, and the login page's detection chain must keep running for
+        // users who never made one.
+        try {
+          if (incoming.language) localStorage.setItem('app_language_server', incoming.language)
+        } catch { /* private mode — the session still has the value in the store */ }
       } catch (err: unknown) {
         // Leave isLoaded false so a transient failure — offline at launch, or a
         // (docker) server cold-start racing the first request — is retried on


### PR DESCRIPTION
Small fix for something I hit using the PWA offline: a cold start with no network boots in English even though my account language is set. Offered in case the approach fits, happy to adjust if you'd prefer a different shape. Based on `dev`.

## What happens

The store boots from `app_language` in localStorage, which is only written when a language is explicitly picked in Settings. A language that lives in the account's server settings never reaches the device, so an offline launch falls back to `en` until a fetch that cannot happen. It looks like the same stranding #1618 addressed for currency and units, with the language left out.

## The change

`loadSettings` mirrors the fetched language into its own key (`app_language_server`), and the boot chain reads: explicit choice, then mirror, then `en`.

I kept it a separate key on purpose: `app_language` currently means "the user chose this", and `hasStoredLanguage()` gates the login page's browser-language detection on it. Mirroring into the same key would have silently disabled that detection after any successful settings load. If you'd rather fold them together anyway, or mirror somewhere else entirely, happy to rework it.

## Tests

- `SETTINGS-LANG-001`: loadSettings mirrors the account language for the next launch
- `SETTINGS-LANG-002`: the mirror never claims to be an explicit choice
- `SETTINGS-LANG-003`: a cold start with no explicit choice boots in the mirrored language
- `SETTINGS-LANG-004`: an explicit in-app choice outranks the mirror

Full client suite passes.
