### PR TITLE
MCP prompts reject every client, and the mobile stay chip opens the day instead of the stay

### DIFF
--- a/client/src/mobile/screens/trip/MTripShell.tsx
+++ b/client/src/mobile/screens/trip/MTripShell.tsx
@@ -40,7 +40,8 @@ export type MTripCollabTab = 'chat' | 'notes' | 'polls'
 /**
  * Currently open bottom/floating sheet. Well-known ids (owned by the sheets
  * screen): 'day' (payload { dayId }), 'days', 'mehr', 'note' (payload
- * { dayId, note? }), 'transport' (payload { reservationId }), 'bract'
+ * { dayId, note? }), 'accommodation' (payload { dayId?, accId?, from? }),
+ * 'transport' (payload { reservationId }), 'bract'
  * (payload { placeId, dayPicker? }), 'import', 'export', 'members',
  * 'tripedit', 'bags', 'task'. The place inspector keys off the planner's
  * place selection instead of a sheet id, and planner-backed editors (place

--- a/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
+++ b/client/src/mobile/screens/trip/plan/MPlanTimeline.tsx
@@ -10,7 +10,7 @@ import { fmtTransitDuration } from '../../../../components/Planner/transitDispla
 import { formatTime } from '../../../../utils/formatters'
 import { useMPlanTimeline, type MPlanTimelineController } from './useMPlanTimeline'
 import { cityPillsForDay, weatherIconFor } from './planTimelineModel'
-import type { PlanRow } from './planTimelineModel'
+import type { HotelChip, PlanRow } from './planTimelineModel'
 import { useMPlanDragReorder } from './useMPlanDragReorder'
 import { useTouchDragBridge } from '../../../../hooks/useTouchDragBridge'
 import { useIsTouch } from '../../../../hooks/useIsTouch'
@@ -56,6 +56,21 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
   const daySchedule = usePluginDaySchedule(planner.tripId)
   const day = tl.day
   const dayId = day?.id
+  // A stay chip opens the stay, the same way the stay card in the day sheet
+  // does: the editor for members who may edit days, otherwise the hotel's
+  // place. A stay with neither still leads to the day sheet, so the chip
+  // never goes dead (#2210).
+  const openStay = (chip: HotelChip) => {
+    if (!day) return
+    if (canEdit) shell.openSheet('accommodation', { dayId: day.id, accId: chip.accId, from: 'timeline' })
+    else if (chip.placeId != null) planner.handlePlaceClick(chip.placeId)
+    else shell.openSheet('day', { dayId: day.id })
+  }
+  // The icon alone tells check-out from check-in; the accessible name says it.
+  const stayLabel = (chip: HotelChip) => {
+    const kind = chip.variant === 'checkin' ? t('day.checkIn') : chip.variant === 'checkout' ? t('day.checkOut') : t('mobileTrip.stay')
+    return `${kind} · ${chip.name}${chip.time ? ` · ${chip.time.slice(0, 5)}` : ''}`
+  }
   // Mirrors MDaySheet's own label so the pill and the sheet it opens agree.
   const dayLabel = day
     ? day.title || t('planner.dayN', { n: day.day_number || planner.days.indexOf(day) + 1 })
@@ -159,6 +174,8 @@ export default function MPlanTimeline({ planner, shell }: MPlanTimelineProps) {
               ? `${t('day.overview')} · ${t('day.weatherFor', { name: tl.weatherPlaceName })}`
               : undefined}
             onOpenDay={() => shell.openSheet('day', { dayId: day.id })}
+            onOpenStay={openStay}
+            stayLabel={stayLabel}
           />
         )}
 
@@ -396,16 +413,20 @@ function EditHeader({ tl, planner, shell }: {
  * (check-out / check-in / stay) and the weather chip.
  *
  * The day pill leads unconditionally. It used to be the accommodation chip that
- * carried this, which left a day without a stay — and, with no weather either,
- * the whole header — with no way into the day sheet at all (#2004).
+ * carried this, which left a day without a stay (and, with no weather either,
+ * the whole header) with no way into the day sheet at all (#2004). Since then
+ * the stay chips have a target of their own: tapping a hotel opens that stay,
+ * not the day (#2210). Only the weather chip still shares the day pill's target.
  */
-function TimelineHeader({ tl, dayLabel, openLabel, weatherLabel, onOpenDay }: {
+function TimelineHeader({ tl, dayLabel, openLabel, weatherLabel, onOpenDay, onOpenStay, stayLabel }: {
   tl: MPlanTimelineController
   dayLabel: string
   openLabel: string
   /** Weather-chip label naming the forecast's anchor place (#2167); falls back to openLabel. */
   weatherLabel?: string
   onOpenDay: () => void
+  onOpenStay: (chip: HotelChip) => void
+  stayLabel: (chip: HotelChip) => string
 }) {
   const WeatherIcon = weatherIconFor(tl.weather?.main)
   return (
@@ -428,7 +449,8 @@ function TimelineHeader({ tl, dayLabel, openLabel, weatherLabel, onOpenDay }: {
           <button
             key={chip.key}
             type="button"
-            onClick={onOpenDay}
+            onClick={() => onOpenStay(chip)}
+            aria-label={stayLabel(chip)}
             className="flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full bg-[color:var(--m-ic)] px-2.5 py-1 font-geist text-[0.6875rem] font-semibold"
           >
             <HotelChipIcon variant={chip.variant} />

--- a/client/src/mobile/screens/trip/plan/planTimelineModel.ts
+++ b/client/src/mobile/screens/trip/plan/planTimelineModel.ts
@@ -153,6 +153,9 @@ export interface HotelChip {
   variant: 'checkout' | 'checkin' | 'stay'
   name: string
   time: string | null
+  /** The stay behind the chip, so a tap can open it rather than the day (#2210). */
+  accId: number
+  placeId: number | null
 }
 
 const accommodationName = (a: Accommodation): string => a.place_name || a.reservation_title || ''
@@ -162,12 +165,13 @@ export function hotelChipsForDay(day: Day, days: Day[], accommodations: Accommod
   const inRange = accommodations.filter(a => isDayInAccommodationRange(day, a.start_day_id, a.end_day_id, days))
   const chips: HotelChip[] = []
   for (const a of inRange) {
+    const stay = { name: accommodationName(a), accId: a.id, placeId: a.place_id ?? null }
     if (a.end_day_id === day.id) {
-      chips.push({ key: `out-${a.id}`, variant: 'checkout', name: accommodationName(a), time: a.check_out || null })
+      chips.push({ ...stay, key: `out-${a.id}`, variant: 'checkout', time: a.check_out || null })
     } else if (a.start_day_id === day.id) {
-      chips.push({ key: `in-${a.id}`, variant: 'checkin', name: accommodationName(a), time: a.check_in || null })
+      chips.push({ ...stay, key: `in-${a.id}`, variant: 'checkin', time: a.check_in || null })
     } else {
-      chips.push({ key: `stay-${a.id}`, variant: 'stay', name: accommodationName(a), time: null })
+      chips.push({ ...stay, key: `stay-${a.id}`, variant: 'stay', time: null })
     }
   }
   const rank = { checkout: 0, checkin: 1, stay: 2 }

--- a/client/src/mobile/screens/trip/sheets/MAccommodationSheet.tsx
+++ b/client/src/mobile/screens/trip/sheets/MAccommodationSheet.tsx
@@ -13,6 +13,8 @@ interface AccommodationPayload {
   dayId?: number
   /** Present = edit an existing accommodation, absent = add. */
   accId?: number
+  /** Opened from the timeline's stay chip: closing returns there, not to the day sheet (#2210). */
+  from?: 'timeline'
 }
 
 interface HotelForm {
@@ -72,10 +74,14 @@ export default function MAccommodationSheet({ planner, shell }: MTripSheetsProps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, payload.dayId, payload.accId])
 
-  // Cancelling / saving returns to the day sheet it was opened from — opened for
-  // an edit there is no dayId in the payload, so fall back to the stay's own
-  // start day instead of leaving the day sheet without one.
-  const back = () => shell.openSheet('day', { dayId: payload.dayId ?? editing?.start_day_id })
+  // Cancelling / saving returns to the day sheet it was opened from. Opened for
+  // an edit there may be no dayId in the payload, so fall back to the stay's own
+  // start day instead of leaving the day sheet without one. Opened straight from
+  // the timeline's stay chip there is no day sheet to return to, so just close.
+  const back = () => {
+    if (payload.from === 'timeline') shell.closeSheet()
+    else shell.openSheet('day', { dayId: payload.dayId ?? editing?.start_day_id })
+  }
 
   const firstId = days[0]?.id
   const lastId = days[days.length - 1]?.id

--- a/client/tests/unit/mobile/trip/MAccommodationSheet.test.tsx
+++ b/client/tests/unit/mobile/trip/MAccommodationSheet.test.tsx
@@ -189,6 +189,24 @@ describe('MAccommodationSheet', () => {
     expect(shell.openSheet).toHaveBeenCalledWith('day', { dayId: 12 })
   })
 
+  it('FE-MOB-ACCSH-011c: opened from the timeline chip, cancel and X close instead of reopening the day (#2210)', () => {
+    const { shell } = setup(makePlanner(), makeShell({ dayId: 12, accId: 77, from: 'timeline' }))
+    expect(screen.getByRole('dialog', { name: 'Edit accommodation' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(shell.closeSheet).toHaveBeenCalledTimes(2)
+    expect(shell.openSheet).not.toHaveBeenCalled()
+  })
+
+  it('FE-MOB-ACCSH-011d: a save from the timeline lands back on the timeline', async () => {
+    vi.spyOn(accommodationsApi, 'update').mockResolvedValue({})
+    const { planner, shell } = setup(makePlanner(), makeShell({ dayId: 12, accId: 77, from: 'timeline' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(planner.loadAccommodations).toHaveBeenCalled())
+    expect(shell.closeSheet).toHaveBeenCalledTimes(1)
+    expect(shell.openSheet).not.toHaveBeenCalled()
+  })
+
   it('FE-MOB-ACCSH-012: the All chip spans the whole trip and reaches the payload', async () => {
     const create = vi.spyOn(accommodationsApi, 'create').mockResolvedValue({})
     setup()

--- a/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
+++ b/client/tests/unit/mobile/trip/MPlanTimeline.test.tsx
@@ -211,14 +211,38 @@ describe('MPlanTimeline', () => {
       expect(screen.getByTitle('Shibuya')).toBeInTheDocument()
     })
 
-    it('FE-MOB-PLTL-006: a chip opens the day sheet', () => {
+    it('FE-MOB-PLTL-006: a stay chip opens the stay editor for members who may edit days (#2210)', () => {
       const { shell } = renderTimeline({
-        hotelChips: [{ key: 'stay-3', variant: 'stay', name: 'Capsule Tokyo', time: null }],
+        hotelChips: [{ key: 'in-3', variant: 'checkin', name: 'Capsule Tokyo', time: '15:00:00', accId: 3, placeId: 301 }],
       })
 
-      fireEvent.click(screen.getByText('Capsule Tokyo'))
+      fireEvent.click(screen.getByRole('button', { name: 'day.checkIn · Capsule Tokyo · 15:00' }))
+
+      expect(shell.openSheet).toHaveBeenCalledWith('accommodation', { dayId: 2, accId: 3, from: 'timeline' })
+    })
+
+    it('FE-MOB-PLTL-006b: without day_edit the chip opens the hotel place instead', () => {
+      const { planner, shell } = renderTimeline(
+        { hotelChips: [{ key: 'stay-3', variant: 'stay', name: 'Capsule Tokyo', time: null, accId: 3, placeId: 301 }] },
+        { can: vi.fn(() => false) },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'mobileTrip.stay · Capsule Tokyo' }))
+
+      expect(planner.handlePlaceClick).toHaveBeenCalledWith(301)
+      expect(shell.openSheet).not.toHaveBeenCalled()
+    })
+
+    it('FE-MOB-PLTL-006c: a stay without a place still leads a read-only member to the day sheet', () => {
+      const { planner, shell } = renderTimeline(
+        { hotelChips: [{ key: 'out-3', variant: 'checkout', name: 'Capsule Tokyo', time: '11:00', accId: 3, placeId: null }] },
+        { can: vi.fn(() => false) },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'day.checkOut · Capsule Tokyo · 11:00' }))
 
       expect(shell.openSheet).toHaveBeenCalledWith('day', { dayId: 2 })
+      expect(planner.handlePlaceClick).not.toHaveBeenCalled()
     })
 
     it('FE-MOB-PLTL-007: still renders, with the day pill, without chips or weather (#2004)', () => {

--- a/client/tests/unit/mobile/trip/planTimelineModel.test.ts
+++ b/client/tests/unit/mobile/trip/planTimelineModel.test.ts
@@ -259,16 +259,16 @@ describe('planTimelineModel — buildPlanRows', () => {
 })
 
 describe('planTimelineModel — hotel chips and legs', () => {
-  it('FE-MOB-PTLM-022: orders check-out before check-in before an ongoing stay', () => {
+  it('FE-MOB-PTLM-022: orders check-out before check-in before an ongoing stay, each chip naming its stay (#2210)', () => {
     const chips = hotelChipsForDay(DAY2, DAYS, [
       accommodation({ id: 1, start_day_id: 1, end_day_id: 3, place_name: 'Long Stay' }),
-      accommodation({ id: 2, start_day_id: 2, end_day_id: 3, place_name: 'New Hotel', check_in: '15:00' }),
+      accommodation({ id: 2, start_day_id: 2, end_day_id: 3, place_name: 'New Hotel', check_in: '15:00', place_id: 102 }),
       accommodation({ id: 3, start_day_id: 1, end_day_id: 2, place_name: 'Old Hotel', check_out: '11:00' }),
     ])
     expect(chips).toEqual([
-      { key: 'out-3', variant: 'checkout', name: 'Old Hotel', time: '11:00' },
-      { key: 'in-2', variant: 'checkin', name: 'New Hotel', time: '15:00' },
-      { key: 'stay-1', variant: 'stay', name: 'Long Stay', time: null },
+      { key: 'out-3', variant: 'checkout', name: 'Old Hotel', time: '11:00', accId: 3, placeId: null },
+      { key: 'in-2', variant: 'checkin', name: 'New Hotel', time: '15:00', accId: 2, placeId: 102 },
+      { key: 'stay-1', variant: 'stay', name: 'Long Stay', time: null, accId: 1, placeId: null },
     ])
   })
 
@@ -277,7 +277,7 @@ describe('planTimelineModel — hotel chips and legs', () => {
       accommodation({ id: 4, place_name: null, reservation_title: 'Airbnb Wieden' }),
       accommodation({ id: 5, place_name: null, reservation_title: null }),
     ])
-    expect(chips).toEqual([{ key: 'stay-4', variant: 'stay', name: 'Airbnb Wieden', time: null }])
+    expect(chips).toEqual([{ key: 'stay-4', variant: 'stay', name: 'Airbnb Wieden', time: null, accId: 4, placeId: null }])
   })
 
   it('FE-MOB-PTLM-042: leaves the chip time empty when the stay has no check-in or check-out', () => {

--- a/client/tests/unit/mobile/trip/useMPlanTimeline.test.ts
+++ b/client/tests/unit/mobile/trip/useMPlanTimeline.test.ts
@@ -133,7 +133,7 @@ describe('useMPlanTimeline', () => {
     expect(result.current.hotelLegs.top?.seg).toBe(out)
     expect(result.current.hotelLegs.bottom?.seg).toBe(back)
     expect(result.current.hotelChips).toEqual([
-      { key: 'stay-71', variant: 'stay', name: 'Hotel Sacher', time: null },
+      { key: 'stay-71', variant: 'stay', name: 'Hotel Sacher', time: null, accId: 71, placeId: null },
     ])
   })
 

--- a/server/src/nest-mcp/README.md
+++ b/server/src/nest-mcp/README.md
@@ -38,6 +38,7 @@ export class ThingsMcp {
 - `@Resource(options)` — fixed URI (`uri`, `mimeType`, …). Handler: `(uri: URL, ctx)`.
 - `@ResourceTemplate(options)` — `uriTemplate` (RFC 6570). Handler: `(uri: URL, variables, ctx)`. (No `list`/`complete` template callbacks yet — extend when a domain needs them.)
 - `@Prompt(options)` — mirrors `registerPrompt` (`argsSchema` entries must be string-valued Zod schemas). Handler: `(args, ctx)`.
+  Prompt arguments arrive as strings, so every `argsSchema` entry has to accept a string (`PromptArgsShape`): parse numbers with `z.string().regex(...).transform(Number)`, never `z.number()`. The handler receives the transformed values.
 
 `ctx` always takes the SDK `extra` slot — the last handler argument.
 

--- a/server/src/nest-mcp/index.ts
+++ b/server/src/nest-mcp/index.ts
@@ -35,6 +35,7 @@ export {
   type McpModuleOptions,
   type McpRegistryListing,
   type McpZodSchema,
+  type PromptArgsShape,
   type PromptOptions,
   type ResourceOptions,
   type ResourceTemplateOptions,

--- a/server/src/nest-mcp/registry.ts
+++ b/server/src/nest-mcp/registry.ts
@@ -368,13 +368,19 @@ export class McpRegistry {
     ctx: McpContext,
     opts?: McpAttachOptions,
   ): void {
+    // An empty shape means "no arguments", and is registered as such: with a
+    // shape the SDK parses request.params.arguments, which a client that has
+    // nothing to send may omit entirely, and z.object({}) then rejects the
+    // undefined with -32602.
+    const argsSchema =
+      options.argsSchema !== undefined && Object.keys(options.argsSchema).length > 0 ? options.argsSchema : undefined;
     const config: Record<string, unknown> = {
       title: options.title,
       description: options.description,
-      argsSchema: options.argsSchema,
+      argsSchema,
     };
     const cb =
-      options.argsSchema !== undefined
+      argsSchema !== undefined
         ? (args: unknown, _extra: unknown) => {
             opts?.onInvoke?.({ kind: 'prompt', name: options.name });
             return handler.call(instance, args, ctx);

--- a/server/src/nest-mcp/types.ts
+++ b/server/src/nest-mcp/types.ts
@@ -1,6 +1,6 @@
 import type { Scope, ScopeGroup } from '../mcp/scopes';
 
-import type { ZodRawShape } from 'zod';
+import type { ZodRawShape, ZodType } from 'zod';
 
 /**
  * The mode half of every scope: 'read' | 'write' | 'delete' | 'share'.
@@ -152,9 +152,18 @@ export interface ResourceTemplateOptions extends McpEntryOptionsBase {
   _meta?: Record<string, unknown>;
 }
 
-/** Mirrors the SDK's `registerPrompt` config (argsSchema entries must be string-valued Zod schemas). */
+/**
+ * Prompt arguments cross the wire as strings (GetPromptRequest.arguments is
+ * a Record<string, string>), so every entry has to accept a string and may
+ * transform from there. A bare z.number() type-checks against ZodRawShape but
+ * rejects every real client with "expected number, received string" (#2207);
+ * the input constraint here turns that into a compile error.
+ */
+export type PromptArgsShape = Record<string, ZodType<unknown, string | undefined>>;
+
+/** Mirrors the SDK's `registerPrompt` config. */
 export interface PromptOptions extends McpEntryOptionsBase {
-  argsSchema?: ZodRawShape;
+  argsSchema?: PromptArgsShape;
 }
 
 export type McpEntryKind = 'tool' | 'resource' | 'resourceTemplate' | 'prompt';

--- a/server/src/nest/mcp-shared/prompt-args.ts
+++ b/server/src/nest/mcp-shared/prompt-args.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+/**
+ * Prompt arguments arrive as strings (GetPromptRequest.arguments is a
+ * Record<string, string>), so a numeric id has to be parsed out of one.
+ * The old z.number().int().positive() failed every client, MCP Inspector
+ * included, with "expected number, received string" (#2207).
+ */
+export const tripIdPromptArg = z
+  .string()
+  .regex(/^[1-9]\d*$/, 'Trip ID must be a positive integer')
+  .transform(Number)
+  .pipe(z.number().int().positive());

--- a/server/src/nest/trips/trip-prompts.mcp.ts
+++ b/server/src/nest/trips/trip-prompts.mcp.ts
@@ -1,8 +1,8 @@
 import { McpController, Prompt, type McpContext } from '../../nest-mcp';
-import { z } from 'zod';
 import { ADDON_IDS } from '../../addons';
 import { addonGate } from '../addons/addon-gate';
 import { AddonsService } from '../addons/addons.service';
+import { tripIdPromptArg } from '../mcp-shared/prompt-args';
 import { PackingService } from '../packing/packing.service';
 import { TripReadModelService } from '../trip-read-model/trip-read-model.service';
 import { TripsService } from './trips.service';
@@ -35,7 +35,7 @@ export class TripPromptsMcp {
     title: 'Budget Overview',
     description: 'Get a formatted budget summary for a trip',
     argsSchema: {
-      tripId: z.number().int().positive().describe('Trip ID'),
+      tripId: tripIdPromptArg.describe('Trip ID'),
     },
     when: budgetAddonOn,
   })
@@ -72,7 +72,7 @@ export class TripPromptsMcp {
     title: 'Packing List',
     description: 'Get a formatted packing checklist for a trip',
     argsSchema: {
-      tripId: z.number().int().positive().describe('Trip ID'),
+      tripId: tripIdPromptArg.describe('Trip ID'),
     },
     when: packingAddonOn,
   })

--- a/server/src/nest/trips/trips.mcp.ts
+++ b/server/src/nest/trips/trips.mcp.ts
@@ -5,6 +5,7 @@ import {
   demoDenied, errorResult, ok,
 } from '../../nest-mcp';
 import { McpToolGuardsService } from '../mcp-shared/mcp-tool-guards.service';
+import { tripIdPromptArg } from '../mcp-shared/prompt-args';
 import { z } from 'zod';
 import { AuthService } from '../auth/auth.service';
 import { CalendarService } from '../calendar/calendar.service';
@@ -579,7 +580,7 @@ export class TripsMcp {
     title: 'Trip Summary',
     description: 'Load a full summary of a trip for context before planning or modifications',
     argsSchema: {
-      tripId: z.number().int().positive().describe('Trip ID to summarize'),
+      tripId: tripIdPromptArg.describe('Trip ID to summarize'),
     },
   })
   async tripSummaryPrompt({ tripId }: { tripId: number }, ctx: McpContext) {

--- a/server/tests/unit/mcp/tools-prompts.test.ts
+++ b/server/tests/unit/mcp/tools-prompts.test.ts
@@ -1,13 +1,17 @@
 /**
  * Unit tests for MCP prompts: token_auth_notice, trip-summary, packing-list, budget-overview.
  *
- * Note: MCP prompt arguments must be Record<string, string> per protocol spec.
- * The prompts.ts argsSchema uses z.number() for tripId, which is incompatible
- * with the MCP client's type-safe getPrompt. We therefore test prompt callbacks
- * directly via the registered prompt handlers on the server instance.
+ * Every prompt is fetched the way a real client fetches it: over an in-memory
+ * transport, with the arguments as the strings the protocol carries
+ * (GetPromptRequest.arguments is Record<string, string>). The tripId schemas
+ * used to be z.number(), which no client could ever satisfy (#2207); these
+ * cases used to sidestep that by calling the callbacks directly.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { Client } from '@modelcontextprotocol/sdk/client/index';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types';
 
 const { testDb, dbMock } = vi.hoisted(() => {
   const Database = require('better-sqlite3');
@@ -175,31 +179,42 @@ afterAll(() => {
   testDb.close();
 });
 
-/** Build a fresh McpServer with prompts registered for the given userId. */
-function buildServer(userId: number, opts: { isStaticToken?: boolean } = {}): McpServer {
+const openSessions: Array<{ client: Client; server: McpServer }> = [];
+
+afterEach(async () => {
+  for (const { client, server } of openSessions.splice(0)) {
+    await client.close();
+    await server.close();
+  }
+});
+
+/** A connected client over a fresh McpServer with the prompts registered for the given userId. */
+async function buildServer(userId: number, opts: { isStaticToken?: boolean } = {}): Promise<Client> {
   const server = new McpServer({ name: 'trek-test', version: '1.0.0' });
   // Every prompt is DI-discovered now; attach them the way registerTools does in
   // production, including the isStaticToken flag the notice's `when` gate reads.
   createTestRegistry([tripsMcp, tripPromptsMcp, packingMcp, budgetMcp, authMcp], { accessPolicy: trekMcpAccessPolicy, validateAccess: trekMcpValidateAccess })
     .attach(server, { userId, scopes: null, isStaticToken: opts.isStaticToken ?? false });
-  return server;
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  openSessions.push({ client, server });
+  return client;
 }
 
-/** Invoke a registered prompt callback directly, bypassing the MCP transport. */
-async function invokePrompt(server: McpServer, name: string, args: Record<string, unknown>): Promise<string> {
-  const prompts = (server as any)._registeredPrompts;
-  const prompt = prompts[name];
-  if (!prompt) throw new Error(`Prompt "${name}" not registered`);
-  const result = await prompt.callback(args, {});
+/** Fetch a prompt over the transport; numeric ids go out as the strings a client sends. */
+async function invokePrompt(client: Client, name: string, args: Record<string, string | number> = {}): Promise<string> {
+  const wireArgs = Object.fromEntries(Object.entries(args).map(([key, value]) => [key, String(value)]));
+  const result = await client.getPrompt({ name, arguments: wireArgs });
   const msg = result.messages[0];
   if (msg?.content?.type === 'text') return msg.content.text;
   return '';
 }
 
-/** List registered prompt names. */
-function listRegisteredPrompts(server: McpServer): string[] {
-  const prompts = (server as any)._registeredPrompts;
-  return Object.keys(prompts);
+/** Prompt names the session advertises. */
+async function listRegisteredPrompts(client: Client): Promise<string[]> {
+  return (await client.listPrompts()).prompts.map((p) => p.name);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -207,8 +222,8 @@ function listRegisteredPrompts(server: McpServer): string[] {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Return only the text of a prompt result, ignoring error shapes. */
-async function invokePromptText(server: McpServer, name: string, args: Record<string, unknown>): Promise<string> {
-  return invokePrompt(server, name, args);
+async function invokePromptText(client: Client, name: string, args: Record<string, string | number>): Promise<string> {
+  return invokePrompt(client, name, args);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -218,19 +233,65 @@ async function invokePromptText(server: McpServer, name: string, args: Record<st
 describe('Prompt: token_auth_notice', () => {
   it('is registered and returns deprecation notice when isStaticToken=true', async () => {
     const { user } = createUser(testDb);
-    const server = buildServer(user.id, { isStaticToken: true });
-    const names = listRegisteredPrompts(server);
+    const client = await buildServer(user.id, { isStaticToken: true });
+    const names = await listRegisteredPrompts(client);
     expect(names).toContain('token_auth_notice');
-    const text = await invokePrompt(server, 'token_auth_notice', {});
+    const text = await invokePrompt(client, 'token_auth_notice', {});
     expect(text).toContain('static API token');
     expect(text).toContain('deprecated');
   });
 
+  it('answers a request that carries no arguments at all', async () => {
+    const { user } = createUser(testDb);
+    const client = await buildServer(user.id, { isStaticToken: true });
+    // The SDK client sends no `arguments` key when none are given; a prompt
+    // without arguments must not demand an empty object.
+    const result = await client.getPrompt({ name: 'token_auth_notice' });
+    expect(result.messages[0]?.content).toMatchObject({ type: 'text' });
+  });
+
   it('is NOT registered when isStaticToken=false', async () => {
     const { user } = createUser(testDb);
-    const server = buildServer(user.id, { isStaticToken: false });
-    const names = listRegisteredPrompts(server);
+    const client = await buildServer(user.id, { isStaticToken: false });
+    const names = await listRegisteredPrompts(client);
     expect(names).not.toContain('token_auth_notice');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prompt arguments on the wire (#2207)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Prompt arguments on the wire', () => {
+  it.each(['trip-summary', 'packing-list', 'budget-overview'])('%s takes the trip id as the string every client sends (#2207)', async (name) => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Wire Trip' });
+    createPackingItem(testDb, trip.id, { name: 'Charger', category: 'Tech' });
+
+    const client = await buildServer(user.id);
+    const result = await client.getPrompt({ name, arguments: { tripId: String(trip.id) } });
+    expect(result.description).toContain('Wire Trip');
+  });
+
+  it.each(['abc', '0', '-3', '1.5', '', '99999999999999999999'])('rejects the trip id %j as invalid params instead of reaching the handler', async (tripId) => {
+    const { user } = createUser(testDb);
+    createTrip(testDb, user.id, { title: 'Untouched' });
+    mockGetTripSummary.mockClear();
+
+    const client = await buildServer(user.id);
+    await expect(client.getPrompt({ name: 'trip-summary', arguments: { tripId } }))
+      .rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    expect(mockGetTripSummary).not.toHaveBeenCalled();
+  });
+
+  it('advertises tripId as a required argument of every trip prompt', async () => {
+    const { user } = createUser(testDb);
+    const client = await buildServer(user.id);
+    const { prompts } = await client.listPrompts();
+    const byName = Object.fromEntries(prompts.map((p) => [p.name, p.arguments]));
+    expect(byName['trip-summary']).toEqual([{ name: 'tripId', description: 'Trip ID to summarize', required: true }]);
+    expect(byName['packing-list']).toEqual([{ name: 'tripId', description: 'Trip ID', required: true }]);
+    expect(byName['budget-overview']).toEqual([{ name: 'tripId', description: 'Trip ID', required: true }]);
   });
 });
 
@@ -241,8 +302,8 @@ describe('Prompt: token_auth_notice', () => {
 describe('Prompt: trip-summary', () => {
   it('is always registered regardless of addons', async () => {
     const { user } = createUser(testDb);
-    const server = buildServer(user.id);
-    expect(listRegisteredPrompts(server)).toContain('trip-summary');
+    const client = await buildServer(user.id);
+    expect(await listRegisteredPrompts(client)).toContain('trip-summary');
   });
 
   it('returns access denied message for non-member trip', async () => {
@@ -250,8 +311,8 @@ describe('Prompt: trip-summary', () => {
     const { user: other } = createUser(testDb);
     const trip = createTrip(testDb, other.id, { title: 'Private Trip' });
 
-    const server = buildServer(user.id);
-    const text = await invokePrompt(server, 'trip-summary', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'trip-summary', { tripId: trip.id });
     expect(text.toLowerCase()).toContain('access denied');
   });
 
@@ -261,18 +322,10 @@ describe('Prompt: trip-summary', () => {
     const trip = createTrip(testDb, user.id, { title: 'Paris Trip', start_date: '2026-07-01', end_date: '2026-07-03' });
     addTripMember(testDb, trip.id, member.id);
 
-    const server = buildServer(user.id);
-    // The prompt callback accesses packing/budget from getTripSummary which returns
-    // object shapes; this verifies the trip is accessible and a response is produced.
-    try {
-      const text = await invokePrompt(server, 'trip-summary', { tripId: trip.id });
-      expect(text).toContain('Paris Trip');
-    } catch (err: any) {
-      // getTripSummary returns { packing: { items, total, checked }, budget: { items, total, ... } }
-      // but prompts.ts calls packing.filter() expecting an array — known source discrepancy.
-      // Verify the trip IS accessible (access denied would not throw, it returns a message).
-      expect(err.message).not.toContain('access denied');
-    }
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'trip-summary', { tripId: trip.id });
+    expect(text).toContain('Paris Trip');
+    expect(text).toContain('Dates: 2026-07-01 to 2026-07-03');
   });
 
   it('returns "Trip not found." when getTripSummary returns null for accessible trip', async () => {
@@ -282,8 +335,8 @@ describe('Prompt: trip-summary', () => {
     // Override mock to return null (covers lines 46-48 in prompts.ts)
     mockGetTripSummary.mockReturnValueOnce(null);
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'trip-summary', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'trip-summary', { tripId: trip.id });
     expect(text).toContain('Trip not found.');
   });
 
@@ -302,8 +355,8 @@ describe('Prompt: trip-summary', () => {
       collabNotes: [],
     });
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'trip-summary', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'trip-summary', { tripId: trip.id });
     expect(text).toContain('Untitled');
     expect(text).toContain('?');   // start/end date fallback
     expect(text).toContain('EUR'); // currency fallback
@@ -318,15 +371,15 @@ describe('Prompt: packing-list', () => {
   it('prompt is NOT registered when packing addon is disabled', async () => {
     isAddonEnabledMock.mockReturnValue(false);
     const { user } = createUser(testDb);
-    const server = buildServer(user.id);
-    expect(listRegisteredPrompts(server)).not.toContain('packing-list');
+    const client = await buildServer(user.id);
+    expect(await listRegisteredPrompts(client)).not.toContain('packing-list');
   });
 
   it('prompt is registered when packing addon is enabled', async () => {
     // isAddonEnabledMock returns true by default
     const { user } = createUser(testDb);
-    const server = buildServer(user.id);
-    expect(listRegisteredPrompts(server)).toContain('packing-list');
+    const client = await buildServer(user.id);
+    expect(await listRegisteredPrompts(client)).toContain('packing-list');
   });
 
   it('returns access denied for non-member trip', async () => {
@@ -334,8 +387,8 @@ describe('Prompt: packing-list', () => {
     const { user: other } = createUser(testDb);
     const trip = createTrip(testDb, other.id);
 
-    const server = buildServer(user.id);
-    const text = await invokePrompt(server, 'packing-list', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'packing-list', { tripId: trip.id });
     expect(text.toLowerCase()).toContain('access denied');
   });
 
@@ -343,8 +396,8 @@ describe('Prompt: packing-list', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Empty Trip' });
 
-    const server = buildServer(user.id);
-    const text = await invokePrompt(server, 'packing-list', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'packing-list', { tripId: trip.id });
     expect(text).toContain('No packing items found');
   });
 
@@ -354,8 +407,8 @@ describe('Prompt: packing-list', () => {
     createPackingItem(testDb, trip.id, { name: 'Sunscreen', category: 'Essentials' });
     createPackingItem(testDb, trip.id, { name: 'Passport', category: 'Documents' });
 
-    const server = buildServer(user.id);
-    const text = await invokePrompt(server, 'packing-list', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'packing-list', { tripId: trip.id });
     expect(text).toContain('Packing List');
     expect(text).toContain('Sunscreen');
     expect(text).toContain('Passport');
@@ -373,8 +426,8 @@ describe('Prompt: packing-list', () => {
     // Null out the getTripSummary call inside packing-list (line 94: || {})
     mockGetTripSummary.mockReturnValueOnce(null);
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'packing-list', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'packing-list', { tripId: trip.id });
     expect(text).toContain('Toothbrush');
     // Falls back to 'Trip' literal since trip?.title is undefined (getTripSummary null → || {})
     expect(text).toContain('Packing List: Trip');
@@ -389,14 +442,14 @@ describe('Prompt: budget-overview', () => {
   it('prompt is NOT registered when budget addon is disabled', async () => {
     isAddonEnabledMock.mockReturnValue(false);
     const { user } = createUser(testDb);
-    const server = buildServer(user.id);
-    expect(listRegisteredPrompts(server)).not.toContain('budget-overview');
+    const client = await buildServer(user.id);
+    expect(await listRegisteredPrompts(client)).not.toContain('budget-overview');
   });
 
   it('prompt is registered when budget addon is enabled', async () => {
     const { user } = createUser(testDb);
-    const server = buildServer(user.id);
-    expect(listRegisteredPrompts(server)).toContain('budget-overview');
+    const client = await buildServer(user.id);
+    expect(await listRegisteredPrompts(client)).toContain('budget-overview');
   });
 
   it('returns access denied for non-member trip', async () => {
@@ -404,8 +457,8 @@ describe('Prompt: budget-overview', () => {
     const { user: other } = createUser(testDb);
     const trip = createTrip(testDb, other.id);
 
-    const server = buildServer(user.id);
-    const text = await invokePrompt(server, 'budget-overview', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'budget-overview', { tripId: trip.id });
     expect(text.toLowerCase()).toContain('access denied');
   });
 
@@ -413,20 +466,9 @@ describe('Prompt: budget-overview', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Budget Trip' });
 
-    const server = buildServer(user.id);
-    // The prompt destructures budget from getTripSummary, which now returns
-    // { items, item_count, total, currency } instead of an array.
-    // prompts.ts calls budget?.reduce() expecting an array — known source discrepancy.
-    // This test verifies the prompt is reachable and the trip access check passes.
-    try {
-      const text = await invokePrompt(server, 'budget-overview', { tripId: trip.id });
-      // If source shape matches, text should contain the trip title
-      expect(text).toContain('Budget Trip');
-    } catch (err: any) {
-      // The TypeError from budget.reduce confirms the trip was accessible
-      // (access denied produces a message, not an exception).
-      expect(err.message).toContain('is not a function');
-    }
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'budget-overview', { tripId: trip.id });
+    expect(text).toContain('Budget Trip');
   });
 
   it('produces output for an accessible trip with budget items', async () => {
@@ -435,14 +477,10 @@ describe('Prompt: budget-overview', () => {
     createBudgetItem(testDb, trip.id, { name: 'Flight', category: 'Transport', total_price: 300 });
     createBudgetItem(testDb, trip.id, { name: 'Hotel', category: 'Accommodation', total_price: 500 });
 
-    const server = buildServer(user.id);
-    try {
-      const text = await invokePrompt(server, 'budget-overview', { tripId: trip.id });
-      expect(text).toContain('Italy Trip');
-    } catch (err: any) {
-      // Confirms trip was accessible; TypeError from budget.reduce is a source discrepancy
-      expect(err.message).toContain('is not a function');
-    }
+    const client = await buildServer(user.id);
+    const text = await invokePrompt(client, 'budget-overview', { tripId: trip.id });
+    expect(text).toContain('Italy Trip');
+    expect(text).toContain('Total: 800');
   });
 
   it('returns "Trip not found." when getTripSummary returns null for accessible trip', async () => {
@@ -452,8 +490,8 @@ describe('Prompt: budget-overview', () => {
     // Override mock to return null (covers lines 116-118 in prompts.ts)
     mockGetTripSummary.mockReturnValueOnce(null);
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'budget-overview', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'budget-overview', { tripId: trip.id });
     expect(text).toContain('Trip not found.');
   });
 
@@ -466,8 +504,8 @@ describe('Prompt: budget-overview', () => {
     createBudgetItem(testDb, trip.id, { name: 'Bus', category: 'Transport', total_price: 50 });
     createBudgetItem(testDb, trip.id, { name: 'Hotel', category: 'Accommodation', total_price: 300 });
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'budget-overview', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'budget-overview', { tripId: trip.id });
     expect(text).toContain('Budget Trip');
     expect(text).toContain('Transport');
     expect(text).toContain('Accommodation');
@@ -479,8 +517,8 @@ describe('Prompt: budget-overview', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id, { title: 'Empty Budget' });
 
-    const server = buildServer(user.id);
-    const text = await invokePromptText(server, 'budget-overview', { tripId: trip.id });
+    const client = await buildServer(user.id);
+    const text = await invokePromptText(client, 'budget-overview', { tripId: trip.id });
     expect(text).toContain('No expenses recorded.');
   });
 });

--- a/server/tests/unit/nest-mcp/attach.test.ts
+++ b/server/tests/unit/nest-mcp/attach.test.ts
@@ -8,6 +8,7 @@ import {
   Tool,
   type McpAccessPolicy,
   type McpContext,
+  type PromptArgsShape,
 } from '../../../src/nest-mcp';
 import { createAttachHarness, type AttachHarness, type TestCtx } from './harness';
 
@@ -70,6 +71,17 @@ class FixtureMcp {
   @Prompt({ name: 'fixture_prompt', description: 'Prompts.', argsSchema: { topic: z.string() } })
   async fixturePrompt({ topic }: { topic: string }, ctx: TestCtx) {
     return { messages: [{ role: 'user', content: { type: 'text', text: `${topic} for ${ctx.userId}` } }] };
+  }
+
+  // Arguments reach the server as strings; a numeric one is parsed on the way in.
+  @Prompt({ name: 'fixture_count', argsSchema: { count: z.string().regex(/^\d+$/).transform(Number) } })
+  async fixtureCount({ count }: { count: number }, ctx: TestCtx) {
+    return { messages: [{ role: 'user', content: { type: 'text', text: `${typeof count} ${count + 1} for ${ctx.userId}` } }] };
+  }
+
+  @Prompt({ name: 'fixture_bare', argsSchema: {} })
+  async fixtureBare(args: Record<string, never>, ctx: TestCtx) {
+    return { messages: [{ role: 'user', content: { type: 'text', text: `${Object.keys(args).length} args for ${ctx.userId}` } }] };
   }
 }
 
@@ -143,8 +155,8 @@ describe('McpRegistry.attach', () => {
     expect(resources).toEqual(['fixture_doc']);
     const templates = (await harness.client.listResourceTemplates()).resourceTemplates.map((t) => t.name);
     expect(templates).toEqual(['fixture_item']);
-    const prompts = (await harness.client.listPrompts()).prompts.map((p) => p.name);
-    expect(prompts).toEqual(['fixture_prompt']);
+    const prompts = (await harness.client.listPrompts()).prompts.map((p) => p.name).sort();
+    expect(prompts).toEqual(['fixture_bare', 'fixture_count', 'fixture_prompt']);
   });
 
   it('filters declarative access through the policy per mode', async () => {
@@ -198,6 +210,34 @@ describe('McpRegistry.attach', () => {
     harness = await createAttachHarness(buildRegistry(), { userId: 3 });
     const result = await harness.client.getPrompt({ name: 'fixture_prompt', arguments: { topic: 'packing' } });
     expect(result.messages[0]?.content).toMatchObject({ type: 'text', text: 'packing for 3' });
+  });
+
+  it('hands prompt handlers the transformed argument, not the wire string (#2207)', async () => {
+    harness = await createAttachHarness(buildRegistry(), { userId: 3 });
+    const result = await harness.client.getPrompt({ name: 'fixture_count', arguments: { count: '41' } });
+    expect(result.messages[0]?.content).toMatchObject({ type: 'text', text: 'number 42 for 3' });
+    await expect(harness.client.getPrompt({ name: 'fixture_count', arguments: { count: 'many' } }))
+      .rejects.toThrow(/Invalid arguments for prompt fixture_count/);
+  });
+
+  it('serves a prompt with an empty argsSchema to a request that omits arguments', async () => {
+    harness = await createAttachHarness(buildRegistry(), { userId: 3 });
+    const result = await harness.client.getPrompt({ name: 'fixture_bare' });
+    expect(result.messages[0]?.content).toMatchObject({ type: 'text', text: '0 args for 3' });
+    const listed = (await harness.client.listPrompts()).prompts.find((p) => p.name === 'fixture_bare');
+    expect(listed?.arguments).toBeUndefined();
+  });
+
+  it('only admits string-input schemas as prompt arguments', () => {
+    // Compile-time contract: a z.number() argument can never be satisfied over
+    // the wire, so PromptArgsShape refuses it while string, optional string and
+    // string-to-number transforms all pass.
+    type Admits<S> = S extends PromptArgsShape ? true : false;
+    const numberRefused: Admits<{ tripId: z.ZodNumber }> = false;
+    const stringAdmitted: Admits<{ topic: z.ZodString }> = true;
+    const optionalAdmitted: Admits<{ topic: z.ZodOptional<z.ZodString> }> = true;
+    const transformAdmitted: Admits<{ count: z.ZodPipe<z.ZodString, z.ZodTransform<number, string>> }> = true;
+    expect([numberRefused, stringAdmitted, optionalAdmitted, transformAdmitted]).toEqual([false, true, true, true]);
   });
 
   it('ANDs `when` in front of declarative access (both must pass)', async () => {


### PR DESCRIPTION
Two reported bugs off the 4.1.1 tag, each reproduced and fixed at the cause.

# Prompts fail with MCP error -32602 (#2207)

The three trip prompts (trip-summary, budget-overview, packing-list) declared their `tripId` argument as `z.number()`, but prompt arguments always arrive as strings, so every `prompts/get` was rejected with "expected number, received string" before the handler ran; the matching tools worked because tool arguments are JSON. The id is now parsed from the string it arrives as, through one shared `tripIdPromptArg`, and `PromptOptions.argsSchema` only admits string-input schemas, so a numeric schema is a compile error from now on. Found on the way: a prompt declared with an empty `argsSchema` (the static-token notice) rejected clients that send no `arguments` key at all; the registry now registers it as argument-free. The prompt tests go through a real in-memory MCP client with string arguments, which is exactly what they had been sidestepping; invalid ids ("abc", "0", "", oversized) are rejected as invalid params before any lookup. Verified against the running server over the HTTP transport as well.

# Mobile: the lodging chip opens the day, not the stay (#2210)

In the Travel tab the hotel chip next to the day pill shared the pill's target, so both opened the day sheet. A chip now carries its stay and opens it the way the stay card inside the day sheet does: the accommodation editor for members who can edit days, otherwise the hotel's place, and the day sheet only when neither applies. Closing the editor returns to the timeline it was opened from instead of surfacing a day sheet nobody opened, and the chip's accessible name now says whether it is a check-in, a check-out or an ongoing stay. Verified on a phone viewport for both an owner and a member without day edit rights.

Closes #2207
Closes #2210
