### PR TITLE
fix(mobile): dashboard filter row viewport overflow and android maskable icon

### DIFF
--- a/client/scripts/generate-icons.mjs
+++ b/client/scripts/generate-icons.mjs
@@ -26,4 +26,25 @@ for (const { name, size } of sizes) {
   console.log(`  \u2713 ${name} (${size}x${size})`);
 }
 
+// Maskable variants: Android lays a maskable icon edge to edge under the round
+// launcher mask, so the glyph has to sit inside the safe zone (a circle of 80%
+// of the canvas). The master SVG draws the glyph nearly full bleed; shrink and
+// recenter it, keeping the brand gradient as the full background.
+const maskableSvg = svgBuffer
+  .toString()
+  .replace('translate(56,51) scale(0.267)', 'translate(81,81) scale(0.234)');
+
+const maskableSizes = [
+  { name: 'icon-maskable-192x192.png', size: 192 },
+  { name: 'icon-maskable-512x512.png', size: 512 },
+];
+
+for (const { name, size } of maskableSizes) {
+  await sharp(Buffer.from(maskableSvg), { density: 300 })
+    .resize(size, size)
+    .png({ compressionLevel: 9 })
+    .toFile(join(iconsDir, name));
+  console.log(`  \u2713 ${name} (${size}x${size}, maskable)`);
+}
+
 console.log('PWA icons generated.');

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,7 +15,14 @@ body { height: 100%; overflow: auto; overscroll-behavior: none; -webkit-overflow
    reloads the installed PWA. Desktop/tablet keep the rules above. */
 @media (max-width: 767px) {
   html { overflow: visible; overscroll-behavior: none; }
-  body { height: auto; overflow: visible; }
+  /* overflow-x clip (not hidden: clip creates no scroll container) so a screen
+     that accidentally overflows sideways cannot widen the document. Android's
+     forced-zoom setting reacts to a wider document by growing the layout
+     viewport that position:fixed resolves against, which pushed the top bar
+     and the dock off the right edge on narrow phones. On body, never on html:
+     body's overflow only propagates to the viewport while html stays visible,
+     and the shared body scroll lock relies on that propagation. */
+  body { height: auto; overflow: visible; overflow-x: clip; }
   /* Transparent so the shell's own background layer, which sits behind the page
      on a negative z-index, is not painted over: a negative layer goes above the
      canvas but below the background of ordinary blocks, and body is one. The

--- a/client/src/mobile/mobile.css
+++ b/client/src/mobile/mobile.css
@@ -363,3 +363,14 @@
   -webkit-appearance: none;
   appearance: none;
 }
+
+/* Horizontal scroller without a visible scrollbar, for control rows that must
+   survive narrow viewports and large system font scales (dashboard filter). */
+.m-hscroll {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+.m-hscroll::-webkit-scrollbar {
+  display: none;
+}

--- a/client/src/mobile/screens/dashboard/MDashboard.tsx
+++ b/client/src/mobile/screens/dashboard/MDashboard.tsx
@@ -132,17 +132,25 @@ export default function MDashboard(): React.ReactElement {
     return (
       <>
         <div className="mt-[14px] flex items-center gap-[7px]">
-          <MSegmented<TripFilter>
-            value={tripFilter}
-            onChange={setTripFilter}
-            variant="intrinsic"
-            options={[
-              { value: 'planned', label: t('dashboard.filter.planned') },
-              { value: 'archive', label: t('dashboard.archived') },
-              { value: 'completed', label: t('dashboard.mobile.completed') },
-            ]}
-          />
-          <MIconBtn ariaLabel={t('dashboard.subscribeAllTrips')} size={36} className="ml-auto" onClick={() => setSubOpen(true)}>
+          {/* The chips scroll inside their own flexible box on narrow viewports
+              or large system font scales; without it this row was the widest
+              thing on the page and dragged the fixed bars off-screen under
+              Android's forced zoom. min-w-max keeps the pill track wrapping
+              its chips instead of getting squeezed to the box. */}
+          <div className="m-hscroll min-w-0 flex-1">
+            <MSegmented<TripFilter>
+              value={tripFilter}
+              onChange={setTripFilter}
+              variant="intrinsic"
+              className="min-w-max"
+              options={[
+                { value: 'planned', label: t('dashboard.filter.planned') },
+                { value: 'archive', label: t('dashboard.archived') },
+                { value: 'completed', label: t('dashboard.mobile.completed') },
+              ]}
+            />
+          </div>
+          <MIconBtn ariaLabel={t('dashboard.subscribeAllTrips')} size={36} className="flex-none" onClick={() => setSubOpen(true)}>
             <CalendarPlus size={15} strokeWidth={2} className="text-m-muted" />
           </MIconBtn>
           <button

--- a/client/tests/unit/mobile/dashboard/MDashboard.test.tsx
+++ b/client/tests/unit/mobile/dashboard/MDashboard.test.tsx
@@ -539,4 +539,19 @@ describe('MDashboard', () => {
     await waitFor(() =>
       expect(screen.queryByText('dashboard.subscribeAllTripsDesc')).not.toBeInTheDocument());
   });
+
+  it('FE-MOB-DASH-038: the filter row cannot widen the document on narrow phones (#discord S26)', async () => {
+    render(<MDashboard />);
+
+    // The chip track scrolls inside its own flexible box; without this the row
+    // was the widest element on the page and dragged the fixed bars off-screen
+    // under Android's forced zoom.
+    const chip = await screen.findByText('dashboard.filter.planned');
+    const track = chip.closest('button')!.parentElement as HTMLElement;
+    expect(track.className).toContain('min-w-max');
+    const wrapper = track.parentElement as HTMLElement;
+    expect(wrapper.className).toContain('m-hscroll');
+    expect(wrapper.className).toContain('min-w-0');
+    expect(wrapper.className).toContain('flex-1');
+  });
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -218,7 +218,10 @@ export default defineConfig(({ mode }) => ({
           { src: 'icons/apple-touch-icon-180x180.png', sizes: '180x180', type: 'image/png' },
           { src: 'icons/icon-192x192.png', sizes: '192x192', type: 'image/png' },
           { src: 'icons/icon-512x512.png', sizes: '512x512', type: 'image/png' },
-          { src: 'icons/icon-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+          // Dedicated safe-zone renders: the full-bleed icon under a maskable
+          // purpose filled the whole Android launcher tile without any padding.
+          { src: 'icons/icon-maskable-192x192.png', sizes: '192x192', type: 'image/png', purpose: 'maskable' },
+          { src: 'icons/icon-maskable-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
           { src: 'icons/icon.svg', sizes: 'any', type: 'image/svg+xml' },
         ],
       },


### PR DESCRIPTION
## Description
Fixes the broken mobile dashboard a user reported on a Galaxy S26 Ultra (top bar, filter row and bottom dock pushed off the right edge while the trip cards fit perfectly, in browser and PWA alike) plus the oversized Android launcher icon.

**Layout:** the dashboard filter row (three chips plus two buttons) needs about 350 to 370 CSS px with German labels, but the S26 Ultra reports a 360px viewport at its default display zoom. The row overflowed, widened the document, and with Android's forced zoom setting Chromium then grows the layout viewport that position fixed resolves against, so exactly the fixed bars rendered against 384px instead of 360px and stuck out. The chip track now scrolls inside its own flexible box (hidden scrollbar, min-w-max keeps the pill wrapping its chips), and body gets overflow-x clip on phones as a general guard so no future screen can widen the document again. clip, not hidden, and on body, not html: no scroll container is created and the shared body scroll lock keeps propagating to the viewport.

**Icon:** the manifest declared purpose maskable on the full-bleed 512px icon, so Android laid it edge to edge under the round mask. The icon script now renders dedicated maskable variants with the glyph scaled into the safe zone over the brand gradient, and the manifest points maskable at those. Installed PWAs pick the new icon up after a reinstall or Chrome's next WebAPK update.

## Related Issue or Discussion
Reported on Discord (S26 Ultra, dashboard offset and giant icon).

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
