### PR TITLE
Fix the 35 defects the v4.1.2 release audit confirmed

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -126,7 +126,7 @@ const RATE_LIMIT_MESSAGES: Record<string, string> = {
 function translateRateLimit(): string {
   const fallback = RATE_LIMIT_MESSAGES['en']!
   try {
-    const lang = localStorage.getItem('app_language') || 'en'
+    const lang = localStorage.getItem('app_language') || localStorage.getItem('app_language_server') || 'en'
     return RATE_LIMIT_MESSAGES[lang] ?? fallback
   } catch {
     return fallback

--- a/client/src/components/Admin/AddonManager.test.tsx
+++ b/client/src/components/Admin/AddonManager.test.tsx
@@ -361,6 +361,63 @@ describe('AddonManager', () => {
     expect(screen.queryByText('Synology Photos')).not.toBeInTheDocument();
   });
 
+  it('FE-ADMIN-ADDON-031: switching Journey off and on again shows the cascaded providers as off', async () => {
+    const user = userEvent.setup();
+    let loads = 0;
+    let journeyOn = true;
+    let immichOn = true;
+    server.use(
+      http.get('/api/admin/addons', () => {
+        loads += 1;
+        return HttpResponse.json({
+          addons: [
+            buildAddon({ id: 'journey', name: 'Journey', type: 'global', icon: 'Compass', enabled: journeyOn }),
+            buildAddon({ id: 'immich', name: 'Immich', description: 'Self-hosted photos', type: 'photo_provider', enabled: immichOn }),
+          ],
+        });
+      }),
+      http.put('/api/admin/addons/journey', async ({ request }) => {
+        journeyOn = (await request.json() as { enabled: boolean }).enabled;
+        // Journey off takes its providers with it, see admin.service.ts.
+        if (!journeyOn) immichOn = false;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    render(<><ToastContainer /><AddonManager /></>);
+    await screen.findByText('Immich');
+
+    await user.click(addonToggle('Journey'));
+    // The toast closes the whole toggle, re-read included.
+    await screen.findByText('Addon updated');
+    expect(loads).toBe(2);
+    expect(screen.queryByText('Immich')).not.toBeInTheDocument();
+
+    await user.click(addonToggle('Journey'));
+
+    await screen.findByText('Immich');
+    expect(isOn(subToggle('Immich'))).toBe(false);
+  });
+
+  it('FE-ADMIN-ADDON-032: a toggle the server does not cascade keeps the snapshot it has', async () => {
+    const user = userEvent.setup();
+    let loads = 0;
+    server.use(
+      http.get('/api/admin/addons', () => {
+        loads += 1;
+        return HttpResponse.json({ addons: [buildAddon({ id: 'todo', enabled: false })] });
+      }),
+      http.put('/api/admin/addons/todo', () => HttpResponse.json({ success: true })),
+    );
+    render(<><ToastContainer /><AddonManager /></>);
+    await screen.findByText('Todo List');
+
+    await user.click(addonToggle('Todo List'));
+
+    await screen.findByText('Addon updated');
+    expect(loads).toBe(1);
+    expect(isOn(addonToggle('Todo List'))).toBe(true);
+  });
+
   it('FE-ADMIN-ADDON-018: the collab sub-features render their state and report the toggled key', async () => {
     const user = userEvent.setup();
     const onToggleCollabFeature = vi.fn();

--- a/client/src/components/Admin/AddonManager.tsx
+++ b/client/src/components/Admin/AddonManager.tsx
@@ -92,18 +92,15 @@ export default function AddonManager({ bagTrackingEnabled, onToggleBagTracking, 
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    loadAddons()
+    loadAddons().finally(() => setLoading(false))
   }, [])
 
   const loadAddons = async () => {
-    setLoading(true)
     try {
       const data = await adminApi.addons()
       setAddons(data.addons)
     } catch (err: unknown) {
       toast.error(t('admin.addons.toast.error'))
-    } finally {
-      setLoading(false)
     }
   }
 
@@ -114,12 +111,17 @@ export default function AddonManager({ bagTrackingEnabled, onToggleBagTracking, 
     setAddons(prev => prev.map(a => a.id === addon.id ? { ...a, enabled: newEnabled } : a))
     try {
       await adminApi.updateAddon(addon.id, { enabled: newEnabled })
-      refreshGlobalAddons()
-      toast.success(t('admin.addons.toast.updated'))
     } catch (err: unknown) {
       setAddons(prev => prev.map(a => a.id === addon.id ? { ...a, enabled: !newEnabled } : a))
       toast.error(t('admin.addons.toast.error'))
+      return
     }
+    refreshGlobalAddons()
+    // Journey off disables every photo provider with it, and the response carries
+    // only Journey. Without re-reading, switching Journey back on brings the shelf
+    // up with providers the database has long since turned off.
+    if (addon.id === 'journey') await loadAddons()
+    toast.success(t('admin.addons.toast.updated'))
   }
 
   const isPhotoProviderAddon = (addon: Addon) => {

--- a/client/src/components/Admin/AdminPluginsPanel.test.tsx
+++ b/client/src/components/Admin/AdminPluginsPanel.test.tsx
@@ -858,6 +858,21 @@ describe('AdminPluginsPanel — row actions', () => {
     expect(screen.getByText('View error log')).toBeInTheDocument() // menu is open
     expect(screen.queryByText('Allowed hosts')).not.toBeInTheDocument()
   })
+
+  it('FE-COMP-PLUGINS-PANEL-050: a long host list scrolls inside the dialog instead of growing past the viewport (#2159)', async () => {
+    server.use(http.get('*/api/admin/plugins/trek-gotify/egress-hosts', () =>
+      HttpResponse.json({ supported: true, hosts: ['gotify.lan', 'ntfy.lan'] })))
+    await openRowMenu()
+
+    fireEvent.click(screen.getByText('Allowed hosts'))
+
+    // The card is capped and its body scrolls, so the input, the Add button and the
+    // restart note below the list stay reachable however many hosts the admin entered.
+    const body = (await screen.findByText('gotify.lan')).closest('.overflow-y-auto')
+    expect(body).not.toBeNull()
+    expect(body).toContainElement(screen.getByPlaceholderText('gotify.example.com'))
+    expect(body!.parentElement!.className).toContain('max-h-[88vh]')
+  })
 })
 
 describe('AdminPluginsPanel — enabling a plugin', () => {
@@ -1461,6 +1476,18 @@ describe('AdminPluginsPanel — Discover cards and the detail modal', () => {
     fireEvent.keyDown(card, { key: 'Enter' })
 
     expect(await screen.findByText('Could not load plugin details.')).toBeInTheDocument()
+  })
+
+  it('FE-COMP-PLUGINS-PANEL-041a: the card opts out of the global press-scale (#2158)', async () => {
+    // jsdom cannot replay the browser mechanics behind #2158: the :active scale on
+    // the card shifted the Install button out from under the pointer, so the click
+    // retargeted onto the card and opened the detail modal instead of installing.
+    // The data-no-press attribute is the pin.
+    discoverWith({})
+    render(<AdminPluginsPanel />)
+    await clickDiscover()
+
+    expect((await screen.findByText('Gotify')).closest('[role="button"]')).toHaveAttribute('data-no-press')
   })
 
   it('FE-COMP-PLUGINS-PANEL-042: the detail modal lists setup fields, metadata and a separate homepage', async () => {
@@ -2342,5 +2369,15 @@ describe('AdminPluginsPanel — instance settings', () => {
 
     expect(await screen.findByText('"Client ID" is required', {}, { timeout: 5000 })).toBeInTheDocument()
     expect(called).toBe(false)
+  })
+
+  it('FE-COMP-PLUGINS-CFG-012: Save paints its label with the accent-text token, so a light accent stays readable', async () => {
+    await openSettings()
+
+    // `--accent-text` flips per scheme and per light/dark; a hard white label vanishes on
+    // the near-white accent the dark theme uses by default.
+    const save = screen.getByRole('button', { name: /^save$/i })
+    expect(save.className).toContain('text-accent-text')
+    expect(save.className).not.toContain('text-white')
   })
 })

--- a/client/src/components/Admin/AdminPluginsPanel.tsx
+++ b/client/src/components/Admin/AdminPluginsPanel.tsx
@@ -1013,12 +1013,12 @@ export default function AdminPluginsPanel() {
       {/* Operator-supplied egress hosts */}
       {egressFor && (
         <div role="presentation" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={() => setEgressFor(null)}>
-          <div role="presentation" className="bg-surface-card border border-edge rounded-2xl w-full max-w-lg shadow-modal" onClick={e => e.stopPropagation()}>
-            <div className="px-5 py-3.5 border-b border-edge-secondary flex items-center justify-between">
+          <div role="presentation" className="bg-surface-card border border-edge rounded-2xl w-full max-w-lg max-h-[88vh] flex flex-col shadow-modal" onClick={e => e.stopPropagation()}>
+            <div className="shrink-0 px-5 py-3.5 border-b border-edge-secondary flex items-center justify-between">
               <span className="text-sm font-semibold text-content flex items-center gap-2"><Globe size={15} /> {egressFor.id} — {t('admin.plugins.allowedHosts')}</span>
               <button type="button" onClick={() => setEgressFor(null)} className="text-content-faint hover:text-content"><X size={16} /></button>
             </div>
-            <div className="p-5 space-y-3">
+            <div className="p-5 space-y-3 min-h-0 flex-1 overflow-y-auto">
               {!egressFor.supported ? (
                 <p className="text-sm text-content-faint">{t('admin.plugins.allowedHosts.unsupported')}</p>
               ) : (
@@ -1109,7 +1109,7 @@ export default function AdminPluginsPanel() {
               <button type="button"
                 disabled={settings.saving}
                 onClick={() => void settings.save()}
-                className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-accent-text disabled:opacity-60"
               >{t('common.save')}</button>
             </div>
           </div>
@@ -1506,6 +1506,10 @@ function RegistryGrid({ items, onInstall, onOpenDetail, busy, t, installedIds, f
         const offer = installOffer(item, t)
         return (
           <div key={item.id} role="button" tabIndex={0} onClick={() => onOpenDetail(item)}
+            // No press-scale on the card: shrinking it mid-click slides the Install
+            // button out from under the pointer, so the click retargets onto the card
+            // and opens the detail modal instead of installing (#2158).
+            data-no-press
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenDetail(item) } }}
             className="group border border-edge rounded-2xl bg-surface-card overflow-hidden flex flex-col cursor-pointer hover:-translate-y-0.5 hover:shadow-elevated hover:border-edge-faint transition-all duration-150">
             <div className="relative">

--- a/client/src/components/Budget/CostsPanel.helpers.ts
+++ b/client/src/components/Budget/CostsPanel.helpers.ts
@@ -11,6 +11,16 @@
  * Amounts are the raw input strings, parsed on use (same as customAmounts).
  */
 
+import { currencyDecimals } from '../../utils/formatters'
+
+// The split and receipt fields guard their own precision on every keystroke, so the
+// guard has to follow the currency: a three-decimal one (KWD, BHD, …) seeds three
+// places, and the old fixed two rejected every keystroke after that, leaving the field
+// unusable until a digit was deleted (#2175). Never stricter than two places, so no
+// value a field accepts today can become uneditable.
+export const amountPattern = (currency: string, signed: boolean) =>
+  new RegExp(`^${signed ? '-?' : ''}\\d*\\.?\\d{0,${Math.max(2, currencyDecimals(currency))}}$`)
+
 /**
  * Spread `amount` across `n` payers in whole cents so the parts sum back exactly.
  * Floor-based, so a negative total (a refund, #2176) splits just as exactly:

--- a/client/src/components/Budget/CostsPanel.test.tsx
+++ b/client/src/components/Budget/CostsPanel.test.tsx
@@ -1890,6 +1890,29 @@ describe('CostsPanel — decimal padding on edit (#2175)', () => {
     await user.click(screen.getAllByTitle('Edit')[1])
     expect(await screen.findByDisplayValue('5,00')).toBeInTheDocument()
   })
+
+  it('FE-W5COSTS-071: a three-decimal currency seeds three places and the split field still takes input', async () => {
+    const user = userEvent.setup()
+    render(<ExpenseModal tripId={1} base="KWD" people={tripMembers} me={1} onClose={() => {}} onSaved={vi.fn()}
+      editing={expense({
+        id: 340, name: 'Museum', category: 'activities', currency: 'KWD', total_price: 3,
+        payers: [{ user_id: 1, amount: 3 }],
+        members: [{ user_id: 1, username: 'alice', amount: 1.5 }, { user_id: 2, username: 'bob', amount: 1.5 }],
+      })} />)
+
+    expect(await screen.findByDisplayValue('3.000')).toBeInTheDocument()
+    const shares = screen.getAllByDisplayValue('1.500') as HTMLInputElement[]
+
+    // The seed is three decimals, so a two-decimal guard would reject every further
+    // keystroke, including one typed in front of the decimal point.
+    await user.type(shares[0], '2', { initialSelectionStart: 0, initialSelectionEnd: 0 })
+    expect(shares[0].value).toBe('21.500')
+
+    // A fourth decimal is still not a fils.
+    await user.clear(shares[1])
+    await user.type(shares[1], '1.5005')
+    expect(shares[1].value).toBe('1.500')
+  })
 })
 
 // ── #2176: negative amounts record partial reimbursements ───────────────────
@@ -1976,6 +1999,38 @@ describe('CostsPanel — negative amounts (#2176)', () => {
     // Food nets 90 − 30 = 60; the fully refunded tour keeps a row of its own.
     expect(within(breakdown).getByText('60 €')).toBeInTheDocument()
     expect(within(breakdown).getByText(/[-−]20\s*€/)).toBeInTheDocument()
+  })
+
+  it('FE-W5COSTS-072: the custom-split hint reads under and over the right way round on a refund', async () => {
+    const user = userEvent.setup()
+    render(<ExpenseModal tripId={1} base="EUR" people={tripMembers} me={1} onClose={() => {}} onSaved={vi.fn()}
+      editing={expense({
+        id: 341, name: 'Hotel refund', category: 'accommodation', total_price: -100,
+        payers: [{ user_id: 1, amount: -100 }],
+        members: [{ user_id: 1, username: 'alice', amount: -70 }, { user_id: 2, username: 'bob' }],
+      })} />)
+
+    // -70 of -100: 30 still to hand out, not 30 too much.
+    expect(await screen.findByText('Sum of splits: €-70.00 of €-100.00 (under by €30.00)')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('-30,00'), '-40')
+    expect(screen.getByText('Sum of splits: €-110.00 of €-100.00 (over by €10.00)')).toBeInTheDocument()
+  })
+
+  it('FE-W5COSTS-073: the total can be turned into a refund without a minus key', async () => {
+    const user = userEvent.setup()
+    render(<ExpenseModal tripId={1} base="EUR" people={tripMembers} me={1} editing={null}
+      onClose={() => {}} onSaved={vi.fn()} />)
+
+    const total = (await screen.findAllByPlaceholderText('0,00'))[0] as HTMLInputElement
+    await user.type(total, '100')
+
+    // The iOS decimal pad has no minus key, so the sign has to be reachable without one.
+    const toggle = screen.getByRole('button', { name: 'Switch between expense and refund' })
+    await user.click(toggle)
+
+    expect(total.value).toBe('-100')
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
   })
 })
 

--- a/client/src/components/Budget/CostsPanel.tsx
+++ b/client/src/components/Budget/CostsPanel.tsx
@@ -17,7 +17,7 @@ import CustomSelect from '../shared/CustomSelect'
 import { CustomDatePicker } from '../shared/CustomDateTimePicker'
 import { localToday } from '../Planner/today'
 import { SYMBOLS, currenciesWith, SPLIT_COLORS } from './BudgetPanel.constants'
-import { calculateTicketShares, hasTicketSplit, NOTE_MAX, payersBalanced, readTicketItems, readUserNote, rebalancePayers, splitEqualShares, writeTicketItems, type TicketItem } from './CostsPanel.helpers'
+import { amountPattern, calculateTicketShares, hasTicketSplit, NOTE_MAX, payersBalanced, readTicketItems, readUserNote, rebalancePayers, splitEqualShares, writeTicketItems, type TicketItem } from './CostsPanel.helpers'
 import { COST_CATEGORY_LIST, catMeta } from './costsCategories'
 import type { BudgetItem } from '../../types'
 import type { TripMember } from './BudgetPanelMemberChips'
@@ -1130,6 +1130,10 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
   const totalNum = isTicketMode ? ticketInfo.total : (Number.parseFloat(total) || 0)
   const splitSum = [...participants].reduce((sum, id) => sum + (Number.parseFloat(customAmounts[id]) || 0), 0)
   const customBalanced = Math.round(splitSum * 100) === Math.round(totalNum * 100)
+  // How much is still to be handed out, read on the total's own side: on a refund
+  // (#2176) the shares run negative, so a plain total minus sum flips under and
+  // over around and sends the user the wrong way.
+  const splitShortfall = totalNum < 0 ? splitSum - totalNum : totalNum - splitSum
   const each = participants.size > 0 ? totalNum / participants.size : 0
   const equalShares = useMemo(() => {
     return splitEqualShares(totalNum, [...participants].map(id => ({ user_id: id })), editing?.id || 0)
@@ -1212,7 +1216,7 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
 
   const handleCustomAmountChange = (id: number, val: string) => {
     val = val.replace(',', '.')
-    if (/^-?\d*\.?\d{0,2}$/.test(val) || val === '') {
+    if (val === '' || amountPattern(currency, true).test(val)) {
       setCustomAmounts(prev => ({ ...prev, [id]: val }))
     }
   }
@@ -1235,7 +1239,7 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
 
   const handleUpdateItemPrice = (id: string, price: string) => {
     price = price.replace(',', '.')
-    if (/^\d*\.?\d{0,2}$/.test(price) || price === '') {
+    if (price === '' || amountPattern(currency, false).test(price)) {
       setTicketItems(prev => prev.map(item => item.id === id ? { ...item, price } : item))
     }
   }
@@ -1352,6 +1356,7 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
             <span className="text-content-faint" style={{ fontSize: 'calc(15px * var(--fs-scale-subtitle, 1))' }}>{sym(currency)}</span>
             <NumericInput mode="signed-decimal" placeholder={localizeAmountInput('0.00', currency)} value={localizeAmountInput(isTicketMode ? ticketInfo.total.toFixed(2) : total, currency)}
               onValueChange={onTotalChange}
+              signToggleLabel={t('costs.toggleSign')}
               disabled={isTicketMode}
               className="text-content" style={{ flex: 1, border: 0, background: 'none', outline: 'none', fontSize: 'calc(15px * var(--fs-scale-subtitle, 1))', fontWeight: 600, paddingLeft: 6, width: '100%' }} />
           </div>
@@ -1607,7 +1612,7 @@ export function ExpenseModal({ tripId, base, people, me, editing, prefill, onClo
                   <span style={{ fontWeight: 600, color: customBalanced ? '#16a34a' : '#dc2626' }}>
                     {customBalanced
                       ? t('costs.splitBalanced')
-                      : t(totalNum - splitSum > 0 ? 'costs.splitSumUnder' : 'costs.splitSumOver', {
+                      : t(splitShortfall > 0 ? 'costs.splitSumUnder' : 'costs.splitSumOver', {
                           sum: sym(currency) + splitSum.toFixed(2),
                           total: sym(currency) + totalNum.toFixed(2),
                           diff: sym(currency) + Math.abs(totalNum - splitSum).toFixed(2),

--- a/client/src/components/Collab/CollabNotes.test.tsx
+++ b/client/src/components/Collab/CollabNotes.test.tsx
@@ -1327,6 +1327,14 @@ function wsHandler(): (msg: Record<string, unknown>) => void {
   return (addListener as ReturnType<typeof vi.fn>).mock.calls[0][0];
 }
 
+function openedNoteBody(): Promise<HTMLElement> {
+  return waitFor(() => {
+    const md = document.querySelector('.collab-note-md-full');
+    if (!md) throw new Error('view modal not open yet');
+    return md as HTMLElement;
+  });
+}
+
 describe('CollabNotes details', () => {
   let addToast: ReturnType<typeof vi.fn<AddToast>>;
   let filesChanged: number;
@@ -1911,5 +1919,32 @@ describe('CollabNotes details', () => {
     expect(screen.getByText('Manage Categories', { selector: 'h3' })).toBeInTheDocument();
     // …and both rejected writes are one message, not one each.
     expect(addToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('FE-W5CNT-033: a placeholder in angle brackets survives sanitizing', async () => {
+    const user = userEvent.setup();
+    serveNotes({ notes: [buildNote({ id: 7, title: 'Hotel', content: 'Zimmernummer <TBD> bestaetigen' })] });
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Hotel');
+    await user.click(screen.getByTitle('collab.notes.expand'));
+    const full = await openedNoteBody();
+    // Notes written before markdown rendering existed keep reading the way they
+    // were typed (#2177).
+    expect(within(full).getByText('Zimmernummer <TBD> bestaetigen')).toBeInTheDocument();
+  });
+
+  it('FE-W5CNT-034: a footnote reference lands on the footnote instead of a new tab', async () => {
+    const user = userEvent.setup();
+    serveNotes({ notes: [buildNote({ id: 8, title: 'Booking', content: 'Hotel gebucht[^1]\n\n[^1]: Bestaetigung ABC123' })] });
+    render(<CollabNotes {...defaultProps} />);
+    await screen.findByText('Booking');
+    await user.click(screen.getByTitle('collab.notes.expand'));
+    const full = await openedNoteBody();
+
+    const ref = within(full).getByRole('link', { name: '1' });
+    const href = ref.getAttribute('href')!;
+    expect(href.startsWith('#')).toBe(true);
+    expect(full.querySelector(`[id="${href.slice(1)}"]`)).not.toBeNull();
+    expect(ref).not.toHaveAttribute('target');
   });
 });

--- a/client/src/components/Collab/CollabNotes.tsx
+++ b/client/src/components/Collab/CollabNotes.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import rehypeSanitize from 'rehype-sanitize'
-import { markdownLinkComponents } from '../shared/markdownLink'
+import { sanitizedMarkdownComponents, sanitizedMarkdownPlugins } from '../shared/markdownSanitize'
 import { createPortal } from 'react-dom'
 import { Plus, Pencil, X, StickyNote, Settings } from 'lucide-react'
 import { collabApi } from '../../api/client'
@@ -447,7 +446,7 @@ function ViewNoteModal(S: NotesState) {
           </div>
         </div>
         <div className="collab-note-md-full" style={{ padding: '16px 20px', overflowY: 'auto', fontSize: 'calc(14px * var(--fs-scale-body, 1))', color: 'var(--text-primary)', lineHeight: 1.7 }}>
-          <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownLinkComponents}>{viewingNote.content || ''}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={sanitizedMarkdownComponents}>{viewingNote.content || ''}</Markdown>
           {(viewingNote.attachments || []).length > 0 && (
             <div style={{ marginTop: 16, paddingTop: 16, borderTop: '1px solid var(--border-primary)' }}>
               <div style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', fontWeight: 600, color: 'var(--text-faint)', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 10 }}>{t('files.title')}</div>

--- a/client/src/components/Collab/CollabNotesCard.tsx
+++ b/client/src/components/Collab/CollabNotesCard.tsx
@@ -3,8 +3,7 @@ import { avatarSrc } from '../../utils/avatarSrc'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import rehypeSanitize from 'rehype-sanitize'
-import { markdownLinkComponents } from '../shared/markdownLink'
+import { sanitizedMarkdownPlugins, sanitizedMarkdownComponents } from '../shared/markdownSanitize'
 import { Trash2, Pin, PinOff, Pencil, Maximize2 } from 'lucide-react'
 import { FONT } from './CollabNotes.constants'
 import { AuthedImg } from './CollabNotesAuthedImg'
@@ -144,7 +143,7 @@ export function NoteCard({ note, currentUser, canEdit, onUpdate, onDelete, onEdi
                 maxHeight: '4.5em', overflow: 'hidden',
                 wordBreak: 'break-word', fontFamily: FONT,
               }}>
-                <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownLinkComponents}>{note.content}</Markdown>
+                <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={sanitizedMarkdownComponents}>{note.content}</Markdown>
               </div>
             )}
           </div>

--- a/client/src/components/Collab/CollabPolls.test.tsx
+++ b/client/src/components/Collab/CollabPolls.test.tsx
@@ -851,4 +851,27 @@ describe('CollabPolls markdown & multiline', () => {
     expect(label.style.overflowWrap).toBe('anywhere');
     expect(label.style.minWidth).toBe('0px');
   });
+
+  it('FE-COMP-POLLS-023: a placeholder in angle brackets survives sanitizing', async () => {
+    server.use(
+      http.get('/api/trips/1/collab/polls', () =>
+        HttpResponse.json({ polls: [buildPoll({ question: 'Treffpunkt <noch offen> oder Hotel?' })] }),
+      ),
+    );
+    render(<CollabPolls {...defaultProps} />);
+    // Questions written before markdown rendering existed must keep reading the
+    // way they were typed, and they cannot be edited afterwards (#2177).
+    expect(await screen.findByText('Treffpunkt <noch offen> oder Hotel?')).toBeInTheDocument();
+  });
+
+  it('FE-COMP-POLLS-024: a script tag is shown as text, never as an element', async () => {
+    server.use(
+      http.get('/api/trips/1/collab/polls', () =>
+        HttpResponse.json({ polls: [buildPoll({ question: 'Plan <script>alert("xss")</script>' })] }),
+      ),
+    );
+    render(<CollabPolls {...defaultProps} />);
+    expect(await screen.findByText('Plan <script>alert("xss")</script>')).toBeInTheDocument();
+    expect(document.querySelector('script')).toBeNull();
+  });
 });

--- a/client/src/components/Collab/CollabPolls.tsx
+++ b/client/src/components/Collab/CollabPolls.tsx
@@ -3,8 +3,7 @@ import { Plus, Trash2, X, Check, BarChart3, Lock, Clock } from 'lucide-react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import rehypeSanitize from 'rehype-sanitize'
-import { markdownLinkComponents } from '../shared/markdownLink'
+import { sanitizedMarkdownComponents, sanitizedMarkdownPlugins } from '../shared/markdownSanitize'
 import { collabApi } from '../../api/client'
 import { addListener, removeListener } from '../../api/websocket'
 import { useTranslation } from '../../i18n'
@@ -43,10 +42,11 @@ const FONT = "var(--font-system)"
 // Block styling for the markdown question (#2177). Tailwind's preflight resets
 // headings/lists, so the sizes are set here — in em, on purpose: they scale with
 // the surrounding calc(13px * var(--fs-scale-body)) base, so the user's
-// text-size setting keeps working. Links come from markdownLinkComponents
-// (#1629): new tab plus rel protection, this is cross-user content.
+// text-size setting keeps working. Links and sanitizing come from
+// markdownSanitize (#1629): new tab plus rel protection, this is cross-user
+// content.
 const pollMarkdownComponents: Components = {
-  ...markdownLinkComponents,
+  ...sanitizedMarkdownComponents,
   p: ({ children }) => (
     <p style={{ margin: '0 0 0.55em' }}>{children}</p>
   ),
@@ -256,7 +256,7 @@ function PollCard({ poll, currentUser, canEdit, onVote, onClose, onDelete, t }: 
       }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 'calc(13px * var(--fs-scale-body, 1))', fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.35, wordBreak: 'break-word' }}>
-            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={pollMarkdownComponents}>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={pollMarkdownComponents}>
               {poll.question}
             </ReactMarkdown>
           </div>

--- a/client/src/components/Collections/CollectionList.test.tsx
+++ b/client/src/components/Collections/CollectionList.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-COLLIST-001 to FE-COMP-COLLIST-010
+// FE-COMP-COLLIST-001 to FE-COMP-COLLIST-011
 import { render, screen } from '../../../tests/helpers/render';
 import userEvent from '@testing-library/user-event';
 import type { CollectionPlace } from '@trek/shared';
@@ -156,5 +156,15 @@ describe('CollectionList', () => {
     // but every place name must sit inside a .col-lrow row element.
     expect(screen.getByText('Blue Bottle Coffee').closest('.col-lrow')).toBeInTheDocument();
     expect(screen.getByText('Golden Gate Bridge').closest('.col-lrow')).toBeInTheDocument();
+  });
+
+  it('FE-COMP-COLLIST-011: the row opts out of the global press-scale (#2158)', () => {
+    // jsdom cannot replay the browser mechanics behind #2158: the :active scale on
+    // the row-wide role="button" shifted the status badge out from under the pointer,
+    // so the click retargeted onto the row and opened the place instead of cycling the
+    // status. The data-no-press attribute is the pin.
+    renderList();
+
+    expect(screen.getByText('Blue Bottle Coffee').closest('.col-lrow')).toHaveAttribute('data-no-press');
   });
 });

--- a/client/src/components/Collections/CollectionList.tsx
+++ b/client/src/components/Collections/CollectionList.tsx
@@ -44,6 +44,10 @@ export default function CollectionList({
             key={place.id}
             ref={active ? selectedRef : undefined}
             role="button"
+            // Opt out of the global :active press-scale: shrinking the row-wide button
+            // slides the status badge out from under the pointer mid-click, so the click
+            // retargets onto the row and opens the place instead of cycling (#2158).
+            data-no-press
             tabIndex={0}
             onClick={() => (selectMode ? onToggleSelect(place.id) : onOpenPlace(place.id))}
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (selectMode) onToggleSelect(place.id); else onOpenPlace(place.id) } }}

--- a/client/src/components/Journey/JourneyDetailPageGalleryView.test.tsx
+++ b/client/src/components/Journey/JourneyDetailPageGalleryView.test.tsx
@@ -1,4 +1,4 @@
-// FE-JRN-GALLERY-001 to FE-JRN-GALLERY-016
+// FE-JRN-GALLERY-001 to FE-JRN-GALLERY-019
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { act, useRef, useState } from 'react'
@@ -372,5 +372,15 @@ describe('GalleryView', () => {
     const { container } = mountGallery([buildGalleryPhoto(), buildGalleryPhoto({ id: 101, photo_id: 101 })])
     expect(container.querySelectorAll('.aspect-square')).toHaveLength(2)
     expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('FE-JRN-GALLERY-019: the tile opts out of the global press-scale (#2158)', () => {
+    // jsdom cannot replay the browser mechanics behind #2158: the :active scale on
+    // the tile shifted its corner delete button out from under the pointer, so the
+    // click retargeted onto the tile and opened the lightbox instead of deleting.
+    // The data-no-press attribute is the pin.
+    const { container } = mountGallery([buildGalleryPhoto()])
+
+    expect(container.querySelector('.aspect-square')).toHaveAttribute('data-no-press')
   })
 })

--- a/client/src/components/Journey/JourneyDetailPageGalleryView.tsx
+++ b/client/src/components/Journey/JourneyDetailPageGalleryView.tsx
@@ -142,6 +142,10 @@ export function GalleryView({ entries, gallery, journeyId, userId, trips, onPhot
             <div
               key={photo.id}
               role="button"
+              // No press-scale on the tile: shrinking it mid-click slides the corner
+              // delete button out from under the pointer, so the click retargets onto
+              // the tile and opens the lightbox instead (#2158).
+              data-no-press
               tabIndex={0}
               className="relative aspect-square rounded-lg overflow-hidden cursor-pointer group"
               onClick={() => onPhotoClick(allPhotos, i)}

--- a/client/src/components/Journey/JourneyMap.test.tsx
+++ b/client/src/components/Journey/JourneyMap.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-JOURNEYMAP-001 to FE-COMP-JOURNEYMAP-027
+// FE-COMP-JOURNEYMAP-001 to FE-COMP-JOURNEYMAP-049
 
 vi.mock('../../api/websocket', () => ({
   connect: vi.fn(),
@@ -602,6 +602,39 @@ describe('JourneyMap', () => {
     const colors = vi.mocked(L.polyline).mock.calls.map(c => (c[1] as any)?.color);
     expect(colors).not.toContain('#ff0000');
     expect(colors).not.toContain('#ffffff');
+  });
+
+  /** The opening viewport is the assertion here, so the frame gets read out of the bounds call. */
+  const fitCoords = () => vi.mocked(L.latLngBounds).mock.calls[0][0] as [number, number][];
+
+  // #2194: a recorded drive across the country used to pull the opening view out to
+  // the whole trip, leaving the journey's own entries as a speck.
+  it('FE-COMP-JOURNEYMAP-048: frames the entries, not the tracks, when the journey has both', () => {
+    const origRAF = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
+    try {
+      render(
+        <JourneyMap checkins={[]} entries={entriesWithCoords} tracks={[track({ points: [[10, 10], [11, 11]] })]} />
+      );
+
+      expect(mockedMap().fitBounds).toHaveBeenCalled();
+      expect(fitCoords()).toEqual([[48.8566, 2.3522], [52.52, 13.405]]);
+    } finally {
+      globalThis.requestAnimationFrame = origRAF;
+    }
+  });
+
+  it('FE-COMP-JOURNEYMAP-049: with nothing else on the map the tracks are framed instead of the world', () => {
+    const origRAF = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
+    try {
+      render(<JourneyMap checkins={[]} entries={entriesWithoutCoords} tracks={[track()]} />);
+
+      expect(fitCoords()).toEqual([[47.1, 11.2], [47.2, 11.3]]);
+      expect(mockedMap().setView).not.toHaveBeenCalledWith([30, 0], 2);
+    } finally {
+      globalThis.requestAnimationFrame = origRAF;
+    }
   });
 
   // A string handed to bindTooltip becomes innerHTML. A track name is a place

--- a/client/src/components/Map/LocationButton.test.tsx
+++ b/client/src/components/Map/LocationButton.test.tsx
@@ -1,4 +1,4 @@
-// FE-MAP-LOCBTN-001 to FE-MAP-LOCBTN-004
+// FE-MAP-LOCBTN-001 to FE-MAP-LOCBTN-005
 import { render } from '@testing-library/react';
 import LocationButton from './LocationButton';
 import type { GeoWatchErrorCode } from '../../hooks/useGeolocation';
@@ -65,5 +65,12 @@ describe('LocationButton', () => {
     rerender(button('timeout'));
     expect(addToast).toHaveBeenCalledTimes(2);
     expect(addToast).toHaveBeenLastCalledWith('map.location.timeout', 'error', 6000);
+  });
+
+  it('FE-MAP-LOCBTN-005: an insecure origin gets the HTTPS hint, not the permission one', () => {
+    const { getByRole } = render(button('insecure-context', 'Only secure origins are allowed'));
+
+    expect(addToast).toHaveBeenCalledWith('journey.editor.locationInsecureContext', 'error', 6000);
+    expect(getByRole('button').getAttribute('title')).toBe('journey.editor.locationInsecureContext');
   });
 });

--- a/client/src/components/Map/LocationButton.tsx
+++ b/client/src/components/Map/LocationButton.tsx
@@ -17,11 +17,14 @@ interface Props {
 // The raw error string from the browser is unlocalized WebKit English, so the
 // user-facing message is looked up from the typed code instead. 'unsupported'
 // shares the generic text: a browser without geolocation cannot locate you.
+// 'insecure-context' borrows the journal editor's wording, which already says
+// exactly this in all locales.
 const ERROR_KEYS: Record<GeoWatchErrorCode, string> = {
   'permission-denied': 'map.location.denied',
   'unavailable': 'map.location.unavailable',
   'timeout': 'map.location.timeout',
   'unsupported': 'map.location.unavailable',
+  'insecure-context': 'journey.editor.locationInsecureContext',
 }
 
 // Three-state FAB. Matches the Apple/Google Maps pattern:

--- a/client/src/components/Packing/useBagTotalsPing.test.tsx
+++ b/client/src/components/Packing/useBagTotalsPing.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-BAGPING-001 to FE-COMP-BAGPING-006
+// FE-COMP-BAGPING-001 to FE-COMP-BAGPING-009
 
 /**
  * The bag-totals ping listener (#2191).
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBagTotalsPing } from './useBagTotalsPing'
+import { setForcedOffline, _resetNetworkMode } from '../../sync/networkMode'
 
 const listeners = new Set<(e: Record<string, unknown>) => void>()
 
@@ -33,10 +34,12 @@ async function flushCoalesce(): Promise<void> {
 
 beforeEach(() => {
   listeners.clear()
+  _resetNetworkMode()
   vi.useFakeTimers()
 })
 
 afterEach(() => {
+  setForcedOffline(false)
   vi.useRealTimers()
 })
 
@@ -116,6 +119,46 @@ describe('useBagTotalsPing', () => {
     await flushCoalesce()
 
     expect(listeners.size).toBe(0)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('FE-COMP-BAGPING-007: reloads when the socket re-joins the room', async () => {
+    // A ping sent while the socket was down is gone for good (a container
+    // restart, a tunnel that dropped), and bags have no offline cache to catch
+    // up from. The re-join is the only notice this client gets.
+    const reload = vi.fn(async () => {})
+    renderHook(() => useBagTotalsPing(true, reload))
+
+    act(() => emit('joined'))
+    await flushCoalesce()
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('FE-COMP-BAGPING-008: reloads on the way back online, not on the way out', async () => {
+    const reload = vi.fn(async () => {})
+    renderHook(() => useBagTotalsPing(true, reload))
+
+    act(() => setForcedOffline(true))
+    await flushCoalesce()
+    expect(reload).not.toHaveBeenCalled()
+
+    // Going online is where the surfaces stop summing locally and show the
+    // server totals again, so those totals had better not be the pre-outage ones.
+    act(() => setForcedOffline(false))
+    await flushCoalesce()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('FE-COMP-BAGPING-009: stops watching the network mode after unmount', async () => {
+    const reload = vi.fn(async () => {})
+    const { unmount } = renderHook(() => useBagTotalsPing(true, reload))
+
+    act(() => setForcedOffline(true))
+    unmount()
+    act(() => setForcedOffline(false))
+    await flushCoalesce()
+
     expect(reload).not.toHaveBeenCalled()
   })
 })

--- a/client/src/components/Packing/useBagTotalsPing.ts
+++ b/client/src/components/Packing/useBagTotalsPing.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { addListener, removeListener } from '../../api/websocket'
+import { isEffectivelyOnline, onNetworkModeChange } from '../../sync/networkMode'
 
 /**
  * How long pings are collected before one refetch goes out.
@@ -20,6 +21,11 @@ const COALESCE_MS = 250
  * requests overlap — the server pings the whole room, the originating socket
  * included, so a busy trip would otherwise have every client refetching once
  * per written item.
+ *
+ * A ping sent while this client is disconnected is gone for good, and bags have
+ * no offline cache to sync back, so the two moments where that can have happened
+ * count as pings of their own: the room re-join after a reconnect, and the
+ * return to online.
  *
  * `reload` may change identity every render; the latest one is always used.
  */
@@ -51,8 +57,7 @@ export function useBagTotalsPing(enabled: boolean, reload: () => Promise<void>):
       })
     }
 
-    const handler = (event: Record<string, unknown>) => {
-      if (event.type !== 'packing:bag-totals') return
+    const schedule = (): void => {
       if (timer) return // already collecting this burst
       timer = setTimeout(() => {
         timer = null
@@ -60,10 +65,29 @@ export function useBagTotalsPing(enabled: boolean, reload: () => Promise<void>):
       }, COALESCE_MS)
     }
 
+    const handler = (event: Record<string, unknown>) => {
+      // 'joined' is the room re-join the socket sends on every reconnect, so it
+      // is also the moment the totals on screen are the ones from before the
+      // drop: whatever moved them in the meantime pinged into a closed socket.
+      if (event.type !== 'packing:bag-totals' && event.type !== 'joined') return
+      schedule()
+    }
+
+    let wasOnline = isEffectivelyOnline()
+    const onMode = (): void => {
+      const online = isEffectivelyOnline()
+      // Only the way back matters: that is when the surfaces stop summing what
+      // this client can see and go back to trusting the server numbers.
+      if (online && !wasOnline) schedule()
+      wasOnline = online
+    }
+
     addListener(handler)
+    const unsubscribeMode = onNetworkModeChange(onMode)
     return () => {
       cancelled = true
       removeListener(handler)
+      unsubscribeMode()
       if (timer) clearTimeout(timer)
     }
   }, [enabled])

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -978,7 +978,11 @@ function useDayPlanSidebar(props: DayPlanSidebarProps) {
     // hotel, or — on a transfer day — a run from the hotel you leave to the one you arrive at.
     const day = days.find(d => d.id === dayId)
     const anchors = day && useSettingsStore.getState().settings.optimize_from_accommodation !== false
-      ? getAccommodationAnchors(day, days, accommodations)
+      ? getAccommodationAnchors(
+          day, days, accommodations,
+          unlockedWithCoords.map(a => ({ lat: a.place!.lat!, lng: a.place!.lng! })),
+          (mergedItemsMap[dayId] || []).some(i => i.type === 'transport' && hasCarrierEndpointOnDay(i.data, dayId)),
+        )
       : {}
     const optimizedAssignments = unlockedWithCoords.length >= 2
       ? optimizeRoute(unlockedWithCoords.map(a => ({ ...a.place, _assignmentId: a.id })), anchors).map(p => unlockedWithCoords.find(a => a.id === p._assignmentId)).filter(Boolean)

--- a/client/src/components/Studio/StudioShell.tsx
+++ b/client/src/components/Studio/StudioShell.tsx
@@ -18,6 +18,7 @@ import { PeerBadges } from './PeerBadges'
 import { TrimField } from './TrimField'
 import '../../styles/dashboard.css'
 import '../../styles/studio.css'
+import './bookFontFaces'
 
 /**
  * The Studio shell: top bar, page rail, workbench, inspector.

--- a/client/src/components/Studio/bookFontFaces.ts
+++ b/client/src/components/Studio/bookFontFaces.ts
@@ -1,0 +1,43 @@
+/**
+ * The @font-face rules behind the book's typefaces.
+ *
+ * bookFonts.ts names the seven families; this is where the faces they need
+ * arrive. Poppins comes with the app chrome in main.tsx and is not repeated
+ * here, and neither are MuseoModerno's 400 and 700: importing a face twice only
+ * duplicates every rule. Its 500 and 600 are the book's alone, which is why
+ * they are down here rather than up there.
+ *
+ * Pulled in by StudioShell rather than by main.tsx: nothing outside the editor
+ * is set in Lora or Bebas Neue, so the faces travel with the Studio chunk and
+ * cost the app's first paint nothing. Once that chunk is loaded they are
+ * ordinary stylesheets on the document, which is what lets printSheets copy
+ * them into the print frame with everything else.
+ *
+ * Upright only, as everywhere else in the app: the editor's italic toggle has
+ * always been the browser's synthetic slant, and a second file per weight is a
+ * lot of download to change that.
+ */
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+
+import '@fontsource/lora/400.css'
+import '@fontsource/lora/500.css'
+import '@fontsource/lora/600.css'
+import '@fontsource/lora/700.css'
+
+import '@fontsource/eb-garamond/400.css'
+import '@fontsource/eb-garamond/500.css'
+import '@fontsource/eb-garamond/600.css'
+import '@fontsource/eb-garamond/700.css'
+
+import '@fontsource/playfair-display/400.css'
+import '@fontsource/playfair-display/500.css'
+import '@fontsource/playfair-display/600.css'
+import '@fontsource/playfair-display/700.css'
+
+import '@fontsource/museomoderno/500.css'
+import '@fontsource/museomoderno/600.css'
+
+import '@fontsource/bebas-neue/400.css'

--- a/client/src/components/Studio/bookFonts.ts
+++ b/client/src/components/Studio/bookFonts.ts
@@ -13,6 +13,10 @@
  * every stack ends in a generic rather than in another named font nobody
  * shipped. What the editor draws is what the renderer has.
  *
+ * The faces themselves are loaded next door in bookFontFaces.ts. A family named
+ * here and not imported there falls back to exactly the system font this file
+ * was written against, which is how five of the seven shipped (#2183).
+ *
  * ── Why these seven ───────────────────────────────────────────────────────
  *
  * A photo book needs more than one voice and fewer than a menu. Two workhorse

--- a/client/src/components/Vacay/VacaySharedCalendars.test.tsx
+++ b/client/src/components/Vacay/VacaySharedCalendars.test.tsx
@@ -141,4 +141,15 @@ describe('VacaySharedCalendars', () => {
 
     expect(shareWithMock).toHaveBeenCalledWith(2)
   })
+
+  it('FE-COMP-VACAYSHARED-008: Incoming row opts out of the global press-scale (#2158)', () => {
+    // jsdom cannot replay the browser mechanics behind #2158: the :active scale on
+    // the row shifted the remove X out from under the pointer, so the click retargeted
+    // onto the row and only toggled visibility. The data-no-press attribute is the pin.
+    seedShares({ incomingShares: [incoming] })
+
+    render(<VacaySharedCalendars />)
+
+    expect(screen.getByText('Carol').closest('[role="button"]')).toHaveAttribute('data-no-press')
+  })
 })

--- a/client/src/components/Vacay/VacaySharedCalendars.tsx
+++ b/client/src/components/Vacay/VacaySharedCalendars.tsx
@@ -78,6 +78,10 @@ export default function VacaySharedCalendars() {
           {incomingShares.map(s => (
             <div key={s.id}
               role="button"
+              // No press-scale on the row: shrinking it mid-click slides the remove X
+              // out from under the pointer, so the click retargets onto the row and
+              // toggles visibility instead of removing the share (#2158).
+              data-no-press
               tabIndex={0}
               onClick={() => handleToggleHidden(s.id, !s.hidden)}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleToggleHidden(s.id, !s.hidden) } }}

--- a/client/src/components/Weather/WeatherWidget.test.tsx
+++ b/client/src/components/Weather/WeatherWidget.test.tsx
@@ -208,4 +208,45 @@ describe('WeatherWidget', () => {
     expect(weatherApi.get).toHaveBeenCalledWith(48.86, 2.35, '2025-06-01', 'de')
     expect(sessionStorage.getItem('weather_48.86_2.35_2025-06-01_de')).not.toBeNull()
   })
+
+  // The day-local anchor (#2167) moves whenever the day is edited, so a single
+  // failed lookup must not keep the badge on the dash for the widget's lifetime.
+  it('FE-COMP-WEATHERWIDGET-016: clears the error dash once a new anchor resolves', async () => {
+    vi.mocked(weatherApi.get).mockRejectedValueOnce(new Error('Network error'))
+    vi.mocked(weatherApi.get).mockResolvedValue(buildWeather({ temp: 21 }))
+    useSettingsStore.setState({ settings: { ...useSettingsStore.getState().settings, temperature_unit: 'celsius' } })
+
+    const { rerender } = render(<WeatherWidget lat={48.86} lng={2.35} date="2025-06-01" />)
+    await waitFor(() => {
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    rerender(<WeatherWidget lat={41.9} lng={12.5} date="2025-06-01" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('21°C')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+  })
+
+  it('FE-COMP-WEATHERWIDGET-017: clears the error dash when the new anchor comes from cache', async () => {
+    vi.mocked(weatherApi.get).mockRejectedValue(new Error('Network error'))
+    sessionStorage.setItem(
+      'weather_41.9_12.5_2025-06-01_en',
+      JSON.stringify({ data: buildWeather({ temp: 24 }), fetchedAt: Date.now() }),
+    )
+    useSettingsStore.setState({ settings: { ...useSettingsStore.getState().settings, temperature_unit: 'celsius' } })
+
+    const { rerender } = render(<WeatherWidget lat={48.86} lng={2.35} date="2025-06-01" />)
+    await waitFor(() => {
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    rerender(<WeatherWidget lat={41.9} lng={12.5} date="2025-06-01" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('24°C')).toBeInTheDocument()
+    })
+    expect(weatherApi.get).toHaveBeenCalledTimes(1)
+  })
 })

--- a/client/src/components/Weather/WeatherWidget.tsx
+++ b/client/src/components/Weather/WeatherWidget.tsx
@@ -63,6 +63,10 @@ export default function WeatherWidget({ lat, lng, date, compact = false, stacked
   useEffect(() => {
     if (!lat || !lng || !date) return
     let cancelled = false
+    // Every anchor, date or language change is a fresh attempt, so a failure from
+    // the previous one must not outlive it. Since #2167 the anchor is day-local and
+    // moves with each edit, which would otherwise pin the badge on the error dash.
+    setFailed(false)
     const rLat = Math.round(lat * 100) / 100
     const rLng = Math.round(lng * 100) / 100
     // The language is part of the key: descriptions come back localized, and the

--- a/client/src/components/shared/NumericInput.test.tsx
+++ b/client/src/components/shared/NumericInput.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-NUMINPUT-001 to FE-COMP-NUMINPUT-008
+// FE-COMP-NUMINPUT-001 to FE-COMP-NUMINPUT-014
 //
 // #1513: tapping a pre-populated numeric field put the caret at the end, so the first
 // digit typed was appended rather than replacing the value — quantity 1 + "6" = "16".
@@ -16,9 +16,9 @@ beforeEach(() => {
 })
 afterEach(() => vi.unstubAllGlobals())
 
-function Harness({ initial, mode }: { initial: string; mode?: NumericMode }) {
+function Harness({ initial, mode, signToggleLabel }: { initial: string; mode?: NumericMode; signToggleLabel?: string }) {
   const [v, setV] = useState(initial)
-  return <NumericInput value={v} onValueChange={setV} mode={mode} aria-label="field" />
+  return <NumericInput value={v} onValueChange={setV} mode={mode} signToggleLabel={signToggleLabel} aria-label="field" />
 }
 
 describe('NumericInput', () => {
@@ -113,6 +113,47 @@ describe('NumericInput', () => {
   it('FE-COMP-NUMINPUT-011: signed-decimal mode uses the decimal keypad', () => {
     render(<Harness initial="" mode="signed-decimal" />)
     expect((screen.getByLabelText('field') as HTMLInputElement).inputMode).toBe('decimal')
+  })
+
+  it('FE-COMP-NUMINPUT-012: the sign toggle flips the sign of what is already there (#2176)', () => {
+    // iOS renders inputMode="decimal" as a pad of digits, separator and backspace, with
+    // no minus key, so a refund is untypeable on a phone without this button.
+    render(<Harness initial="" mode="signed-decimal" signToggleLabel="Toggle sign" />)
+    const input = screen.getByLabelText('field') as HTMLInputElement
+    const toggle = screen.getByRole('button', { name: 'Toggle sign' })
+
+    fireEvent.change(input, { target: { value: '12,50' } })
+    fireEvent.click(toggle)
+    expect(input.value).toBe('-12,50')
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(toggle)
+    expect(input.value).toBe('12,50')
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // The button must not take the focus, or the phone keypad closes mid-entry.
+    expect(fireEvent.mouseDown(toggle)).toBe(false)
+  })
+
+  it('FE-COMP-NUMINPUT-013: an empty field toggles to a bare minus so the digits follow', () => {
+    render(<Harness initial="" mode="signed-decimal" signToggleLabel="Toggle sign" />)
+    const input = screen.getByLabelText('field') as HTMLInputElement
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle sign' }))
+    expect(input.value).toBe('-')
+
+    // The caret stays in the field, so the next keystroke appends to the sign.
+    fireEvent.change(input, { target: { value: '-1' } })
+    expect(input.value).toBe('-1')
+  })
+
+  it('FE-COMP-NUMINPUT-014: there is no toggle without a label, and none on an unsigned field', () => {
+    const { unmount } = render(<Harness initial="" mode="signed-decimal" />)
+    expect(screen.queryByRole('button')).toBeNull()
+    unmount()
+
+    render(<Harness initial="" mode="decimal" signToggleLabel="Toggle sign" />)
+    expect(screen.queryByRole('button')).toBeNull()
   })
 
   it('FE-COMP-NUMINPUT-009: typing inside the one-frame window is not swallowed by the deferred select', async () => {

--- a/client/src/components/shared/NumericInput.tsx
+++ b/client/src/components/shared/NumericInput.tsx
@@ -24,6 +24,8 @@ const SANITIZERS: Record<NumericMode, (raw: string) => string> = {
   },
 }
 
+const flipSign = (raw: string) => (raw.startsWith('-') ? raw.slice(1) : `-${raw}`)
+
 type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | 'value'> & {
   value: string | number | null | undefined
   /** Receives the sanitized raw string. Callers keep their own state and commit logic. */
@@ -31,6 +33,13 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | '
   mode?: NumericMode
   /** Escape hatch for a field that must not steal the caret (none today). */
   selectOnFocus?: boolean
+  /**
+   * Accessible name for a sign toggle rendered beside the field. Set it on a signed
+   * money field: iOS draws inputMode="decimal" as a pad with digits, separator and
+   * backspace only, so a refund (#2176) has no minus key to type. Ignored on the
+   * unsigned modes, where there is no sign to flip.
+   */
+  signToggleLabel?: string
   ref?: Ref<HTMLInputElement>
 }
 
@@ -62,34 +71,54 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | '
  * others on blur. This owns only the part that was uniformly broken.
  */
 export function NumericInput({
-  value, onValueChange, mode = 'integer', selectOnFocus = true, onFocus, inputMode, ref, ...rest
+  value, onValueChange, mode = 'integer', selectOnFocus = true, onFocus, inputMode, signToggleLabel, ref, ...rest
 }: Props) {
   // Set while a deferred select() is queued; any input in that window cancels it.
   const selectPending = useRef(false)
+  const raw = String(value ?? '')
+  const signable = mode === 'signed' || mode === 'signed-decimal'
 
   return (
-    <input
-      {...rest}
-      ref={ref}
-      type="text"
-      inputMode={inputMode ?? (mode === 'integer' ? 'numeric' : 'decimal')}
-      value={value ?? ''}
-      onChange={e => {
-        selectPending.current = false
-        onValueChange(SANITIZERS[mode](e.target.value))
-      }}
-      onFocus={e => {
-        if (selectOnFocus) {
-          const el = e.currentTarget
-          el.select()
-          selectPending.current = true
-          requestAnimationFrame(() => {
-            if (selectPending.current && document.activeElement === el) el.select()
-            selectPending.current = false
-          })
-        }
-        onFocus?.(e)
-      }}
-    />
+    <>
+      <input
+        {...rest}
+        ref={ref}
+        type="text"
+        inputMode={inputMode ?? (mode === 'integer' ? 'numeric' : 'decimal')}
+        value={value ?? ''}
+        onChange={e => {
+          selectPending.current = false
+          onValueChange(SANITIZERS[mode](e.target.value))
+        }}
+        onFocus={e => {
+          if (selectOnFocus) {
+            const el = e.currentTarget
+            el.select()
+            selectPending.current = true
+            requestAnimationFrame(() => {
+              if (selectPending.current && document.activeElement === el) el.select()
+              selectPending.current = false
+            })
+          }
+          onFocus?.(e)
+        }}
+      />
+      {signToggleLabel && signable && (
+        <button
+          type="button"
+          aria-label={signToggleLabel}
+          aria-pressed={raw.startsWith('-')}
+          disabled={rest.disabled}
+          // Keeps the caret (and on a phone the keypad) in the field, so the sign can
+          // be flipped mid-entry and typing carries on where it left off.
+          onMouseDown={e => e.preventDefault()}
+          onClick={() => onValueChange(SANITIZERS[mode](flipSign(raw)))}
+          className="text-content-faint"
+          style={{ border: 0, background: 'none', padding: '0 2px', font: 'inherit', lineHeight: 1, cursor: 'pointer' }}
+        >
+          ±
+        </button>
+      )}
+    </>
   )
 }

--- a/client/src/components/shared/markdownSanitize.tsx
+++ b/client/src/components/shared/markdownSanitize.tsx
@@ -1,0 +1,51 @@
+import type { Components, Options } from 'react-markdown'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+
+type HastNode = { type: string; children?: HastNode[] }
+
+/**
+ * react-markdown never builds an element out of raw HTML, it shows the markup
+ * verbatim instead. It does that after the rehype plugins ran, though, so the
+ * sanitizer gets the raw nodes first and drops them without a trace: a note
+ * reading "Zimmernummer <TBD>" loses the placeholder on screen while the stored
+ * text still has it (#2177). Turning raw into text up front keeps it readable
+ * and still yields no element.
+ */
+function rehypeRawAsText() {
+  return (tree: HastNode) => {
+    const walk = (node: HastNode) => {
+      if (node.type === 'raw') node.type = 'text'
+      for (const child of node.children || []) walk(child)
+    }
+    walk(tree)
+  }
+}
+
+// remark-gfm already writes footnote ids with the `user-content-` prefix, and
+// the hrefs pointing at them carry it too. Clobbering them a second time only
+// makes target and reference disagree.
+const schema = { ...defaultSchema, clobberPrefix: '' }
+
+export const sanitizedMarkdownPlugins: NonNullable<Options['rehypePlugins']> = [
+  rehypeRawAsText,
+  [rehypeSanitize, schema],
+]
+
+/**
+ * Links as in markdownLinkComponents (#1629): own tab plus `rel` protection.
+ * The exception is a footnote or heading link, which points inside the text
+ * that is already on screen, so opening a tab for it would only reload the trip
+ * somewhere else.
+ */
+export const sanitizedMarkdownComponents: Components = {
+  a: ({ children, href, ...rest }) =>
+    href?.startsWith('#') ? (
+      <a {...rest} href={href}>
+        {children}
+      </a>
+    ) : (
+      <a {...rest} href={href} target="_blank" rel="noopener noreferrer nofollow">
+        {children}
+      </a>
+    ),
+}

--- a/client/src/hooks/useGeolocation.test.ts
+++ b/client/src/hooks/useGeolocation.test.ts
@@ -1,4 +1,4 @@
-// FE-HOOK-GEO-001 to FE-HOOK-GEO-029
+// FE-HOOK-GEO-001 to FE-HOOK-GEO-031
 import { StrictMode } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { GeoOnceError, getCurrentPositionOnce, useGeolocation } from './useGeolocation';
@@ -352,6 +352,30 @@ describe('useGeolocation', () => {
     expect(result.current.error).toBeNull();
     expect(result.current.errorCode).toBeNull();
     expect(result.current.position).not.toBeNull();
+  });
+
+  it('FE-HOOK-GEO-030: an insecure origin is named as such, not as a blocked permission', async () => {
+    // Plain-HTTP self-hosting: the browser would answer PERMISSION_DENIED and the
+    // user would be sent into device settings that are already correct.
+    vi.stubGlobal('isSecureContext', false);
+    const { result } = renderHook(() => useGeolocation());
+
+    await act(() => result.current.cycleMode());
+
+    expect(watchPosition).not.toHaveBeenCalled();
+    expect(result.current.mode).toBe('off');
+    expect(result.current.errorCode).toBe('insecure-context');
+  });
+
+  it('FE-HOOK-GEO-031: a secure origin is not mistaken for an insecure one', async () => {
+    vi.stubGlobal('isSecureContext', true);
+    const { result } = renderHook(() => useGeolocation());
+
+    await act(() => result.current.cycleMode());
+
+    expect(result.current.mode).toBe('show');
+    expect(result.current.errorCode).toBeNull();
+    expect(watchPosition).toHaveBeenCalledTimes(1);
   });
 
   it('FE-HOOK-GEO-019: stops the watch when the component unmounts', async () => {

--- a/client/src/hooks/useGeolocation.ts
+++ b/client/src/hooks/useGeolocation.ts
@@ -20,7 +20,7 @@ export type TrackingMode = 'off' | 'show' | 'follow'
 // Typed counterpart to the raw error string. The string is whatever the
 // browser produced (raw WebKit English on iOS), so the UI keys off this
 // code to show a localized, actionable message instead.
-export type GeoWatchErrorCode = 'permission-denied' | 'unavailable' | 'timeout' | 'unsupported'
+export type GeoWatchErrorCode = 'permission-denied' | 'unavailable' | 'timeout' | 'unsupported' | 'insecure-context'
 
 export interface UseGeolocationReturn {
   position: GeoPosition | null
@@ -137,6 +137,14 @@ export function useGeolocation(): UseGeolocationReturn {
     if (!('geolocation' in navigator)) {
       setError('Geolocation is not supported in this browser')
       setErrorCode('unsupported')
+      return false
+    }
+    // Same block getCurrentPositionOnce guards against: on a plain-HTTP origin
+    // the browser answers PERMISSION_DENIED, which would otherwise read as a
+    // revoked device permission and send the user into their OS settings.
+    if (window.isSecureContext === false) {
+      setError('Location requires a secure (HTTPS) connection')
+      setErrorCode('insecure-context')
       return false
     }
     // Already watching, or still waiting on the iOS prompt below: a second

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -148,6 +148,9 @@ body { height: 100%; overflow: auto; overscroll-behavior: none; -webkit-overflow
 .atlas-tooltip-scroll-inner {
   max-height: min(200px, 40vh);
   overflow-y: hidden;
+  /* Leaflet puts touch-action: none on the map container; without widening it
+     back here a touch swipe over the note can never scroll it (#2153). */
+  touch-action: pan-y;
 }
 .atlas-tooltip-scroll-inner::-webkit-scrollbar { width: 6px; }
 .atlas-tooltip-scroll-inner::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.25); border-radius: 3px; }

--- a/client/src/mobile/components/MToastHost.test.tsx
+++ b/client/src/mobile/components/MToastHost.test.tsx
@@ -1,0 +1,70 @@
+// FE-COMP-MTOASTHOST-001 to FE-COMP-MTOASTHOST-005
+import { act, render, screen } from '@testing-library/react'
+import MToastHost from './MToastHost'
+
+// The geolocation hint from discussion #2095: the longest string the toast bus
+// carries, and the one whose actionable half used to sit behind the ellipsis.
+const LONG = 'Location access is blocked. Check your device settings; an installed app has its own location permission, separate from the browser.'
+
+// Tailwind emits the display plugin AFTER lineClamp, so any display utility on
+// the same element overrides `line-clamp-*`'s own `-webkit-box`.
+const DISPLAY_UTILITIES = ['block', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid', 'flow-root', 'contents', 'inline']
+
+function push(message: string, type: 'success' | 'error' | 'warning' | 'info' = 'info', duration = 3000): void {
+  act(() => { window.__addToast?.(message, type, duration) })
+}
+
+afterEach(() => {
+  delete window.__addToast
+})
+
+describe('MToastHost', () => {
+  it('FE-COMP-MTOASTHOST-001: takes over the toast bus and hands it back on unmount', () => {
+    const previous = vi.fn(() => 1)
+    window.__addToast = previous
+
+    const { unmount } = render(<MToastHost />)
+    expect(window.__addToast).not.toBe(previous)
+
+    unmount()
+    expect(window.__addToast).toBe(previous)
+  })
+
+  it('FE-COMP-MTOASTHOST-002: keeps a short message on the single-line pill', () => {
+    render(<MToastHost />)
+    push('Trip saved')
+
+    const text = screen.getByText('Trip saved')
+    expect(text.className.split(/\s+/)).toContain('truncate')
+    expect(text.parentElement!.className).toContain('rounded-full')
+  })
+
+  it('FE-COMP-MTOASTHOST-003: wraps a long message instead of cutting it off', () => {
+    render(<MToastHost />)
+    push(LONG, 'error', 6000)
+
+    const classes = screen.getByText(LONG).className.split(/\s+/)
+    expect(classes).not.toContain('truncate')
+    expect(classes).toContain('line-clamp-4')
+    DISPLAY_UTILITIES.forEach(utility => expect(classes).not.toContain(utility))
+  })
+
+  it('FE-COMP-MTOASTHOST-004: softens the pill into a card once the message wraps', () => {
+    render(<MToastHost />)
+    push(LONG, 'error', 6000)
+
+    const pill = screen.getByText(LONG).parentElement!
+    expect(pill.className).toContain('rounded-2xl')
+    expect(pill.className).not.toContain('rounded-full')
+    expect(pill.className).toContain('items-start')
+  })
+
+  it('FE-COMP-MTOASTHOST-005: a wrapping sticky toast is still tappable', () => {
+    render(<MToastHost />)
+    push(LONG, 'error', 0)
+
+    const pill = screen.getByRole('button')
+    expect(pill.className).toContain('pointer-events-auto')
+    expect(pill.className).toContain('rounded-2xl')
+  })
+})

--- a/client/src/mobile/components/MToastHost.tsx
+++ b/client/src/mobile/components/MToastHost.tsx
@@ -27,6 +27,26 @@ const TYPE_DOT: Partial<Record<ToastType, MStatus>> = {
   warning: 'pending',
 }
 
+function MToastPill({ toast, onDismiss }: { toast: MToast; onDismiss: (id: number) => void }) {
+  const dot = TYPE_DOT[toast.type]
+  const wraps = toast.message.length > PILL_CHARS
+  return (
+    <div
+      role={toast.sticky ? 'button' : undefined}
+      tabIndex={toast.sticky ? 0 : undefined}
+      onClick={toast.sticky ? () => onDismiss(toast.id) : undefined}
+      onKeyDown={toast.sticky ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDismiss(toast.id) } } : undefined}
+      className={`flex max-w-full gap-2 bg-m-act px-4 py-2 text-[0.75rem] font-semibold text-m-actfg shadow-[0_10px_30px_-8px_rgba(0,0,0,.5)] ${
+        wraps ? 'items-start rounded-2xl' : 'items-center rounded-full'
+      } ${toast.sticky ? 'pointer-events-auto cursor-pointer' : ''} ${toast.removing ? 'm-toast-out' : 'm-toast-in'}`}
+    >
+      {dot && <MStatusDot status={dot} size={6} className={wraps ? 'mt-[0.45rem]' : ''} />}
+      {/* No display utility next to line-clamp: Tailwind emits it later and kills the clamp. */}
+      <span className={`min-w-0 ${wraps ? 'line-clamp-4 leading-[1.45]' : 'truncate'}`}>{toast.message}</span>
+    </div>
+  )
+}
+
 /**
  * Mobile toast presenter. Takes over the global `window.__addToast` bridge
  * (fed by useToast / store/notify) while the mobile shell is mounted, so every
@@ -78,26 +98,9 @@ export default function MToastHost() {
 
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--bottom-nav-h,84px)+16px)] z-[90] flex flex-col-reverse items-center gap-2 px-6">
-      {toasts.map((toast) => {
-        const dot = TYPE_DOT[toast.type]
-        const wraps = toast.message.length > PILL_CHARS
-        return (
-          <div
-            key={toast.id}
-            role={toast.sticky ? 'button' : undefined}
-            tabIndex={toast.sticky ? 0 : undefined}
-            onClick={toast.sticky ? () => dismissToast(toast.id) : undefined}
-            onKeyDown={toast.sticky ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); dismissToast(toast.id) } } : undefined}
-            className={`flex max-w-full gap-2 bg-m-act px-4 py-2 text-[0.75rem] font-semibold text-m-actfg shadow-[0_10px_30px_-8px_rgba(0,0,0,.5)] ${
-              wraps ? 'items-start rounded-2xl' : 'items-center rounded-full'
-            } ${toast.sticky ? 'pointer-events-auto cursor-pointer' : ''} ${toast.removing ? 'm-toast-out' : 'm-toast-in'}`}
-          >
-            {dot && <MStatusDot status={dot} size={6} className={wraps ? 'mt-[0.45rem]' : ''} />}
-            {/* No display utility next to line-clamp: Tailwind emits it later and kills the clamp. */}
-            <span className={`min-w-0 ${wraps ? 'line-clamp-4 leading-[1.45]' : 'truncate'}`}>{toast.message}</span>
-          </div>
-        )
-      })}
+      {toasts.map((toast) => (
+        <MToastPill key={toast.id} toast={toast} onDismiss={dismissToast} />
+      ))}
     </div>
   )
 }

--- a/client/src/mobile/components/MToastHost.tsx
+++ b/client/src/mobile/components/MToastHost.tsx
@@ -15,6 +15,11 @@ interface MToast {
 let toastId = 0
 const EXIT_MS = 220
 
+// Roughly what one line of the pill holds on a 375px phone. Longer messages
+// (the geolocation permission hint runs ~150 characters) render as a wrapping
+// card instead, or the actionable half disappears behind the ellipsis.
+const PILL_CHARS = 42
+
 // info stays the plain act-pill; the other types get a status dot.
 const TYPE_DOT: Partial<Record<ToastType, MStatus>> = {
   success: 'confirmed',
@@ -25,7 +30,8 @@ const TYPE_DOT: Partial<Record<ToastType, MStatus>> = {
 /**
  * Mobile toast presenter. Takes over the global `window.__addToast` bridge
  * (fed by useToast / store/notify) while the mobile shell is mounted, so every
- * existing toast call renders as the design's act-pill above the bottom nav.
+ * existing toast call renders above the bottom nav, as the design's act-pill or,
+ * for a message too long for one line, as a wrapping card.
  * The desktop ToastContainer handler is restored on unmount.
  */
 export default function MToastHost() {
@@ -74,6 +80,7 @@ export default function MToastHost() {
     <div className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--bottom-nav-h,84px)+16px)] z-[90] flex flex-col-reverse items-center gap-2 px-6">
       {toasts.map((toast) => {
         const dot = TYPE_DOT[toast.type]
+        const wraps = toast.message.length > PILL_CHARS
         return (
           <div
             key={toast.id}
@@ -81,12 +88,13 @@ export default function MToastHost() {
             tabIndex={toast.sticky ? 0 : undefined}
             onClick={toast.sticky ? () => dismissToast(toast.id) : undefined}
             onKeyDown={toast.sticky ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); dismissToast(toast.id) } } : undefined}
-            className={`flex max-w-full items-center gap-2 rounded-full bg-m-act px-4 py-2 text-[0.75rem] font-semibold text-m-actfg shadow-[0_10px_30px_-8px_rgba(0,0,0,.5)] ${
-              toast.sticky ? 'pointer-events-auto cursor-pointer' : ''
-            } ${toast.removing ? 'm-toast-out' : 'm-toast-in'}`}
+            className={`flex max-w-full gap-2 bg-m-act px-4 py-2 text-[0.75rem] font-semibold text-m-actfg shadow-[0_10px_30px_-8px_rgba(0,0,0,.5)] ${
+              wraps ? 'items-start rounded-2xl' : 'items-center rounded-full'
+            } ${toast.sticky ? 'pointer-events-auto cursor-pointer' : ''} ${toast.removing ? 'm-toast-out' : 'm-toast-in'}`}
           >
-            {dot && <MStatusDot status={dot} size={6} />}
-            <span className="min-w-0 truncate">{toast.message}</span>
+            {dot && <MStatusDot status={dot} size={6} className={wraps ? 'mt-[0.45rem]' : ''} />}
+            {/* No display utility next to line-clamp: Tailwind emits it later and kills the clamp. */}
+            <span className={`min-w-0 ${wraps ? 'line-clamp-4 leading-[1.45]' : 'truncate'}`}>{toast.message}</span>
           </div>
         )
       })}

--- a/client/src/mobile/screens/admin/MAdminAddonManager.tsx
+++ b/client/src/mobile/screens/admin/MAdminAddonManager.tsx
@@ -83,18 +83,15 @@ export default function MAdminAddonManager({ bagTrackingEnabled, onToggleBagTrac
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    loadAddons()
+    loadAddons().finally(() => setLoading(false))
   }, [])
 
   const loadAddons = async () => {
-    setLoading(true)
     try {
       const data = await adminApi.addons()
       setAddons(data.addons)
     } catch (err: unknown) {
       toast.error(t('admin.addons.toast.error'))
-    } finally {
-      setLoading(false)
     }
   }
 
@@ -104,13 +101,18 @@ export default function MAdminAddonManager({ bagTrackingEnabled, onToggleBagTrac
     setAddons(prev => prev.map(a => a.id === addon.id ? { ...a, enabled: newEnabled } : a))
     try {
       await adminApi.updateAddon(addon.id, { enabled: newEnabled })
-      refreshGlobalAddons()
-      toast.success(t('admin.addons.toast.updated'))
     } catch (err: unknown) {
       // Rollback
       setAddons(prev => prev.map(a => a.id === addon.id ? { ...a, enabled: !newEnabled } : a))
       toast.error(t('admin.addons.toast.error'))
+      return
     }
+    refreshGlobalAddons()
+    // Journey off disables every photo provider with it, and the response carries
+    // only Journey. Without re-reading, switching Journey back on brings the shelf
+    // up with providers the database has long since turned off.
+    if (addon.id === 'journey') await loadAddons()
+    toast.success(t('admin.addons.toast.updated'))
   }
 
   const isPhotoProviderAddon = (addon: Addon) => {

--- a/client/src/mobile/screens/admin/MAdminPluginsPanel.tsx
+++ b/client/src/mobile/screens/admin/MAdminPluginsPanel.tsx
@@ -1544,6 +1544,8 @@ function RegistryList({ items, onInstall, onOpenDetail, busy, t, installedIds, f
         const offer = installOffer(item, t)
         return (
           <div key={item.id} role="button" tabIndex={0} onClick={() => onOpenDetail(item)}
+            // Same press-scale opt-out as the desktop Discover card (#2158).
+            data-no-press
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenDetail(item) } }}
             className="overflow-hidden rounded-[18px] border border-[color:var(--m-rowbr)] bg-[color:var(--m-sheetop)]">
             <div className="relative">

--- a/client/src/mobile/screens/collections/MCollections.tsx
+++ b/client/src/mobile/screens/collections/MCollections.tsx
@@ -169,9 +169,11 @@ export default function MCollections() {
         )}
       </div>
 
-      {/* List switcher dropdown (in flow, like the design) */}
+      {/* List switcher dropdown (in flow, like the design). In map view it is a
+          flex item of a viewport-high column, so it has to cap itself and give
+          way rather than push its last entries under the dock (#2104). */}
       {drop && (
-        <div className="-mt-[6px] mb-3 rounded-2xl border border-[color:var(--m-rowbr)] bg-m-sheetop p-[6px] shadow-[0_16px_40px_-20px_rgba(0,0,0,.4)]">
+        <div className="-mt-[6px] mb-3 max-h-[50dvh] min-h-0 overflow-y-auto rounded-2xl border border-[color:var(--m-rowbr)] bg-m-sheetop p-[6px] shadow-[0_16px_40px_-20px_rgba(0,0,0,.4)]">
           <button
             type="button"
             onClick={() => selectList(ALL_SAVED)}

--- a/client/src/mobile/screens/dashboard/MDashboard.tsx
+++ b/client/src/mobile/screens/dashboard/MDashboard.tsx
@@ -132,12 +132,13 @@ export default function MDashboard(): React.ReactElement {
     return (
       <>
         <div className="mt-[14px] flex items-center gap-[7px]">
-          {/* The chips scroll inside their own flexible box on narrow viewports
-              or large system font scales; without it this row was the widest
-              thing on the page and dragged the fixed bars off-screen under
-              Android's forced zoom. min-w-max keeps the pill track wrapping
-              its chips instead of getting squeezed to the box. */}
-          <div className="m-hscroll min-w-0 flex-1">
+          {/* The chips scroll inside their own box on narrow viewports or large
+              system font scales; without it this row was the widest thing on
+              the page and dragged the fixed bars off-screen under Android's
+              forced zoom. min-w-max keeps the pill track wrapping its chips,
+              and the box stays content-wide (no flex-1) so the pill still hugs
+              them on wide phones while ml-auto parks the icons on the right. */}
+          <div className="m-hscroll min-w-0">
             <MSegmented<TripFilter>
               value={tripFilter}
               onChange={setTripFilter}
@@ -150,7 +151,7 @@ export default function MDashboard(): React.ReactElement {
               ]}
             />
           </div>
-          <MIconBtn ariaLabel={t('dashboard.subscribeAllTrips')} size={36} className="flex-none" onClick={() => setSubOpen(true)}>
+          <MIconBtn ariaLabel={t('dashboard.subscribeAllTrips')} size={36} className="ml-auto" onClick={() => setSubOpen(true)}>
             <CalendarPlus size={15} strokeWidth={2} className="text-m-muted" />
           </MIconBtn>
           <button

--- a/client/src/mobile/screens/journey/MJourneySettingsSheet.tsx
+++ b/client/src/mobile/screens/journey/MJourneySettingsSheet.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import {
   X, Image, Plus, Trash2, UserPlus, Link as LinkIcon,
-  List, Grid3x3, MapPin, Archive, ArchiveRestore,
+  List, Grid3x3, MapPin, Route, Archive, ArchiveRestore,
 } from 'lucide-react'
 import MSheet from '../../components/MSheet'
 import MIconBtn from '../../components/MIconBtn'
@@ -62,6 +62,7 @@ export default function MJourneySettingsSheet({
   const [availableTrips, setAvailableTrips] = useState<AvailableTrip[]>([])
   const [linkingTripId, setLinkingTripId] = useState<number | null>(null)
   const [shareLink, setShareLink] = useState<ShareLink | null>(null)
+  const [savingTracks, setSavingTracks] = useState(false)
   const [copied, setCopied] = useState(false)
   const coverRef = useRef<HTMLInputElement>(null)
 
@@ -95,6 +96,22 @@ export default function MJourneySettingsSheet({
       onRefresh()
     } catch {
       toast.error(t('journey.settings.coverFailed'))
+    }
+  }
+
+  // Written on the spot rather than on Save, like the archive button: it is a view
+  // setting and the point of it is watching the map change (#2194). onRefresh, not
+  // onSaved, because onSaved closes the sheet the instant the switch is flipped and
+  // would drop a title the owner has typed but not saved yet.
+  const handleTracksToggle = async (next: boolean) => {
+    setSavingTracks(true)
+    try {
+      await updateJourney(journey.id, { show_trip_tracks: next })
+      onRefresh()
+    } catch {
+      toast.error(t('journey.settings.saveFailed'))
+    } finally {
+      setSavingTracks(false)
     }
   }
 
@@ -235,6 +252,22 @@ export default function MJourneySettingsSheet({
           placeholder={t('journey.settings.subtitlePlaceholder')}
           className={`${inputShell} text-[0.8125rem] font-medium`}
         />
+
+        {/* Trip GPX tracks on the journey map (#2194) */}
+        <div className={`${eyebrow} mb-[6px] mt-[14px]`}>{t('journey.settings.tracks')}</div>
+        <div className="flex items-center gap-[11px] rounded-[14px] bg-[color:var(--m-ic)] px-3 py-[10px]">
+          <Route size={16} strokeWidth={2} className="flex-none text-m-muted" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[0.8125rem] font-bold">{t('journey.settings.showTripTracks')}</div>
+            <div className="font-geist text-[0.625rem] text-m-muted">{t('journey.settings.showTripTracksHint')}</div>
+          </div>
+          <MToggle
+            checked={!!journey.show_trip_tracks}
+            onChange={handleTracksToggle}
+            disabled={savingTracks}
+            ariaLabel={t('journey.settings.showTripTracks')}
+          />
+        </div>
 
         {/* Synced trips */}
         <div className={`${eyebrow} mb-[6px] mt-[14px]`}>{t('journey.detail.syncedTrips')}</div>

--- a/client/src/mobile/screens/trip/lib/dayRoute.ts
+++ b/client/src/mobile/screens/trip/lib/dayRoute.ts
@@ -31,6 +31,7 @@ export function optimizeDayOrder(
   dayAssignments: Assignment[],
   accommodations: Accommodation[],
   fromAccommodation: boolean,
+  dayHasCarrier?: boolean,
 ): OptimizedDay | null {
   const locked = new Map<number, Assignment>()
   const movable: Assignment[] = []
@@ -41,7 +42,10 @@ export function optimizeDayOrder(
   const withCoords = movable.filter(a => a.place?.lat != null && a.place?.lng != null)
   if (withCoords.length < 2) return null
   const noCoords = movable.filter(a => a.place?.lat == null || a.place?.lng == null)
-  const anchors = fromAccommodation ? getAccommodationAnchors(day, days, accommodations) : {}
+  const anchors = fromAccommodation
+    ? getAccommodationAnchors(day, days, accommodations,
+        withCoords.map(a => ({ lat: a.place!.lat!, lng: a.place!.lng! })), dayHasCarrier)
+    : {}
   const optimized = optimizeRoute(
     withCoords.map(a => ({ lat: a.place!.lat!, lng: a.place!.lng!, _assignmentId: a.id })),
     anchors,

--- a/client/src/mobile/screens/trip/plan/useMPlanTimeline.ts
+++ b/client/src/mobile/screens/trip/plan/useMPlanTimeline.ts
@@ -302,7 +302,7 @@ export function useMPlanTimeline(planner: TripPlanner) {
     if (!day) return
     const prevIds = dayAssignments.map(a => a.id)
     const result = optimizeDayOrder(
-      day, days, dayAssignments, tripAccommodations, settings.optimize_from_accommodation !== false,
+      day, days, dayAssignments, tripAccommodations, settings.optimize_from_accommodation !== false, dayHasCarrier,
     )
     if (!result) { toast.info(t('dayplan.toast.needTwoPlaces')); return }
     try {
@@ -315,7 +315,7 @@ export function useMPlanTimeline(planner: TripPlanner) {
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : t('trip.toast.reorderError'))
     }
-  }, [day, dayAssignments, days, tripAccommodations, settings, tripActions, tripId, pushUndo, updateRouteForDay, toast, t])
+  }, [day, dayAssignments, days, tripAccommodations, settings, dayHasCarrier, tripActions, tripId, pushUndo, updateRouteForDay, toast, t])
 
   const exportGoogleMaps = useCallback(() => {
     if (!day) return

--- a/client/src/mobile/screens/trip/sheets/MCostSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MCostSheet.tsx
@@ -13,7 +13,7 @@ import { formatMoney, localizeAmountInput, amountToInputString } from '../../../
 import { SYMBOLS, SPLIT_COLORS, currenciesWith } from '../../../../components/Budget/BudgetPanel.constants'
 import { COST_CATEGORY_LIST, catMeta } from '../../../../components/Budget/costsCategories'
 import { localToday } from '../../../../components/Planner/today'
-import { calculateTicketShares, hasTicketSplit, NOTE_MAX, readTicketItems, readUserNote, splitEqualShares, writeTicketItems, type TicketItem } from '../../../../components/Budget/CostsPanel.helpers'
+import { amountPattern, calculateTicketShares, hasTicketSplit, NOTE_MAX, readTicketItems, readUserNote, splitEqualShares, writeTicketItems, type TicketItem } from '../../../../components/Budget/CostsPanel.helpers'
 import type { ExpensePrefill } from '../../../../components/Budget/CostsPanel'
 import { payersBalanced, rebalancePayers } from '../../../../components/Budget/CostsPanel.helpers'
 import GuestBadge from '../../../../components/shared/GuestBadge'
@@ -203,7 +203,7 @@ export default function MCostSheet({ tripId, base, people, me, editing, prefill,
 
   const handleCustomAmountChange = (id: number, val: string) => {
     val = val.replace(',', '.')
-    if (/^-?\d*\.?\d{0,2}$/.test(val) || val === '') setCustomAmounts(prev => ({ ...prev, [id]: val }))
+    if (val === '' || amountPattern(currency, true).test(val)) setCustomAmounts(prev => ({ ...prev, [id]: val }))
   }
 
   const handleAddEmptyItem = () => {
@@ -215,7 +215,7 @@ export default function MCostSheet({ tripId, base, people, me, editing, prefill,
   const handleUpdateItemName = (id: string, itemName: string) => setTicketItems(prev => prev.map(item => item.id === id ? { ...item, name: itemName } : item))
   const handleUpdateItemPrice = (id: string, price: string) => {
     price = price.replace(',', '.')
-    if (/^\d*\.?\d{0,2}$/.test(price) || price === '') setTicketItems(prev => prev.map(item => item.id === id ? { ...item, price } : item))
+    if (price === '' || amountPattern(currency, false).test(price)) setTicketItems(prev => prev.map(item => item.id === id ? { ...item, price } : item))
   }
   const handleRemoveItem = (id: string) => setTicketItems(prev => prev.filter(item => item.id !== id))
   const handleToggleItemParticipant = (itemId: string, userId: number) => {
@@ -346,6 +346,7 @@ export default function MCostSheet({ tripId, base, people, me, editing, prefill,
           <span className="text-[0.84375rem] font-medium text-m-faint">{sym(currency)}</span>
           <NumericInput
             mode="signed-decimal"
+            signToggleLabel={t('costs.toggleSign')}
             placeholder={localizeAmountInput('0.00', currency)}
             value={localizeAmountInput(isTicketMode ? ticketInfo.total.toFixed(2) : total, currency)}
             onValueChange={onTotalChange}
@@ -465,6 +466,7 @@ export default function MCostSheet({ tripId, base, people, me, editing, prefill,
                         <span className="text-[0.75rem] text-m-faint">{sym(currency)}</span>
                         <NumericInput
                           mode="signed-decimal"
+                          signToggleLabel={t('costs.toggleSign')}
                           placeholder={localizeAmountInput('0.00', currency)}
                           value={localizeAmountInput(payerAmounts[p.id] || '', currency)}
                           onValueChange={v => onPayerAmountChange(p.id, v)}

--- a/client/src/mobile/screens/trip/sheets/MDaySheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MDaySheet.tsx
@@ -172,7 +172,7 @@ export default function MDaySheet({ planner, shell }: MTripSheetsProps) {
   const optimizeDay = () => {
     if (!day || dayAssignments.length < 3) return
     const result = optimizeDayOrder(
-      day, planner.days, dayAssignments, planner.tripAccommodations, optimizeFromAccommodation !== false,
+      day, planner.days, dayAssignments, planner.tripAccommodations, optimizeFromAccommodation !== false, dayHasCarrier,
     )
     if (!result) return
     planner.handleReorder(day.id, result.order.map(a => a.id))

--- a/client/src/mobile/screens/trip/tabs/MCollabNotes.tsx
+++ b/client/src/mobile/screens/trip/tabs/MCollabNotes.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import rehypeSanitize from 'rehype-sanitize'
-import { markdownLinkComponents } from '../../../../components/shared/markdownLink'
+import { sanitizedMarkdownPlugins, sanitizedMarkdownComponents } from '../../../../components/shared/markdownSanitize'
 import { Check, FileText, Paperclip, Pin, PinOff, Plus, StickyNote, Trash2, X } from 'lucide-react'
 import MDancingTrek from '../../../components/MDancingTrek'
 import { collabApi } from '../../../../api/client'
@@ -338,7 +337,7 @@ function NoteCardRow({ note, color, canEdit, onTap, onTogglePin, onDelete, t }: 
       <button type="button" onClick={onTap} className="block w-full px-3 pb-3 pt-[9px] text-left">
         {note.content && (
           <div className="line-clamp-3 font-geist text-[0.75rem] leading-[1.5] text-m-muted [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:mb-1 [&_strong]:font-bold [&_ul]:list-disc [&_ul]:pl-4">
-            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownLinkComponents}>{note.content}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={sanitizedMarkdownComponents}>{note.content}</Markdown>
           </div>
         )}
         <div className={`flex items-center gap-[6px] ${note.content ? 'mt-2' : ''}`}>
@@ -602,7 +601,7 @@ function NoteViewSheet({ open, note, onClose, t }: {
       <div className="min-h-0 flex-1 overflow-y-auto px-[18px] pb-4 pt-1">
         {snapshot?.content && (
           <div className="font-geist text-[0.8125rem] leading-[1.6] text-m-ink [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-2 [&_strong]:font-bold [&_ul]:list-disc [&_ul]:pl-5">
-            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownLinkComponents}>{snapshot.content}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={sanitizedMarkdownComponents}>{snapshot.content}</Markdown>
           </div>
         )}
         {(snapshot?.attachments.length ?? 0) > 0 && (

--- a/client/src/mobile/screens/trip/tabs/MCollabPolls.tsx
+++ b/client/src/mobile/screens/trip/tabs/MCollabPolls.tsx
@@ -3,9 +3,8 @@ import { BarChart3, Check, Clock, Lock, Plus, Trash2, X } from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import rehypeSanitize from 'rehype-sanitize'
+import { sanitizedMarkdownPlugins, sanitizedMarkdownComponents } from '../../../../components/shared/markdownSanitize'
 import MDancingTrek from '../../../components/MDancingTrek'
-import { markdownLinkComponents } from '../../../../components/shared/markdownLink'
 import { collabApi } from '../../../../api/client'
 import { addListener, removeListener } from '../../../../api/websocket'
 import { useAuthStore } from '../../../../store/authStore'
@@ -262,7 +261,7 @@ function PollCardRow({ poll, canEdit, currentUserId, t, onVote, onClosePoll, onD
               inert, links open in a new tab with rel protection (#1629).
               Heading/list sizes are em-based so they follow the text scale. */}
           <div className="break-words text-[0.8125rem] font-bold leading-[1.35] text-m-ink [&_a]:underline [&_h1]:mb-1 [&_h1]:text-[1.35em] [&_h1]:leading-[1.2] [&_h2]:mb-1 [&_h2]:text-[1.2em] [&_h2]:leading-[1.25] [&_h3]:mb-1 [&_h3]:text-[1.1em] [&_h3]:leading-[1.3] [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:mb-1 [&_ul]:list-disc [&_ul]:pl-4">
-            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownLinkComponents}>
+            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={sanitizedMarkdownPlugins} components={sanitizedMarkdownComponents}>
               {poll.question}
             </Markdown>
           </div>

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -89,6 +89,33 @@ function JourneyDetailPageDesktop() {
   const skeletonLabel = hideSkeletons ? t('journey.skeletons.show') : t('journey.skeletons.hide')
   const barButton = 'w-10 h-10 flex-shrink-0 rounded-lg bg-surface-elevated backdrop-blur-lg border border-edge shadow-lg text-content-secondary flex items-center justify-center hover:bg-surface-hover active:scale-95 transition-transform'
 
+  // Adding photos hangs off the controls row, which is hidden below 1024px, so
+  // the gallery takes the actions over there instead. Exactly one host renders
+  // them, never both.
+  const galleryActions = canEditEntries && view === 'gallery' ? (
+    <div className="flex items-center gap-2">
+      {galleryProviders.map(p => (
+        <button type="button"
+          key={p.id}
+          onClick={() => galleryBrowseRef.current?.(p.id)}
+          className="inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-[13px] font-semibold transition-transform hover:-translate-y-0.5"
+          style={{ background: 'var(--vg-ink)', color: 'var(--vg-bg)' }}
+        >
+          <Image size={16} strokeWidth={2.4} />
+          {p.name}
+        </button>
+      ))}
+      <button type="button"
+        onClick={() => galleryUploadRef.current?.()}
+        className="inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-[13px] font-semibold transition-transform hover:-translate-y-0.5"
+        style={{ background: 'var(--vg-ink)', color: 'var(--vg-bg)' }}
+      >
+        <Plus size={16} strokeWidth={2.4} />
+        {t('common.upload')}
+      </button>
+    </div>
+  ) : null
+
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
       <Navbar />
@@ -346,29 +373,7 @@ function JourneyDetailPageDesktop() {
                     {t('journey.detail.addEntry')}
                   </button>
                 )}
-                {canEditEntries && view === 'gallery' && (
-                  <div className="flex items-center gap-2">
-                    {galleryProviders.map(p => (
-                      <button type="button"
-                        key={p.id}
-                        onClick={() => galleryBrowseRef.current?.(p.id)}
-                        className="inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-[13px] font-semibold transition-transform hover:-translate-y-0.5"
-                        style={{ background: 'var(--vg-ink)', color: 'var(--vg-bg)' }}
-                      >
-                        <Image size={16} strokeWidth={2.4} />
-                        {p.name}
-                      </button>
-                    ))}
-                    <button type="button"
-                      onClick={() => galleryUploadRef.current?.()}
-                      className="inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-[13px] font-semibold transition-transform hover:-translate-y-0.5"
-                      style={{ background: 'var(--vg-ink)', color: 'var(--vg-bg)' }}
-                    >
-                      <Plus size={16} strokeWidth={2.4} />
-                      {t('common.upload')}
-                    </button>
-                  </div>
-                )}
+                {!isMobileChromeless && galleryActions}
               </div>
 
               {/* Timeline (desktop only — mobile uses fullscreen combined view above) */}
@@ -464,6 +469,9 @@ function JourneyDetailPageDesktop() {
                 className={view === 'gallery' ? '' : 'hidden'}
                 style={showMobileGallery ? { paddingTop: 'calc(var(--nav-h, 56px) + 64px)' } : undefined}
               >
+                {showMobileGallery && galleryActions && (
+                  <div className="flex justify-end mb-4">{galleryActions}</div>
+                )}
                 <GalleryView
                   onRegisterUpload={(fn) => { galleryUploadRef.current = fn }}
                   onRegisterProviders={(providers, browse) => { setGalleryProviders(providers); galleryBrowseRef.current = browse }}

--- a/client/src/pages/JourneyDetailPage.wiring.test.tsx
+++ b/client/src/pages/JourneyDetailPage.wiring.test.tsx
@@ -524,4 +524,55 @@ describe('JourneyDetailPage wiring', () => {
     expect(screen.getByRole('button', { name: 'journey.studio.openAria' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'journey.skeletons.hide' })).toBeInTheDocument();
   });
+
+  // ── Gallery actions between 768 and 1023px ────────────────────────────────
+  // The controls row that hosts them is `hidden` there, and a tablet has no
+  // other door into the gallery (phones run the MJourneyDetail screen instead).
+
+  const immich = [{ id: 'immich', name: 'Immich' }];
+
+  it('FE-JRN-DETWIRE-037: the narrow gallery renders upload and providers outside the hidden controls row', () => {
+    setup({ isMobile: true, view: 'gallery', galleryProviders: immich });
+
+    expect(screen.getByText('common.upload').closest('.hidden')).toBeNull();
+    expect(screen.getByText('Immich').closest('.hidden')).toBeNull();
+  });
+
+  it('FE-JRN-DETWIRE-038: those buttons open the picker and the provider browser', () => {
+    const upload = vi.fn();
+    const browse = vi.fn();
+    setup({
+      isMobile: true, view: 'gallery', galleryProviders: immich,
+      galleryUploadRef: { current: upload }, galleryBrowseRef: { current: browse },
+    });
+
+    fireEvent.click(screen.getByText('common.upload'));
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Immich'));
+    expect(browse).toHaveBeenCalledWith('immich');
+  });
+
+  it('FE-JRN-DETWIRE-039: only one host renders them, on either side of the breakpoint', () => {
+    const { unmount } = setup({ isMobile: true, view: 'gallery', galleryProviders: immich });
+    expect(screen.getAllByText('common.upload')).toHaveLength(1);
+    expect(screen.getAllByText('Immich')).toHaveLength(1);
+    unmount();
+
+    setup({ view: 'gallery', galleryProviders: immich });
+    expect(screen.getAllByText('common.upload')).toHaveLength(1);
+    expect(screen.getAllByText('Immich')).toHaveLength(1);
+  });
+
+  it('FE-JRN-DETWIRE-040: a read-only viewer gets no upload or provider button there', () => {
+    setup({ isMobile: true, view: 'gallery', canEditEntries: false, galleryProviders: immich });
+    expect(screen.queryByText('common.upload')).not.toBeInTheDocument();
+    expect(screen.queryByText('Immich')).not.toBeInTheDocument();
+  });
+
+  it('FE-JRN-DETWIRE-041: the narrow timeline tab keeps the gallery actions away', () => {
+    setup({ isMobile: true, view: 'timeline', galleryProviders: immich });
+    expect(screen.queryByText('common.upload')).not.toBeInTheDocument();
+    expect(screen.queryByText('Immich')).not.toBeInTheDocument();
+  });
 });

--- a/client/src/pages/atlas/atlasModel.test.ts
+++ b/client/src/pages/atlas/atlasModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   A2_TO_A3,
+  bucketTooltipHeight,
   bucketTooltipNeedsScroll,
   bucketTooltipPlacement,
   bucketTooltipWidth,
@@ -310,36 +311,60 @@ describe('bucketTooltipWidth (#2153)', () => {
   });
 });
 
+describe('bucketTooltipHeight (#2153)', () => {
+  it('is the 200px content cap plus the tooltip chrome, offset and arrow margin', () => {
+    expect(bucketTooltipHeight(1080)).toBe(242);
+  });
+
+  it('follows the 40vh cap down on a short viewport', () => {
+    expect(bucketTooltipHeight(400)).toBe(202);
+  });
+});
+
 describe('bucketTooltipPlacement (#2153)', () => {
+  const viewport = { width: 1000, height: 1080 };
+
   it('opens above a marker with room on all sides, centred with no horizontal nudge', () => {
-    const placement = bucketTooltipPlacement({ x: 500, y: 400 }, 1000, 480);
+    const placement = bucketTooltipPlacement({ x: 500, y: 400 }, viewport, 480);
     expect(placement.direction).toBe('top');
     expect(placement.offset).toEqual([0, -14]);
   });
 
   it('flips to open below the marker when there is no room above it', () => {
-    const placement = bucketTooltipPlacement({ x: 500, y: 100 }, 1000, 480);
+    const placement = bucketTooltipPlacement({ x: 500, y: 100 }, viewport, 480);
     expect(placement.direction).toBe('bottom');
     expect(placement.offset[1]).toBe(14);
+  });
+
+  it('still flips for a marker that clears 220px but not the tooltip itself', () => {
+    // 225px of room used to read as "fits above", which clipped the top 17px away.
+    const placement = bucketTooltipPlacement({ x: 500, y: 225 }, viewport, 480);
+    expect(placement.direction).toBe('bottom');
+  });
+
+  it('keeps the tooltip above when neither side fits but there is more room above', () => {
+    // Landscape phone, 300px tall: the tooltip wants 162px and gets 152 above, 132 below.
+    const placement = bucketTooltipPlacement({ x: 500, y: 160 }, { width: 1000, height: 300 }, 480);
+    expect(placement.direction).toBe('top');
   });
 
   it('nudges right when centring the tooltip would clip the left edge', () => {
     // Marker at x=50 with a 480px-wide tooltip centred on it would start at
     // x=-190; the offset needs to push the tooltip's left edge to the margin (8px).
-    const placement = bucketTooltipPlacement({ x: 50, y: 400 }, 1000, 480);
+    const placement = bucketTooltipPlacement({ x: 50, y: 400 }, viewport, 480);
     const defaultLeft = 50 - 480 / 2;
     expect(placement.offset[0]).toBe(8 - defaultLeft);
   });
 
   it('nudges left when centring the tooltip would clip the right edge', () => {
-    const placement = bucketTooltipPlacement({ x: 950, y: 400 }, 1000, 480);
+    const placement = bucketTooltipPlacement({ x: 950, y: 400 }, viewport, 480);
     const defaultLeft = 950 - 480 / 2;
     const clampedLeft = 1000 - 8 - 480;
     expect(placement.offset[0]).toBe(clampedLeft - defaultLeft);
   });
 
   it('does not nudge horizontally when the tooltip already fits', () => {
-    const placement = bucketTooltipPlacement({ x: 500, y: 400 }, 1000, 480);
+    const placement = bucketTooltipPlacement({ x: 500, y: 400 }, viewport, 480);
     expect(placement.offset[0]).toBe(0);
   });
 });

--- a/client/src/pages/atlas/atlasModel.ts
+++ b/client/src/pages/atlas/atlasModel.ts
@@ -218,6 +218,13 @@ export function bucketTooltipWidth(viewportWidth: number): number {
   return Math.min(480, viewportWidth - 32)
 }
 
+/** Vertical space (CSS px) the bucket-list tooltip claims beside its marker: the
+ * .atlas-tooltip-scroll-inner cap of min(200px, 40vh), plus .atlas-tooltip's padding and
+ * border (2x10 + 2x1), plus the 14px offset and Leaflet's 6px .leaflet-tooltip-top margin. */
+export function bucketTooltipHeight(viewportHeight: number): number {
+  return Math.min(200, viewportHeight * 0.4) + 22 + 20
+}
+
 export interface TooltipPlacement {
   direction: 'top' | 'bottom'
   offset: [number, number]
@@ -225,18 +232,19 @@ export interface TooltipPlacement {
 
 /** Keeps the bucket-list marker tooltip on-screen (#2153): Leaflet has no viewport
  * awareness, so flip below the marker when there's no room above, and nudge the
- * horizontal offset to keep it within [margin, viewportWidth - margin]. */
+ * horizontal offset to keep it within [margin, viewport.width - margin]. */
 export function bucketTooltipPlacement(
   markerScreen: { x: number; y: number },
-  viewportWidth: number,
+  viewport: { width: number; height: number },
   tooltipWidth: number,
-  opts: { margin?: number; topThreshold?: number } = {},
+  opts: { margin?: number } = {},
 ): TooltipPlacement {
   const margin = opts.margin ?? 8
-  const topThreshold = opts.topThreshold ?? 220
-  const flip = markerScreen.y < topThreshold
+  const roomAbove = markerScreen.y - margin
+  const roomBelow = viewport.height - markerScreen.y - margin
+  const flip = roomAbove < bucketTooltipHeight(viewport.height) && roomBelow > roomAbove
   const defaultLeft = markerScreen.x - tooltipWidth / 2
-  const clampedLeft = Math.min(Math.max(defaultLeft, margin), viewportWidth - margin - tooltipWidth)
+  const clampedLeft = Math.min(Math.max(defaultLeft, margin), viewport.width - margin - tooltipWidth)
   const dx = clampedLeft - defaultLeft
   return { direction: flip ? 'bottom' : 'top', offset: [dx, flip ? 14 : -14] }
 }

--- a/client/src/pages/atlas/useAtlas.test.tsx
+++ b/client/src/pages/atlas/useAtlas.test.tsx
@@ -30,6 +30,18 @@ interface MockLayer {
   getBounds: ReturnType<typeof vi.fn>;
 }
 
+interface MockMarker {
+  /** One list per event: the bucket marker binds two mouseover handlers. */
+  handlers: Record<string, ((e?: unknown) => void)[]>;
+  tooltipEl: HTMLElement;
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  getLatLng: ReturnType<typeof vi.fn>;
+  bindTooltip: ReturnType<typeof vi.fn>;
+  getTooltip: () => { options: Record<string, unknown> } | undefined;
+  closeTooltip: ReturnType<typeof vi.fn>;
+}
+
 const lf = vi.hoisted(() => ({
   mapHandlers: {} as Record<string, ((e?: unknown) => void)[]>,
   geoJson: [] as unknown[],
@@ -44,6 +56,12 @@ const lf = vi.hoisted(() => ({
   mapsCreated: 0,
   mapsRemoved: 0,
   markers: 0,
+  bucketMarkers: [] as MockMarker[],
+  // Where the map places a marker inside its container; the container itself sits at
+  // 0,0 in jsdom, so this doubles as the marker's screen position.
+  markerPoint: { x: 500, y: 400 },
+  scrollPropagationOff: [] as HTMLElement[],
+  clickPropagationOff: [] as HTMLElement[],
   map: null as null | { setView: ReturnType<typeof vi.fn> },
   reset() {
     this.mapHandlers = {};
@@ -57,6 +75,10 @@ const lf = vi.hoisted(() => ({
     this.mapsCreated = 0;
     this.mapsRemoved = 0;
     this.markers = 0;
+    this.bucketMarkers = [];
+    this.markerPoint = { x: 500, y: 400 };
+    this.scrollPropagationOff = [];
+    this.clickPropagationOff = [];
   },
 }));
 
@@ -97,6 +119,8 @@ vi.mock('leaflet', () => {
     return layer;
   };
 
+  const mapContainer = document.createElement('div');
+
   const map = {
     setView: vi.fn(() => map),
     on: vi.fn((event: string, cb: () => void) => { (lf.mapHandlers[event] ||= []).push(cb); return map; }),
@@ -117,6 +141,8 @@ vi.mock('leaflet', () => {
     hasLayer: vi.fn(() => lf.hasLayer),
     createPane: vi.fn((name: string) => { lf.panes[name] = { style: {} }; }),
     getPane: vi.fn((name: string) => lf.panes[name]),
+    getContainer: vi.fn(() => mapContainer),
+    latLngToContainerPoint: vi.fn(() => lf.markerPoint),
   };
   // Published so a test can assert the map actually moved (place search flies
   // there before the region lookup returns).
@@ -131,21 +157,31 @@ vi.mock('leaflet', () => {
     divIcon: vi.fn(() => ({})),
     marker: vi.fn(() => {
       lf.markers += 1;
-      let tooltip: { options: Record<string, unknown>; getElement: () => null } | undefined;
-      const m = {
-        on: vi.fn(() => m),
+      const handlers: Record<string, ((e?: unknown) => void)[]> = {};
+      const tooltipEl = document.createElement('div');
+      let tooltip: { options: Record<string, unknown>; getElement: () => HTMLElement } | undefined;
+      const m: MockMarker = {
+        handlers,
+        tooltipEl,
+        on: vi.fn((event: string, cb: (e?: unknown) => void) => { (handlers[event] ||= []).push(cb); return m; }),
         off: vi.fn(() => m),
         getLatLng: vi.fn(() => ({ lat: 0, lng: 0 })),
-        bindTooltip: vi.fn(() => {
-          tooltip = { options: { direction: 'top', offset: [0, -14] }, getElement: () => null };
+        bindTooltip: vi.fn((html: string, options: Record<string, unknown>) => {
+          tooltipEl.innerHTML = html;
+          tooltip = { options: { ...options }, getElement: () => tooltipEl };
           return m;
         }),
         getTooltip: vi.fn(() => tooltip),
         closeTooltip: vi.fn(),
       };
+      lf.bucketMarkers.push(m);
       return m;
     }),
     layerGroup: vi.fn(() => ({ addTo: vi.fn(() => ({})) })),
+    DomEvent: {
+      disableScrollPropagation: vi.fn((el: HTMLElement) => { lf.scrollPropagationOff.push(el); }),
+      disableClickPropagation: vi.fn((el: HTMLElement) => { lf.clickPropagationOff.push(el); }),
+    },
     geoJSON: vi.fn((data: { features?: Record<string, unknown>[] }, options: Record<string, unknown>) => {
       const record = { data, options, entries: [] as unknown[], styles: [] as unknown[], attached: false };
       const style = options?.style as ((f: unknown) => unknown) | undefined;
@@ -1255,6 +1291,76 @@ describe('useAtlas', () => {
       // FR is in the fixture as visited with places, so the country flow opens its detail
       // rather than the mark dialog — either way, not a region dialog.
       expect(atlas.confirmAction?.type).not.toBe('choose-region');
+    });
+  });
+
+  // ── Bucket-list note tooltip (#2153) ───────────────────────────────────────
+  describe('the note tooltip on a bucket-list marker', () => {
+    const kyoto = { id: 1, name: 'Kyoto', lat: 35, lng: 135, country_code: 'JP', notes: 'Kinkaku-ji at opening time', target_date: null };
+
+    const fire = (marker: MockMarker, event: string) => (marker.handlers[event] ?? []).forEach((cb) => cb());
+
+    async function mountWithMarker(): Promise<MockMarker> {
+      await mountAtlas({ bucket: [kyoto] });
+      await waitFor(() => expect(lf.bucketMarkers.length).toBeGreaterThan(0));
+      return lf.bucketMarkers[lf.bucketMarkers.length - 1];
+    }
+
+    it('FE-HOOK-ATLAS-057: binds the note as an interactive, scrollable tooltip', async () => {
+      const marker = await mountWithMarker();
+
+      expect(marker.bindTooltip).toHaveBeenCalledWith(
+        expect.stringContaining('atlas-tooltip-scroll-inner'),
+        expect.objectContaining({ className: 'atlas-tooltip atlas-tooltip-scrollable', interactive: true }),
+      );
+    });
+
+    it('FE-HOOK-ATLAS-058: flips the tooltip below a marker with no room for it above', async () => {
+      const marker = await mountWithMarker();
+
+      lf.markerPoint = { x: 500, y: 400 };
+      act(() => fire(marker, 'mouseover'));
+      expect(marker.getTooltip()!.options).toMatchObject({ direction: 'top', offset: [0, -14] });
+
+      // 230px of headroom clears the old 220px threshold but not the 242px the tooltip
+      // really occupies, which is what kept clipping its top edge.
+      lf.markerPoint = { x: 500, y: 230 };
+      act(() => fire(marker, 'mouseover'));
+      expect(marker.getTooltip()!.options).toMatchObject({ direction: 'bottom', offset: [0, 14] });
+    });
+
+    it('FE-HOOK-ATLAS-059: keeps wheel and touch gestures over the tooltip away from the map', async () => {
+      const marker = await mountWithMarker();
+      act(() => fire(marker, 'tooltipopen'));
+
+      expect(lf.scrollPropagationOff).toContain(marker.tooltipEl);
+      expect(lf.clickPropagationOff).toContain(marker.tooltipEl);
+    });
+
+    describe('handing the pointer between marker and tooltip', () => {
+      beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+      afterEach(() => vi.useRealTimers());
+
+      it('FE-HOOK-ATLAS-060: stays open when the pointer walks back from the tooltip onto the marker', async () => {
+        const marker = await mountWithMarker();
+        act(() => fire(marker, 'tooltipopen'));
+
+        act(() => { marker.tooltipEl.dispatchEvent(new MouseEvent('mouseleave')); });
+        act(() => fire(marker, 'mouseover'));
+        await act(async () => { await vi.advanceTimersByTimeAsync(400); });
+
+        expect(marker.closeTooltip).not.toHaveBeenCalled();
+      });
+
+      it('FE-HOOK-ATLAS-061: closes shortly after the pointer leaves the tooltip for good', async () => {
+        const marker = await mountWithMarker();
+        act(() => fire(marker, 'tooltipopen'));
+
+        act(() => { marker.tooltipEl.dispatchEvent(new MouseEvent('mouseleave')); });
+        await act(async () => { await vi.advanceTimersByTimeAsync(400); });
+
+        expect(marker.closeTooltip).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/client/src/pages/atlas/useAtlas.ts
+++ b/client/src/pages/atlas/useAtlas.ts
@@ -1102,7 +1102,11 @@ export function useAtlas() {
         const point = map.latLngToContainerPoint(marker.getLatLng())
         const screenX = containerRect.left + point.x
         const screenY = containerRect.top + point.y
-        const placement = bucketTooltipPlacement({ x: screenX, y: screenY }, window.innerWidth, bucketTooltipWidth(window.innerWidth))
+        const placement = bucketTooltipPlacement(
+          { x: screenX, y: screenY },
+          { width: window.innerWidth, height: window.innerHeight },
+          bucketTooltipWidth(window.innerWidth),
+        )
         tooltip.options.direction = placement.direction
         tooltip.options.offset = placement.offset
       })
@@ -1118,11 +1122,19 @@ export function useAtlas() {
       const scheduleClose = () => { closeTimer = setTimeout(() => marker.closeTooltip(), 200) }
       marker.off('mouseout', marker.closeTooltip, marker)
       marker.on('mouseout', scheduleClose)
+      // The way back from the tooltip onto the marker fires the tooltip's mouseleave
+      // first, so the close it just scheduled has to be taken back here.
+      marker.on('mouseover', cancelClose)
       marker.on('tooltipopen', () => {
         const el = marker.getTooltip()?.getElement()
         if (!el) return
         el.addEventListener('mouseenter', cancelClose)
         el.addEventListener('mouseleave', scheduleClose)
+        // The tooltip pane lives inside the map container, where Leaflet cancels both
+        // gestures before they reach the note: the wheel would zoom the map and a touch
+        // swipe would pan it instead of scrolling.
+        L.DomEvent.disableScrollPropagation(el)
+        L.DomEvent.disableClickPropagation(el)
         const inner = el.querySelector<HTMLElement>('.atlas-tooltip-scroll-inner')
         if (inner) inner.style.overflowY = bucketTooltipNeedsScroll(inner.scrollHeight, inner.clientHeight) ? 'auto' : 'hidden'
       })

--- a/client/src/pages/journeyDetail/useJourneyDetail.test.tsx
+++ b/client/src/pages/journeyDetail/useJourneyDetail.test.tsx
@@ -1,12 +1,13 @@
-// FE-JRN-DETHOOK-001 to FE-JRN-DETHOOK-025
+// FE-JRN-DETHOOK-001 to FE-JRN-DETHOOK-029
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { useLocation } from 'react-router';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { server } from '../../../tests/helpers/msw/server';
 import { render, screen, fireEvent, waitFor } from '../../../tests/helpers/render';
 import { addListener, removeListener } from '../../api/websocket';
 import { useJourneyStore } from '../../store/journeyStore';
 import type { JourneyDetail, JourneyEntry } from '../../store/journeyStore';
+import type { JourneyTrack } from '@trek/shared';
 import { useJourneyDetail } from './useJourneyDetail';
 
 let routeParams: { id?: string } = { id: '7' };
@@ -51,6 +52,20 @@ function buildDetail(over: Partial<JourneyDetail> = {}): JourneyDetail {
 
 function serveJourney(detail: JourneyDetail | Record<string, unknown>): void {
   server.use(http.get('/api/journeys/7', () => HttpResponse.json(detail)));
+}
+
+function buildTrack(over: Partial<JourneyTrack> = {}): JourneyTrack {
+  return { place_id: 4, trip_id: 2, name: 'Ridge walk', color: '#ff0000', points: [[47.1, 11.2], [47.2, 11.3]], ...over };
+}
+
+/** Counts what the map's geometry endpoint is actually asked for. */
+function serveTracks(journeyId: number, tracks: JourneyTrack[] = []) {
+  const asked = vi.fn();
+  server.use(http.get(`/api/journeys/${journeyId}/tracks`, () => {
+    asked();
+    return HttpResponse.json({ tracks });
+  }));
+  return asked;
 }
 
 // ── Harness ──────────────────────────────────────────────────────────────────
@@ -382,5 +397,58 @@ describe('useJourneyDetail', () => {
 
     latest.scrollFeedTo('bottom');
     expect(scrollTo).toHaveBeenLastCalledWith({ top: 9000, behavior: 'smooth' });
+  });
+
+  // ── Trip GPX tracks (#2194) ────────────────────────────────────────────────
+  // The switch gates the request, not the drawing: the endpoint ships unthinned
+  // geometry, megabytes of it for a trip with a season of recorded drives.
+
+  it('FE-JRN-DETHOOK-026: a journey with the switch off never asks for the geometry', async () => {
+    const asked = serveTracks(7, [buildTrack()]);
+    setup();
+    await waitFor(() => expect(latest.current).not.toBeNull());
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(asked).not.toHaveBeenCalled();
+    expect(latest.tracks).toEqual([]);
+  });
+
+  it('FE-JRN-DETHOOK-027: with the switch on the tracks are fetched and handed on', async () => {
+    // The column is INTEGER, so what arrives over the wire is 1, not true.
+    serveJourney(buildDetail({ show_trip_tracks: 1 }));
+    const asked = serveTracks(7, [buildTrack()]);
+    setup();
+
+    await waitFor(() => expect(latest.tracks).toHaveLength(1));
+    expect(latest.tracks[0].name).toBe('Ridge walk');
+    expect(asked).toHaveBeenCalledTimes(1);
+  });
+
+  it('FE-JRN-DETHOOK-028: the geometry follows the route id, not the journey still on screen', async () => {
+    // loadJourney leaves the previous journey in place while the next one loads, so an
+    // unguarded read of the flag would fetch journey B's tracks off journey A's setting.
+    routeParams = { id: '8' };
+    useJourneyStore.setState({ current: buildDetail({ show_trip_tracks: 1 }) });
+    const asked = serveTracks(8, [buildTrack()]);
+    server.use(http.get('/api/journeys/8', async () => {
+      await delay(20);
+      return HttpResponse.json(buildDetail({ id: 8, title: 'Norway 2027' }));
+    }));
+    setup();
+
+    await waitFor(() => expect(latest.current?.id).toBe(8));
+    expect(asked).not.toHaveBeenCalled();
+    expect(latest.tracks).toEqual([]);
+  });
+
+  it('FE-JRN-DETHOOK-029: a failed geometry lookup costs the map its lines, not the page', async () => {
+    serveJourney(buildDetail({ show_trip_tracks: 1 }));
+    server.use(http.get('/api/journeys/7/tracks', () => new HttpResponse(null, { status: 500 })));
+    setup();
+
+    await waitFor(() => expect(latest.current?.title).toBe('Japan 2026'));
+    await new Promise(r => setTimeout(r, 20));
+    expect(latest.tracks).toEqual([]);
+    expect(addToast).not.toHaveBeenCalled();
   });
 });

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -12,6 +12,7 @@ import { useSystemNoticeStore } from './systemNoticeStore.js'
 import { clearAppearanceSnapshot } from '../theme/applyAppearance'
 import { clearAllPluginSessions } from './pluginStore'
 import { forgetStartDestination } from '../utils/startDestination'
+import { forgetServerLanguage } from './settingsStore'
 import { markSignedOut, clearSignedOut } from '../utils/signedOut'
 
 interface AuthResponse {
@@ -236,6 +237,10 @@ export const useAuthStore = create<AuthState>()(
     // And the startup-destination mirror, or the next account on this browser
     // gets bounced into a trip it may not even be able to see.
     forgetStartDestination()
+    // Likewise the language mirror: the login page only overrides it when the
+    // browser language is one TREK ships, so otherwise the next user here stays
+    // in the previous account's language, launch after launch.
+    forgetServerLanguage()
     // 4. Tell server to clear the httpOnly cookie (best-effort).
     await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
     // 5. Clear service worker caches containing sensitive data.

--- a/client/src/store/settingsStore.test.ts
+++ b/client/src/store/settingsStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { DEFAULT_SETTINGS, useSettingsStore } from './settingsStore'
+import { DEFAULT_SETTINGS, forgetServerLanguage, useSettingsStore } from './settingsStore'
 import { settingsApi } from '../api/client'
 import { clearTileCache } from '../sync/tilePrefetcher'
 
@@ -127,5 +127,36 @@ describe('offline language fallback', () => {
     vi.resetModules()
     const fresh = await import('./settingsStore')
     expect(fresh.DEFAULT_SETTINGS.language).toBe('de')
+  })
+
+  // The account of the user who just signed in decides, and an account without a
+  // language of its own sends no language key at all. Leaving the previous
+  // account's mirror standing is what stranded the next user on a shared browser.
+  it('SETTINGS-LANG-005: an account with no language of its own clears the mirror', async () => {
+    localStorage.setItem('app_language_server', 'ja')
+    vi.mocked(settingsApi.get).mockResolvedValue({ settings: { default_currency: 'EUR' } } as never)
+
+    await useSettingsStore.getState().loadSettings()
+
+    expect(localStorage.getItem('app_language_server')).toBeNull()
+  })
+
+  it('SETTINGS-LANG-006: a language TREK does not ship never reaches the mirror', async () => {
+    localStorage.setItem('app_language_server', 'ja')
+    vi.mocked(settingsApi.get).mockResolvedValue({ settings: { language: 'kl' } } as never)
+
+    await useSettingsStore.getState().loadSettings()
+
+    expect(localStorage.getItem('app_language_server')).toBeNull()
+  })
+
+  it('SETTINGS-LANG-007: forgetServerLanguage drops the mirror and leaves the explicit choice alone', () => {
+    localStorage.setItem('app_language', 'de')
+    localStorage.setItem('app_language_server', 'ja')
+
+    forgetServerLanguage()
+
+    expect(localStorage.getItem('app_language_server')).toBeNull()
+    expect(localStorage.getItem('app_language')).toBe('de')
   })
 })

--- a/client/src/store/settingsStore.ts
+++ b/client/src/store/settingsStore.ts
@@ -24,6 +24,33 @@ interface SettingsState {
 export const hasStoredLanguage = (): boolean =>
   typeof localStorage !== 'undefined' && !!localStorage.getItem('app_language')
 
+const SERVER_LANGUAGE_KEY = 'app_language_server'
+
+// An account that never picked a language sends no language key at all
+// (getUserSettings returns only what was set), so a mirror left over from
+// whoever used this browser before has to go rather than survive the load.
+function rememberServerLanguage(settings: Partial<Settings>): void {
+  try {
+    const language = settings.language
+    if (language && SUPPORTED_LANGUAGE_CODES.includes(language)) {
+      localStorage.setItem(SERVER_LANGUAGE_KEY, language)
+    } else {
+      localStorage.removeItem(SERVER_LANGUAGE_KEY)
+    }
+  } catch {
+    // Private mode: the session still has the value in the store.
+  }
+}
+
+/** On logout, so the next account on this browser starts in its own language. */
+export function forgetServerLanguage(): void {
+  try {
+    localStorage.removeItem(SERVER_LANGUAGE_KEY)
+  } catch {
+    // Nothing to clean up if storage is unavailable.
+  }
+}
+
 // The effective client-side defaults for a fresh instance. The server sends no value for
 // a setting an admin hasn't defaulted (see settingsService.getAdminUserDefaults), so these
 // are what a brand-new user actually sees. Keep them internally consistent — one
@@ -39,7 +66,7 @@ export const DEFAULT_SETTINGS: Settings = {
   // language (written by loadSettings below), then English. Without the mirror
   // an offline cold start boots in English: the account's language lives on the
   // server, and the fetch that would apply it cannot happen.
-  language: localStorage.getItem('app_language') || localStorage.getItem('app_language_server') || 'en',
+  language: localStorage.getItem('app_language') || localStorage.getItem(SERVER_LANGUAGE_KEY) || 'en',
   temperature_unit: 'celsius',
   distance_unit: 'metric',
   time_format: '24h',
@@ -110,9 +137,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         // key rather than 'app_language': that one means an explicit in-app
         // choice, and the login page's detection chain must keep running for
         // users who never made one.
-        try {
-          if (incoming.language) localStorage.setItem('app_language_server', incoming.language)
-        } catch { /* private mode — the session still has the value in the store */ }
+        rememberServerLanguage(incoming)
       } catch (err: unknown) {
         // Leave isLoaded false so a transient failure — offline at launch, or a
         // (docker) server cold-start racing the first request — is retried on

--- a/client/src/sync/glPrefetcher.ts
+++ b/client/src/sync/glPrefetcher.ts
@@ -15,7 +15,7 @@
  * The style, sprite and glyphs are per device rather than per trip: about
  * 980 KB once, not per journey.
  */
-import { computeBbox, lngToTileX, latToTileY, type TileBbox } from './tilePrefetcher'
+import { computeBbox, tileRange, type TileBbox } from './tilePrefetcher'
 import type { Place } from '../types'
 
 /** OpenFreeMap serves vector tiles up to z14 and overzooms from there. */
@@ -104,12 +104,11 @@ async function openVectorCache(): Promise<Cache | null> {
 function enumerateVectorTiles(bbox: TileBbox, minZoom: number, maxZoom: number): [number, number, number][] {
   const out: [number, number, number][] = []
   for (let z = minZoom; z <= maxZoom; z++) {
-    const x0 = lngToTileX(bbox.minLng, z)
-    const x1 = lngToTileX(bbox.maxLng, z)
-    const y0 = latToTileY(bbox.maxLat, z)
-    const y1 = latToTileY(bbox.minLat, z)
-    for (let x = Math.min(x0, x1); x <= Math.max(x0, x1); x++) {
-      for (let y = Math.min(y0, y1); y <= Math.max(y0, y1); y++) {
+    // Same screen-widened rectangle as the raster side: the opening fitBounds
+    // view shows more than the places extent on the non-limiting axis (#2180).
+    const { minX, maxX, minY, maxY } = tileRange(bbox, z)
+    for (let x = minX; x <= maxX; x++) {
+      for (let y = minY; y <= maxY; y++) {
         out.push([z, x, y])
         if (out.length >= MAX_VECTOR_TILES) return out
       }

--- a/client/src/sync/tilePrefetcher.ts
+++ b/client/src/sync/tilePrefetcher.ts
@@ -7,7 +7,9 @@
  *   2. For zooms 0–16, enumerate tile XYZ coordinates within bbox. The low
  *      zooms cost next to nothing (a handful of tiles) but are what the trip
  *      map actually opens at for a multi-city bbox — a z10 floor left the
- *      fitBounds view empty offline (#2180).
+ *      fitBounds view empty offline (#2180). The rectangle is widened to the
+ *      screen that view fills, or the map opens with grey either side of the
+ *      places.
  *   3. Stop when cumulative tile estimate exceeds MAX_TILES (~50 MB).
  *   4. Fetch each tile URL so the Service Worker CacheFirst handler caches it,
  *      at most TILE_CONCURRENCY at a time.
@@ -55,6 +57,12 @@ export const TILE_CONCURRENCY = 6
 /** Name of the Workbox runtime cache holding map tiles (see vite.config.js). */
 const TILE_CACHE = 'map-tiles'
 
+/** Leaflet draws raster tiles at 256 px, which is what makes a screen N tiles wide. */
+const TILE_PX = 256
+
+/** Map size to assume where there is no window (SSR, plain-node callers). */
+const FALLBACK_MAP_PX = { width: 1024, height: 768 }
+
 const DEFAULT_TILE_URL = OFM_POSITRON
 
 /**
@@ -79,18 +87,27 @@ function subdomainFor(x: number, y: number): string {
 
 // ── Tile math ──────────────────────────────────────────────────────────────────
 
+/** Longitude → fractional tile X, i.e. where in the tile grid a coordinate sits. */
+function tileXFor(lng: number, zoom: number): number {
+  return ((lng + 180) / 360) * Math.pow(2, zoom)
+}
+
+/** Latitude → fractional tile Y (Web Mercator, y increases southward). */
+function tileYFor(lat: number, zoom: number): number {
+  const latRad = (lat * Math.PI) / 180
+  return (
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * Math.pow(2, zoom)
+  )
+}
+
 /** Longitude → tile X at given zoom. */
 export function lngToTileX(lng: number, zoom: number): number {
-  return Math.floor(((lng + 180) / 360) * Math.pow(2, zoom))
+  return Math.floor(tileXFor(lng, zoom))
 }
 
 /** Latitude → tile Y at given zoom (Web Mercator, y increases southward). */
 export function latToTileY(lat: number, zoom: number): number {
-  const n = Math.pow(2, zoom)
-  const latRad = (lat * Math.PI) / 180
-  return Math.floor(
-    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n,
-  )
+  return Math.floor(tileYFor(lat, zoom))
 }
 
 /** Expand a single-point bbox to min 0.1° span (~10 km) in each axis. */
@@ -139,16 +156,63 @@ export function computeBbox(places: Place[], paddingFraction = 0.1): TileBbox | 
 }
 
 /**
+ * The map column is narrower than the window, so taking the window overstates
+ * it. That is the safe direction: it only ever widens the rectangle below.
+ */
+function mapSizePx(): { width: number; height: number } {
+  if (typeof window === 'undefined') return FALLBACK_MAP_PX
+  return {
+    width: window.innerWidth || FALLBACK_MAP_PX.width,
+    height: window.innerHeight || FALLBACK_MAP_PX.height,
+  }
+}
+
+/**
+ * Tile rectangle to prefetch at one zoom: the bbox, widened to the screen the
+ * trip map opens on.
+ *
+ * fitBounds fills the container, so the opening view is only as tight as the
+ * bbox on the axis that limits it: a north-south trip opens with several times
+ * the bbox's longitude in view. Prefetching the places extent alone left that
+ * view grey to the left and right of the trip (#2180). From the zoom where the
+ * bbox outgrows the screen the widening adds nothing, so it costs a few dozen
+ * tiles at the low zooms and nothing at the detail ones.
+ */
+export function tileRange(
+  bbox: TileBbox,
+  zoom: number,
+): { minX: number; maxX: number; minY: number; maxY: number } {
+  const { width, height } = mapSizePx()
+  const west = tileXFor(bbox.minLng, zoom)
+  const east = tileXFor(bbox.maxLng, zoom)
+  const north = tileYFor(bbox.maxLat, zoom)
+  const south = tileYFor(bbox.minLat, zoom)
+
+  // The camera centres the bbox in projected space, the way computeMapViewport does.
+  const centerX = (west + east) / 2
+  const centerY = (north + south) / 2
+  const halfScreenX = width / 2 / TILE_PX
+  const halfScreenY = height / 2 / TILE_PX
+
+  const last = Math.pow(2, zoom) - 1
+  const clamp = (value: number) => Math.max(0, Math.min(last, Math.floor(value)))
+
+  return {
+    minX: clamp(Math.min(west, centerX - halfScreenX)),
+    maxX: clamp(Math.max(east, centerX + halfScreenX)),
+    minY: clamp(Math.min(north, centerY - halfScreenY)),
+    maxY: clamp(Math.max(south, centerY + halfScreenY)),
+  }
+}
+
+/**
  * Count tiles that would be fetched across the zoom range for a bbox.
  * Used to enforce the size guard without actually fetching.
  */
 export function countTiles(bbox: TileBbox, minZoom: number, maxZoom: number): number {
   let total = 0
   for (let z = minZoom; z <= maxZoom; z++) {
-    const minX = lngToTileX(bbox.minLng, z)
-    const maxX = lngToTileX(bbox.maxLng, z)
-    const minY = latToTileY(bbox.maxLat, z) // northern edge → smaller y
-    const maxY = latToTileY(bbox.minLat, z) // southern edge → larger y
+    const { minX, maxX, minY, maxY } = tileRange(bbox, z)
     total += (maxX - minX + 1) * (maxY - minY + 1)
     if (total > MAX_TILES) return total
   }
@@ -188,10 +252,7 @@ function enumerateTiles(
   const coords: Array<[number, number, number]> = []
 
   for (let z = minZoom; z <= maxZoom; z++) {
-    const minX = lngToTileX(bbox.minLng, z)
-    const maxX = lngToTileX(bbox.maxLng, z)
-    const minY = latToTileY(bbox.maxLat, z)
-    const maxY = latToTileY(bbox.minLat, z)
+    const { minX, maxX, minY, maxY } = tileRange(bbox, z)
 
     if (coords.length + (maxX - minX + 1) * (maxY - minY + 1) > MAX_TILES) break
 
@@ -226,7 +287,8 @@ async function openTileCache(): Promise<Cache | null> {
  * (background sync) leave the promise floating.
  *
  * Returns the number of tiles actually fetched — tiles already in the cache are
- * skipped without touching the network.
+ * skipped without touching the network, and a request the browser refused is not
+ * counted at all.
  */
 export async function prefetchTiles(
   bbox: TileBbox,
@@ -259,9 +321,12 @@ export async function prefetchTiles(
 
       if (cache && (await cache.match(url))) continue
 
-      // The SW CacheFirst handler stores the response.
-      await fetch(url, { mode: 'no-cors' }).catch(() => {})
-      fetched++
+      // The SW CacheFirst handler stores the response. A rejected request (a CSP
+      // refusal, a provider that is down, DNS) leaves nothing in the cache and
+      // must not count towards the tally the caller logs as tiles cached: that
+      // is what let a fully blocked prefetch still report success (#2180).
+      const reached = await fetch(url, { mode: 'no-cors' }).then(() => true, () => false)
+      if (reached) fetched++
     }
   }
 

--- a/client/src/utils/dayOrder.test.ts
+++ b/client/src/utils/dayOrder.test.ts
@@ -81,6 +81,39 @@ describe('getAccommodationAnchors', () => {
       end: { lat: 9, lng: 9 },
     })
   })
+
+  // A Reykjavík stay checking in on day 1 and out on day 3, with neither time recorded,
+  // and untimed stops the optimizer is free to reorder.
+  const reykjavik = { lat: 64.14, lng: -21.94 }
+  const stay = () => hotel({ start_day_id: 10, end_day_id: 30, place_lat: reykjavik.lat, place_lng: reykjavik.lng })
+  const home = { lat: 50.11, lng: 8.68 }
+  const blueLagoon = { lat: 63.88, lng: -22.45 }
+  const hallgrimskirkja = { lat: 64.145, lng: -21.93 }
+
+  it('drops the check-in anchor when the day reaches past a day trip from the hotel (#2157)', () => {
+    // The optimizer half of the same bug. Pinning both ends to a hotel you have not
+    // reached yet made one click on "Optimize route" sort Home between the two Icelandic
+    // stops, because that is the shortest loop, and the user had to drag it back by hand.
+    expect(getAccommodationAnchors(days[0], days, [stay()], [home, blueLagoon, hallgrimskirkja]))
+      .toEqual({ end: reykjavik })
+  })
+
+  it('drops the check-out anchor when a carrier takes you out of the day (#2157)', () => {
+    // Mirror on the departure day: you woke up here, so the hotel still starts the
+    // route, but the flight home means nothing comes back to it.
+    expect(getAccommodationAnchors(days[2], days, [stay()], [hallgrimskirkja], true))
+      .toEqual({ start: reykjavik })
+  })
+
+  it('keeps the loop when every stop is a day out of the hotel (#2009 preserved)', () => {
+    expect(getAccommodationAnchors(days[0], days, [stay()], [blueLagoon, hallgrimskirkja]))
+      .toEqual({ start: reykjavik, end: reykjavik })
+  })
+
+  it('has nothing to weigh the anchors against when the stop list is empty', () => {
+    expect(getAccommodationAnchors(days[0], days, [stay()], []))
+      .toEqual({ start: reykjavik, end: reykjavik })
+  })
 })
 
 describe('getDayBookendHotels', () => {
@@ -253,13 +286,25 @@ describe('shouldDrawMorningLeg', () => {
     expect(shouldDrawMorningLeg(bookends, checkInDay, { isPlace: true, time: '06:00' }, true)).toBe(true)
   })
 
-  it('the no-time default does not reach an edge place out of drive range (#2157)', () => {
+  it('the no-time default does not reach an edge place out of day-trip range (#2157)', () => {
     // "Home", an ocean away from the hotel, with no carrier recorded at all: the
     // closed loop is a guess, and a guess does not get a 2400 km leg.
     const noCheckIn = { morning: into({ check_in: null }), morningIsSleptHere: false }
     expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: null, lat: 21.28, lng: -157.83 })).toBe(false)
     // A nearby untimed place keeps the #2009 loop.
     expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: null, lat: 48.2, lng: 11.6 })).toBe(true)
+  })
+
+  it('a drivable edge place is still out of range when no day out of the hotel reaches it (#2157)', () => {
+    // The issue's literal repro, driven rather than flown: hotel in Warnemünde, "Home"
+    // in Frankfurt, 508 km apart. The router answers that pair happily, so a
+    // reachability limit (2000 km, all of Europe) never fired and the arrival day kept
+    // starting at a hotel nobody had reached yet. What rules it out is that no day out
+    // of that hotel goes to Frankfurt and back.
+    const noCheckIn = { morning: into({ check_in: null, place_lat: 54.18, place_lng: 12.08 }), morningIsSleptHere: false }
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: null, lat: 50.11, lng: 8.68 })).toBe(false)
+    // The day trip that hotel does send you on (Rostock zoo, 11 km) keeps its leg.
+    expect(shouldDrawMorningLeg(noCheckIn, checkInDay, { isPlace: true, time: null, lat: 54.08, lng: 12.10 })).toBe(true)
   })
 })
 
@@ -348,9 +393,18 @@ describe('shouldDrawEveningLeg', () => {
     expect(shouldDrawEveningLeg(bookends, checkOutDay, { isPlace: true, time: '23:00' }, true)).toBe(true)
   })
 
-  it('the no-time default does not reach an edge place out of drive range (#2157)', () => {
+  it('the no-time default does not reach an edge place out of day-trip range (#2157)', () => {
     const noCheckOut = { evening: out({ check_out: null }), eveningIsOvernight: false }
     expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: null, lat: 21.28, lng: -157.83 })).toBe(false)
     expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: null, lat: 48.2, lng: 11.6 })).toBe(true)
+  })
+
+  it('a drivable edge place is still out of range when no day out of the hotel reaches it (#2157)', () => {
+    // Mirror of the morning case: the reporter drives home from Warnemünde to Frankfurt
+    // on the last day, and nothing routes those 508 km back to the hotel he checked
+    // out of that morning.
+    const noCheckOut = { evening: out({ check_out: null, place_lat: 54.18, place_lng: 12.08 }), eveningIsOvernight: false }
+    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: null, lat: 50.11, lng: 8.68 })).toBe(false)
+    expect(shouldDrawEveningLeg(noCheckOut, checkOutDay, { isPlace: true, time: null, lat: 54.08, lng: 12.10 })).toBe(true)
   })
 })

--- a/client/src/utils/dayOrder.ts
+++ b/client/src/utils/dayOrder.ts
@@ -1,6 +1,6 @@
 import type { Day, Accommodation, RouteAnchors } from '../types'
 import { parseTimeToMinutes } from './dayMerge'
-import { withinDriveRange } from './geo'
+import { haversineKm, withinDayTripRange } from './geo'
 
 /**
  * Set on an edge waypoint that is the endpoint of a booking which CARRIES you out of
@@ -14,6 +14,23 @@ export type CarrierEdge = 'departure' | 'arrival' | null
 
 export const getDayOrder = (day: Day, days: Day[]): number =>
   day.day_number ?? days.indexOf(day)
+
+type EdgeStop = { isPlace: boolean; time?: string | null; carrierEdge?: CarrierEdge; lat?: number; lng?: number }
+
+/**
+ * The #2009 default on a stay that records no check-in/check-out time: the loop closes,
+ * because a day out of a hotel comes back to it. It is a guess about a day nobody timed,
+ * and two things disprove it (#2157). A carrier on the day means you changed geography by
+ * air/rail/sea, so the hotel is one end of the day and not both. And an edge stop past
+ * day-trip range is where you travelled from or to, not somewhere the hotel sent you out
+ * to: the reported 500 km drive home is as much a disproof as the 2400 km flight, which
+ * is why the radius is a day's driving and not the router's reachability limit.
+ */
+const noTimeLoopHolds = (hotel: Accommodation, stop?: EdgeStop, dayHasCarrier?: boolean): boolean => {
+  if (dayHasCarrier) return false
+  if (stop?.lat == null || stop.lng == null || hotel.place_lat == null || hotel.place_lng == null) return true
+  return withinDayTripRange({ lat: hotel.place_lat, lng: hotel.place_lng }, { lat: stop.lat, lng: stop.lng })
+}
 
 // The two hotels that bookend a day: the one you woke up in (morning) and the one you sleep in
 // tonight (evening). On a transfer day these differ; on any other day both are the single hotel.
@@ -55,16 +72,36 @@ export const getDayBookendHotels = (
 // Derives route anchors from the accommodation(s) active on a day. A single hotel is the day's home
 // base, so the route is a loop that starts and ends there. A transfer day — checking out of one hotel
 // and into another — instead runs from the morning hotel to the evening one.
+//
+// `stops` are the located stops the optimizer is about to reorder, and they decide the same way the
+// drawn bookend legs do: an anchor the map would not draw a leg to is not an anchor the optimizer
+// gets to pin the day on either, or it sorts a "Home" 500 km out into the middle of the day (#2157).
+// Since the order is what the optimizer is still deciding, no stop is the day's edge yet, so the one
+// farthest from the hotel stands in: a day reaching past what the hotel could send you out to and
+// back from is not a day that hotel bookends. Passing no stops means no evidence, and the anchors
+// stay where they have always been.
 export const getAccommodationAnchors = (
   day: Day,
   days: Day[],
   accommodations: Accommodation[],
+  stops?: { lat: number; lng: number }[],
+  dayHasCarrier?: boolean,
 ): RouteAnchors => {
-  const { morning, evening } = getDayBookendHotels(day, days, accommodations)
+  const bookends = getDayBookendHotels(day, days, accommodations)
+  const { morning, evening } = bookends
   if (!morning || !evening) return {}
+  const at = (h: Accommodation) => ({ lat: h.place_lat as number, lng: h.place_lng as number })
+  // The optimizer only ever moves untimed stops, so the stand-in carries no time.
+  const farthestFrom = (h: Accommodation): EdgeStop | undefined => {
+    if (!stops?.length) return undefined
+    const from = at(h)
+    const far = stops.reduce((a, b) => (haversineKm(from, b) > haversineKm(from, a) ? b : a))
+    return { isPlace: true, time: null, lat: far.lat, lng: far.lng }
+  }
+  const hasStops = !!stops?.length
   return {
-    start: { lat: morning.place_lat as number, lng: morning.place_lng as number },
-    end: { lat: evening.place_lat as number, lng: evening.place_lng as number },
+    start: !hasStops || shouldDrawMorningLeg(bookends, day, farthestFrom(morning), dayHasCarrier) ? at(morning) : undefined,
+    end: !hasStops || shouldDrawEveningLeg(bookends, day, farthestFrom(evening), dayHasCarrier) ? at(evening) : undefined,
   }
 }
 
@@ -75,11 +112,11 @@ export const getAccommodationAnchors = (
 // transport arrival (you flew in, weren't at the hotel yet, #1321), or an un-timed place ("Home"
 // before driving out, #1597) all mean no leg — mirroring the evening rule below. With no
 // check-in time recorded the loop closes by default (#2009), except on a day a carrier
-// takes you there or towards an edge place out of drive range (#2157).
+// takes you there or towards an edge place too far out to be a day trip (#2157).
 export const shouldDrawMorningLeg = (
   bookends: { morning?: Accommodation; morningIsSleptHere?: boolean },
   day: Day,
-  firstStop?: { isPlace: boolean; time?: string | null; carrierEdge?: CarrierEdge; lat?: number; lng?: number },
+  firstStop?: EdgeStop,
   dayHasCarrier?: boolean,
 ): boolean => {
   // You landed here. Whatever hotel the day belongs to, nobody drove out of it to the
@@ -91,21 +128,13 @@ export const shouldDrawMorningLeg = (
   if (!m || m.start_day_id !== day.id || !firstStop?.isPlace) return false
   const checkIn = parseTimeToMinutes(m.check_in)
   // No check-in time on the stay means there is no bar to clear, and "no
-  // information" was being read as "proof against" — which silently opened the
+  // information" was being read as "proof against", which silently opened the
   // loop at the start of every arrival day, since the hotel picker leaves the
-  // time blank by default (#2009). With a time set, #1465 still holds: an
-  // earlier stop is a place you reached before the hotel and draws no leg.
-  if (checkIn == null) {
-    // ...but the closed loop is a guess, and two things disprove it (#2157): a
-    // carrier on the day means you arrive at this hotel by air/rail/sea — on its
-    // check-in day the hotel is where the day ENDS, not where it starts — and an
-    // edge place no drive of the hotel could reach ("Home", an ocean away) was
-    // where you came FROM, not somewhere the hotel sent you.
-    if (dayHasCarrier) return false
-    if (firstStop.lat != null && firstStop.lng != null && m.place_lat != null && m.place_lng != null
-      && !withinDriveRange({ lat: m.place_lat, lng: m.place_lng }, { lat: firstStop.lat, lng: firstStop.lng })) return false
-    return true
-  }
+  // time blank by default (#2009). That loop is still only a guess, so an arrival
+  // in the wide sense (a carrier, or a first stop too far out to be a day trip)
+  // puts the hotel at the day's END instead (#2157). With a time set, #1465 still
+  // holds: an earlier stop is a place you reached before the hotel and draws no leg.
+  if (checkIn == null) return noTimeLoopHolds(m, firstStop, dayHasCarrier)
   const stop = parseTimeToMinutes(firstStop.time)
   return stop != null && stop >= checkIn
 }
@@ -118,7 +147,7 @@ export const shouldDrawMorningLeg = (
 export const shouldDrawEveningLeg = (
   bookends: { evening?: Accommodation; eveningIsOvernight?: boolean },
   day: Day,
-  lastStop?: { isPlace: boolean; time?: string | null; carrierEdge?: CarrierEdge; lat?: number; lng?: number },
+  lastStop?: EdgeStop,
   dayHasCarrier?: boolean,
 ): boolean => {
   // Mirror: you took off from here, so no drive leads from it back to tonight's hotel —
@@ -129,16 +158,10 @@ export const shouldDrawEveningLeg = (
   if (!e || e.end_day_id !== day.id || !lastStop?.isPlace) return false
   const checkOut = parseTimeToMinutes(e.check_out)
   // Mirror of the morning rule: with no check-out time recorded there is nothing
-  // to have missed, so the return leg is drawn and the loop closes (#2009).
-  if (checkOut == null) {
-    // Same two disproofs as the morning (#2157): a carrier on the check-out day
-    // means the hotel is where the day STARTS and nothing drives back to it, and
-    // an edge place out of drive range is where you went instead of returning.
-    if (dayHasCarrier) return false
-    if (lastStop.lat != null && lastStop.lng != null && e.place_lat != null && e.place_lng != null
-      && !withinDriveRange({ lat: e.place_lat, lng: e.place_lng }, { lat: lastStop.lat, lng: lastStop.lng })) return false
-    return true
-  }
+  // to have missed, so the return leg is drawn and the loop closes (#2009), unless
+  // the day disproves it (#2157). A carrier, or a last stop too far out to be a day
+  // trip, is a departure, and the hotel is then where the day STARTS.
+  if (checkOut == null) return noTimeLoopHolds(e, lastStop, dayHasCarrier)
   const stop = parseTimeToMinutes(lastStop.time)
   return stop != null && stop <= checkOut
 }

--- a/client/src/utils/dayOrder.ts
+++ b/client/src/utils/dayOrder.ts
@@ -95,7 +95,7 @@ export const getAccommodationAnchors = (
   const farthestFrom = (h: Accommodation): EdgeStop | undefined => {
     if (!stops?.length) return undefined
     const from = at(h)
-    const far = stops.reduce((a, b) => (haversineKm(from, b) > haversineKm(from, a) ? b : a))
+    const far = stops.reduce((a, b) => (haversineKm(from, b) > haversineKm(from, a) ? b : a), stops[0])
     return { isPlace: true, time: null, lat: far.lat, lng: far.lng }
   }
   const hasStops = !!stops?.length

--- a/client/src/utils/geo.ts
+++ b/client/src/utils/geo.ts
@@ -31,3 +31,20 @@ export const MAX_DRIVE_KM = 2000
 export function withinDriveRange(a: { lat: number; lng: number }, b: { lat: number; lng: number }): boolean {
   return haversineKm(a, b) <= MAX_DRIVE_KM
 }
+
+/**
+ * How far a day out of a hotel and back plausibly reaches, straight-line.
+ *
+ * Consulted where a stay records no check-in/check-out time and the shape of the day is
+ * therefore a guess (#2157): a stop inside this radius is somewhere the hotel sent you out
+ * to for the day, a stop outside it is where you travelled from or to. It has to be a
+ * road-day radius rather than the booking-geometry MAX_DRIVE_KM above: 2000 km spans the
+ * whole of Europe, so every car journey on the continent passed as a day trip and kept the
+ * phantom hotel leg the issue reported.
+ */
+export const MAX_DAY_TRIP_KM = 150
+
+/** Whether a stop is near enough a hotel to be a day out from it and back. */
+export function withinDayTripRange(a: { lat: number; lng: number }, b: { lat: number; lng: number }): boolean {
+  return haversineKm(a, b) <= MAX_DAY_TRIP_KM
+}

--- a/client/tests/integration/hooks/useRouteCalculation.test.ts
+++ b/client/tests/integration/hooks/useRouteCalculation.test.ts
@@ -914,4 +914,56 @@ describe('useRouteCalculation', () => {
     // The one real journey — you woke at the hotel and travelled home — stays.
     expect(legs).toContainEqual([`${hotel.lat},${hotel.lng}`, `${home.lat},${home.lng}`]);
   });
+
+  it('FE-HOOK-ROUTE-033: #2157 the reporter drives home, and 508 km is still no way back to the hotel', async () => {
+    // FE-HOOK-ROUTE-032 with the trip the issue actually describes: a car holiday
+    // inside Germany, no booking of any kind, and a last day that ends at "Home" in
+    // Frankfurt, 508 km from the Warnemünde hotel. Every road router happily answers
+    // that pair, which is why a reachability limit left the reported leg on the map.
+    const hotel = { lat: 54.18, lng: 12.08 };                  // Warnemünde
+    const home = buildPlace({ lat: 50.11, lng: 8.68 });        // untimed "Home"
+    const a1 = buildAssignment({ day_id: 2, order_index: 0, place: home });
+    const accommodations = [{ id: 1, start_day_id: 1, end_day_id: 2, place_lat: hotel.lat, place_lng: hotel.lng }];
+    const store = { assignments: { '2': [a1] } } as unknown as TripStoreState;
+    useTripStore.setState({
+      assignments: store.assignments,
+      reservations: [],
+      days: [{ id: 1, day_number: 1 }, { id: 2, day_number: 2 }],
+    } as any);
+
+    const { result } = renderHook(() =>
+      useRouteCalculation(store, 2, true, 'driving', accommodations as any)
+    );
+    await act(async () => {});
+
+    const legs = (result.current.route ?? []).map(run => run.map(p => `${p[0]},${p[1]}`));
+    expect(legs).not.toContainEqual([`${home.lat},${home.lng}`, `${hotel.lat},${hotel.lng}`]);
+    expect(legs).toContainEqual([`${hotel.lat},${hotel.lng}`, `${home.lat},${home.lng}`]);
+  });
+
+  it('FE-HOOK-ROUTE-034: #2157 the same drive on the arrival day starts at Home, not at the hotel', async () => {
+    // The reporter's second screenshot: day one of the car holiday, "Home" untimed, and
+    // a hotel checking in tonight with no check-in time. The day leaves Frankfurt for
+    // Warnemünde, so nothing drove out of that hotel this morning.
+    const hotel = { lat: 54.18, lng: 12.08 };                  // Warnemünde
+    const home = buildPlace({ lat: 50.11, lng: 8.68 });        // untimed "Home"
+    const a1 = buildAssignment({ day_id: 1, order_index: 0, place: home });
+    const accommodations = [{ id: 1, start_day_id: 1, end_day_id: 2, place_lat: hotel.lat, place_lng: hotel.lng }];
+    const store = { assignments: { '1': [a1] } } as unknown as TripStoreState;
+    useTripStore.setState({
+      assignments: store.assignments,
+      reservations: [],
+      days: [{ id: 1, day_number: 1 }, { id: 2, day_number: 2 }],
+    } as any);
+
+    const { result } = renderHook(() =>
+      useRouteCalculation(store, 1, true, 'driving', accommodations as any)
+    );
+    await act(async () => {});
+
+    const legs = (result.current.route ?? []).map(run => run.map(p => `${p[0]},${p[1]}`));
+    expect(legs).not.toContainEqual([`${hotel.lat},${hotel.lng}`, `${home.lat},${home.lng}`]);
+    // Tonight's hotel is still where the day ends.
+    expect(legs).toContainEqual([`${home.lat},${home.lng}`, `${hotel.lat},${hotel.lng}`]);
+  });
 });

--- a/client/tests/unit/mobile/admin/MAdminAddonManager.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminAddonManager.test.tsx
@@ -299,6 +299,63 @@ describe('MAdminAddonManager', () => {
     await waitFor(() => expect(screen.getByRole('switch', { name: 'Unsplash' })).toHaveAttribute('aria-checked', 'false'));
   });
 
+  it('FE-MOB-AADD-026: switching the journey addon off and on again shows the cascaded providers as off', async () => {
+    const user = userEvent.setup();
+    let loads = 0;
+    let journeyOn = true;
+    let immichOn = true;
+    server.use(
+      http.get('/api/admin/addons', () => {
+        loads += 1;
+        return HttpResponse.json({
+          addons: [
+            buildAddon({ id: 'journey', name: 'Journey', type: 'global', icon: 'Compass', enabled: journeyOn }),
+            buildAddon({ id: 'immich', name: 'Immich', description: 'Self-hosted photos', type: 'photo_provider', enabled: immichOn }),
+          ],
+        });
+      }),
+      http.put('/api/admin/addons/journey', async ({ request }) => {
+        journeyOn = (await request.json() as { enabled: boolean }).enabled;
+        // Journey off takes its providers with it, see admin.service.ts.
+        if (!journeyOn) immichOn = false;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    render(<><ToastContainer /><MAdminAddonManager /></>);
+    await screen.findByText('Immich');
+
+    await user.click(screen.getByRole('switch', { name: 'Journey' }));
+    // The toast closes the whole toggle, re-read included.
+    await screen.findByText('Addon updated');
+    expect(loads).toBe(2);
+    expect(screen.queryByText('Immich')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('switch', { name: 'Journey' }));
+
+    await screen.findByText('Immich');
+    expect(screen.getByRole('switch', { name: 'Immich' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('FE-MOB-AADD-027: a toggle the server does not cascade keeps the snapshot it has', async () => {
+    const user = userEvent.setup();
+    let loads = 0;
+    server.use(
+      http.get('/api/admin/addons', () => {
+        loads += 1;
+        return HttpResponse.json({ addons: [buildAddon({ id: 'todo', enabled: false })] });
+      }),
+      http.put('/api/admin/addons/todo', () => HttpResponse.json({ success: true })),
+    );
+    render(<><ToastContainer /><MAdminAddonManager /></>);
+    await screen.findByText('Todo List');
+
+    await user.click(screen.getByRole('switch', { name: 'Todo List' }));
+
+    await screen.findByText('Addon updated');
+    expect(loads).toBe(1);
+    expect(screen.getByRole('switch', { name: 'Todo List' })).toHaveAttribute('aria-checked', 'true');
+  });
+
   it('FE-MOB-AADD-016: a disabled AI-parsing addon renders the integration row without its config', async () => {
     server.use(addonsRoute([llmAddon({ provider: 'local' })].map(a => ({ ...a, enabled: false }))));
     render(<MAdminAddonManager />);

--- a/client/tests/unit/mobile/admin/MAdminPluginsPanel.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminPluginsPanel.test.tsx
@@ -452,6 +452,16 @@ describe('MAdminPluginsPanel — Discover', () => {
     fireEvent.keyDown(card, { key: 'Enter' });
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
+
+  it('FE-MOB-PLUGP-093: the card opts out of the global press-scale (#2158)', async () => {
+    // jsdom cannot replay the browser mechanics behind #2158: the :active scale on
+    // the card shifted the Install button out from under the pointer, so the tap
+    // retargeted onto the card and opened the detail sheet instead of installing.
+    // The data-no-press attribute is the pin.
+    await openDiscover([registryEntry()]);
+
+    expect((await screen.findByText('Acme')).closest('[role="button"]')).toHaveAttribute('data-no-press');
+  });
 });
 
 describe('MAdminPluginsPanel — the registry detail sheet', () => {

--- a/client/tests/unit/mobile/collections/MCollections.test.tsx
+++ b/client/tests/unit/mobile/collections/MCollections.test.tsx
@@ -490,6 +490,19 @@ describe('MCollections', () => {
     expect(container.firstElementChild!.className).not.toContain('h-dvh')
   })
 
+  it('FE-MOB-COLSCR-019d: the open list switcher scrolls instead of hiding its last entries behind the dock (#2104)', () => {
+    mocks.coll = makeHook({ view: 'map' })
+    render(<MCollections />)
+
+    fireEvent.click(switcher())
+    // In the viewport-high map column the panel is the only item that can give
+    // way, so it has to cap and scroll itself to keep "new list" reachable.
+    const panel = screen.getByRole('button', { name: /collections.newList/ }).parentElement!
+    expect(panel.className).toContain('overflow-y-auto')
+    expect(panel.className).toContain('min-h-0')
+    expect(panel.className).toMatch(/max-h-\[/)
+  })
+
   it('FE-MOB-COLSCR-020: a map view with nothing mappable falls back to the empty note', () => {
     mocks.coll = makeHook({ view: 'map', mappable: [] })
     render(<MCollections />)

--- a/client/tests/unit/mobile/dashboard/MDashboard.test.tsx
+++ b/client/tests/unit/mobile/dashboard/MDashboard.test.tsx
@@ -552,6 +552,17 @@ describe('MDashboard', () => {
     const wrapper = track.parentElement as HTMLElement;
     expect(wrapper.className).toContain('m-hscroll');
     expect(wrapper.className).toContain('min-w-0');
-    expect(wrapper.className).toContain('flex-1');
+  });
+
+  it('FE-MOB-DASH-039: the filter pill hugs its chips instead of filling the row', async () => {
+    render(<MDashboard />);
+
+    // flex-1 on the scroll box stretched the grey pill track all the way to the
+    // calendar icon on phones from ~400px up; the icons ride on ml-auto instead.
+    const chip = await screen.findByText('dashboard.filter.planned');
+    const wrapper = chip.closest('button')!.parentElement!.parentElement as HTMLElement;
+    expect(wrapper.className).not.toContain('flex-1');
+    expect(screen.getByRole('button', { name: 'dashboard.subscribeAllTrips' }).className)
+      .toContain('ml-auto');
   });
 });

--- a/client/tests/unit/mobile/journey/MJourneySettingsSheet.test.tsx
+++ b/client/tests/unit/mobile/journey/MJourneySettingsSheet.test.tsx
@@ -1,4 +1,4 @@
-// FE-MOB-JSET-001 to FE-MOB-JSET-030
+// FE-MOB-JSET-001 to FE-MOB-JSET-034
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '../../../helpers/render';
 import MJourneySettingsSheet from '../../../../src/mobile/screens/journey/MJourneySettingsSheet';
@@ -251,7 +251,9 @@ describe('MJourneySettingsSheet', () => {
 
     expect(await screen.findByText(`${window.location.origin}/public/journey/tok-1`)).toBeInTheDocument();
     expect(addToast).toHaveBeenCalledWith('Share link created', 'success', undefined);
-    expect(screen.getAllByRole('switch')).toHaveLength(3);
+    for (const section of ['Timeline', 'Gallery', 'Map']) {
+      expect(screen.getByRole('switch', { name: section })).toBeInTheDocument();
+    }
   });
 
   it('FE-MOB-JSET-019: a failing share-link creation shows an error toast', async () => {
@@ -397,5 +399,43 @@ describe('MJourneySettingsSheet', () => {
       expect(document.querySelector('img[src="/uploads/covers/j.jpg"]')).toBeInTheDocument(),
     );
     expect(screen.getByRole('button', { name: 'Change cover' })).toBeInTheDocument();
+  });
+
+  // #2194: the phone is the only surface a mobile-only owner ever sees, so the
+  // switch has to live here too, with the semantics of the desktop dialog.
+  it('FE-MOB-JSET-032: the trip-GPX switch reads off by default and turns on in one tap', async () => {
+    const { props } = setup();
+
+    const tracks = await screen.findByRole('switch', { name: /GPX/i });
+    expect(tracks).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(tracks);
+
+    await waitFor(() => expect(updateJourney).toHaveBeenCalledWith(12, { show_trip_tracks: true }));
+    // Refresh, never onSaved: onSaved closes the sheet as the switch is flipped.
+    await waitFor(() => expect(props.onRefresh).toHaveBeenCalled());
+    expect(props.onSaved).not.toHaveBeenCalled();
+  });
+
+  it('FE-MOB-JSET-033: a journey that already draws its tracks switches them back off', async () => {
+    // The column is INTEGER, so what arrives over the wire is 1, not true.
+    setup({ show_trip_tracks: 1 });
+
+    const tracks = await screen.findByRole('switch', { name: /GPX/i });
+    expect(tracks).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(tracks);
+    await waitFor(() => expect(updateJourney).toHaveBeenCalledWith(12, { show_trip_tracks: false }));
+  });
+
+  it('FE-MOB-JSET-034: a failing switch write says so and leaves the sheet open', async () => {
+    updateJourney.mockRejectedValueOnce(new Error('nope'));
+    const { props } = setup();
+
+    fireEvent.click(await screen.findByRole('switch', { name: /GPX/i }));
+
+    await waitFor(() => expect(addToast).toHaveBeenCalledWith('Failed to save', 'error', undefined));
+    expect(props.onRefresh).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 });

--- a/client/tests/unit/stores/authStore.test.ts
+++ b/client/tests/unit/stores/authStore.test.ts
@@ -759,4 +759,20 @@ describe('authStore', () => {
       expect(syncTriggers.registerSyncTriggers).toHaveBeenCalled();
     });
   });
+
+  // The mirror of the account's server-side language is a per-device copy like the
+  // appearance snapshot and the startup destination, and gets dropped with them.
+  // 'app_language' is not a mirror but this device's own choice, so it stays.
+  describe('FE-STORE-AUTH-034: logout drops the language mirror', () => {
+    it('clears the account language but keeps an explicit in-app choice', async () => {
+      localStorage.setItem('app_language_server', 'ja');
+      localStorage.setItem('app_language', 'de');
+      useAuthStore.setState({ user: buildUser(), isAuthenticated: true });
+
+      await useAuthStore.getState().logout();
+
+      expect(localStorage.getItem('app_language_server')).toBeNull();
+      expect(localStorage.getItem('app_language')).toBe('de');
+    });
+  });
 });

--- a/client/tests/unit/studio/bookFontFaces.test.ts
+++ b/client/tests/unit/studio/bookFontFaces.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { BOOK_FONTS_IDS } from '@trek/shared'
+import { BOOK_FONTS, type BookFontId } from '../../../src/components/Studio/bookFonts'
+// Loaded for real as well as read: a weight a family does not ship fails to
+// resolve here rather than in the build.
+import '../../../src/components/Studio/bookFontFaces'
+
+/**
+ * The faces behind the stacks (#2183).
+ *
+ * The stacks were right while five of the seven families were never loaded at
+ * all, so Lora, EB Garamond and Playfair Display each came out as Georgia and
+ * picking between them changed nothing on screen or on paper. The checks read
+ * the imports themselves rather than a list of names copied out of them, which
+ * is the kind of second copy that let this go a release unnoticed.
+ */
+
+const APP = 'src/main.tsx'
+const STUDIO = 'src/components/Studio/bookFontFaces.ts'
+
+// Vitest runs with the client package as its root, so cwd is stable here.
+const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), 'utf8')
+
+/** Every `@fontsource/<package>/<weight>.css` a file imports. */
+function facesIn(rel: string): string[] {
+  return [...read(rel).matchAll(/@fontsource\/([a-z0-9-]+)\/(\d+)\.css/g)]
+    .map(m => `${m[1]}/${m[2]}`)
+}
+
+/** @fontsource names its packages after the family, lowercased and hyphenated. */
+function faceOf(id: BookFontId, weight: number): string {
+  return `${BOOK_FONTS[id].name.toLowerCase().replace(/ /g, '-')}/${weight}`
+}
+
+describe('the bundled faces', () => {
+  it('loads every family the picker offers, in the weights it offers', () => {
+    const loaded = [...facesIn(APP), ...facesIn(STUDIO)]
+    for (const id of BOOK_FONTS_IDS) {
+      for (const weight of BOOK_FONTS[id].weights) {
+        expect(loaded, `${BOOK_FONTS[id].name} ${weight}`).toContain(faceOf(id, weight))
+      }
+    }
+  })
+
+  /* A weight nothing can ask for is a download nobody wanted. */
+  it('loads no weight the registry does not declare', () => {
+    const declared = BOOK_FONTS_IDS.flatMap(id => BOOK_FONTS[id].weights.map(w => faceOf(id, w)))
+    for (const face of facesIn(STUDIO)) {
+      expect(declared, face).toContain(face)
+    }
+  })
+
+  /*
+   * The book's faces are a few hundred kilobytes that only the editor uses, so
+   * they belong to the lazy Studio chunk. Loading them from main.tsx would put
+   * them in front of every first paint, including the ones that never open a
+   * book.
+   */
+  it('rides the Studio chunk rather than the app shell', () => {
+    expect(read('src/components/Studio/StudioShell.tsx')).toContain("import './bookFontFaces'")
+    for (const face of facesIn(STUDIO)) {
+      expect(facesIn(APP), face).not.toContain(face)
+    }
+  })
+})

--- a/client/tests/unit/sync/glPrefetcher.test.ts
+++ b/client/tests/unit/sync/glPrefetcher.test.ts
@@ -156,6 +156,22 @@ describe('prefetchVectorForPlaces', () => {
     expect([...zooms].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
   });
 
+  it('FE-SYNC-GLPF-014: reaches as far as the screen the map opens on, not just the places extent', async () => {
+    // Berlin + Munich: fitBounds is height-limited, so the opening view shows far
+    // more longitude than the places extent, and that band was grey offline (#2180).
+    await prefetchVectorForPlaces([
+      buildPlace({ lat: 52.52, lng: 13.405 }),
+      buildPlace({ lat: 48.14, lng: 11.58 }),
+    ], STYLE_URL);
+
+    const xs = [...cache.store.keys()]
+      .filter(u => u.endsWith('.pbf') && u.includes('/planet/'))
+      .map(u => u.split('/planet/')[1]!.split('/'))
+      .filter(parts => Number(parts[1]) === 7)
+      .map(parts => Number(parts[2]));
+    expect((Math.max(...xs) - Math.min(...xs) + 1) * 256).toBeGreaterThanOrEqual(window.innerWidth);
+  });
+
   it('FE-SYNC-GLPF-008: does nothing offline', async () => {
     Object.defineProperty(navigator, 'onLine', { value: false, writable: true, configurable: true });
     await expect(prefetchVectorForPlaces(places, STYLE_URL)).resolves.toEqual({ tiles: 0, template: null });

--- a/client/tests/unit/sync/tilePrefetcher.test.ts
+++ b/client/tests/unit/sync/tilePrefetcher.test.ts
@@ -561,3 +561,88 @@ describe('prefetch covers the opening zoom (#2180)', () => {
     expect(urls.some(u => u.includes('/7/'))).toBe(true);
   });
 });
+
+describe('prefetch covers the opening viewport (#2180)', () => {
+  const tmpl = 'https://tile.example.com/{z}/{x}/{y}.png';
+
+  const tileCoords = () =>
+    vi.mocked(fetch).mock.calls
+      .map(call => /\/(\d+)\/(\d+)\/(\d+)\.png$/.exec(String(call[0])))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map(m => ({ z: Number(m[1]), x: Number(m[2]), y: Number(m[3]) }));
+
+  const spanPx = (values: number[]) => (Math.max(...values) - Math.min(...values) + 1) * 256;
+
+  it('reaches as far as the screen the map opens on, not just the places extent', async () => {
+    // Berlin + Munich: fitBounds is limited by the north-south span, so the map
+    // opens with several times the trip's longitude in view. The places extent
+    // is two tile columns wide at that zoom, and everything beside it was grey.
+    const bbox = computeBbox([
+      buildPlace({ lat: 52.52, lng: 13.405 }),
+      buildPlace({ lat: 48.14, lng: 11.58 }),
+    ])!;
+
+    await prefetchTiles(bbox, tmpl, 7, 7);
+
+    const opening = tileCoords().filter(t => t.z === 7);
+    expect(spanPx(opening.map(t => t.x))).toBeGreaterThanOrEqual(window.innerWidth);
+    expect(spanPx(opening.map(t => t.y))).toBeGreaterThanOrEqual(window.innerHeight);
+  });
+
+  it('still covers the places extent corner to corner', async () => {
+    // The screen is a widening, not a replacement: past the opening zoom the
+    // bbox is the larger of the two and stays the thing being prefetched.
+    const bbox: TileBbox = { minLat: 48.0, maxLat: 49.0, minLng: 2.0, maxLng: 3.0 };
+
+    await prefetchTiles(bbox, tmpl, 9, 9);
+
+    const urls = vi.mocked(fetch).mock.calls.map(c => String(c[0]));
+    expect(urls).toContain(buildTileUrl(tmpl, 9, lngToTileX(2.0, 9), latToTileY(49.0, 9)));
+    expect(urls).toContain(buildTileUrl(tmpl, 9, lngToTileX(3.0, 9), latToTileY(48.0, 9)));
+  });
+
+  it('never asks for a tile outside the grid', async () => {
+    // Widening a world-spanning bbox at z0 would otherwise run x from -2 to 3,
+    // and every one of those URLs is a 404 stored as an opaque cache entry.
+    const bbox: TileBbox = { minLat: -60, maxLat: 60, minLng: -180, maxLng: 180 };
+
+    await prefetchTiles(bbox, tmpl, 0, 2);
+
+    // The whole grid at z0..z2 and not one tile more.
+    expect(tileCoords()).toHaveLength(1 + 4 + 16);
+    for (const { z, x, y } of tileCoords()) {
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThan(Math.pow(2, z));
+      expect(y).toBeLessThan(Math.pow(2, z));
+    }
+  });
+});
+
+describe('prefetchTiles: a refused tile is not a cached tile (#2180)', () => {
+  const bbox: TileBbox = { minLat: 48.8, maxLat: 48.9, minLng: 2.3, maxLng: 2.4 };
+  const tmpl = 'https://tile.example.com/{z}/{x}/{y}.png';
+
+  it('counts nothing when every request is refused', async () => {
+    // What a CSP block looks like from here. Counting these is how a prefetch
+    // that stored not one tile still reported "cached N tiles" to the console.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const fetched = await prefetchTiles(bbox, tmpl, 10, 11);
+
+    expect(vi.mocked(fetch)).toHaveBeenCalled();
+    expect(fetched).toBe(0);
+  });
+
+  it('counts the tiles that did go through', async () => {
+    let calls = 0;
+    vi.stubGlobal('fetch', vi.fn(() => (++calls % 2 === 1
+      ? Promise.resolve({ ok: true })
+      : Promise.reject(new TypeError('Failed to fetch')))));
+
+    const fetched = await prefetchTiles(bbox, tmpl, 10, 11);
+
+    expect(fetched).toBeGreaterThan(0);
+    expect(fetched).toBeLessThan(calls);
+  });
+});

--- a/plugin-sdk/src/index.ts
+++ b/plugin-sdk/src/index.ts
@@ -109,7 +109,7 @@ export interface PluginContext {
     /** A trip's packing items (hydrated bags/assignees). Needs `db:read:packing`. */
     list(tripId: number): Promise<PackingItem[]>;
     /** Add a packing item (owner = acting user). Needs `db:write:packing` + packing_edit. */
-    create(tripId: number, input: { name: string; category?: string; checked?: boolean; is_private?: boolean; visibility?: 'common' | 'personal' | 'shared'; recipient_ids?: number[] }): Promise<PackingItem>;
+    create(tripId: number, input: { name: string; category?: string; checked?: boolean; weight_grams?: number | null; bag_id?: number | null; quantity?: number; is_private?: boolean; visibility?: 'common' | 'personal' | 'shared'; recipient_ids?: number[] }): Promise<PackingItem>;
     /** Update a packing item. Needs `db:write:packing` + packing_edit. */
     update(tripId: number, itemId: number, input: Record<string, unknown>): Promise<PackingItem>;
     /** Delete a packing item. Needs `db:write:packing` + packing_edit. */
@@ -118,7 +118,7 @@ export interface PluginContext {
     // `db:write:packing` + packing_edit.
     /** Needs 'db:write:packing' (intentional — bags are the write-side structure; packing.list is the read surface). */
     listBags(tripId: number): Promise<unknown[]>;
-    createBag(tripId: number, input: { name: string; color?: string }): Promise<unknown>;
+    createBag(tripId: number, input: { name: string; color?: string; weight_limit_grams?: number }): Promise<unknown>;
     updateBag(tripId: number, bagId: number, input: Record<string, unknown>): Promise<unknown>;
     deleteBag(tripId: number, bagId: number): Promise<{ deleted: boolean }>;
     setBagMembers(tripId: number, bagId: number, userIds: number[]): Promise<unknown>;

--- a/server/src/middleware/globalMiddleware.ts
+++ b/server/src/middleware/globalMiddleware.ts
@@ -198,6 +198,11 @@ export function applyGlobalMiddleware(
           // retired the a/b/c/d shards (#1733). The sharded hosts stay listed
           // for tile templates users saved before that.
           "https://tile.openstreetmap.org", "https://*.tile.openstreetmap.org",
+          // The other two raster presets TREK ships. `mode: 'no-cors'` relaxes
+          // CORS, not CSP, so without these the tile prefetch is refused in the
+          // document and never reaches the Service Worker that would cache it
+          // (#2180). routing.openstreetmap.de below is a different host.
+          "https://tile.openstreetmap.de", "https://tiles.stadiamaps.com",
           "https://unpkg.com", "https://open-meteo.com", "https://api.open-meteo.com",
           "https://geocoding-api.open-meteo.com", "https://api.frankfurter.dev",
           "https://router.project-osrm.org/route/v1/", "https://routing.openstreetmap.de/",

--- a/server/src/nest/auth/auth.service.ts
+++ b/server/src/nest/auth/auth.service.ts
@@ -230,6 +230,26 @@ export class AuthService {
   // App config (public)
   // -------------------------------------------------------------------------
 
+  /**
+   * Whether a passkey ceremony can actually complete on this deployment. With
+   * nothing configured at all, getAppUrl() invents `http://localhost:{PORT}` and
+   * the resolver returns a localhost RP for it: a phantom config that every real
+   * browser is turned away from at the options step (#2147), so advertising it
+   * as configured only produces a button whose every click 400s. A localhost RP
+   * the operator pointed here themselves (APP_URL, ALLOWED_ORIGINS or the
+   * webauthn settings) is a real single-machine install and still counts.
+   */
+  private passkeyConfigured(): boolean {
+    const cfg = this.webauthn.resolve();
+    if (!cfg) return false;
+    if (cfg.rpID !== 'localhost' || cfg.explicitOrigins) return true;
+    const env = readEnv();
+    const declaredRpId = (
+      env.webauthn.rpId || this.db.get<{ value: string }>("SELECT value FROM app_settings WHERE key = 'webauthn_rp_id'")?.value
+    )?.trim();
+    return !!(declaredRpId || env.app.appUrl || env.http.allowedOriginsRaw);
+  }
+
   getAppConfig(authenticatedUser: User | undefined | null) {
     const userCount = this.db.get<{ count: number }>('SELECT COUNT(*) as count FROM users WHERE COALESCE(is_guest, 0) = 0')!.count;
     const isDemo = readEnv().demo.enabled;
@@ -281,7 +301,7 @@ export class AuthService {
       // are true. `passkey_configured` stays a pure boolean — it never leaks the
       // resolved RP ID / origin / APP_URL on this unauthenticated endpoint.
       passkey_login: toggles.passkey_login,
-      passkey_configured: this.webauthn.isConfigured(),
+      passkey_configured: this.passkeyConfigured(),
       env_override_oidc_only: readEnv().oidc.only,
       has_users: userCount > 0,
       setup_complete: setupComplete,

--- a/server/src/nest/auth/passkey.service.ts
+++ b/server/src/nest/auth/passkey.service.ts
@@ -146,10 +146,15 @@ export class PasskeyService {
    * The origins handed to the verifier for this ceremony. An explicit operator
    * list is honored verbatim. A derived config (APP_URL fallback) often carries
    * the wrong scheme or port (TLS-terminating proxy, first ALLOWED_ORIGINS
-   * entry), so the browser-asserted origin is added IF it falls within the RP
-   * ID's WebAuthn scope — the same suffix rule the browser enforces before it
-   * runs the ceremony at all. rpIdHash, challenge and signature checks are
-   * untouched, so this never accepts an origin the RP ID doesn't cover.
+   * entry), so the browser-asserted origin is added when it is the RP ID's own
+   * host and only the scheme or port drifted.
+   *
+   * The HOST is never widened, even though the browser's rule would run a
+   * ceremony from any subdomain of the RP ID: on an apex RP ID that exact-origin
+   * list is the only thing between a taken-over sibling subdomain and an
+   * assertion this server would accept, and the browser cannot supply it. A
+   * deployment that really spans several hosts under one RP ID lists them in
+   * webauthn_origins / WEBAUTHN_ORIGINS, which is honored verbatim above.
    */
   private expectedOrigins(cfg: WebauthnConfig, resp: unknown): string[] {
     if (cfg.explicitOrigins) return cfg.origins;
@@ -157,6 +162,8 @@ export class PasskeyService {
     if (!clientOrigin || cfg.origins.includes(clientOrigin) || !originWithinRpScope(clientOrigin, cfg.rpID)) {
       return cfg.origins;
     }
+    // Parsing cannot throw here: originWithinRpScope only says yes on a URL it parsed.
+    if (new URL(clientOrigin).hostname !== cfg.rpID) return cfg.origins;
     return [...cfg.origins, clientOrigin];
   }
 

--- a/server/src/nest/calendar/calendar.service.ts
+++ b/server/src/nest/calendar/calendar.service.ts
@@ -329,6 +329,16 @@ export class CalendarService {
       return t && isTime(t) ? t : null;
     };
 
+    // Per stay, the booking whose all-day block its two markers replace. Decided
+    // once here rather than twice, because the markers have to hand on exactly
+    // what the block they replaced would have said (#2136).
+    const stayCarriedByMarkers = new Map<number, any>();
+    for (const r of reservations) {
+      if (isTime(r.stay_check_in) && isTime(r.stay_check_out) && r.stay_first_reservation_id === r.id) {
+        stayCarriedByMarkers.set(Number(r.accommodation_id), r);
+      }
+    }
+
     // Build the DTSTART/DTEND lines for a reservation, or null when it has no
     // calendar-placeable time. Transports keep a per-side wall clock + IANA zone
     // on their endpoints, so consult a timed departure endpoint FIRST: transports
@@ -356,8 +366,7 @@ export class CalendarService {
       // emitted once per stay and titled from its lowest-id reservation, so a
       // second room on the same stay is represented by nothing else and keeps
       // its block.
-      const markersCover = isTime(r.stay_check_in) && isTime(r.stay_check_out)
-        && r.stay_first_reservation_id === r.id;
+      const markersCover = stayCarriedByMarkers.get(Number(r.accommodation_id)) === r;
       if (isDate(r.stay_start_date) && !markersCover) {
         const lastDay = isDate(r.stay_end_date) && r.stay_end_date >= r.stay_start_date
           ? r.stay_end_date
@@ -606,6 +615,14 @@ export class CalendarService {
       const zone = resolveTimeZone(stay.place_lat, stay.place_lng);
       // No end day (the day row was removed) → check out on the arrival day.
       const checkOutDate = isDate(stay.end_date) ? stay.end_date : stay.start_date;
+      // Where these markers ARE the booking, they inherit what its block used to
+      // carry: confirmation number, notes, and (for a stay whose place holds no
+      // address) the booking's own location. Otherwise the block still says all
+      // of that, and repeating it would change a feed that already went out: the
+      // same rule the hand-overs follow (#2068, #2136).
+      const booking = stayCarriedByMarkers.get(stay.id);
+      const desc = booking ? describeReservation(booking) : '';
+      const address = stay.place_address || (booking ? booking.location : null);
 
       const marker = (
         kind: 'checkin' | 'checkout',
@@ -618,7 +635,14 @@ export class CalendarService {
         let ev = `BEGIN:VEVENT\r\nUID:${uid(stay.id, kind)}\r\nDTSTAMP:${now}\r\n`;
         ev += dtLine('DTSTART', time, zone, ref);
         if (isTime(endTime)) {
-          ev += dtLine('DTEND', endTime!, zone, ref);
+          // An until-clock that is not later than the check-in is a late-arrival
+          // window running past midnight ("22:00 to 02:00"): nothing on the way
+          // in orders the two, and emitting it as recorded puts the DTEND before
+          // the DTSTART, which clients drop outright. Since the stay lost its
+          // all-day block there is nothing left to fall back on, so the window
+          // ends on the following day (#2136).
+          const endDate = endTime!.slice(0, 5) <= time.slice(0, 5) ? addDays(date, 1) : date;
+          ev += dtLine('DTEND', endTime!, zone, `${endDate}T00:00`);
         } else {
           // No recorded end → the same default hour the hand-overs read as.
           // Without a DTEND the marker is a zero-length point, and since a fully
@@ -630,7 +654,8 @@ export class CalendarService {
           ev += dtLine('DTEND', stop.time, zone, `${stop.date}T00:00`);
         }
         ev += `SUMMARY:${esc(summary)}\r\n`;
-        if (stay.place_address) ev += `LOCATION:${esc(stay.place_address)}\r\n`;
+        if (desc) ev += `DESCRIPTION:${esc(desc)}\r\n`;
+        if (address) ev += `LOCATION:${esc(address)}\r\n`;
         ev += `END:VEVENT\r\n`;
         events.push(ev);
       };

--- a/server/src/nest/packing/packing.mcp.ts
+++ b/server/src/nest/packing/packing.mcp.ts
@@ -363,6 +363,9 @@ export class PackingMcp {
     // { bagId } matches the REST route and the plugin host (the legacy
     // registrar's { id } was the odd one out).
     this.guards.safeBroadcast(tripId, 'packing:bag-deleted', { bagId });
+    // packing_items.bag_id is ON DELETE SET NULL, so the contents land in the
+    // unassigned pile and both numbers move (#2191), as on REST and plugin RPC.
+    this.packing.broadcastBagTotals(String(tripId));
     return ok({ success: true });
   }
 

--- a/server/src/nest/plugins/plugins.controller.ts
+++ b/server/src/nest/plugins/plugins.controller.ts
@@ -147,16 +147,37 @@ export class PluginsController {
   /**
    * Save the admin-owned `scope:'instance'` settings. A RUNNING plugin gets its config
    * once, in the child's init envelope — so a save re-spawns it (like the egress-hosts
-   * PUT), and `restarted` tells the UI whether that happened.
+   * PUT), and `restarted` tells the UI whether that happened. A respawn that fails
+   * answers 409 `{ error, code: 'RESTART_FAILED', config }`: the save itself landed,
+   * so the envelope still carries the stored config.
    */
   @Put(':id/config')
   async updateConfig(@Param('id') id: string, @Body() body: PluginConfigDto): Promise<PluginInstanceConfigUpdated> {
+    // Same gate as the egress-hosts twin: the respawn below is a spawn, and the kill
+    // switch is read live, so a save must not start a child while plugins are off.
+    if (!pluginsEnabled()) throw new HttpException({ error: 'Plugins are disabled by server configuration' }, 503);
+    let config: Record<string, unknown>;
     try {
-      const config = this.plugins.updateInstanceConfig(id, body || {});
-      return { config, restarted: await this.runtime.respawnIfActive(id) };
+      config = this.plugins.updateInstanceConfig(id, body || {});
     } catch (e) {
       if (e instanceof MissingRequiredSettingError) throw new HttpException({ error: e.message }, 400);
       throw e;
+    }
+    try {
+      return { config, restarted: await this.runtime.respawnIfActive(id) };
+    } catch (e) {
+      // The config IS written by this point, only bringing the child back up failed
+      // (a widened permission set awaiting re-consent, a dependency that went away).
+      // Reporting that as a failed save would be a lie, so the envelope carries the
+      // saved config and names the restart as the part that broke. `disable()` leaves
+      // the row enabled while no child runs, so record the plugin as off: the enable
+      // toggle is where the real reason is offered as a decision the admin can take.
+      await this.runtime.deactivate(id).catch(() => {});
+      const reason = e instanceof Error ? e.message : 'restart failed';
+      throw new HttpException(
+        { error: `Settings saved, but ${id} could not be restarted: ${reason}`, code: 'RESTART_FAILED', config },
+        409,
+      );
     }
   }
 

--- a/server/src/nest/plugins/runtime/plugin-sdk.ts
+++ b/server/src/nest/plugins/runtime/plugin-sdk.ts
@@ -91,7 +91,7 @@ export interface PluginContext {
     /** A trip's packing items (hydrated bags/assignees). Needs 'db:read:packing'. */
     list(tripId: number): Promise<unknown[]>;
     /** Add a packing item (owner = acting user). Needs 'db:write:packing' + 'packing_edit'. */
-    create(tripId: number, input: { name: string; category?: string; checked?: boolean; is_private?: boolean; visibility?: 'common' | 'personal' | 'shared'; recipient_ids?: number[] }): Promise<unknown>;
+    create(tripId: number, input: { name: string; category?: string; checked?: boolean; weight_grams?: number | null; bag_id?: number | null; quantity?: number; is_private?: boolean; visibility?: 'common' | 'personal' | 'shared'; recipient_ids?: number[] }): Promise<unknown>;
     /** Update a packing item. Needs 'db:write:packing' + 'packing_edit'. */
     update(tripId: number, itemId: number, input: Record<string, unknown>): Promise<unknown>;
     /** Delete a packing item. Needs 'db:write:packing' + 'packing_edit'. */
@@ -103,7 +103,7 @@ export interface PluginContext {
      * (intentional — bags are the write-side structure; packing.list is the read surface).
      */
     listBags(tripId: number): Promise<unknown[]>;
-    createBag(tripId: number, input: { name: string; color?: string }): Promise<unknown>;
+    createBag(tripId: number, input: { name: string; color?: string; weight_limit_grams?: number }): Promise<unknown>;
     updateBag(tripId: number, bagId: number, input: Record<string, unknown>): Promise<unknown>;
     deleteBag(tripId: number, bagId: number): Promise<{ deleted: boolean }>;
     setBagMembers(tripId: number, bagId: number, userIds: number[]): Promise<unknown>;

--- a/server/tests/unit/mcp/tools-packing-advanced.test.ts
+++ b/server/tests/unit/mcp/tools-packing-advanced.test.ts
@@ -256,6 +256,27 @@ describe('Tool: delete_packing_bag', () => {
     });
   });
 
+  it('pings the room to re-read the bag weights (#2191)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const r = testDb.prepare('INSERT INTO packing_bags (trip_id, name, color) VALUES (?, ?, ?)').run(trip.id, 'Carry-on', '#000000');
+    const bagId = r.lastInsertRowid as number;
+    testDb.prepare('INSERT INTO packing_items (trip_id, name, category, checked, bag_id, weight_grams) VALUES (?, ?, ?, 0, ?, ?)')
+      .run(trip.id, 'Tent', 'Camping', bagId, 3000);
+    await withHarness(user.id, async (h) => {
+      await h.client.callTool({
+        name: 'delete_packing_bag',
+        arguments: { tripId: trip.id, bagId },
+      });
+      // bag_id is ON DELETE SET NULL, so the 3 kg move into the unassigned pile:
+      // both numbers change and every client has to re-read them, exactly as on
+      // the REST route and the plugin RPC.
+      expect(broadcastMock).toHaveBeenCalledWith(String(trip.id), 'packing:bag-totals', {}, undefined);
+      expect(broadcastMock).toHaveBeenCalledTimes(2);
+      expect(testDb.prepare('SELECT bag_id FROM packing_items WHERE trip_id = ?').get(trip.id)).toEqual({ bag_id: null });
+    });
+  });
+
   it('returns access denied for non-member', async () => {
     const { user } = createUser(testDb);
     const { user: other } = createUser(testDb);

--- a/server/tests/unit/middleware/globalMiddleware.csp.test.ts
+++ b/server/tests/unit/middleware/globalMiddleware.csp.test.ts
@@ -33,6 +33,25 @@ describe('global CSP: OpenStreetMap tile hosts (#1733)', () => {
   });
 });
 
+describe('global CSP: the other shipped raster presets (#2180)', () => {
+  it('allows tile.openstreetmap.de', async () => {
+    // The prefetcher fetches tiles with mode 'no-cors', which relaxes CORS and
+    // nothing else: a host missing here is refused in the document, so the
+    // Service Worker never sees the request and caches no tile at all.
+    expect(await connectSrcSources()).toContain('https://tile.openstreetmap.de');
+  });
+
+  it('allows tiles.stadiamaps.com', async () => {
+    expect(await connectSrcSources()).toContain('https://tiles.stadiamaps.com');
+  });
+
+  it('keeps the routing host, which is a different host and covers nothing here', async () => {
+    // routing.openstreetmap.de was on the list all along and looks close enough
+    // to hide the gap: a CSP source matches a host, not a suffix of one.
+    expect(await connectSrcSources()).toContain('https://routing.openstreetmap.de/');
+  });
+});
+
 describe('global CSP: script-src', () => {
   it("allows 'wasm-unsafe-eval' so the WASM decoders keep running", async () => {
     expect(await directiveSources('script-src')).toContain("'wasm-unsafe-eval'");

--- a/server/tests/unit/nest/auth.service.test.ts
+++ b/server/tests/unit/nest/auth.service.test.ts
@@ -614,6 +614,38 @@ describe('getAppConfig', () => {
     expect(cfg.password_registration).toBe(true);
     vi.unstubAllEnvs();
   });
+
+  it('AUTH-DB-052d: an instance that declared nothing reports passkeys as not configured (#2147)', () => {
+    // APP_URL unset, so getAppUrl() invents http://localhost:{PORT} and the
+    // resolver hands back a localhost RP. No browser on the real domain can
+    // finish a ceremony against it, and the options step says so, so the client
+    // must not advertise a button whose every click 400s.
+    createUser(testDb);
+    expect(svc.getAppConfig(null).passkey_configured).toBe(false);
+  });
+
+  it('AUTH-DB-052e: a localhost RP the operator declared themselves still counts', () => {
+    createUser(testDb);
+    vi.stubEnv('APP_URL', 'http://localhost:5173');
+    expect(svc.getAppConfig(null).passkey_configured).toBe(true);
+    vi.unstubAllEnvs();
+
+    vi.stubEnv('ALLOWED_ORIGINS', 'http://localhost:5173');
+    expect(svc.getAppConfig(null).passkey_configured).toBe(true);
+    vi.unstubAllEnvs();
+
+    testDb.prepare("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('webauthn_rp_id', 'localhost')").run();
+    expect(svc.getAppConfig(null).passkey_configured).toBe(true);
+  });
+
+  it('AUTH-DB-052f: a real domain is configured, a bare IP host is not', () => {
+    createUser(testDb);
+    vi.stubEnv('APP_URL', 'https://trek.example.org');
+    expect(svc.getAppConfig(null).passkey_configured).toBe(true);
+    vi.stubEnv('APP_URL', 'http://192.168.1.50:3001');
+    expect(svc.getAppConfig(null).passkey_configured).toBe(false);
+    vi.unstubAllEnvs();
+  });
 });
 
 describe('demoLogin', () => {

--- a/server/tests/unit/nest/calendar.service.test.ts
+++ b/server/tests/unit/nest/calendar.service.test.ts
@@ -804,6 +804,10 @@ describe('accommodations', () => {
       withReservation?: boolean;
       lat?: number;
       lng?: number;
+      address?: string | null;
+      confirmation?: string;
+      notes?: string;
+      location?: string;
     },
   ) => {
     const place = createPlace(testDb, tripId, {
@@ -811,7 +815,8 @@ describe('accommodations', () => {
       lat: opts.lat ?? 48.8566,
       lng: opts.lng ?? 2.3522,
     });
-    testDb.prepare('UPDATE places SET address = ? WHERE id = ?').run('1 Rue de Rivoli', place.id);
+    testDb.prepare('UPDATE places SET address = ? WHERE id = ?')
+      .run(opts.address === undefined ? '1 Rue de Rivoli' : opts.address, place.id);
     const startDay = createDay(testDb, tripId, { date: opts.start ?? undefined });
     const endDay = opts.end === undefined
       ? startDay
@@ -826,9 +831,13 @@ describe('accommodations', () => {
 
     if (opts.withReservation !== false) {
       testDb.prepare(`
-        INSERT INTO reservations (trip_id, day_id, title, reservation_time, status, type, accommodation_id)
-        VALUES (?, ?, ?, ?, 'confirmed', 'hotel', ?)
-      `).run(tripId, startDay.id, opts.title ?? 'Hotel Bellevue', opts.start, String(stayId));
+        INSERT INTO reservations (trip_id, day_id, title, reservation_time, status, type, accommodation_id,
+                                  confirmation_number, notes, location)
+        VALUES (?, ?, ?, ?, 'confirmed', 'hotel', ?, ?, ?, ?)
+      `).run(
+        tripId, startDay.id, opts.title ?? 'Hotel Bellevue', opts.start, String(stayId),
+        opts.confirmation ?? null, opts.notes ?? null, opts.location ?? null,
+      );
     }
     return { stayId, placeId: place.id };
   };
@@ -886,6 +895,58 @@ describe('accommodations', () => {
 
     expect(ics).toContain('SUMMARY:Bellevue second room');
     expect(ics).toContain('SUMMARY:Check-in: Hotel Bellevue');
+  });
+
+  it('CAL-025e: the markers of a fully timed stay carry what the dropped block said (#2136)', () => {
+    // Losing the block must not lose the confirmation number and the notes with
+    // it, the same handover the split window bookings do (#2068).
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris' });
+    createStay(trip.id, {
+      start: '2026-07-07', end: '2026-07-12',
+      check_in: '15:00', check_out: '11:00',
+      confirmation: 'HTL-77291', notes: 'Key box code 4711',
+    });
+
+    const { ics } = svc.exportICS(trip.id);
+
+    const unfolded = ics.replaceAll('\r\n ', '');
+    const descriptions = unfolded.split('\r\n').filter(l => l.startsWith('DESCRIPTION:Type: hotel'));
+    expect(descriptions).toHaveLength(2);
+    expect(descriptions[0]).toContain('Confirmation: HTL-77291');
+    expect(descriptions[0]).toContain('Key box code 4711');
+  });
+
+  it('CAL-025f: a stay whose place has no address takes the booking location instead', () => {
+    // place_id is nullable (ON DELETE SET NULL) and an address is optional, so
+    // without the fallback the only two events left name no address at all.
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris' });
+    createStay(trip.id, {
+      start: '2026-07-07', end: '2026-07-12',
+      check_in: '15:00', check_out: '11:00',
+      address: null, location: '12 Hotel Street',
+    });
+
+    const { ics } = svc.exportICS(trip.id);
+
+    expect(ics.match(/LOCATION:12 Hotel Street/g)).toHaveLength(2);
+  });
+
+  it('CAL-025g: a stay that keeps its block does not repeat the description on its markers', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris' });
+    createStay(trip.id, {
+      start: '2026-07-07', end: '2026-07-12',
+      check_in: '15:00', confirmation: 'HTL-77291',
+    });
+
+    const { ics } = svc.exportICS(trip.id);
+
+    // The block is still emitted and still says it; saying it a second time on
+    // the check-in marker would change a feed that already went out.
+    const unfolded = ics.replaceAll('\r\n ', '');
+    expect(unfolded.split('\r\n').filter(l => l.startsWith('DESCRIPTION:Type: hotel'))).toHaveLength(1);
   });
 
   it('CAL-025c: knowing only one end keeps the block, since nothing else carries the other', () => {
@@ -955,6 +1016,23 @@ describe('accommodations', () => {
     // drop an event whose end precedes its start.
     expect(ics).toContain('DTSTART;TZID=Europe/Paris:20260712T233000');
     expect(ics).toContain('DTEND;TZID=Europe/Paris:20260713T003000');
+  });
+
+  it('CAL-026e: a check-in window that ends before it starts runs past midnight (#2136)', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Paris' });
+    createStay(trip.id, {
+      start: '2026-07-07', end: '2026-07-12',
+      check_in: '22:00', check_in_end: '02:00', check_out: '11:00',
+    });
+
+    const { ics } = svc.exportICS(trip.id);
+
+    // A late-arrival window, and nothing on the way in (REST, MCP, plugin SDK)
+    // orders the two clocks. Emitted as recorded the DTEND precedes the DTSTART,
+    // clients drop the event, and since the block is gone the arrival is gone.
+    expect(ics).toContain('DTSTART;TZID=Europe/Paris:20260707T220000');
+    expect(ics).toContain('DTEND;TZID=Europe/Paris:20260708T020000');
   });
 
   it('CAL-027: a stay without times emits the all-day range and nothing else', () => {

--- a/server/tests/unit/nest/passkey.service.test.ts
+++ b/server/tests/unit/nest/passkey.service.test.ts
@@ -1,13 +1,14 @@
 /**
  * Unit tests for the DI-native PasskeyService — PASSKEY-SVC-001 through
- * PASSKEY-SVC-039. Written fresh with the DI fold: the legacy
+ * PASSKEY-SVC-041. Written fresh with the DI fold: the legacy
  * services/passkeyService had no service-level suite, so these characterize
  * the relocated behavior (challenge store semantics, WebAuthn ceremony error
  * paths, clone detection, management CRUD) over a real in-memory SQLite DB;
  * 031–032 pin the post-fold `fix(server)` quirk fix (the transactional
- * dup-check → INSERT with its 409-vs-400 sentinel split); 033–039 pin the
+ * dup-check → INSERT with its 409-vs-400 sentinel split); 033 to 041 pin the
  * #2147 origin hardening (pre-ceremony Origin gate for the derived localhost
- * fallback, in-scope widening of expectedOrigin for derived configs).
+ * fallback, scheme/port widening of expectedOrigin for derived configs, and
+ * that the host itself is never widened).
  * The @simplewebauthn/server ceremony functions are mocked — the library's
  * crypto is not under test, the service's handling of its verdicts is.
  * Constructed directly (no TestingModule, repo convention).
@@ -441,6 +442,25 @@ describe('passkeyRegisterVerify', () => {
     await svc.passkeyRegisterVerify(user.id, { attestationResponse: ceremonyResponse('w3', {}, { origin: 'https://evil.example.net' }) });
     expect(swMock.verifyRegistrationResponse.mock.calls[1][0].expectedOrigin).toEqual(['https://trek.example.com']);
   });
+
+  it('PASSKEY-SVC-040: a derived config heals scheme and port, never the host (#2147)', async () => {
+    // With the RP ID on an apex domain the browser runs a ceremony from any
+    // subdomain of it, so a taken-over sibling could hand over an assertion
+    // nothing else in the chain rejects. The exact-origin list is the only
+    // defence there, so only scheme/port drift on the RP ID's host is healed.
+    resolveWebauthnConfigMock.mockReturnValue({ rpID: 'example.com', rpName: 'TREK', origins: ['https://example.com'], explicitOrigins: false });
+    const { user } = createUser(testDb);
+
+    seedChallenge('w4', user.id, 'registration');
+    swMock.verifyRegistrationResponse.mockResolvedValueOnce(registrationVerdict({}, { id: 'sibling-cred' }));
+    await svc.passkeyRegisterVerify(user.id, { attestationResponse: ceremonyResponse('w4', {}, { origin: 'https://blog.example.com' }) });
+    expect(swMock.verifyRegistrationResponse.mock.calls[0][0].expectedOrigin).toEqual(['https://example.com']);
+
+    seedChallenge('w5', user.id, 'registration');
+    swMock.verifyRegistrationResponse.mockResolvedValueOnce(registrationVerdict({}, { id: 'port-cred' }));
+    await svc.passkeyRegisterVerify(user.id, { attestationResponse: ceremonyResponse('w5', {}, { origin: 'https://example.com:8443' }) });
+    expect(swMock.verifyRegistrationResponse.mock.calls[1][0].expectedOrigin).toEqual(['https://example.com', 'https://example.com:8443']);
+  });
 });
 
 // ── passkeyLoginOptions ───────────────────────────────────────────────────────
@@ -613,6 +633,20 @@ describe('passkeyLoginVerify', () => {
     expect(result.token).toBeTruthy();
     expect(swMock.verifyAuthenticationResponse.mock.calls[0][0].expectedOrigin)
       .toEqual(['http://trek.example.org', 'https://trek.example.org']);
+  });
+
+  it('PASSKEY-SVC-041: login never widens to a sibling subdomain of the RP ID (#2147)', async () => {
+    // The relay path the exact-origin list exists for: a challenge fetched from
+    // the public options endpoint, spent by a ceremony a compromised sibling
+    // subdomain ran against the apex RP ID.
+    resolveWebauthnConfigMock.mockReturnValue({ rpID: 'example.com', rpName: 'TREK', origins: ['https://example.com'], explicitOrigins: false });
+    const { user } = createUser(testDb);
+    insertCredential(user.id, { credential_id: 'apex-cred' });
+    seedChallenge('a11', null, 'authentication');
+    swMock.verifyAuthenticationResponse.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 1 } });
+
+    await svc.passkeyLoginVerify({ assertionResponse: ceremonyResponse('a11', { id: 'apex-cred' }, { origin: 'https://blog.example.com' }) });
+    expect(swMock.verifyAuthenticationResponse.mock.calls[0][0].expectedOrigin).toEqual(['https://example.com']);
   });
 });
 

--- a/server/tests/unit/plugins/plugin-instance-settings.test.ts
+++ b/server/tests/unit/plugins/plugin-instance-settings.test.ts
@@ -7,6 +7,7 @@
  * the child once, in its init envelope), and an inactive plugin is left alone.
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { HttpException } from '@nestjs/common';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -25,7 +26,7 @@ import { createTables } from '../../../src/db/schema';
 import { runMigrations } from '../../../src/db/migrations';
 import { PluginsService } from '../../../src/nest/plugins/plugins.service';
 import { PluginsController } from '../../../src/nest/plugins/plugins.controller';
-import type { PluginRuntimeService } from '../../../src/nest/plugins/plugin-runtime.service';
+import { PluginConsentRequired, type PluginRuntimeService } from '../../../src/nest/plugins/plugin-runtime.service';
 import type { PluginRegistryService } from '../../../src/nest/plugins/registry/registry.service';
 import type { RuntimeEnvService } from '../../../src/nest/app-config/runtime-env.service';
 import { AddonsService } from '../../../src/nest/addons/addons.service';
@@ -259,6 +260,48 @@ describe('admin config endpoints (controller)', () => {
     const out = await controllerWith({ respawnIfActive }).updateConfig('p', undefined as never);
     expect(out.config).toEqual({});
     expect(out.restarted).toBe(false);
+  });
+
+  it('INS-010: with the kill switch off the save is refused before anything is written', async () => {
+    install('p');
+    declareField('p', 'apiUrl', 'instance');
+    process.env.TREK_PLUGINS_ENABLED = 'false';
+    const respawnIfActive = vi.fn(async () => false);
+
+    const failed = await controllerWith({ respawnIfActive })
+      .updateConfig('p', { apiUrl: 'https://y.example' })
+      .then(() => null, (e: unknown) => e as HttpException);
+
+    expect(failed?.getStatus()).toBe(503);
+    // The respawn is a spawn: it must not run while the whole plugin system is off.
+    expect(respawnIfActive).not.toHaveBeenCalled();
+    expect(svc().getInstanceConfig('p')).toEqual({});
+  });
+
+  it('INS-011: a respawn that fails reports the save that DID happen, and stops claiming the plugin runs', async () => {
+    install('p');
+    declareField('p', 'apiUrl', 'instance');
+    const deactivate = vi.fn(async () => {});
+    const respawnIfActive = vi.fn(async () => {
+      throw new PluginConsentRequired('plugin p requires consent for db:read:trips', ['db:read:trips']);
+    });
+
+    const failed = await controllerWith({ respawnIfActive, deactivate })
+      .updateConfig('p', { apiUrl: 'https://y.example' })
+      .then(() => null, (e: unknown) => e as HttpException);
+
+    expect(failed?.getStatus()).toBe(409);
+    // The envelope carries the saved config and names the restart as the part that broke:
+    // the message must not read as "your settings were lost", because they were not.
+    expect(failed?.getResponse()).toMatchObject({
+      code: 'RESTART_FAILED',
+      config: { apiUrl: 'https://y.example' },
+      error: expect.stringMatching(/Settings saved.*db:read:trips/),
+    });
+    expect(svc().getInstanceConfig('p')).toEqual({ apiUrl: 'https://y.example' });
+    // disable() leaves the row enabled, so the admin list would keep showing a plugin
+    // that no longer has a child. The enable toggle is where the reason is offered.
+    expect(deactivate).toHaveBeenCalledWith('p');
   });
 });
 

--- a/shared/src/i18n/ar/budget.ts
+++ b/shared/src/i18n/ar/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'التقسيم يطابق الإجمالي',
   'costs.splitSumUnder': 'مجموع الحصص: {sum} من {total} (ناقص {diff})',
   'costs.splitSumOver': 'مجموع الحصص: {sum} من {total} (زائد {diff})',
+  'costs.toggleSign': 'التبديل بين المصروف والاسترداد',
 };
 export default budget;

--- a/shared/src/i18n/br/budget.ts
+++ b/shared/src/i18n/br/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'A divisão bate com o total',
   'costs.splitSumUnder': 'Soma das partes: {sum} de {total} (faltam {diff})',
   'costs.splitSumOver': 'Soma das partes: {sum} de {total} (sobram {diff})',
+  'costs.toggleSign': 'Alternar entre despesa e reembolso',
 };
 export default budget;

--- a/shared/src/i18n/ca/budget.ts
+++ b/shared/src/i18n/ca/budget.ts
@@ -146,6 +146,7 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'El repartiment quadra amb el total',
   'costs.splitSumUnder': 'Suma de les parts: {sum} de {total} (en falten {diff})',
   'costs.splitSumOver': 'Suma de les parts: {sum} de {total} ({diff} de més)',
+  'costs.toggleSign': 'Alterna entre despesa i devolució',
 };
 
 export default budget;

--- a/shared/src/i18n/cs/budget.ts
+++ b/shared/src/i18n/cs/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Rozdělení sedí s celkem',
   'costs.splitSumUnder': 'Součet podílů: {sum} z {total} (chybí {diff})',
   'costs.splitSumOver': 'Součet podílů: {sum} z {total} (o {diff} více)',
+  'costs.toggleSign': 'Přepnout mezi výdajem a vratkou',
 };
 export default budget;

--- a/shared/src/i18n/de/budget.ts
+++ b/shared/src/i18n/de/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Aufteilung passt zur Summe',
   'costs.splitSumUnder': 'Summe der Anteile: {sum} von {total} (es fehlen {diff})',
   'costs.splitSumOver': 'Summe der Anteile: {sum} von {total} ({diff} zu viel)',
+  'costs.toggleSign': 'Zwischen Ausgabe und Erstattung wechseln',
 };
 export default budget;

--- a/shared/src/i18n/en/budget.ts
+++ b/shared/src/i18n/en/budget.ts
@@ -146,6 +146,7 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Split matches total',
   'costs.splitSumUnder': 'Sum of splits: {sum} of {total} (under by {diff})',
   'costs.splitSumOver': 'Sum of splits: {sum} of {total} (over by {diff})',
+  'costs.toggleSign': 'Switch between expense and refund',
 };
 
 export default budget;

--- a/shared/src/i18n/es/budget.ts
+++ b/shared/src/i18n/es/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'El reparto cuadra con el total',
   'costs.splitSumUnder': 'Suma de las partes: {sum} de {total} (faltan {diff})',
   'costs.splitSumOver': 'Suma de las partes: {sum} de {total} (sobran {diff})',
+  'costs.toggleSign': 'Cambiar entre gasto y reembolso',
 };
 export default budget;

--- a/shared/src/i18n/fr/budget.ts
+++ b/shared/src/i18n/fr/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'La répartition correspond au total',
   'costs.splitSumUnder': 'Somme des parts : {sum} sur {total} (il manque {diff})',
   'costs.splitSumOver': 'Somme des parts : {sum} sur {total} ({diff} de trop)',
+  'costs.toggleSign': 'Basculer entre dépense et remboursement',
 };
 export default budget;

--- a/shared/src/i18n/gr/budget.ts
+++ b/shared/src/i18n/gr/budget.ts
@@ -147,5 +147,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Ο διαμοιρασμός ταιριάζει με το σύνολο',
   'costs.splitSumUnder': 'Άθροισμα μεριδίων: {sum} από {total} (λείπουν {diff})',
   'costs.splitSumOver': 'Άθροισμα μεριδίων: {sum} από {total} ({diff} παραπάνω)',
+  'costs.toggleSign': 'Εναλλαγή μεταξύ εξόδου και επιστροφής',
 };
 export default budget;

--- a/shared/src/i18n/hu/budget.ts
+++ b/shared/src/i18n/hu/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'A felosztás megegyezik a végösszeggel',
   'costs.splitSumUnder': 'A részek összege: {sum} / {total} (hiányzik {diff})',
   'costs.splitSumOver': 'A részek összege: {sum} / {total} ({diff} a többlet)',
+  'costs.toggleSign': 'Váltás kiadás és visszatérítés között',
 };
 export default budget;

--- a/shared/src/i18n/id/budget.ts
+++ b/shared/src/i18n/id/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Pembagian sudah pas dengan total',
   'costs.splitSumUnder': 'Jumlah bagian: {sum} dari {total} (kurang {diff})',
   'costs.splitSumOver': 'Jumlah bagian: {sum} dari {total} (lebih {diff})',
+  'costs.toggleSign': 'Beralih antara pengeluaran dan pengembalian dana',
 };
 export default budget;

--- a/shared/src/i18n/it/budget.ts
+++ b/shared/src/i18n/it/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'La divisione corrisponde al totale',
   'costs.splitSumUnder': 'Somma delle quote: {sum} di {total} (mancano {diff})',
   'costs.splitSumOver': 'Somma delle quote: {sum} di {total} ({diff} in più)',
+  'costs.toggleSign': 'Passa da spesa a rimborso',
 };
 export default budget;

--- a/shared/src/i18n/ja/budget.ts
+++ b/shared/src/i18n/ja/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': '分割は合計と一致しています',
   'costs.splitSumUnder': '分割の合計: {total} のうち {sum}（{diff} 不足）',
   'costs.splitSumOver': '分割の合計: {total} のうち {sum}（{diff} 超過）',
+  'costs.toggleSign': '支出と返金を切り替える',
 };
 export default budget;

--- a/shared/src/i18n/ko/budget.ts
+++ b/shared/src/i18n/ko/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': '분할 금액이 합계와 일치합니다',
   'costs.splitSumUnder': '분할 합계: {total} 중 {sum} ({diff} 부족)',
   'costs.splitSumOver': '분할 합계: {total} 중 {sum} ({diff} 초과)',
+  'costs.toggleSign': '지출과 환불 전환',
 };
 export default budget;

--- a/shared/src/i18n/nl/budget.ts
+++ b/shared/src/i18n/nl/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Verdeling klopt met het totaal',
   'costs.splitSumUnder': 'Som van de delen: {sum} van {total} ({diff} te weinig)',
   'costs.splitSumOver': 'Som van de delen: {sum} van {total} ({diff} te veel)',
+  'costs.toggleSign': 'Wisselen tussen uitgave en terugbetaling',
 };
 export default budget;

--- a/shared/src/i18n/pl/budget.ts
+++ b/shared/src/i18n/pl/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Podział zgadza się z sumą',
   'costs.splitSumUnder': 'Suma podziałów: {sum} z {total} (brakuje {diff})',
   'costs.splitSumOver': 'Suma podziałów: {sum} z {total} (o {diff} za dużo)',
+  'costs.toggleSign': 'Przełącz między wydatkiem a zwrotem',
 };
 export default budget;

--- a/shared/src/i18n/ru/budget.ts
+++ b/shared/src/i18n/ru/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Разделение совпадает с итогом',
   'costs.splitSumUnder': 'Сумма долей: {sum} из {total} (не хватает {diff})',
   'costs.splitSumOver': 'Сумма долей: {sum} из {total} (больше на {diff})',
+  'costs.toggleSign': 'Переключить между расходом и возвратом',
 };
 export default budget;

--- a/shared/src/i18n/sv/budget.ts
+++ b/shared/src/i18n/sv/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Fördelningen stämmer med totalen',
   'costs.splitSumUnder': 'Summan av delarna: {sum} av {total} ({diff} saknas)',
   'costs.splitSumOver': 'Summan av delarna: {sum} av {total} ({diff} för mycket)',
+  'costs.toggleSign': 'Växla mellan utgift och återbetalning',
 };
 export default budget;

--- a/shared/src/i18n/tr/budget.ts
+++ b/shared/src/i18n/tr/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Bölüşüm toplamla eşleşiyor',
   'costs.splitSumUnder': 'Payların toplamı: {total} tutarın {sum} kadarı ({diff} eksik)',
   'costs.splitSumOver': 'Payların toplamı: {total} tutarın {sum} kadarı ({diff} fazla)',
+  'costs.toggleSign': 'Gider ve iade arasında geçiş yap',
 };
 export default budget;

--- a/shared/src/i18n/uk/budget.ts
+++ b/shared/src/i18n/uk/budget.ts
@@ -146,5 +146,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Розподіл збігається із сумою',
   'costs.splitSumUnder': 'Сума часток: {sum} з {total} (бракує {diff})',
   'costs.splitSumOver': 'Сума часток: {sum} з {total} (більше на {diff})',
+  'costs.toggleSign': 'Перемкнути між витратою та поверненням',
 };
 export default budget;

--- a/shared/src/i18n/vi/budget.ts
+++ b/shared/src/i18n/vi/budget.ts
@@ -146,6 +146,7 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': 'Phần chia khớp với tổng',
   'costs.splitSumUnder': 'Tổng các phần: {sum} trên {total} (thiếu {diff})',
   'costs.splitSumOver': 'Tổng các phần: {sum} trên {total} (thừa {diff})',
+  'costs.toggleSign': 'Chuyển giữa khoản chi và khoản hoàn',
 };
 
 export default budget;

--- a/shared/src/i18n/zh-TW/budget.ts
+++ b/shared/src/i18n/zh-TW/budget.ts
@@ -145,5 +145,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': '分攤金額與總額相符',
   'costs.splitSumUnder': '分攤合計：{total} 中的 {sum}（少 {diff}）',
   'costs.splitSumOver': '分攤合計：{total} 中的 {sum}（多 {diff}）',
+  'costs.toggleSign': '在支出與退款之間切換',
 };
 export default budget;

--- a/shared/src/i18n/zh/budget.ts
+++ b/shared/src/i18n/zh/budget.ts
@@ -145,5 +145,6 @@ const budget: TranslationStrings = {
   'costs.splitBalanced': '分摊金额与总额相符',
   'costs.splitSumUnder': '分摊合计：{total} 中的 {sum}（少 {diff}）',
   'costs.splitSumOver': '分摊合计：{total} 中的 {sum}（多 {diff}）',
+  'costs.toggleSign': '在支出和退款之间切换',
 };
 export default budget;


### PR DESCRIPTION
An adversarial audit of every fix in the v4.1.2 release PR (#2161) confirmed 35 defects across 30 fixes, from a release blocker down to test gaps. This PR resolves all of them. Highlights:

# The fixes that did not actually fix

- **Offline maps (#2180):** the prefetch for the OSM DE and Stadia presets was blocked by our own CSP before the service worker ever saw a request, and the swallowed error still counted as a cached tile, so the progress bar lied. Both hosts are in connect-src now, only reached tiles count, and the prefetch rectangle is widened to the screen the opening fitBounds view fills, on the raster and the default vector path alike.
- **Studio fonts (#2183):** the @fontsource packages for five of the seven book fonts were declared but never imported, so the stack fix still rendered Georgia and friends. The faces load with the lazy Studio chunk now, in exactly the weights the registry uses; a guard test derives the required imports from BOOK_FONTS.
- **Hotel bookends (#2157):** the reported car trip stayed broken, since only a carrier booking or a 2000 km edge stop suppressed the untimed bookend leg. The threshold is a day-trip distance now, and the route optimizer anchors through the same rule on desktop and mobile.

# Regressions caught before release

- Fully timed stays lost their confirmation number, notes and location in the calendar feed; the check-in/check-out markers carry them now (#2136).
- On tablets between 768 and 1023px the journey gallery had no way left to add photos, the row holding upload and provider buttons is hidden there; the gallery actions render below the floating bar (regression from the gallery header rework).
- A check-in window ending before it starts swallowed the arrival event; it reads as a late arrival past midnight now (#2136).

# The rest, grouped

- **Atlas (#2153):** the mouse wheel scrolls the note instead of zooming the map, hovering back to the marker keeps the tooltip open, the flip threshold matches the real tooltip height, touch swipes scroll.
- **Geolocation (#2095):** the phone toast wraps instead of truncating exactly before the settings hint, and an http selfhost gets an insecure-context message instead of a wrong permission diagnosis.
- **Journey (#2194):** the linked-trip tracks switch exists on phones too, and the request gate plus fitBounds behaviour are pinned by tests.
- **Packing (#2191, #2154):** bag totals refetch after reconnect and when coming back online, MCP bag deletes ping the room like REST and the plugin RPC, and the plugin SDK types know the create fields the routes accept.
- **Costs (#2175, #2176):** three-decimal currencies stay typable in the split and receipt fields (desktop and mobile sheet share the guard now), signed amounts get a sign toggle since the iOS decimal pad has no minus key, and the under/over hint keeps its direction for negative totals.
- **Language (#2146):** the offline language mirror is cleared on logout instead of leaking the previous account's language to the next one.
- **Passkeys (#2147):** passkey_configured stops advertising the phantom localhost config, and the origin check binds to the expected origins again instead of any subdomain of the RP id (that widening never shipped).
- **Press-scale (#2158):** the remaining composite buttons (collections rows, gallery tiles, vacay calendar cards, plugin discover cards on desktop and phone) carry the no-press hardening.
- **Admin addons (#2156):** the panel re-reads after a journey toggle, so cascaded-off photo providers stop showing as active.
- **Collab markdown (#2177):** the sanitizer keeps angle-bracket text as literal text instead of eating saved content, footnotes land on their anchor, and one shared plugin set drives all five render surfaces.
- **Plugins (#2170, #2159):** the instance-settings save button is readable in dark mode, a failed respawn after saving is reported honestly, and the allowed-hosts dialog scrolls.
- **Mobile (#2104):** the dashboard filter pill hugs its chips, the collections list switcher clears the dock.
- **Weather (#2167):** one failed fetch no longer parks the badge on its error dash.

Every fix carries tests that go red on revert. Two visible behaviour changes worth noting for the release text: calendar markers of fully timed stays gain a description line, and instances without APP_URL no longer advertise passkeys they cannot register.
