### PR TITLE
Test email diagnostics, chronological journey gallery, all linked bookings on a place

### DIFF
--- a/client/src/api/client.surface.test.ts
+++ b/client/src/api/client.surface.test.ts
@@ -864,4 +864,21 @@ describe('client > multipart uploads', () => {
     expect(post.mock.calls[1][0]).toBe('/backup/upload-restore')
     expect(((post.mock.calls[1][1] as FormData).get('backup') as File).name).toBe('backup.zip')
   })
+
+  it('FE-APISURF-053: every channel test outlives the 8s global timeout', async () => {
+    const post = spyPost()
+
+    // The server budgets up to 20s for an SMTP dial and 10s for a webhook or
+    // ntfy ping; aborting at 8s threw away the reason and left the admin with a
+    // bare "failed" (#2196).
+    await notificationsApi.testSmtp('a@b.c')
+    await notificationsApi.testWebhook('https://hook')
+    await notificationsApi.testNtfy({ topic: 't' })
+    await notificationsApi.testChannel('plugin/ch')
+
+    expect(post.mock.calls).toHaveLength(4)
+    for (const call of post.mock.calls) {
+      expect(call[2]).toMatchObject({ timeout: 40000 })
+    }
+  })
 })

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1232,15 +1232,21 @@ export const tripInviteApi = {
   accept: (token: string) => apiClient.post(`/trip-invites/${token}/accept`).then(r => r.data),
 }
 
+// A channel test dials a third party the admin just typed in, and the server
+// budgets for it: up to 20s for a wrong SMTP port, 10s for a webhook or ntfy
+// endpoint. The 8s instance timeout aborted those before the reason came back,
+// so the toast could only ever say "failed" (#2196).
+const CHANNEL_TEST_TIMEOUT = 40000
+
 export const notificationsApi = {
   getPreferences: () => apiClient.get('/notifications/preferences').then(r => r.data),
   updatePreferences: (prefs: Record<string, Record<string, boolean>>) => apiClient.put('/notifications/preferences', prefs).then(r => r.data),
-  testSmtp: (email?: string) => apiClient.post('/notifications/test-smtp', { email }).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testSmtp')),
-  testWebhook: (url?: string) => apiClient.post('/notifications/test-webhook', { url }).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testWebhook')),
-  testNtfy: (payload: { topic?: string; server?: string | null; token?: string | null }) => apiClient.post('/notifications/test-ntfy', payload).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testNtfy')),
+  testSmtp: (email?: string) => apiClient.post('/notifications/test-smtp', { email }, { timeout: CHANNEL_TEST_TIMEOUT }).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testSmtp')),
+  testWebhook: (url?: string) => apiClient.post('/notifications/test-webhook', { url }, { timeout: CHANNEL_TEST_TIMEOUT }).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testWebhook')),
+  testNtfy: (payload: { topic?: string; server?: string | null; token?: string | null }) => apiClient.post('/notifications/test-ntfy', payload, { timeout: CHANNEL_TEST_TIMEOUT }).then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testNtfy')),
   // Generic channel test — this is how a PLUGIN channel's "Send test" button works.
   testChannel: (channelId: string) =>
-    apiClient.post(`/notifications/test/${encodeURIComponent(channelId)}`)
+    apiClient.post(`/notifications/test/${encodeURIComponent(channelId)}`, undefined, { timeout: CHANNEL_TEST_TIMEOUT })
       .then(r => checkInDev(channelTestResultSchema, r.data, 'notifications.testChannel')),
 }
 

--- a/client/src/components/Planner/DayPlanSidebar.test.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.test.tsx
@@ -3529,6 +3529,34 @@ describe('DayPlanSidebar', () => {
     expect(screen.getByText(/Reservation pending/)).toBeInTheDocument()
   })
 
+  it('FE-PLANNER-DAYPLAN-163b: every booking on the stop gets its own chip line (#2201)', async () => {
+    const user = userEvent.setup()
+    const place = buildPlace({ id: 1, name: 'Zoo' })
+    const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })
+    const a = buildAssignment({ id: 11, day_id: 10, order_index: 0, place })
+    const parking = buildReservation({
+      id: 530, type: 'parking', title: 'Parking pass', status: 'confirmed', assignment_id: 11,
+      reservation_time: '2025-06-01T09:00:00', reservation_end_time: '2025-06-01T09:30:00',
+    } as any)
+    const tickets = buildReservation({
+      id: 531, type: 'activity', title: 'Zoo tickets', status: 'pending', assignment_id: 11,
+      reservation_time: '2025-06-01T10:15:00',
+    } as any)
+    const onEditReservation = vi.fn()
+    render(<DayPlanSidebar {...makeDefaultProps({
+      // Newest first, the order the store hands them over after a local create.
+      days: [day], places: [place], assignments: { '10': [a] }, reservations: [tickets, parking],
+      onEditReservation,
+    })} />)
+    expect(screen.getByText('09:00 – 09:30')).toBeInTheDocument()
+    expect(screen.getByText('10:15')).toBeInTheDocument()
+    expect(screen.getByText(/Reservation confirmed/)).toBeInTheDocument()
+    expect(screen.getByText(/Reservation pending/)).toBeInTheDocument()
+    // Earliest first, so the first pencil belongs to the parking pass.
+    await user.click(screen.getAllByTitle('Edit')[0])
+    expect(onEditReservation).toHaveBeenCalledWith(parking)
+  })
+
   it('FE-PLANNER-DAYPLAN-164: travellers on a place row are shown as avatars with an overflow count', () => {
     const place = buildPlace({ id: 1, name: 'Group visit' })
     const day = buildDay({ id: 10, date: '2025-06-01', title: 'Day 1' })

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -31,6 +31,7 @@ import { isDayInAccommodationRange, getAccommodationAnchors, getDayBookendHotels
 import {
   TRANSPORT_TYPES, parseTimeToMinutes, getSpanPhase, hidesOnMiddleDay, getDisplayTimeForDay, getTransportRouteEndpoints,
   getTransportForDay as _getTransportForDay, getMergedItems as _getMergedItems, isCarrierTransport, hasCarrierEndpointOnDay,
+  getAssignmentReservations,
   type MergedItem,
 } from '../../utils/dayMerge'
 import { withinDriveRange } from '../../utils/geo'
@@ -2141,86 +2142,97 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar(props: DayPlanSidebarP
                                 </div>
                               )}
                               {(() => {
-                                const res = reservations.find(r => r.assignment_id === assignment.id)
-                                if (!res) return null
-                                const confirmed = res.status === 'confirmed'
-                                const hasEndpoints = onToggleConnection && (res.endpoints || []).length >= 2
-                                const active = hasEndpoints ? visibleConnectionIds.includes(res.id) : false
-                                // The status, the time and the flight/train number used to sit in one
-                                // pill strung together on a middle dot, which read as one run-on
-                                // sentence. They are separate chips now: same tint so they still
-                                // belong together, own outline so the eye can take them one at a time.
-                                const RI = RES_ICONS[res.type] || Ticket
-                                const tint = confirmed ? 'bg-[rgba(22,163,74,0.1)] text-[#16a34a]' : 'bg-[rgba(217,119,6,0.1)] text-[#d97706]'
-                                const chip: React.CSSProperties = {
-                                  display: 'inline-flex', alignItems: 'center', gap: 3,
-                                  padding: '1px 6px', borderRadius: 5,
-                                  fontSize: 'calc(9px * var(--fs-scale-caption, 1))', fontWeight: 600,
-                                  whiteSpace: 'nowrap',
-                                }
-                                const { time: st } = splitReservationDateTime(res.reservation_time)
-                                const { time: et } = splitReservationDateTime(res.reservation_end_time)
-                                const timeLabel = st || et
-                                  ? `${st ? formatTime(st, locale, timeFormat) : ''}${et ? ` – ${formatTime(et, locale, timeFormat)}` : ''}`
-                                  : ''
-                                let meta: any = {}
-                                try { meta = typeof res.metadata === 'string' ? JSON.parse(res.metadata || '{}') : (res.metadata || {}) } catch { meta = {} }
-                                const carrierLabel = meta
-                                  ? (meta.airline && meta.flight_number ? `${meta.airline} ${meta.flight_number}` : meta.flight_number || meta.train_number || '')
-                                  : ''
+                                const linked = getAssignmentReservations(reservations, assignment.id)
+                                if (linked.length === 0) return null
+                                // A stop can carry more than one booking (a parking pass and the
+                                // tickets for the same zoo), and every one of them is kept out of
+                                // the timeline, so this row is where they have to appear (#2201).
+                                // Stacked, because the chip lines are inline-flex and would
+                                // otherwise run together on one.
                                 return (
-                                  // No wrapping: the time belongs to the status it qualifies, so the
-                                  // chips stay on one line even when the row gets narrow.
-                                  <div style={{ marginTop: 3, display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'nowrap' }}>
-                                    <div className={tint} style={chip}>
-                                      <RI size={8} />
-                                      <span className="hidden sm:inline">{confirmed ? t('planner.resConfirmed') : t('planner.resPending')}</span>
-                                    </div>
-                                    {timeLabel && <span className={tint} style={{ ...chip, fontWeight: 500 }}>{timeLabel}</span>}
-                                    {carrierLabel && <span className={tint} style={{ ...chip, fontWeight: 500 }}>{carrierLabel}</span>}
-                                    {hasEndpoints && (
-                                      <button
-                                        type="button"
-                                        onClick={e => { e.stopPropagation(); onToggleConnection!(res.id) }}
-                                        title={t(active ? 'map.hideConnections' : 'map.showConnections')}
-                                        className={active ? 'bg-[#3b82f6] text-[#fff]' : 'bg-transparent text-content-faint'}
-                                        style={{
-                                          flexShrink: 0, appearance: 'none',
-                                          width: 20, height: 20, borderRadius: 4,
-                                          display: 'grid', placeItems: 'center', cursor: 'pointer',
-                                          border: 'none',
-                                          transition: 'color 120ms cubic-bezier(0.23,1,0.32,1), background 120ms cubic-bezier(0.23,1,0.32,1)',
-                                        }}
-                                        onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--text-primary)' }}
-                                        onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--text-faint)' }}
-                                      >
-                                        <RouteIcon size={11} />
-                                      </button>
-                                    )}
-                                    {canEditDays && (() => {
-                                      const isTransport = TRANSPORT_TYPES.has(res.type)
-                                      const handler = isTransport ? onEditTransport : onEditReservation
-                                      if (!handler) return null
+                                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                                    {linked.map(res => {
+                                      const confirmed = res.status === 'confirmed'
+                                      const hasEndpoints = onToggleConnection && (res.endpoints || []).length >= 2
+                                      const active = hasEndpoints ? visibleConnectionIds.includes(res.id) : false
+                                      // The status, the time and the flight/train number used to sit in one
+                                      // pill strung together on a middle dot, which read as one run-on
+                                      // sentence. They are separate chips now: same tint so they still
+                                      // belong together, own outline so the eye can take them one at a time.
+                                      const RI = RES_ICONS[res.type] || Ticket
+                                      const tint = confirmed ? 'bg-[rgba(22,163,74,0.1)] text-[#16a34a]' : 'bg-[rgba(217,119,6,0.1)] text-[#d97706]'
+                                      const chip: React.CSSProperties = {
+                                        display: 'inline-flex', alignItems: 'center', gap: 3,
+                                        padding: '1px 6px', borderRadius: 5,
+                                        fontSize: 'calc(9px * var(--fs-scale-caption, 1))', fontWeight: 600,
+                                        whiteSpace: 'nowrap',
+                                      }
+                                      const { time: st } = splitReservationDateTime(res.reservation_time)
+                                      const { time: et } = splitReservationDateTime(res.reservation_end_time)
+                                      const timeLabel = st || et
+                                        ? `${st ? formatTime(st, locale, timeFormat) : ''}${et ? ` – ${formatTime(et, locale, timeFormat)}` : ''}`
+                                        : ''
+                                      let meta: any = {}
+                                      try { meta = typeof res.metadata === 'string' ? JSON.parse(res.metadata || '{}') : (res.metadata || {}) } catch { meta = {} }
+                                      const carrierLabel = meta
+                                        ? (meta.airline && meta.flight_number ? `${meta.airline} ${meta.flight_number}` : meta.flight_number || meta.train_number || '')
+                                        : ''
                                       return (
-                                        <button
-                                          type="button"
-                                          onClick={e => { e.stopPropagation(); handler(res) }}
-                                          title={t('common.edit')}
-                                          className="bg-transparent text-content-faint"
-                                          style={{
-                                            flexShrink: 0, appearance: 'none',
-                                            width: 20, height: 20, borderRadius: 4,
-                                            display: 'grid', placeItems: 'center', cursor: 'pointer',
-                                            border: 'none',
-                                            transition: 'color 120ms cubic-bezier(0.23,1,0.32,1), background 120ms cubic-bezier(0.23,1,0.32,1)',
-                                          }}
-                                          onMouseEnter={e => { e.currentTarget.style.color = 'var(--text-primary)' }}
-                                          onMouseLeave={e => { e.currentTarget.style.color = 'var(--text-faint)' }}
-                                        >
-                                          <Pencil size={11} />
-                                        </button>
+                                        // No wrapping: the time belongs to the status it qualifies, so the
+                                        // chips stay on one line even when the row gets narrow.
+                                        <div key={res.id} style={{ marginTop: 3, display: 'inline-flex', alignItems: 'center', gap: 3, flexWrap: 'nowrap' }}>
+                                          <div className={tint} style={chip}>
+                                            <RI size={8} />
+                                            <span className="hidden sm:inline">{confirmed ? t('planner.resConfirmed') : t('planner.resPending')}</span>
+                                          </div>
+                                          {timeLabel && <span className={tint} style={{ ...chip, fontWeight: 500 }}>{timeLabel}</span>}
+                                          {carrierLabel && <span className={tint} style={{ ...chip, fontWeight: 500 }}>{carrierLabel}</span>}
+                                          {hasEndpoints && (
+                                            <button
+                                              type="button"
+                                              onClick={e => { e.stopPropagation(); onToggleConnection!(res.id) }}
+                                              title={t(active ? 'map.hideConnections' : 'map.showConnections')}
+                                              className={active ? 'bg-[#3b82f6] text-[#fff]' : 'bg-transparent text-content-faint'}
+                                              style={{
+                                                flexShrink: 0, appearance: 'none',
+                                                width: 20, height: 20, borderRadius: 4,
+                                                display: 'grid', placeItems: 'center', cursor: 'pointer',
+                                                border: 'none',
+                                                transition: 'color 120ms cubic-bezier(0.23,1,0.32,1), background 120ms cubic-bezier(0.23,1,0.32,1)',
+                                              }}
+                                              onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--text-primary)' }}
+                                              onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--text-faint)' }}
+                                            >
+                                              <RouteIcon size={11} />
+                                            </button>
+                                          )}
+                                          {canEditDays && (() => {
+                                            const isTransport = TRANSPORT_TYPES.has(res.type)
+                                            const handler = isTransport ? onEditTransport : onEditReservation
+                                            if (!handler) return null
+                                            return (
+                                              <button
+                                                type="button"
+                                                onClick={e => { e.stopPropagation(); handler(res) }}
+                                                title={t('common.edit')}
+                                                className="bg-transparent text-content-faint"
+                                                style={{
+                                                  flexShrink: 0, appearance: 'none',
+                                                  width: 20, height: 20, borderRadius: 4,
+                                                  display: 'grid', placeItems: 'center', cursor: 'pointer',
+                                                  border: 'none',
+                                                  transition: 'color 120ms cubic-bezier(0.23,1,0.32,1), background 120ms cubic-bezier(0.23,1,0.32,1)',
+                                                }}
+                                                onMouseEnter={e => { e.currentTarget.style.color = 'var(--text-primary)' }}
+                                                onMouseLeave={e => { e.currentTarget.style.color = 'var(--text-faint)' }}
+                                              >
+                                                <Pencil size={11} />
+                                              </button>
+                                            )
+                                          })()}
+                                        </div>
                                       )
-                                    })()}
+                                    })}
                                   </div>
                                 )
                               })()}

--- a/client/src/components/Planner/PlaceInspector.test.tsx
+++ b/client/src/components/Planner/PlaceInspector.test.tsx
@@ -425,6 +425,33 @@ describe('PlaceInspector', () => {
     expect(screen.getByText('Museum Ticket')).toBeTruthy();
   });
 
+  it('FE-PLANNER-INSPECTOR-030g: every booking on the stop gets its own strip (#2201)', () => {
+    const onEditReservation = vi.fn();
+    const parking = buildReservation({
+      id: 530, title: 'Parking pass', status: 'confirmed', type: 'parking', assignment_id: 99,
+      reservation_time: '2025-06-01T09:00:00',
+    } as any);
+    const tickets = buildReservation({
+      id: 531, title: 'Zoo tickets', status: 'pending', type: 'activity', assignment_id: 99,
+      reservation_time: '2025-06-01T10:15:00',
+    } as any);
+    const assignmentInDay = [{ id: 99, place, day_id: 1, place_id: place.id, order_index: 0, notes: null }];
+    render(
+      <PlaceInspector
+        {...defaultProps}
+        selectedDayId={1}
+        selectedAssignmentId={99}
+        assignments={{ '1': assignmentInDay }}
+        reservations={[tickets, parking]}
+        onEditReservation={onEditReservation}
+      />
+    );
+    expect(screen.getByText('Parking pass')).toBeTruthy();
+    expect(screen.getByText('Zoo tickets')).toBeTruthy();
+    fireEvent.click(screen.getByText('Zoo tickets').closest('[role="button"]') as HTMLElement);
+    expect(onEditReservation).toHaveBeenCalledWith(tickets);
+  });
+
   it('FE-PLANNER-INSPECTOR-030b: the linked reservation opens its editor (#2012)', () => {
     const onEditReservation = vi.fn();
     const reservation = buildReservation({ title: 'Museum Ticket', status: 'confirmed', assignment_id: 99 } as any);

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -30,7 +30,7 @@ import { splitReservationDateTime, formatTime, formatMoney } from '../../utils/f
 import { useTripStore } from '../../store/tripStore'
 import { formatDistance, formatElevation } from '../../utils/units'
 import { getNavigationTargets, openNavigationTarget } from './placeNavigation'
-import { TRANSPORT_TYPES } from '../../utils/dayMerge'
+import { TRANSPORT_TYPES, getAssignmentReservations } from '../../utils/dayMerge'
 import { NavigationMenu } from '../shared/NavigationMenu'
 import { resolveOpenNow, resolvePlaceTimeZone, placeWeekdayIndex } from './placeOpenState'
 import { convertHoursLine } from './placeHoursFormat'
@@ -839,96 +839,101 @@ function PlaceReservationParticipants({ selectedAssignmentId, reservations, assi
   return (
     <>
           {(() => {
-            const res = selectedAssignmentId ? reservations.find(r => r.assignment_id === selectedAssignmentId) : null
+            const linked = getAssignmentReservations<Reservation>(reservations, selectedAssignmentId)
             const assignment = selectedAssignmentId ? (assignments[String(selectedDayId)] || []).find(a => a.id === selectedAssignmentId) : null
             const currentParticipants = assignment?.participants || []
             const participantIds = currentParticipants.map(p => p.user_id)
             const allJoined = currentParticipants.length === 0
             const showParticipants = selectedAssignmentId && tripMembers.length > 1
-            if (!res && !showParticipants) return null
+            if (linked.length === 0 && !showParticipants) return null
             return (
-              <div className={`grid ${res && showParticipants ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'} gap-2`}>
-                {/* Reservation */}
-                {res && (() => {
-                  const confirmed = res.status === 'confirmed'
-                  // The strip summarised the booking but went nowhere, so its
-                  // attachments and fields had no route from the map (#2012).
-                  // A transport has its own form; picking by type is what the day
-                  // sidebar does, and an absent handler means this user may not
-                  // open this one — so the strip stays inert rather than lying.
-                  const editor = TRANSPORT_TYPES.has(res.type) ? onEditTransport : onEditReservation
-                  const open = editor ? () => editor(res) : undefined
-                  return (
-                    <div
-                      role={open ? 'button' : undefined}
-                      // No press-scale on the composite strip — shrinking it
-                      // mid-click slides the links inside out from under the
-                      // pointer (#2158).
-                      data-no-press
-                      aria-label={open ? t('inspector.editRes') : undefined}
-                      tabIndex={open ? 0 : undefined}
-                      onClick={open}
-                      onKeyDown={open ? (e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open() }
-                      } : undefined}
-                      title={open ? t('inspector.editRes') : undefined}
-                      style={{ borderRadius: 12, overflow: 'hidden', border: `1px solid ${confirmed ? 'rgba(22,163,74,0.2)' : 'rgba(217,119,6,0.2)'}`, cursor: open ? 'pointer' : undefined, textAlign: 'left' }}
-                    >
-                      <div className={confirmed ? 'bg-[rgba(22,163,74,0.08)]' : 'bg-[rgba(217,119,6,0.08)]'} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px' }}>
-                        <div className={confirmed ? 'bg-[#16a34a]' : 'bg-[#d97706]'} style={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0 }} />
-                        <span className={confirmed ? 'text-[#16a34a]' : 'text-[#d97706]'} style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 700 }}>{confirmed ? t('reservations.confirmed') : t('reservations.pending')}</span>
-                        <span style={{ flex: 1 }} />
-                        <span className="text-content" style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{res.title}</span>
-                      </div>
-                      <div style={{ padding: '6px 10px', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                        {(() => {
-                          const { date, time: startTime } = splitReservationDateTime(res.reservation_time)
-                          const { time: endTime } = splitReservationDateTime(res.reservation_end_time)
-                          return (
-                            <>
-                              {date && (
-                                <div>
-                                  <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.date')}</div>
-                                  <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>{new Date(date + 'T00:00:00Z').toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'UTC' })}</div>
-                                </div>
-                              )}
-                              {(startTime || endTime) && (
-                                <div>
-                                  <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.time')}</div>
-                                  <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>
-                                    {startTime ? formatTime(startTime, locale, timeFormat) : ''}
-                                    {endTime ? ` – ${formatTime(endTime, locale, timeFormat)}` : ''}
-                                  </div>
-                                </div>
-                              )}
-                            </>
-                          )
-                        })()}
-                        {res.confirmation_number && (
-                          <div>
-                            <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.confirmationCode')}</div>
-                            <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>{res.confirmation_number}</div>
+              <div className={`grid ${linked.length > 0 && showParticipants ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'} gap-2`}>
+                {/* Bookings pinned to this stop; several can share one (#2201) */}
+                {linked.length > 0 && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {linked.map(res => {
+                      const confirmed = res.status === 'confirmed'
+                      // The strip summarised the booking but went nowhere, so its
+                      // attachments and fields had no route from the map (#2012).
+                      // A transport has its own form; picking by type is what the day
+                      // sidebar does, and an absent handler means this user may not
+                      // open this one, so the strip stays inert rather than lying.
+                      const editor = TRANSPORT_TYPES.has(res.type) ? onEditTransport : onEditReservation
+                      const open = editor ? () => editor(res) : undefined
+                      return (
+                        <div
+                          key={res.id}
+                          role={open ? 'button' : undefined}
+                          // No press-scale on the composite strip: shrinking it
+                          // mid-click slides the links inside out from under the
+                          // pointer (#2158).
+                          data-no-press
+                          aria-label={open ? t('inspector.editRes') : undefined}
+                          tabIndex={open ? 0 : undefined}
+                          onClick={open}
+                          onKeyDown={open ? (e: React.KeyboardEvent) => {
+                            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open() }
+                          } : undefined}
+                          title={open ? t('inspector.editRes') : undefined}
+                          style={{ borderRadius: 12, overflow: 'hidden', border: `1px solid ${confirmed ? 'rgba(22,163,74,0.2)' : 'rgba(217,119,6,0.2)'}`, cursor: open ? 'pointer' : undefined, textAlign: 'left' }}
+                        >
+                          <div className={confirmed ? 'bg-[rgba(22,163,74,0.08)]' : 'bg-[rgba(217,119,6,0.08)]'} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px' }}>
+                            <div className={confirmed ? 'bg-[#16a34a]' : 'bg-[#d97706]'} style={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0 }} />
+                            <span className={confirmed ? 'text-[#16a34a]' : 'text-[#d97706]'} style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 700 }}>{confirmed ? t('reservations.confirmed') : t('reservations.pending')}</span>
+                            <span style={{ flex: 1 }} />
+                            <span className="text-content" style={{ fontSize: 'calc(11px * var(--fs-scale-caption, 1))', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{res.title}</span>
                           </div>
-                        )}
-                      </div>
-                      {res.notes && <div className="collab-note-md text-content-faint" style={{ padding: '0 10px 6px', fontSize: 'calc(10px * var(--fs-scale-caption, 1))', lineHeight: 1.4, wordBreak: 'break-word', overflowWrap: 'anywhere' }}><Markdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownLinkComponents}>{res.notes}</Markdown></div>}
-                      {(() => {
-                        const meta = typeof res.metadata === 'string' ? JSON.parse(res.metadata || '{}') : (res.metadata || {})
-                        if (!meta || Object.keys(meta).length === 0) return null
-                        const parts: string[] = []
-                        if (meta.airline && meta.flight_number) parts.push(`${meta.airline} ${meta.flight_number}`)
-                        else if (meta.flight_number) parts.push(meta.flight_number)
-                        if (meta.departure_airport && meta.arrival_airport) parts.push(`${meta.departure_airport} → ${meta.arrival_airport}`)
-                        if (meta.train_number) parts.push(meta.train_number)
-                        if (meta.platform) parts.push(`Gl. ${meta.platform}`)
-                        if (meta.check_in_time) parts.push(`Check-in ${meta.check_in_time}`)
-                        if (meta.check_out_time) parts.push(`Check-out ${meta.check_out_time}`)
-                        if (parts.length === 0) return null
-                        return <div className="text-content-muted" style={{ padding: '0 10px 6px', fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500 }}>{parts.join(' · ')}</div>
-                      })()}
-                    </div>
-                  )
-                })()}
+                          <div style={{ padding: '6px 10px', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                            {(() => {
+                              const { date, time: startTime } = splitReservationDateTime(res.reservation_time)
+                              const { time: endTime } = splitReservationDateTime(res.reservation_end_time)
+                              return (
+                                <>
+                                  {date && (
+                                    <div>
+                                      <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.date')}</div>
+                                      <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>{new Date(date + 'T00:00:00Z').toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'UTC' })}</div>
+                                    </div>
+                                  )}
+                                  {(startTime || endTime) && (
+                                    <div>
+                                      <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.time')}</div>
+                                      <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>
+                                        {startTime ? formatTime(startTime, locale, timeFormat) : ''}
+                                        {endTime ? ` – ${formatTime(endTime, locale, timeFormat)}` : ''}
+                                      </div>
+                                    </div>
+                                  )}
+                                </>
+                              )
+                            })()}
+                            {res.confirmation_number && (
+                              <div>
+                                <div className="text-content-faint" style={{ fontSize: 'calc(8px * var(--fs-scale-caption, 1))', fontWeight: 600, textTransform: 'uppercase' }}>{t('reservations.confirmationCode')}</div>
+                                <div className="text-content" style={{ fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500, marginTop: 1 }}>{res.confirmation_number}</div>
+                              </div>
+                            )}
+                          </div>
+                          {res.notes && <div className="collab-note-md text-content-faint" style={{ padding: '0 10px 6px', fontSize: 'calc(10px * var(--fs-scale-caption, 1))', lineHeight: 1.4, wordBreak: 'break-word', overflowWrap: 'anywhere' }}><Markdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownLinkComponents}>{res.notes}</Markdown></div>}
+                          {(() => {
+                            const meta = typeof res.metadata === 'string' ? JSON.parse(res.metadata || '{}') : (res.metadata || {})
+                            if (!meta || Object.keys(meta).length === 0) return null
+                            const parts: string[] = []
+                            if (meta.airline && meta.flight_number) parts.push(`${meta.airline} ${meta.flight_number}`)
+                            else if (meta.flight_number) parts.push(meta.flight_number)
+                            if (meta.departure_airport && meta.arrival_airport) parts.push(`${meta.departure_airport} → ${meta.arrival_airport}`)
+                            if (meta.train_number) parts.push(meta.train_number)
+                            if (meta.platform) parts.push(`Gl. ${meta.platform}`)
+                            if (meta.check_in_time) parts.push(`Check-in ${meta.check_in_time}`)
+                            if (meta.check_out_time) parts.push(`Check-out ${meta.check_out_time}`)
+                            if (parts.length === 0) return null
+                            return <div className="text-content-muted" style={{ padding: '0 10px 6px', fontSize: 'calc(10px * var(--fs-scale-caption, 1))', fontWeight: 500 }}>{parts.join(' · ')}</div>
+                          })()}
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
 
                 {/* Participants */}
                 {showParticipants && (

--- a/client/src/mobile/screens/admin/MAdminNotificationsSection.tsx
+++ b/client/src/mobile/screens/admin/MAdminNotificationsSection.tsx
@@ -187,9 +187,12 @@ export default function MAdminNotificationsSection({ admin, t }: MAdminNotificat
           {smtpLoaded &&
             SMTP_FIELDS.map((field) => (
               <MAdminField key={field.key} label={field.label}>
+                {/* A stored password comes back masked. Showing the mask as the VALUE meant
+                    typing a new one appended it to eight bullet characters and saved that,
+                    so the same treatment as the webhook URL below: mask as placeholder. */}
                 <MAdminInput
                   type={field.type || 'text'}
-                  value={smtpValues[field.key] || ''}
+                  value={smtpValues[field.key] === '••••••••' ? '' : smtpValues[field.key] || ''}
                   onChange={(e) => setSmtpValues((prev) => ({ ...prev, [field.key]: e.target.value }))}
                   placeholder={field.placeholder}
                 />

--- a/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
@@ -175,7 +175,7 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
                   <PlaceRow
                     assignment={row.assignment}
                     fullPlace={tl.fullPlaceOf(row.assignment)}
-                    linkedRes={row.linkedRes}
+                    linkedReservations={row.linkedReservations}
                     chrome={chrome}
                     reorder={reorderFor(row.item)}
                     drag={dragFor(row)}

--- a/client/src/mobile/screens/trip/plan/MPlanTimelineRows.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimelineRows.tsx
@@ -119,10 +119,10 @@ const TIME_CHIP = 'flex-none whitespace-nowrap rounded-[6px] bg-[color:var(--m-i
 
 // ── b3) Place row ────────────────────────────────────────────────────────────
 
-export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, drag, onOpen, onEdit, onRemove }: {
+export function PlaceRow({ assignment, fullPlace, linkedReservations, chrome, reorder, drag, onOpen, onEdit, onRemove }: {
   assignment: Assignment
   fullPlace: Place | undefined
-  linkedRes: Reservation | null
+  linkedReservations: Reservation[]
   chrome: RowChrome
   reorder: ReactNode
   drag?: RowDrag
@@ -134,11 +134,19 @@ export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, dr
   const place = assignment.place
   const CatIcon = getCategoryIcon(place?.category?.icon)
   const time = fmtTime(place?.place_time, chrome)
-  const sub = linkedRes
-    ? [
-        linkedRes.status === 'confirmed' ? t('dayplan.confirmed') : t('dayplan.pendingRes'),
-        linkedRes.confirmation_number ? `#${linkedRes.confirmation_number}` : '',
-      ].filter(Boolean).join(' · ')
+  // One line per booking on the stop (#2201). A single one keeps the bare
+  // status line it always had; once there are several, the title tells them
+  // apart, since "Confirmed" twice over says nothing.
+  const bookingLines = linkedReservations.map(r => ({
+    id: r.id,
+    text: [
+      linkedReservations.length > 1 ? r.title : '',
+      r.status === 'confirmed' ? t('dayplan.confirmed') : t('dayplan.pendingRes'),
+      r.confirmation_number ? `#${r.confirmation_number}` : '',
+    ].filter(Boolean).join(' · '),
+  }))
+  const sub = bookingLines.length > 0
+    ? bookingLines[0].text
     : place?.address || place?.description || ''
 
   return (
@@ -175,7 +183,7 @@ export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, dr
         <div className="flex items-center gap-1.5">
           <CatIcon size={12} strokeWidth={2.2} className="flex-none text-m-muted" />
           <span className="min-w-0 truncate text-[0.875rem] font-semibold">{place?.name}</span>
-          {linkedRes && (
+          {bookingLines.length > 0 && (
             <span className="flex flex-none items-center gap-1 rounded-full bg-[color:var(--m-ic)] px-[7px] py-[2px] text-[0.5625rem] font-bold tracking-[.04em]">
               <Ticket size={10} strokeWidth={2.2} />
               {t('mobileTrip.resBadge')}
@@ -188,6 +196,11 @@ export function PlaceRow({ assignment, fullPlace, linkedRes, chrome, reorder, dr
             {sub && <span className="min-w-0 truncate font-geist text-[0.71875rem] text-m-muted">{sub}</span>}
           </div>
         )}
+        {bookingLines.slice(1).map(line => (
+          <div key={line.id} className="mt-[2px] flex min-w-0 items-center gap-1.5">
+            <span className="min-w-0 truncate font-geist text-[0.71875rem] text-m-muted">{line.text}</span>
+          </div>
+        ))}
         {assignment.notes && (
           // Day-specific note on this stop (#2163) — mirror of the desktop
           // timeline's caption line, so the phone shows the note exists

--- a/client/src/mobile/screens/trip/plan/planTimelineModel.test.ts
+++ b/client/src/mobile/screens/trip/plan/planTimelineModel.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlanRows } from './planTimelineModel'
+import type { MergedItem } from '../../../../utils/dayMerge'
+import type { Reservation } from '../../../../types'
+
+// FE-MOBILE-PLANROWS-001 to FE-MOBILE-PLANROWS-003
+
+const zooStop = [
+  { type: 'place', sortKey: 0, data: { id: 11, day_id: 5, order_index: 0, place: { id: 1, name: 'Zoo' } } },
+] as unknown as MergedItem[]
+
+describe('buildPlanRows', () => {
+  it('FE-MOBILE-PLANROWS-001: carries every booking linked to the stop, earliest first (#2201)', () => {
+    const reservations = [
+      { id: 531, assignment_id: 11, title: 'Zoo tickets', reservation_time: '2025-06-01T10:15:00' },
+      { id: 530, assignment_id: 11, title: 'Parking pass', reservation_time: '2025-06-01T09:00:00' },
+      { id: 532, assignment_id: 12, title: 'Another stop', reservation_time: null },
+    ] as unknown as Reservation[]
+    const rows = buildPlanRows({ merged: zooStop, reservations, routeSegments: [], dayId: 5 })
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    if (row.kind !== 'place') throw new Error('expected a place row')
+    expect(row.linkedReservations.map(r => r.id)).toEqual([530, 531])
+  })
+
+  it('FE-MOBILE-PLANROWS-002: a stop without bookings gets an empty list', () => {
+    const reservations = [
+      { id: 532, assignment_id: 12, title: 'Another stop', reservation_time: null },
+    ] as unknown as Reservation[]
+    const rows = buildPlanRows({ merged: zooStop, reservations, routeSegments: [], dayId: 5 })
+    const row = rows[0]
+    if (row.kind !== 'place') throw new Error('expected a place row')
+    expect(row.linkedReservations).toEqual([])
+  })
+
+  it('FE-MOBILE-PLANROWS-003: an unlinked booking stays a transport row of its own', () => {
+    const merged = [
+      ...zooStop,
+      { type: 'transport', sortKey: 1, data: { id: 540, type: 'taxi', day_id: 5, title: 'Cab' } },
+    ] as unknown as MergedItem[]
+    const reservations = [
+      { id: 540, assignment_id: null, type: 'taxi', title: 'Cab', reservation_time: null },
+    ] as unknown as Reservation[]
+    const rows = buildPlanRows({ merged, reservations, routeSegments: [], dayId: 5 })
+    expect(rows.map(r => r.kind)).toEqual(['place', 'transport'])
+    const place = rows[0]
+    if (place.kind !== 'place') throw new Error('expected a place row')
+    expect(place.linkedReservations).toEqual([])
+  })
+})

--- a/client/src/mobile/screens/trip/plan/planTimelineModel.ts
+++ b/client/src/mobile/screens/trip/plan/planTimelineModel.ts
@@ -1,6 +1,6 @@
 import { Cloud, CloudDrizzle, CloudLightning, CloudRain, CloudSnow, Sun, Wind } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import { getDisplayTimeForDay, getSpanPhase, hidesOnMiddleDay, parseTimeToMinutes } from '../../../../utils/dayMerge'
+import { getAssignmentReservations, getDisplayTimeForDay, getSpanPhase, hidesOnMiddleDay, parseTimeToMinutes } from '../../../../utils/dayMerge'
 import { getDayBookendHotels, isDayInAccommodationRange } from '../../../../utils/dayOrder'
 import type { MergedItem } from '../../../../utils/dayMerge'
 import type { TransitLegDisplay } from '../../../../components/Planner/transitDisplay'
@@ -24,7 +24,7 @@ export interface TransitMeta {
 }
 
 export type PlanRow =
-  | { key: string; kind: 'place'; item: MergedItem; assignment: Assignment; linkedRes: Reservation | null }
+  | { key: string; kind: 'place'; item: MergedItem; assignment: Assignment; linkedReservations: Reservation[] }
   | { key: string; kind: 'transport'; item: MergedItem; res: TransportEntry }
   | { key: string; kind: 'transit'; item: MergedItem; res: TransportEntry; transit: TransitMeta }
   | { key: string; kind: 'note'; item: MergedItem; note: DayNote }
@@ -100,7 +100,10 @@ export function buildPlanRows(opts: {
         kind: 'place',
         item,
         assignment,
-        linkedRes: reservations.find(r => r.assignment_id === assignment.id) ?? null,
+        // All of them: a stop can carry a parking pass and the tickets for the same
+        // attraction, and getTransportForDay keeps every linked booking out of the
+        // timeline, so anything dropped here is gone from the plan tab (#2201).
+        linkedReservations: getAssignmentReservations(reservations, assignment.id),
       })
     } else if (item.type === 'note') {
       const note = item.data as DayNote

--- a/client/src/mobile/screens/trip/plan/useMPlanDragReorder.test.ts
+++ b/client/src/mobile/screens/trip/plan/useMPlanDragReorder.test.ts
@@ -11,7 +11,7 @@ const items = [
 ] as unknown as MergedItem[]
 
 const rowFor = (i: number): PlanRow =>
-  ({ key: `row-${i}`, kind: 'place', item: items[i], assignment: {}, linkedRes: null }) as unknown as PlanRow
+  ({ key: `row-${i}`, kind: 'place', item: items[i], assignment: {}, linkedReservations: [] }) as unknown as PlanRow
 
 const connRow = { key: 'conn-1', kind: 'conn', seg: {} } as unknown as PlanRow
 

--- a/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MPlaceSheet.tsx
@@ -21,7 +21,8 @@ import { safeHttpUrl } from '../../../../utils/safeUrl'
 import { openFile } from '../../../../utils/fileDownload'
 import { getNavigationTargets, openNavigationTarget } from '../../../../components/Planner/placeNavigation'
 import { NavigationMenu } from '../../../../components/shared/NavigationMenu'
-import type { Assignment, Day, TripMember } from '../../../../types'
+import { getAssignmentReservations } from '../../../../utils/dayMerge'
+import type { Assignment, Day, Reservation, TripMember } from '../../../../types'
 import { ActionCircle, Eyebrow, INNER_CLS } from './MTripSheetUi'
 
 /**
@@ -85,28 +86,27 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
     ? ((planner.selectedAssignmentId ? dayAssignments.find(a => a.id === planner.selectedAssignmentId) : null)
       ?? dayAssignments.find(a => a.place?.id === place?.id))
     : null
-  // The booking attached to that assignment. The desktop inspector shows this
+  // The bookings attached to that assignment. The desktop inspector shows this
   // strip; the phone sheet never did, so a booking reached from a map marker was
-  // just as unreachable here, only invisibly so (#2012).
-  const linkedRes = assignmentInDay
-    ? planner.reservations.find(r => r.assignment_id === assignmentInDay.id) ?? null
-    : null
+  // just as unreachable here, only invisibly so (#2012). All of them, because a
+  // stop can carry a parking pass next to its tickets (#2201).
+  const linkedReservations = getAssignmentReservations(planner.reservations, assignmentInDay?.id)
   // A ferry or a flight has its own form — the reservation modal cannot hold one.
   // Resolved up front so a user without the matching right gets no button at all,
   // rather than one that does nothing (#2012).
-  const canOpenLinkedRes = !!linkedRes && planner.can(
-    planner.TRANSPORT_TYPES.has(linkedRes.type) ? 'day_edit' : 'reservation_edit',
+  const canOpenRes = (res: Reservation) => planner.can(
+    planner.TRANSPORT_TYPES.has(res.type) ? 'day_edit' : 'reservation_edit',
     planner.trip,
   )
-  const openLinkedRes = () => {
-    if (!linkedRes || !canOpenLinkedRes) return
-    if (planner.TRANSPORT_TYPES.has(linkedRes.type)) {
-      planner.setEditingTransport(linkedRes)
-      planner.setTransportModalDayId(linkedRes.day_id ?? null)
+  const openRes = (res: Reservation) => {
+    if (!canOpenRes(res)) return
+    if (planner.TRANSPORT_TYPES.has(res.type)) {
+      planner.setEditingTransport(res)
+      planner.setTransportModalDayId(res.day_id ?? null)
       planner.setTransportModalAutomated(false)
       planner.setShowTransportModal(true)
     } else {
-      planner.setEditingReservation(linkedRes)
+      planner.setEditingReservation(res)
       planner.setShowReservationModal(true)
     }
     // This sheet hangs off the place selection, not the sheet stack, so its own
@@ -452,27 +452,32 @@ export default function MPlaceSheet({ planner, shell }: MTripSheetsProps) {
               </>
             )}
 
-            {/* ── The booking attached to this stop (#2012) ── */}
-            {linkedRes && (
+            {/* ── The bookings attached to this stop (#2012, #2201) ── */}
+            {linkedReservations.length > 0 && (
               <>
                 <Eyebrow className="mb-[6px] mt-3">{t('reservations.title')}</Eyebrow>
-                <button
-                  type="button"
-                  onClick={openLinkedRes}
-                  disabled={!canOpenLinkedRes}
-                  aria-label={canOpenLinkedRes ? t('inspector.editRes') : undefined}
-                  className={`flex w-full items-center gap-2 rounded-[14px] px-3 py-[10px] text-left ${INNER_CLS}`}
-                >
-                  <span
-                    className="h-2 w-2 flex-none rounded-full"
-                    style={{ background: linkedRes.status === 'confirmed' ? 'var(--m-st-confirmed)' : 'var(--m-st-pending)' }}
-                  />
-                  <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-semibold">{linkedRes.title}</span>
-                  <span className="flex-none font-geist text-[0.65625rem] text-m-muted">
-                    {linkedRes.status === 'confirmed' ? t('reservations.confirmed') : t('reservations.pending')}
-                  </span>
-                  {canOpenLinkedRes && <ChevronRight size={14} strokeWidth={2} className="flex-none text-m-faint" />}
-                </button>
+                <div className="flex flex-col gap-[6px]">
+                  {linkedReservations.map(res => (
+                    <button
+                      key={res.id}
+                      type="button"
+                      onClick={() => openRes(res)}
+                      disabled={!canOpenRes(res)}
+                      aria-label={canOpenRes(res) ? t('inspector.editRes') : undefined}
+                      className={`flex w-full items-center gap-2 rounded-[14px] px-3 py-[10px] text-left ${INNER_CLS}`}
+                    >
+                      <span
+                        className="h-2 w-2 flex-none rounded-full"
+                        style={{ background: res.status === 'confirmed' ? 'var(--m-st-confirmed)' : 'var(--m-st-pending)' }}
+                      />
+                      <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-semibold">{res.title}</span>
+                      <span className="flex-none font-geist text-[0.65625rem] text-m-muted">
+                        {res.status === 'confirmed' ? t('reservations.confirmed') : t('reservations.pending')}
+                      </span>
+                      {canOpenRes(res) && <ChevronRight size={14} strokeWidth={2} className="flex-none text-m-faint" />}
+                    </button>
+                  ))}
+                </div>
               </>
             )}
 

--- a/client/src/pages/admin/AdminNotificationsTab.test.tsx
+++ b/client/src/pages/admin/AdminNotificationsTab.test.tsx
@@ -539,4 +539,24 @@ describe('AdminNotificationsTab', () => {
 
     await waitFor(() => expect(admin.toast.error).toHaveBeenCalledWith('Error'));
   });
+
+  it('FE-ADMNOT-042: a stored SMTP password is a placeholder, so a new one replaces it', async () => {
+    let body: Record<string, unknown> | null = null;
+    server.use(
+      http.put('/api/auth/app-settings', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({});
+      }),
+      http.get('/api/auth/app-config', () => HttpResponse.json({}))
+    );
+    render(<StatefulHarness initial={{ ...EMAIL_ON, smtp_pass: '••••••••' }} />);
+
+    // Typing into the eight bullet characters used to save them along with the
+    // password, which then failed to authenticate with nothing in the log.
+    expect(screen.getByPlaceholderText('••••••••')).toHaveValue('');
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'hunter2' } });
+    fireEvent.click(within(card('Email (SMTP)')).getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(body).toEqual({ smtp_host: 'mail.example.com', smtp_pass: 'hunter2' }));
+  });
 });

--- a/client/src/pages/admin/AdminNotificationsTab.tsx
+++ b/client/src/pages/admin/AdminNotificationsTab.tsx
@@ -87,9 +87,12 @@ export default function AdminNotificationsTab({ admin, t }: AdminNotificationsTa
           ].map(field => (
             <div key={field.key}>
               <label className="block text-xs font-medium text-slate-500 mb-1">{field.label}</label>
+              {/* A stored password comes back masked. Showing the mask as the VALUE meant
+                  typing a new one appended it to eight bullet characters and saved that,
+                  so the same treatment as the webhook URL below: mask as placeholder. */}
               <input
                 type={field.type || 'text'}
-                value={smtpValues[field.key] || ''}
+                value={smtpValues[field.key] === '••••••••' ? '' : smtpValues[field.key] || ''}
                 onChange={e => setSmtpValues(prev => ({ ...prev, [field.key]: e.target.value }))}
                 placeholder={field.placeholder}
                 className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-slate-400 focus:border-transparent"

--- a/client/src/utils/dayMerge.test.ts
+++ b/client/src/utils/dayMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseTimeToMinutes, getSpanPhase, hidesOnMiddleDay, getTransportRouteEndpoints, getDisplayTimeForDay, getTransportForDay, getMergedItems } from './dayMerge'
+import { parseTimeToMinutes, getSpanPhase, hidesOnMiddleDay, getTransportRouteEndpoints, getDisplayTimeForDay, getTransportForDay, getAssignmentReservations, getMergedItems } from './dayMerge'
 
 describe('parseTimeToMinutes', () => {
   it('parses HH:MM string', () => {
@@ -196,6 +196,41 @@ describe('getTransportForDay', () => {
     const rows = getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [], days })
     expect(rows).toHaveLength(1)
     expect(rows[0].__leg).toBeUndefined()
+  })
+})
+
+describe('getAssignmentReservations', () => {
+  it('returns every booking pinned to the assignment, not just the first (#2201)', () => {
+    const reservations = [
+      { id: 1, assignment_id: 42, reservation_time: '2025-06-01T10:00:00' },
+      { id: 2, assignment_id: 42, reservation_time: '2025-06-01T09:00:00' },
+      { id: 3, assignment_id: 7, reservation_time: '2025-06-01T08:00:00' },
+    ]
+    expect(getAssignmentReservations(reservations, 42).map(r => r.id)).toEqual([2, 1])
+  })
+
+  it('puts untimed bookings last and breaks ties on the id', () => {
+    const reservations = [
+      { id: 5, assignment_id: 42, reservation_time: null },
+      { id: 4, assignment_id: 42, reservation_time: null },
+      { id: 6, assignment_id: 42, reservation_time: '2025-06-01T09:00:00' },
+    ]
+    expect(getAssignmentReservations(reservations, 42).map(r => r.id)).toEqual([6, 4, 5])
+  })
+
+  it('returns nothing without an assignment', () => {
+    const reservations = [{ id: 1, assignment_id: 42, reservation_time: null }]
+    expect(getAssignmentReservations(reservations, null)).toEqual([])
+    expect(getAssignmentReservations(reservations, undefined)).toEqual([])
+  })
+
+  it('leaves the caller array untouched', () => {
+    const reservations = [
+      { id: 1, assignment_id: 42, reservation_time: '2025-06-01T10:00:00' },
+      { id: 2, assignment_id: 42, reservation_time: '2025-06-01T09:00:00' },
+    ]
+    getAssignmentReservations(reservations, 42)
+    expect(reservations.map(r => r.id)).toEqual([1, 2])
   })
 })
 

--- a/client/src/utils/dayMerge.ts
+++ b/client/src/utils/dayMerge.ts
@@ -236,6 +236,36 @@ export function getTransportForDay(opts: {
 }
 
 /**
+ * Every booking pinned to one day assignment. A stop can carry several (the parking
+ * pass and the tickets for the same zoo), and the exclusion above keeps all of them
+ * out of the timeline, so the place row is the only surface that can show them, and
+ * a `find()` there dropped the rest without trace (#2201).
+ *
+ * Earliest first, untimed last, id as the tiebreaker: the store's array order is
+ * newest-first for locally created bookings and load order otherwise, which would
+ * shuffle the same two bookings between a reload and a live update.
+ */
+export function getAssignmentReservations<T extends {
+  id: number
+  assignment_id?: number | null
+  reservation_time?: string | null
+}>(reservations: T[], assignmentId: number | null | undefined): T[] {
+  if (!assignmentId) return []
+  return reservations
+    .filter(r => r.assignment_id === assignmentId)
+    .sort((a, b) => {
+      const at = a.reservation_time || ''
+      const bt = b.reservation_time || ''
+      if (at !== bt) {
+        if (!at) return 1
+        if (!bt) return -1
+        return at < bt ? -1 : 1
+      }
+      return a.id - b.id
+    })
+}
+
+/**
  * Order items chronologically: anything with a time (a place's place_time, a
  * transport/leg display time, a timed note) sorts by that time. An item WITHOUT a
  * time inherits the time of the timed item before it, so untimed items stay where

--- a/client/tests/unit/mobile/admin/MAdminNotificationsSection.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminNotificationsSection.test.tsx
@@ -65,6 +65,10 @@ function ntfyTokenInput() {
   return Array.from(document.querySelectorAll<HTMLInputElement>('input[type="password"]'))[1];
 }
 
+function smtpPasswordInput() {
+  return Array.from(document.querySelectorAll<HTMLInputElement>('input[type="password"]'))[0];
+}
+
 beforeEach(() => {
   resetAllStores();
 });
@@ -536,5 +540,22 @@ describe('MAdminNotificationsSection', () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Notification settings saved'));
     expect(setTripRemindersEnabled).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('FE-MOB-ANOTIF-032: a stored SMTP password is a placeholder, so a new one replaces it', async () => {
+    const bodies = captureAppSettings();
+    const user = userEvent.setup();
+    render(<Harness initial={{ smtp_host: 'mail.test', smtp_pass: MASK }} />);
+
+    const password = smtpPasswordInput();
+    expect(password).toHaveValue('');
+
+    await user.type(password, 'hunter2');
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    // Typing into the eight bullet characters used to save them along with the
+    // password, which then failed to authenticate with nothing in the log.
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0].smtp_pass).toBe('hunter2');
   });
 });

--- a/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
+++ b/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
@@ -73,12 +73,12 @@ const M_PLACE2: MergedItem = { type: 'place', sortKey: 4, data: PARK }
 const MERGED = [M_PLACE, M_FLIGHT, M_TRANSIT, M_NOTE, M_PLACE2]
 
 const ROWS: PlanRow[] = [
-  { key: 'pl-11', kind: 'place', item: M_PLACE, assignment: MUSEUM, linkedRes: null },
+  { key: 'pl-11', kind: 'place', item: M_PLACE, assignment: MUSEUM, linkedReservations: [] },
   { key: 'conn-pl-11', kind: 'conn', seg: SEG, assignmentId: 11 },
   { key: 'tr-21', kind: 'transport', item: M_FLIGHT, res: FLIGHT },
   { key: 'tr-22', kind: 'transit', item: M_TRANSIT, res: TRANSIT_RES, transit: TRANSIT },
   { key: 'note-41', kind: 'note', item: M_NOTE, note: NOTE },
-  { key: 'pl-12', kind: 'place', item: M_PLACE2, assignment: PARK, linkedRes: null },
+  { key: 'pl-12', kind: 'place', item: M_PLACE2, assignment: PARK, linkedReservations: [] },
   { key: 'conn-orphan', kind: 'conn', seg: { ...SEG, mode: 'walking' } },
 ]
 
@@ -265,7 +265,7 @@ describe('MPlanTimeline', () => {
 
     it('FE-MOB-PLTL-011: a place row without a place still reports the assignment', () => {
       const orphan = { id: 13, day_id: 2, place_id: 103, order_index: 2, place: null } as unknown as Assignment
-      const rows: PlanRow[] = [{ key: 'pl-13', kind: 'place', item: M_PLACE, assignment: orphan, linkedRes: null }]
+      const rows: PlanRow[] = [{ key: 'pl-13', kind: 'place', item: M_PLACE, assignment: orphan, linkedReservations: [] }]
       const { planner, container } = renderTimeline({ rows })
 
       fireEvent.click(container.querySelector('.cursor-pointer.items-center') as HTMLElement)
@@ -411,7 +411,7 @@ describe('MPlanTimeline', () => {
         byPosition: { 2: { start: [{ pluginId: 'ev', id: 's1', dayId: 2, position: 'start', label: 'Morning prep', tone: 'default' }], end: [] } },
         minutesByDay: { 2: 35 },
       }
-      const rows: PlanRow[] = [{ key: 'pl-11', kind: 'place', item: M_PLACE, assignment: MUSEUM, linkedRes: null }]
+      const rows: PlanRow[] = [{ key: 'pl-11', kind: 'place', item: M_PLACE, assignment: MUSEUM, linkedReservations: [] }]
       renderTimeline({ day: undefined, rows })
 
       expect(screen.queryByText('Charging stop')).not.toBeInTheDocument()

--- a/client/tests/unit/mobile/trip/MPlanTimelineRows.test.tsx
+++ b/client/tests/unit/mobile/trip/MPlanTimelineRows.test.tsx
@@ -82,7 +82,7 @@ describe('PlaceRow', () => {
   const props = {
     assignment: assignment(),
     fullPlace: undefined,
-    linkedRes: null,
+    linkedReservations: [],
     chrome: chrome(),
     reorder: REORDER,
     onOpen: vi.fn(),
@@ -116,7 +116,7 @@ describe('PlaceRow', () => {
 
   it('FE-MOB-PLROW-007: a linked booking replaces the subtitle and adds the booking badge', () => {
     const linkedRes = { id: 31, status: 'confirmed', confirmation_number: 'X9K' } as unknown as Reservation
-    render(<PlaceRow {...props} linkedRes={linkedRes} />)
+    render(<PlaceRow {...props} linkedReservations={[linkedRes]} />)
 
     expect(screen.getByText('dayplan.confirmed · #X9K')).toBeInTheDocument()
     expect(screen.getByText('mobileTrip.resBadge')).toBeInTheDocument()
@@ -124,7 +124,7 @@ describe('PlaceRow', () => {
 
   it('FE-MOB-PLROW-008: a pending booking without a number shows just the status', () => {
     const linkedRes = { id: 31, status: 'pending', confirmation_number: null } as unknown as Reservation
-    render(<PlaceRow {...props} linkedRes={linkedRes} />)
+    render(<PlaceRow {...props} linkedReservations={[linkedRes]} />)
 
     expect(screen.getByText('dayplan.pendingRes')).toBeInTheDocument()
   })

--- a/client/tests/unit/mobile/trip/planTimelineModel.test.ts
+++ b/client/tests/unit/mobile/trip/planTimelineModel.test.ts
@@ -166,8 +166,8 @@ describe('planTimelineModel — buildPlanRows', () => {
       merged: [placeItem(museum), placeItem(park)], reservations: [dinner], routeSegments: [], dayId: 2,
     })
     const [first, second] = rows.filter(r => r.kind === 'place')
-    expect(first.kind === 'place' && first.linkedRes).toBe(dinner)
-    expect(second.kind === 'place' && second.linkedRes).toBeNull()
+    expect(first.kind === 'place' && first.linkedReservations[0]).toBe(dinner)
+    expect(second.kind === 'place' && second.linkedReservations.length === 0).toBe(true)
   })
 
   it('FE-MOB-PTLM-014: keys a synthetic leg row by its leg index', () => {

--- a/server/src/nest/journey/journey-domain.service.ts
+++ b/server/src/nest/journey/journey-domain.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { avatarUrl } from '../common/avatarUrl';
 import type { Journey, JourneyEntry, JourneyPhoto, JourneyContributor } from '../../types';
 import { decodeEntryRow, type JourneyEntryWire } from './journey-entry-row';
+import { GALLERY_CHRONOLOGICAL_ORDER } from './journey-gallery-order';
 import { DatabaseService } from '../database/database.service';
 import { RealtimeService } from '../realtime/realtime.service';
 import type { JourneyStats, JourneyTrack, TrekWsUserEventName } from '@trek/shared';
@@ -246,7 +247,7 @@ export class JourneyDomainService {
 
     const gallery = this.db
       .prepare(
-        `SELECT ${GALLERY_SELECT} FROM ${GALLERY_JOIN} WHERE gp.journey_id = ? ORDER BY gp.sort_order ASC, gp.id ASC`,
+        `SELECT ${GALLERY_SELECT} FROM ${GALLERY_JOIN} WHERE gp.journey_id = ? ${GALLERY_CHRONOLOGICAL_ORDER}`,
       )
       .all(journeyId);
 

--- a/server/src/nest/journey/journey-gallery-order.ts
+++ b/server/src/nest/journey/journey-gallery-order.ts
@@ -1,0 +1,38 @@
+/**
+ * How the journey gallery is ordered (#2200).
+ *
+ * `journey_photos.sort_order` is nothing but MAX+1 at insert time and no surface
+ * ever writes it again, so ordering by it is ordering by "whenever this got
+ * added". Upload day one's pictures after day two's and the gallery stays
+ * shuffled, with nothing in the UI to straighten it out.
+ *
+ * The anchor is instead the best time TREK knows for the picture:
+ *
+ *  1. its capture time, when EXIF or the photo provider gave one up,
+ *  2. otherwise the date of the earliest entry it hangs on, which is where the
+ *     journey itself says the reader was standing when it was taken,
+ *  3. otherwise the moment it was added, the old behaviour and the only thing
+ *     left to go on for a loose photo whose EXIF was stripped.
+ *
+ * All three are compared as ISO text. Entry dates are local wall clock and
+ * capture times are UTC, which only disagree in the hours either side of
+ * midnight, and a gallery is read by the day.
+ *
+ * `sort_order`, then the row id, break ties: insertion order still decides
+ * between two pictures taken in the same minute, and the id makes the order
+ * total, so paging through the gallery cannot show or skip a photo twice.
+ *
+ * Consumers must alias journey_photos as `gp` and trek_photos as `tp`.
+ */
+export const GALLERY_CHRONOLOGICAL_ORDER = `
+  ORDER BY COALESCE(
+             NULLIF(tp.taken_at, ''),
+             (SELECT MIN(je.entry_date || 'T' || COALESCE(NULLIF(je.entry_time, ''), '00:00'))
+                FROM journey_entry_photos jep
+                JOIN journey_entries je ON je.id = jep.entry_id
+               WHERE jep.journey_photo_id = gp.id),
+             strftime('%Y-%m-%dT%H:%M:%SZ', gp.created_at / 1000, 'unixepoch')
+           ) ASC,
+           gp.sort_order ASC,
+           gp.id ASC
+`;

--- a/server/src/nest/journey/journey-share.service.ts
+++ b/server/src/nest/journey/journey-share.service.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
 import { JourneyDomainService } from './journey-domain.service';
 import { decodeEntryRow } from './journey-entry-row';
+import { GALLERY_CHRONOLOGICAL_ORDER } from './journey-gallery-order';
 import { SettingsService } from '../settings/settings.service';
 
 interface JourneySharePermissions {
@@ -185,12 +186,12 @@ export class JourneyShareService {
 
     const gallery = this.db.prepare(`
       SELECT gp.id, gp.journey_id, gp.photo_id, gp.caption, gp.shared, gp.sort_order, gp.created_at,
-             tkp.provider, tkp.asset_id, tkp.owner_id, tkp.file_path, tkp.thumbnail_path, tkp.width, tkp.height,
-             tkp.media_type, tkp.duration_ms, tkp.taken_at, tkp.lat, tkp.lng
+             tp.provider, tp.asset_id, tp.owner_id, tp.file_path, tp.thumbnail_path, tp.width, tp.height,
+             tp.media_type, tp.duration_ms, tp.taken_at, tp.lat, tp.lng
       FROM journey_photos gp
-      JOIN trek_photos tkp ON tkp.id = gp.photo_id
+      JOIN trek_photos tp ON tp.id = gp.photo_id
       WHERE gp.journey_id = ?
-      ORDER BY gp.sort_order
+      ${GALLERY_CHRONOLOGICAL_ORDER}
     `).all(row.journey_id) as any[];
 
     const enrichedEntries = entries

--- a/server/src/nest/notifications/mailer/mailer.service.ts
+++ b/server/src/nest/notifications/mailer/mailer.service.ts
@@ -6,6 +6,7 @@ import { logError, logInfo, logDebug, logWarn } from '../../audit/audit-log.logg
 import { decrypt_api_key } from '../../common/crypto/apiKeyCrypto';
 import { DatabaseService } from '../../database/database.service';
 import { buildEmailHtml, buildPasswordResetHtml } from './email-html';
+import { describeSmtpFailure, describeSmtpGap, parseSmtpPort, type SmtpTarget } from './smtp-diagnostics';
 
 interface SmtpConfig {
   host: string;
@@ -15,6 +16,20 @@ interface SmtpConfig {
   from: string;
   secure: boolean;
 }
+
+/**
+ * Nodemailer's own defaults are 2 minutes to connect and 30 seconds for the
+ * greeting, both of which outlive the browser's 8-second API timeout: an admin
+ * pressing "Send test email" against a blocked port got a dead "Test email
+ * failed" while the socket was still waiting, and the eventual error had nobody
+ * left to tell. A relay that needs more than ten seconds to accept a connection
+ * or to send its banner is broken either way, so those two are cut hard. The
+ * inactivity timeout stays generous (nodemailer's default is ten minutes)
+ * because a relay that scans the message can be slow to acknowledge DATA.
+ */
+const CONNECT_TIMEOUT_MS = 10_000;
+const GREETING_TIMEOUT_MS = 10_000;
+const SOCKET_TIMEOUT_MS = 30_000;
 
 /**
  * Outgoing mail: SMTP config resolution, the password-reset delivery and the
@@ -36,21 +51,31 @@ export class MailerService {
     return this.db.get<{ value: string }>('SELECT value FROM app_settings WHERE key = ?', key)?.value || null;
   }
 
-  private getSmtpConfig(): SmtpConfig | null {
+  /** Env wins over the admin panel, per field. Read fresh on every send. */
+  private readSmtpSettings() {
     const smtpEnv = readEnv().smtp;
-    const host = smtpEnv.host || this.getAppSetting('smtp_host');
-    const port = smtpEnv.port || this.getAppSetting('smtp_port');
-    const user = smtpEnv.user || this.getAppSetting('smtp_user');
-    const pass = smtpEnv.pass || decrypt_api_key(this.getAppSetting('smtp_pass')) || '';
-    const from = smtpEnv.from || this.getAppSetting('smtp_from');
-    if (!host || !port || !from) return null;
+    return {
+      host: smtpEnv.host || this.getAppSetting('smtp_host'),
+      port: smtpEnv.port || this.getAppSetting('smtp_port'),
+      user: smtpEnv.user || this.getAppSetting('smtp_user'),
+      pass: smtpEnv.pass || decrypt_api_key(this.getAppSetting('smtp_pass')) || '',
+      from: smtpEnv.from || this.getAppSetting('smtp_from'),
+    };
+  }
+
+  private getSmtpConfig(): SmtpConfig | null {
+    const { host, port, user, pass, from } = this.readSmtpSettings();
+    // An unusable port counts as unconfigured rather than as a dial: net.connect
+    // on NaN throws from inside nodemailer, where the reason gets lost.
+    const portNumber = parseSmtpPort(port);
+    if (!host || !portNumber || !from) return null;
     return {
       host,
-      port: Number.parseInt(port, 10),
+      port: portNumber,
       user: user || '',
       pass: pass || '',
       from,
-      secure: Number.parseInt(port, 10) === 465,
+      secure: portNumber === 465,
     };
   }
 
@@ -69,6 +94,9 @@ export class MailerService {
       port: config.port,
       secure: config.secure,
       auth: config.user ? { user: config.user, pass: config.pass } : undefined,
+      connectionTimeout: CONNECT_TIMEOUT_MS,
+      greetingTimeout: GREETING_TIMEOUT_MS,
+      socketTimeout: SOCKET_TIMEOUT_MS,
       // The operator's opt-out for a relay with a self-signed certificate, off by
       // default and reachable only through SMTP_SKIP_TLS_VERIFY or the matching
       // admin setting. It stays because self-hosted installs behind an internal
@@ -155,7 +183,7 @@ export class MailerService {
       logInfo(`Password reset email sent to=${to}`);
       return { delivered: 'email' };
     } catch (err) {
-      logError(`Password reset email failed to=${to}: ${err instanceof Error ? err.message : err}`);
+      logError(`Password reset email failed to=${to} ${this.explain(err, smtpCfg)}`);
       return { delivered: 'failed' };
     }
   }
@@ -184,14 +212,26 @@ export class MailerService {
       logDebug(`Email smtp=${config.host}:${config.port} from=${config.from} to=${to}`);
       return true;
     } catch (err) {
-      logError(`Email send failed to=${to}: ${err instanceof Error ? err.message : err}`);
+      logError(`Email send failed to=${to} ${this.explain(err, config)}`);
       return false;
     }
   }
 
+  /**
+   * The admin's "Send test email" button. Unlike the delivery paths this one has
+   * somebody waiting for an answer, so the classified reason goes into the
+   * response as well as the log. Issue #2196 was an admin staring at "Test email
+   * failed" with an empty container log, unable to tell a wrong password from a
+   * blocked port.
+   */
   async testSmtp(to: string): Promise<{ success: boolean; error?: string }> {
     const config = this.getSmtpConfig();
-    if (!config) return { success: false, error: 'SMTP not configured' };
+    if (!config) {
+      const { host, port, from } = this.readSmtpSettings();
+      const reason = describeSmtpGap({ host, port, from });
+      logWarn(`SMTP test not attempted to=${to}: ${reason}`);
+      return { success: false, error: reason };
+    }
     try {
       await this.createTransport(config).sendMail({
         from: config.from,
@@ -199,9 +239,27 @@ export class MailerService {
         subject: 'TREK — Test Notification',
         text: 'This is a test email from TREK. If you received this, your SMTP configuration is working correctly.',
       });
+      logInfo(`SMTP test email sent to=${to} ${this.describeTarget(config)}`);
       return { success: true };
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+      const failure = describeSmtpFailure(err, this.target(config), config.pass);
+      logError(`SMTP test email failed to=${to} ${this.describeTarget(config)} code=${failure.code}: ${failure.reason}`);
+      return { success: false, error: failure.reason };
     }
+  }
+
+  private target(config: SmtpConfig): SmtpTarget {
+    return { host: config.host, port: config.port, secure: config.secure };
+  }
+
+  /** The tail every failed-send log line carries: where it went, and why it broke. */
+  private explain(err: unknown, config: SmtpConfig): string {
+    const failure = describeSmtpFailure(err, this.target(config), config.pass);
+    return `${this.describeTarget(config)} code=${failure.code}: ${failure.reason}`;
+  }
+
+  /** Never the user or the password: the relay and how it was dialled. */
+  private describeTarget(config: SmtpConfig): string {
+    return `smtp=${config.host}:${config.port} secure=${config.secure} auth=${config.user ? 'yes' : 'no'}`;
   }
 }

--- a/server/src/nest/notifications/mailer/smtp-diagnostics.ts
+++ b/server/src/nest/notifications/mailer/smtp-diagnostics.ts
@@ -1,0 +1,111 @@
+/**
+ * Turning an SMTP failure into something an admin can act on.
+ *
+ * Nodemailer throws an Error carrying `code`, `command` and, when the relay said
+ * something back, `response` (already appended to the message). None of it used
+ * to reach anywhere: the test-email button logged nothing at all, so a wrong
+ * password and a blocked port looked identical from the outside. The classifier
+ * below keeps the relay's own words, which are the most useful part, and puts
+ * the diagnosis in front of them.
+ *
+ * Everything here is pure, so the wording can be pinned in unit tests without a
+ * socket.
+ */
+
+export interface SmtpTarget {
+  host: string;
+  port: number;
+  secure: boolean;
+}
+
+export interface SmtpFailure {
+  /** Nodemailer's error code, or 'UNKNOWN' when the throw carried none. */
+  code: string;
+  /** Admin-facing and credential-free: safe for both the log and the response. */
+  reason: string;
+}
+
+const MAX_REASON_LENGTH = 400;
+const MAX_ECHOED_VALUE = 32;
+
+/** A port TREK can actually dial, or null. Rejects '', 'abc', '0', '70000', '587abc'. */
+export function parseSmtpPort(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const trimmed = String(raw).trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const port = Number.parseInt(trimmed, 10);
+  return port >= 1 && port <= 65535 ? port : null;
+}
+
+/**
+ * Why getSmtpConfig() came back empty. Named per field: "SMTP not configured" on
+ * its own sent admins hunting through a form where four of the five fields were
+ * filled in.
+ */
+export function describeSmtpGap(raw: { host?: string | null; port?: string | null; from?: string | null }): string {
+  if (raw.port && !parseSmtpPort(raw.port)) {
+    return `SMTP not configured: the port "${clip(String(raw.port), MAX_ECHOED_VALUE)}" is not a number between 1 and 65535.`;
+  }
+  const missing: string[] = [];
+  if (!raw.host) missing.push('host (SMTP_HOST)');
+  if (!raw.port) missing.push('port (SMTP_PORT)');
+  if (!raw.from) missing.push('from address (SMTP_FROM)');
+  return `SMTP not configured: missing ${missing.join(', ')}. Set it under Admin > Notifications or as the matching environment variable.`;
+}
+
+export function describeSmtpFailure(err: unknown, target: SmtpTarget, secret = ''): SmtpFailure {
+  const thrown = (err ?? {}) as { code?: unknown; message?: unknown };
+  const code = typeof thrown.code === 'string' && thrown.code ? thrown.code : 'UNKNOWN';
+  const message = scrub(typeof thrown.message === 'string' && thrown.message ? thrown.message : String(err), secret);
+  const where = `${target.host}:${target.port}`;
+
+  if (code === 'EAUTH') {
+    return { code, reason: `${where} rejected the credentials. Check the SMTP user and password, and whether the account needs an app-specific password. Server said: ${message}` };
+  }
+  if (code === 'EDNS' || /ENOTFOUND|EAI_AGAIN/.test(message)) {
+    return { code, reason: `The host ${target.host} could not be resolved: ${message}` };
+  }
+  if (/ECONNREFUSED/.test(message)) {
+    return { code, reason: `${where} refused the connection: nothing is listening on that port, or a firewall closed it. ${portHint(target)}` };
+  }
+  if (/EHOSTUNREACH|ENETUNREACH|EACCES/.test(message)) {
+    return { code, reason: `${where} is unreachable from the TREK container: ${message}` };
+  }
+  if (code === 'ETIMEDOUT' || /timed? ?out|Greeting never received/i.test(message)) {
+    return { code, reason: `${where} did not answer in time: ${message}. Outbound mail ports are often blocked by the host or the hosting provider. ${portHint(target)}` };
+  }
+  if (/certificate|self.signed/i.test(message)) {
+    return { code, reason: `The TLS certificate of ${where} was not accepted: ${message}. For an internal relay with its own certificate, turn on "Skip TLS certificate check".` };
+  }
+  if (/wrong version number|packet length too long|ssl|routines|tlsv1/i.test(message)) {
+    return { code, reason: `The TLS handshake with ${where} failed: ${message}. ${portHint(target)}` };
+  }
+  if (code === 'EENVELOPE') {
+    return { code, reason: `${where} rejected the envelope. The from address normally has to belong to the authenticated account. Server said: ${message}` };
+  }
+  if (code === 'EMESSAGE') {
+    return { code, reason: `${where} accepted the connection but rejected the message: ${message}` };
+  }
+  return { code, reason: `Sending through ${where} failed (${code}): ${message}` };
+}
+
+/**
+ * The 465-versus-587 mix-up is the one that produces a silent hang rather than a
+ * refusal, so every connection-level diagnosis carries it.
+ */
+function portHint(target: SmtpTarget): string {
+  return target.secure
+    ? 'Port 465 is dialled with implicit TLS; a relay that expects STARTTLS listens on 587.'
+    : `Port ${target.port} is dialled in plain mode with STARTTLS; a relay that expects TLS from the first byte listens on 465.`;
+}
+
+/** The relay's words, minus anything that could carry the credential back out. */
+function scrub(text: string, secret: string): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  const redacted = secret.length >= 4 ? collapsed.split(secret).join('***') : collapsed;
+  return clip(redacted, MAX_REASON_LENGTH);
+}
+
+function clip(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}

--- a/server/tests/unit/nest/journey-domain.service.test.ts
+++ b/server/tests/unit/nest/journey-domain.service.test.ts
@@ -2059,6 +2059,55 @@ describe('journey gallery', () => {
     const [gallery] = svc.uploadGalleryPhotos(journey.id, user.id, [{ path: 'journey/a.jpg' }]);
     expect(svc.deleteGalleryPhoto(gallery.id, stranger.id)).toBeNull();
   });
+
+  // #2200: the gallery used to come out in upload order, so pictures caught up
+  // with after the trip landed behind the ones added while it was running.
+  it('JOURNEY-SVC-PHOTO-008: the gallery reads in capture order, not upload order', () => {
+    const { user } = createUser(testDb);
+    const journey = svc.createJourney(user.id, { title: 'J' });
+
+    const shot = (path: string, takenAt: string) => {
+      const [row] = svc.uploadGalleryPhotos(journey.id, user.id, [{ path }]);
+      testDb.prepare('UPDATE trek_photos SET taken_at = ? WHERE id = ?').run(takenAt, row.photo_id);
+    };
+
+    shot('journey/day3.jpg', '2026-05-03T18:00:00.000Z');
+    shot('journey/day1.jpg', '2026-05-01T08:30:00.000Z');
+    shot('journey/day2.jpg', '2026-05-02T12:00:00.000Z');
+
+    const gallery = svc.getJourneyFull(journey.id, user.id)!.gallery as { file_path: string }[];
+    expect(gallery.map((p) => p.file_path)).toEqual([
+      'journey/day1.jpg',
+      'journey/day2.jpg',
+      'journey/day3.jpg',
+    ]);
+  });
+
+  it('JOURNEY-SVC-PHOTO-009: a photo with no capture time rides on the date of the stop it hangs on', () => {
+    const { user } = createUser(testDb);
+    const journey = svc.createJourney(user.id, { title: 'J' });
+    const day1 = svc.createEntry(journey.id, user.id, { entry_date: '2026-05-01', title: 'Day 1' })!;
+    const day2 = svc.createEntry(journey.id, user.id, { entry_date: '2026-05-02', title: 'Day 2' })!;
+
+    // Day two was sorted out first and day one caught up afterwards, with the
+    // EXIF gone (an iPhone upload is converted before it leaves the browser).
+    const [dayTwoPhoto] = svc.uploadGalleryPhotos(journey.id, user.id, [{ path: 'journey/day2.jpg' }]);
+    const [dayOnePhoto] = svc.uploadGalleryPhotos(journey.id, user.id, [{ path: 'journey/day1.jpg' }]);
+    const [loose] = svc.uploadGalleryPhotos(journey.id, user.id, [{ path: 'journey/loose.jpg' }]);
+    svc.linkPhotoToEntry(day2.id, dayTwoPhoto.id, user.id);
+    svc.linkPhotoToEntry(day1.id, dayOnePhoto.id, user.id);
+    // Pin the loose photo's upload time so the run does not depend on today's date.
+    testDb
+      .prepare('UPDATE journey_photos SET created_at = ? WHERE id = ?')
+      .run(Date.parse('2026-06-01T00:00:00Z'), loose.id);
+
+    const gallery = svc.getJourneyFull(journey.id, user.id)!.gallery as { file_path: string }[];
+    expect(gallery.map((p) => p.file_path)).toEqual([
+      'journey/day1.jpg',
+      'journey/day2.jpg',
+      'journey/loose.jpg',
+    ]);
+  });
 });
 
 describe('per-user journey preferences', () => {

--- a/server/tests/unit/nest/journey-share.service.test.ts
+++ b/server/tests/unit/nest/journey-share.service.test.ts
@@ -635,6 +635,30 @@ describe('getPublicJourney', () => {
     expect((result.entries[0] as Record<string, unknown>).photos).toEqual([]); // inline photos withheld too
   });
 
+  // #2200: the reader of a shared journey gets the same chronology as the owner,
+  // so the public gallery cannot fall back to upload order.
+  it('JOURNEY-SHARE-031: the public gallery reads in capture order, not upload order', () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const day1 = createJourneyEntry(testDb, journey.id, user.id, {
+      type: 'entry', title: 'Day 1', entry_date: '2026-05-01',
+    });
+    const day2 = createJourneyEntry(testDb, journey.id, user.id, {
+      type: 'entry', title: 'Day 2', entry_date: '2026-05-02',
+    });
+
+    const late = insertJourneyPhoto(day2.id, { filePath: '/photos/day2.jpg' });
+    insertJourneyPhoto(day1.id, { filePath: '/photos/day1.jpg' });
+    testDb.prepare('UPDATE trek_photos SET taken_at = ? WHERE id = ?').run('2026-05-02T16:00:00.000Z', late);
+
+    const { token } = svc.createOrUpdateJourneyShareLink(journey.id, user.id, {
+      share_timeline: true, share_gallery: true, share_map: true,
+    });
+
+    const gallery = svc.getPublicJourney(token)!.gallery as Record<string, unknown>[];
+    expect(gallery.map(p => p.file_path)).toEqual(['/photos/day1.jpg', '/photos/day2.jpg']);
+  });
+
   it('JOURNEY-SHARE-030: cartoApiKey resolves owner setting → admin instance default → empty (#2054)', () => {
     const { user } = createUser(testDb);
     const journey = createJourney(testDb, user.id);

--- a/server/tests/unit/nest/mailer.service.test.ts
+++ b/server/tests/unit/nest/mailer.service.test.ts
@@ -4,6 +4,9 @@
  * Covers the SMTP transport options MailerService hands to nodemailer, and in
  * particular the skip-TLS opt-out: it must stay reachable for operators behind an
  * internal relay, and it must announce itself instead of downgrading quietly.
+ * The second half covers what the admin sees when a send goes wrong (#2196):
+ * bounded phases, a classified reason in the response, a line in the log, and
+ * the password in neither.
  * Constructed directly (no TestingModule, repo convention).
  */
 
@@ -46,7 +49,7 @@ import { runMigrations } from '../../../src/db/migrations';
 import { resetTestDb } from '../../helpers/test-db';
 import { MailerService } from '../../../src/nest/notifications/mailer/mailer.service';
 import { DatabaseService } from '../../../src/nest/database/database.service';
-import { logWarn } from '../../../src/nest/audit/audit-log.logger';
+import { logError, logInfo, logWarn } from '../../../src/nest/audit/audit-log.logger';
 
 function setAppSetting(key: string, value: string): void {
   testDb.prepare('INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)').run(key, value);
@@ -142,5 +145,108 @@ describe('MailerService TLS options', () => {
 
     expect(createTransport).not.toHaveBeenCalled();
     expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('MAILER-007: every SMTP phase is bounded, so a dead relay fails instead of hanging', async () => {
+    configureSmtp();
+
+    await newMailer().sendEmail('someone@example.com', 'Subject', 'Body');
+
+    // Nodemailer's own defaults (120s / 30s / 600s) all outlive the client's 8s
+    // API timeout, which is how #2196 produced a failure nobody could read.
+    expect(lastTransportOptions()).toMatchObject({
+      connectionTimeout: 10_000,
+      greetingTimeout: 10_000,
+      socketTimeout: 30_000,
+    });
+  });
+});
+
+describe('MailerService test send', () => {
+  /** The nodemailer shape: an Error carrying the SMTP code and the relay's reply. */
+  function smtpError(message: string, code: string): Error {
+    return Object.assign(new Error(message), { code });
+  }
+
+  it('MAILER-008: an incomplete configuration names the fields that are missing', async () => {
+    setAppSetting('smtp_host', 'mail.internal.example');
+    setAppSetting('smtp_port', '587');
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('SMTP_FROM');
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
+  it('MAILER-009: an unusable port is refused before anything reaches a socket', async () => {
+    setAppSetting('smtp_host', 'mail.internal.example');
+    setAppSetting('smtp_port', 'smtp.example.com');
+    setAppSetting('smtp_from', 'trek@example.com');
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('smtp.example.com');
+    expect(result.error).toContain('65535');
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
+  it('MAILER-010: a rejected login comes back as a reason, not as a bare failure', async () => {
+    configureSmtp();
+    sendMail.mockRejectedValueOnce(smtpError('Invalid login: 535 5.7.8 Username and Password not accepted', 'EAUTH'));
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('rejected the credentials');
+    expect(result.error).toContain('535 5.7.8');
+  });
+
+  it('MAILER-011: a refused connection is classified and reaches the log with its code', async () => {
+    configureSmtp();
+    sendMail.mockRejectedValueOnce(smtpError('connect ECONNREFUSED 10.0.0.5:587', 'ESOCKET'));
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.error).toContain('refused the connection');
+    expect(logError).toHaveBeenCalledTimes(1);
+    const line = vi.mocked(logError).mock.calls[0][0];
+    expect(line).toContain('SMTP test email failed to=admin@example.com');
+    expect(line).toContain('smtp=mail.internal.example:587');
+    expect(line).toContain('code=ESOCKET');
+  });
+
+  it('MAILER-012: a stalled relay is named as a timeout and points at the 465/587 split', async () => {
+    setAppSetting('smtp_host', 'mail.internal.example');
+    setAppSetting('smtp_port', '465');
+    setAppSetting('smtp_from', 'trek@example.com');
+    sendMail.mockRejectedValueOnce(smtpError('Greeting never received', 'ETIMEDOUT'));
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.error).toContain('did not answer in time');
+    expect(result.error).toContain('587');
+  });
+
+  it('MAILER-013: the password appears in neither the response nor the log', async () => {
+    configureSmtp();
+    setAppSetting('smtp_user', 'trek@example.com');
+    setAppSetting('smtp_pass', 'correct-horse-battery');
+    sendMail.mockRejectedValueOnce(smtpError('Invalid login for correct-horse-battery', 'EAUTH'));
+
+    const result = await newMailer().testSmtp('admin@example.com');
+
+    expect(result.error).not.toContain('correct-horse-battery');
+    expect(vi.mocked(logError).mock.calls[0][0]).not.toContain('correct-horse-battery');
+  });
+
+  it('MAILER-014: a successful test leaves a line in the log naming the relay', async () => {
+    configureSmtp();
+
+    expect(await newMailer().testSmtp('admin@example.com')).toEqual({ success: true });
+
+    const lines = vi.mocked(logInfo).mock.calls.map(call => call[0]);
+    expect(lines.some(line => line.includes('SMTP test email sent to=admin@example.com smtp=mail.internal.example:587'))).toBe(true);
   });
 });

--- a/server/tests/unit/nest/smtp-diagnostics.test.ts
+++ b/server/tests/unit/nest/smtp-diagnostics.test.ts
@@ -1,0 +1,204 @@
+/**
+ * smtp-diagnostics.test.ts
+ *
+ * The wording an admin gets when a test email does not go out (#2196). Pure
+ * functions, no socket and no DB: what is pinned here is that every common SMTP
+ * failure comes back as a cause rather than as "failed", and that the credential
+ * never rides along.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  describeSmtpFailure,
+  describeSmtpGap,
+  parseSmtpPort,
+  type SmtpTarget,
+} from '../../../src/nest/notifications/mailer/smtp-diagnostics';
+
+const PLAIN: SmtpTarget = { host: 'mail.example.com', port: 587, secure: false };
+const IMPLICIT_TLS: SmtpTarget = { host: 'mail.example.com', port: 465, secure: true };
+
+/** The nodemailer shape: an Error carrying the SMTP code and the relay's reply. */
+function smtpError(message: string, code?: string): Error {
+  return code ? Object.assign(new Error(message), { code }) : new Error(message);
+}
+
+describe('parseSmtpPort', () => {
+  it('SMTPDIAG-001: accepts a port number, with or without surrounding space', () => {
+    expect(parseSmtpPort('587')).toBe(587);
+    expect(parseSmtpPort(' 465 ')).toBe(465);
+    expect(parseSmtpPort('1')).toBe(1);
+    expect(parseSmtpPort('65535')).toBe(65535);
+  });
+
+  it('SMTPDIAG-002: refuses everything that would reach net.connect as NaN or out of range', () => {
+    expect(parseSmtpPort(null)).toBeNull();
+    expect(parseSmtpPort(undefined)).toBeNull();
+    expect(parseSmtpPort('')).toBeNull();
+    expect(parseSmtpPort('smtp.example.com')).toBeNull();
+    expect(parseSmtpPort('587abc')).toBeNull();
+    expect(parseSmtpPort('58.7')).toBeNull();
+    expect(parseSmtpPort('-1')).toBeNull();
+    expect(parseSmtpPort('0')).toBeNull();
+    expect(parseSmtpPort('65536')).toBeNull();
+  });
+});
+
+describe('describeSmtpGap', () => {
+  it('SMTPDIAG-003: lists every field that is still empty', () => {
+    const gap = describeSmtpGap({ host: null, port: null, from: null });
+
+    expect(gap).toContain('SMTP_HOST');
+    expect(gap).toContain('SMTP_PORT');
+    expect(gap).toContain('SMTP_FROM');
+  });
+
+  it('SMTPDIAG-004: names only the one that is missing', () => {
+    const gap = describeSmtpGap({ host: 'mail.example.com', port: '587', from: null });
+
+    expect(gap).toContain('SMTP_FROM');
+    expect(gap).not.toContain('SMTP_HOST');
+  });
+
+  it('SMTPDIAG-005: a port that is not a port is reported as such, not as absent', () => {
+    const gap = describeSmtpGap({ host: 'mail.example.com', port: 'ssl', from: null });
+
+    expect(gap).toContain('"ssl"');
+    expect(gap).toContain('65535');
+    expect(gap).not.toContain('missing');
+  });
+
+  it('SMTPDIAG-006: an absurd port value is clipped before it is echoed back', () => {
+    const gap = describeSmtpGap({ host: 'mail.example.com', port: 'x'.repeat(500), from: 'a@b.c' });
+
+    expect(gap.length).toBeLessThan(120);
+    expect(gap).toContain('...');
+  });
+});
+
+describe('describeSmtpFailure', () => {
+  it('SMTPDIAG-007: a rejected login points at the credentials and keeps the relay reply', () => {
+    const failure = describeSmtpFailure(
+      smtpError('Invalid login: 535 5.7.8 Username and Password not accepted', 'EAUTH'),
+      PLAIN,
+    );
+
+    expect(failure.code).toBe('EAUTH');
+    expect(failure.reason).toContain('rejected the credentials');
+    expect(failure.reason).toContain('535 5.7.8');
+  });
+
+  it('SMTPDIAG-008: an unresolvable host is named as DNS', () => {
+    const byCode = describeSmtpFailure(smtpError('getaddrinfo failed', 'EDNS'), PLAIN);
+    const byMessage = describeSmtpFailure(smtpError('getaddrinfo ENOTFOUND mail.example.com', 'ESOCKET'), PLAIN);
+
+    expect(byCode.reason).toContain('could not be resolved');
+    expect(byMessage.reason).toContain('could not be resolved');
+  });
+
+  it('SMTPDIAG-009: a refused connection separates "closed port" from "wrong password"', () => {
+    const failure = describeSmtpFailure(smtpError('connect ECONNREFUSED 10.0.0.5:587', 'ESOCKET'), PLAIN);
+
+    expect(failure.reason).toContain('refused the connection');
+    expect(failure.reason).toContain('mail.example.com:587');
+  });
+
+  it('SMTPDIAG-010: an unroutable relay is reported as unreachable', () => {
+    const failure = describeSmtpFailure(smtpError('connect EHOSTUNREACH 10.0.0.5:587', 'ESOCKET'), PLAIN);
+
+    expect(failure.reason).toContain('unreachable');
+  });
+
+  it('SMTPDIAG-011: a stalled greeting on 465 suggests the STARTTLS port', () => {
+    const failure = describeSmtpFailure(smtpError('Greeting never received', 'ETIMEDOUT'), IMPLICIT_TLS);
+
+    expect(failure.reason).toContain('did not answer in time');
+    expect(failure.reason).toContain('587');
+  });
+
+  it('SMTPDIAG-012: a connection timeout on 587 suggests the implicit-TLS port', () => {
+    const failure = describeSmtpFailure(smtpError('Connection timeout', 'ETIMEDOUT'), PLAIN);
+
+    expect(failure.reason).toContain('465');
+  });
+
+  it('SMTPDIAG-013: an untrusted certificate points at the skip-verification switch', () => {
+    const failure = describeSmtpFailure(
+      smtpError('unable to verify the first certificate', 'ESOCKET'),
+      IMPLICIT_TLS,
+    );
+
+    expect(failure.reason).toContain('Skip TLS certificate check');
+  });
+
+  it('SMTPDIAG-014: a handshake against a plain-text port is named as TLS', () => {
+    const failure = describeSmtpFailure(
+      smtpError('140A:error:0A00010B:SSL routines:ssl3_get_record:wrong version number', 'ESOCKET'),
+      IMPLICIT_TLS,
+    );
+
+    expect(failure.reason).toContain('TLS handshake');
+    expect(failure.reason).toContain('587');
+  });
+
+  it('SMTPDIAG-015: a rejected envelope points at the from address', () => {
+    const failure = describeSmtpFailure(
+      smtpError('Mail command failed: 550 5.7.1 Sender address rejected', 'EENVELOPE'),
+      PLAIN,
+    );
+
+    expect(failure.reason).toContain('from address');
+    expect(failure.reason).toContain('550 5.7.1');
+  });
+
+  it('SMTPDIAG-016: a rejected message says the connection itself was fine', () => {
+    const failure = describeSmtpFailure(smtpError('Message failed: 552 too large', 'EMESSAGE'), PLAIN);
+
+    expect(failure.reason).toContain('rejected the message');
+  });
+
+  it('SMTPDIAG-017: an unclassified failure still carries the code and the message', () => {
+    const failure = describeSmtpFailure(smtpError('something odd happened', 'EPROTOCOL'), PLAIN);
+
+    expect(failure.code).toBe('EPROTOCOL');
+    expect(failure.reason).toContain('EPROTOCOL');
+    expect(failure.reason).toContain('something odd happened');
+  });
+
+  it('SMTPDIAG-018: a throw that is not an Error is still described', () => {
+    const failure = describeSmtpFailure('boom', PLAIN);
+
+    expect(failure.code).toBe('UNKNOWN');
+    expect(failure.reason).toContain('boom');
+  });
+
+  it('SMTPDIAG-019: the password is redacted wherever it turns up in the message', () => {
+    const failure = describeSmtpFailure(
+      smtpError('Invalid login for user with correct-horse-battery', 'EAUTH'),
+      PLAIN,
+      'correct-horse-battery',
+    );
+
+    expect(failure.reason).not.toContain('correct-horse-battery');
+    expect(failure.reason).toContain('***');
+  });
+
+  it('SMTPDIAG-020: a secret too short to be one is left alone rather than blanking the text', () => {
+    const failure = describeSmtpFailure(smtpError('bad login at a b c', 'EAUTH'), PLAIN, 'a b');
+
+    expect(failure.reason).toContain('bad login at a b c');
+  });
+
+  it('SMTPDIAG-021: a runaway relay reply is collapsed and clipped', () => {
+    const failure = describeSmtpFailure(smtpError(`550 ${'x'.repeat(2000)}`, 'EENVELOPE'), PLAIN);
+
+    expect(failure.reason.length).toBeLessThan(700);
+    expect(failure.reason).toContain('...');
+  });
+
+  it('SMTPDIAG-022: newlines in a multi-line reply become one readable line', () => {
+    const failure = describeSmtpFailure(smtpError('550 first\n  550 second', 'EENVELOPE'), PLAIN);
+
+    expect(failure.reason).toContain('550 first 550 second');
+  });
+});

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -257,6 +257,30 @@ docker logs <container> 2>&1 | grep "OIDC"
 
 ---
 
+## "Send test email" fails and says nothing else
+
+**Cause:** older builds swallowed the SMTP error. Nothing was written to the container log, and the toast fell back to a bare *Test email failed*. A blocked port made it worse: nodemailer waited up to two minutes for the connection while the browser gave up after eight seconds, so the eventual error had nobody left to report to. Both are fixed. Every SMTP phase is now bounded, and the button names the cause.
+
+**Fix:** press **Send test email** again and read the toast. The same diagnosis, plus the SMTP error code, is in the log:
+
+```bash
+docker logs <container> 2>&1 | grep -E "SMTP test email (sent|failed)|SMTP test not attempted"
+```
+
+| What the message says | What to change |
+|-----------------------|----------------|
+| `rejected the credentials` (`code=EAUTH`) | Wrong SMTP user or password. Mailboxes with 2FA normally need an app-specific password, not the account one. |
+| `refused the connection` | Nothing is listening on that port, or a firewall closed it. |
+| `did not answer in time` | The port is filtered, or 465 and 587 are swapped: TREK dials 465 with implicit TLS and every other port in plain mode with STARTTLS. |
+| `could not be resolved` | The container's DNS cannot resolve the host. Test with `docker exec <container> nc -zv <SMTP_HOST> <SMTP_PORT>`. |
+| `TLS certificate ... was not accepted` | Turn on **Skip TLS certificate check** (or `SMTP_SKIP_TLS_VERIFY=true`) for an internal relay carrying its own certificate. |
+| `rejected the envelope` | The from address usually has to belong to the authenticated mailbox. |
+| `SMTP not configured: ...` | The named field is empty, or the port is not a number. Host, port and from address are all required. |
+
+> **Note:** a saved SMTP password is shown as a placeholder, never as a value. Leave the field alone to keep it, or type into it to replace it.
+
+---
+
 ## Password reset emails are not delivered / SMTP is silent
 
 **Cause:** SMTP failures are logged but do not surface as errors to the end user — the "reset email sent" message appears regardless. Common causes: wrong `SMTP_HOST` or `SMTP_PORT`, bad credentials, firewall blocking outbound on the SMTP port, or a self-signed certificate on the SMTP server.


### PR DESCRIPTION
Three reported bugs, each verified against the code, reproduced and fixed at the cause.

# Send test email fails with no log (#2196)

`testSmtp` logged nothing at all, and the transport ran on nodemailer's defaults (a two-minute connect timeout) while the browser gave up after eight seconds, so every hanging relay ended as the generic "Test email failed" toast over an empty docker log. The test now logs every outcome (success, failure with SMTP code, missing configuration naming the missing field), never with credentials, and answers with a classified, scrubbed cause the admin UI already displays: authentication rejected, DNS, connection refused, filtered port, the 465-implicit-TLS-versus-587-STARTTLS mismatch, certificate errors, plus the relay's own scrubbed response. The transport gets real timeouts (10 s connect and greeting, 30 s socket) and the channel test calls wait long enough to receive the verdict.

Verifying also surfaced why a known-good account can fail here: the SMTP password field rendered its stored-value mask as the input value, so typing a replacement saved the eight bullets as part of the new password, with no log either. It behaves like the webhook twin now (mask as placeholder), on desktop and the phone admin. `wiki/Troubleshooting.md` gains a section with the matching `docker logs` grep and a message-to-remedy table.

# Journey gallery in upload order (#2200)

`journey_photos.sort_order` is only ever the insert counter, so photos added later landed behind days they belong before. Both gallery readers (the app and a shared journey) now order chronologically through one shared SQL fragment: capture time (EXIF or provider) first, else the timestamp of the stop the photo belongs to, else upload time; ties keep the previous order, so existing galleries only move where chronology demands it. The manual photo order inside an entry stays untouched, and TREK Studio keeps the layouts of saved books.

# One booking shown where several are linked (#2201)

Four render sites resolved a day assignment's booking with `find()`, while the booking dialog happily links several bookings to the same stop, so the parking pass hid the zoo tickets. A shared selector in `dayMerge` returns all of them, time-sorted and stable across reloads, and the desktop plan tab, the place inspector, the mobile timeline and the mobile place sheet render the full list. With a single booking every surface is unchanged pixel for pixel.

Not part of this PR, noted while fixing: the PDF export and the shared trip page never showed assignment-linked bookings at all (also not the first one); that is an older, separate gap.

Closes #2196
Closes #2200
Closes #2201
