### PR TITLE
fix: offline tile coverage for all shipped presets and real studio font stacks

### DIFF
--- a/client/src/components/Studio/SpreadView.tsx
+++ b/client/src/components/Studio/SpreadView.tsx
@@ -2,7 +2,8 @@ import type { CSSProperties } from 'react'
 import type {
   BookElement, BookIconElement, BookPageSetup, BookPhotoElement, BookShapeElement, BookSpread,
 } from '@trek/shared'
-import { FONT_STACKS, photoSrc } from './bookRender'
+import { photoSrc } from './bookRender'
+import { fontStack } from './bookFonts'
 import { iconComponent } from './iconLibrary'
 import { HOLED_SHAPES, SHAPE_PATHS, scalePath, unitPath } from './shapes'
 import { TravelElementView } from './TravelElements'
@@ -223,7 +224,7 @@ function PhotoView({ el, big, print, dropLabel }: {
       {roomy && dropLabel && (
         <span
           style={{
-            fontFamily: FONT_STACKS.sans,
+            fontFamily: fontStack('sans'),
             fontSize: `${labelSize}mm`,
             fontWeight: 600,
             letterSpacing: '0.16em',
@@ -403,7 +404,7 @@ export function ElementView({
         // pt, not px: the document speaks the print's language, and CSS knows
         // the conversion exactly.
         fontSize: `${el.size}pt`,
-        fontFamily: FONT_STACKS[el.font],
+        fontFamily: fontStack(el.font),
         fontWeight: el.weight,
         fontStyle: el.italic ? 'italic' : undefined,
         lineHeight: el.leading,

--- a/client/src/components/Studio/StudioCanvas.tsx
+++ b/client/src/components/Studio/StudioCanvas.tsx
@@ -4,7 +4,7 @@ import type { BookElement, BookPageSetup, BookSpread } from '@trek/shared'
 import { SpreadFold, SpreadView } from './SpreadView'
 import { PeerCursors } from './PeerCursors'
 import type { PeerCursor } from './useBookPresence'
-import { FONT_STACKS } from './bookRender'
+import { fontStack } from './bookFonts'
 import { useSpreadInteraction, type HandleId } from './useSpreadInteraction'
 import { useStudioStore } from '../../store/studioStore'
 import { useTranslation } from '../../i18n'
@@ -271,7 +271,7 @@ export function StudioCanvas({
               height: el.frame.h * scaled,
               // The document is in pt; the overlay is on screen at the same zoom.
               fontSize: `${el.size * (96 / 72) * zoom}px`,
-              fontFamily: FONT_STACKS[el.font],
+              fontFamily: fontStack(el.font),
               fontWeight: el.weight,
               fontStyle: el.italic ? 'italic' : undefined,
               lineHeight: el.leading,

--- a/client/src/components/Studio/bookRender.ts
+++ b/client/src/components/Studio/bookRender.ts
@@ -6,19 +6,9 @@
  * exactly the kind of file you edit constantly while designing.
  */
 
-/**
- * The book's typefaces.
- *
- * Poppins ships with the client already; Georgia is a system serif. Print will
- * need these self-hosted and identical on the server, or the renderer silently
- * substitutes — which is what the current Journey PDF export does today, asking
- * for Inter while only Poppins is bundled.
- */
-export const FONT_STACKS: Record<string, string> = {
-  sans: '"Poppins", system-ui, sans-serif',
-  serif: 'Georgia, "Times New Roman", serif',
-  display: '"MuseoModerno", "Poppins", system-ui, sans-serif',
-}
+// The typefaces live in bookFonts.ts (fontStack et al.) — a second stack map
+// here is exactly how #2183 happened: the renderer kept a three-font copy
+// while the picker grew to seven, and everything else fell back to Poppins.
 
 export function photoSrc(photoId: number, big: boolean): string {
   return `/api/photos/${photoId}/${big ? 'original' : 'thumbnail'}`

--- a/client/src/sync/glPrefetcher.ts
+++ b/client/src/sync/glPrefetcher.ts
@@ -20,7 +20,10 @@ import type { Place } from '../types'
 
 /** OpenFreeMap serves vector tiles up to z14 and overzooms from there. */
 const VECTOR_MAX_ZOOM = 14
-const VECTOR_MIN_ZOOM = 10
+// Zoom 0, not 10: MapLibre can only overzoom upward, so a wide trip opening at
+// its fitBounds zoom (z6–9) rendered nothing offline with a z10 floor (#2180).
+// The low zooms cost a few dozen tiles at most.
+const VECTOR_MIN_ZOOM = 0
 
 /** Requests in flight, kept low for the same reason the raster side keeps it low. */
 const CONCURRENCY = 6

--- a/client/src/sync/tilePrefetcher.ts
+++ b/client/src/sync/tilePrefetcher.ts
@@ -4,7 +4,10 @@
  *
  * Algorithm:
  *   1. Compute bbox from trip's place coordinates + padding.
- *   2. For zooms 10–16, enumerate tile XYZ coordinates within bbox.
+ *   2. For zooms 0–16, enumerate tile XYZ coordinates within bbox. The low
+ *      zooms cost next to nothing (a handful of tiles) but are what the trip
+ *      map actually opens at for a multi-city bbox — a z10 floor left the
+ *      fitBounds view empty offline (#2180).
  *   3. Stop when cumulative tile estimate exceeds MAX_TILES (~50 MB).
  *   4. Fetch each tile URL so the Service Worker CacheFirst handler caches it,
  *      at most TILE_CONCURRENCY at a time.
@@ -228,7 +231,7 @@ async function openTileCache(): Promise<Cache | null> {
 export async function prefetchTiles(
   bbox: TileBbox,
   tileUrlTemplate: string,
-  minZoom = 10,
+  minZoom = 0,
   maxZoom = 16,
   cartoKey?: string,
 ): Promise<number> {
@@ -362,7 +365,7 @@ export async function prefetchTilesForTrip(
   // tile providers that don't send CORS headers. To stop the browser evicting
   // these tiles under the inflated quota, we request persistent storage at app
   // init instead (sync/persistentStorage.ts).
-  const fetched = await prefetchTiles(bbox, template, 10, 16, cartoKey)
+  const fetched = await prefetchTiles(bbox, template, 0, 16, cartoKey)
 
   // Update syncMeta with bbox and tile count
   const meta = await offlineDb.syncMeta.get(tripId)

--- a/client/tests/unit/studio/SpreadView.test.tsx
+++ b/client/tests/unit/studio/SpreadView.test.tsx
@@ -388,3 +388,28 @@ describe('travel elements', () => {
     expect(el.style.width).toBe('80mm')
   })
 })
+
+describe('text typefaces (#2183)', () => {
+  const text = (font: string): BookElement => ({
+    ...common, id: 't1', kind: 'text', text: 'A heading', font,
+    size: 11, weight: 400, italic: false, align: 'left',
+    leading: 1.45, tracking: 0, color: '#1a1a1a',
+  } as unknown as BookElement)
+
+  it('sets every picker font on the element, not just the three the old map knew', () => {
+    // The regression: a second stack map in bookRender.ts covered sans/serif/
+    // display only, so playfair and friends silently inherited Poppins.
+    expect(firstElement(draw([text('playfair')]).container)!.style.fontFamily).toContain('Playfair Display')
+    expect(firstElement(draw([text('inter')]).container)!.style.fontFamily).toContain('Inter')
+    expect(firstElement(draw([text('garamond')]).container)!.style.fontFamily).toContain('EB Garamond')
+    expect(firstElement(draw([text('bebas')]).container)!.style.fontFamily).toContain('Bebas Neue')
+  })
+
+  it('serif means Lora, matching the picker, not the bare system Georgia', () => {
+    expect(firstElement(draw([text('serif')]).container)!.style.fontFamily).toContain('Lora')
+  })
+
+  it('an unknown family still falls back to Poppins instead of the machine default', () => {
+    expect(firstElement(draw([text('comic-sans')]).container)!.style.fontFamily).toContain('Poppins')
+  })
+})

--- a/client/tests/unit/sync/glPrefetcher.test.ts
+++ b/client/tests/unit/sync/glPrefetcher.test.ts
@@ -139,7 +139,7 @@ describe('prefetchStyleAssets', () => {
 describe('prefetchVectorForPlaces', () => {
   const places = [buildPlace({ lat: 52.52, lng: 13.405 })];
 
-  it('FE-SYNC-GLPF-007: downloads the tiles covering the trip, z10 to z14', async () => {
+  it('FE-SYNC-GLPF-007: downloads the tiles covering the trip, z0 to z14', async () => {
     const result = await prefetchVectorForPlaces(places, STYLE_URL);
     expect(result.template).toBe(TILE_TEMPLATE);
     expect(result.tiles).toBeGreaterThan(0);
@@ -151,7 +151,9 @@ describe('prefetchVectorForPlaces', () => {
     );
     // z14 is the last one OpenFreeMap serves; MapLibre scales it beyond that
     // rather than asking for another, which is why this stops where raster could not.
-    expect([...zooms].sort((a, b) => a - b)).toEqual([10, 11, 12, 13, 14]);
+    // The floor is z0: MapLibre cannot overzoom downward, so the fitBounds view
+    // of a wide trip needs the low zooms cached too (#2180).
+    expect([...zooms].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
   });
 
   it('FE-SYNC-GLPF-008: does nothing offline', async () => {

--- a/client/tests/unit/sync/tilePrefetcher.test.ts
+++ b/client/tests/unit/sync/tilePrefetcher.test.ts
@@ -519,3 +519,45 @@ describe('the GL style document is not served stale (#1924)', () => {
     expect(config).toMatch(/cacheName:\s*'gl-map-styles'/);
   });
 });
+
+describe('shipped raster presets reach the map-tiles cache (#2180)', () => {
+  const config = readFileSync(resolve(process.cwd(), 'vite.config.js'), 'utf8');
+
+  // First-match semantics, like the #1924 harness above, but capturing the
+  // cacheName too: a preset whose tiles land in some other cache is as offline-
+  // dead as one that matches nothing.
+  const rules = [...config.matchAll(/urlPattern:\s*(\/[^\n]*?\/i),\s*\n\s*handler:\s*'([A-Za-z]+)',\s*\n\s*options:\s*\{\s*\n\s*cacheName:\s*'([^']+)'/g)].map(m => ({
+    pattern: new RegExp(m[1].slice(1, m[1].lastIndexOf('/')), 'i'),
+    handler: m[2],
+    cacheName: m[3],
+  }));
+  const firstMatch = (url: string) => rules.find(r => r.pattern.test(url));
+
+  it('OpenStreetMap DE tiles are cached — the preset used to match no rule at all', () => {
+    const rule = firstMatch('https://tile.openstreetmap.de/13/4091/2722.png');
+    expect(rule?.handler).toBe('CacheFirst');
+    expect(rule?.cacheName).toBe('map-tiles');
+  });
+
+  it('Stadia tiles are cached the same way', () => {
+    const rule = firstMatch('https://tiles.stadiamaps.com/tiles/alidade_smooth/13/4091/2722.png');
+    expect(rule?.handler).toBe('CacheFirst');
+    expect(rule?.cacheName).toBe('map-tiles');
+  });
+
+  it('still refuses look-alike hosts', () => {
+    expect(firstMatch('https://tile.openstreetmap.de.example.com/13/4091/2722.png')).toBeUndefined();
+  });
+});
+
+describe('prefetch covers the opening zoom (#2180)', () => {
+  it('fetches the low zooms too, so a wide trip has tiles at its fitBounds view', async () => {
+    // A ~3° multi-city bbox opens around z7 — the old z10 floor left that view
+    // completely uncached offline.
+    const bbox: TileBbox = { minLat: 47.0, maxLat: 50.0, minLng: 6.0, maxLng: 9.0 };
+    await prefetchTiles(bbox, 'https://tile.example.com/{z}/{x}/{y}.png');
+    const urls = vi.mocked(fetch).mock.calls.map(c => String(c[0]));
+    expect(urls.some(u => u.includes('/0/'))).toBe(true);
+    expect(urls.some(u => u.includes('/7/'))).toBe(true);
+  });
+});

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -93,6 +93,28 @@ export default defineConfig(({ mode }) => ({
             },
           },
           {
+            // OpenStreetMap DE — a shipped preset that matched no rule at all, so
+            // "Store map tiles offline" fetched thousands of tiles and stored none
+            // of them (#2180). Same cache, same limits as the rules above.
+            urlPattern: /^https:\/\/tile\.openstreetmap\.de\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'map-tiles',
+              expiration: { maxEntries: 12288, maxAgeSeconds: 30 * 24 * 60 * 60 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Stadia Smooth — the other shipped raster preset with the same hole (#2180).
+            urlPattern: /^https:\/\/tiles\.stadiamaps\.com\/tiles\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'map-tiles',
+              expiration: { maxEntries: 12288, maxAgeSeconds: 30 * 24 * 60 * 60 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
             // The GL style DOCUMENT, for both providers. It has to be matched
             // before the tile rules below, because Workbox takes the first route
             // that matches and the broad tile patterns cover this URL too (#1924).


### PR DESCRIPTION
## Description
Two follow-up fixes from today's issue intake.

**Offline map tiles (#2180)** — two independent defects, both confirmed against the code:
- The service worker's `map-tiles` cache rules only matched CARTO and `tile.openstreetmap.org`. The shipped **OpenStreetMap DE** and **Stadia Smooth** presets matched no rule at all, so "Download for offline use" fetched thousands of tiles, stored none, and still reported success. Both hosts get their own `CacheFirst` rule into the same cache with the same limits.
- The prefetcher only covered **z10–16**, but a multi-city trip opens at its fitBounds zoom (z6–9) — exactly the "a few tiles, but not many" the report describes. The floor drops to z0 on both the raster and the vector pipeline (the default OpenFreeMap basemap had the identical defect, and MapLibre cannot overzoom downward); the low zooms cost a handful of tiles.

Notes: existing offline users need to press "Download for offline use" once more after updating (the passive sync skips an unchanged bbox). Offline zoom beyond z16 stays uncached by design. Custom/self-hosted tile templates still cannot be matched by build-time rules — that needs a runtime allowlist and is left as a separate decision, as are a "nothing was stored" warning and the shared 12k-tile budget across multiple offline trips.

**Studio fonts (#2183)** — the canvas and the print renderer resolved fonts through a stale three-entry `FONT_STACKS` map in `bookRender.ts` while the picker grew to seven faces in `bookFonts.ts`; everything outside sans/serif/display silently fell back to Poppins, and serif rendered Georgia instead of Lora. Both render paths now use `fontStack()` and the duplicate map is gone. Good catch by the reporter, who pointed at the exact lines.

## Related Issue or Discussion
Closes #2180, Closes #2183

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
