### PR TITLE
fix(maps): register the RTL text plugin so Arabic labels join

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
     "@fontsource/museomoderno": "^5.3.0",
     "@fontsource/playfair-display": "^5.3.0",
     "@fontsource/poppins": "^5.2.7",
+    "@mapbox/mapbox-gl-rtl-text": "^0.4.0",
     "@maplibre/maplibre-gl-leaflet": "0.1.4",
     "@simplewebauthn/browser": "^13.1.2",
     "@trek/shared": "*",

--- a/client/rtlTextAlias.js
+++ b/client/rtlTextAlias.js
@@ -1,0 +1,25 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/**
+ * setRTLTextPlugin() takes the URL of a classic script that the GL worker pulls in
+ * with importScripts. mapbox-gl-rtl-text ships exactly that as
+ * dist/mapbox-gl-rtl-text.js, but its "exports" field publishes only the ESM/WASM
+ * entry, so the resolver refuses the subpath. Resolving the entry it does publish
+ * and stepping across to dist keeps this working wherever npm hoists the package.
+ *
+ * Shared by vite.config.js and vitest.config.ts: the build needs it to emit the
+ * asset, and the test run needs it because a lazily imported engine module reaches
+ * the same specifier.
+ *
+ * The pattern is a regex, not a string key: the import carries a `?url` suffix,
+ * which a string alias will not match. It is left unanchored on purpose so the
+ * query survives the rewrite and Vite still emits an asset URL.
+ */
+export const rtlTextAlias = {
+  find: /^@mapbox\/mapbox-gl-rtl-text\/dist\/mapbox-gl-rtl-text\.js/,
+  replacement: path.join(
+    path.dirname(createRequire(import.meta.url).resolve('@mapbox/mapbox-gl-rtl-text')),
+    '../dist/mapbox-gl-rtl-text.js',
+  ),
+};

--- a/client/src/components/Map/engines/mapbox.ts
+++ b/client/src/components/Map/engines/mapbox.ts
@@ -1,5 +1,7 @@
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import rtlTextPluginUrl from '@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js?url'
+import { registerRtlTextPlugin } from '../rtlText'
 
 /**
  * The only module in the client that pulls mapbox-gl in at runtime.
@@ -8,4 +10,8 @@ import 'mapbox-gl/dist/mapbox-gl.css'
  * a static import from anywhere in the tree drags 1.8 MB into the parent chunk and
  * quietly undoes the split. `npm run check:gl-split` fails on that.
  */
+// Arabic/Hebrew/Persian labels come out unjoined and reversed without this.
+// Mapbox's signature is (url, callback, deferred) — see rtlText.ts.
+registerRtlTextPlugin(() => mapboxgl.setRTLTextPlugin(rtlTextPluginUrl, null, true))
+
 export default mapboxgl

--- a/client/src/components/Map/engines/maplibre.ts
+++ b/client/src/components/Map/engines/maplibre.ts
@@ -1,5 +1,7 @@
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
+import rtlTextPluginUrl from '@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js?url'
+import { registerRtlTextPlugin } from '../rtlText'
 
 /**
  * The only module in the client that pulls maplibre-gl in at runtime. Same rule as
@@ -10,4 +12,8 @@ import 'maplibre-gl/dist/maplibre-gl.css'
  * stay engine-agnostic. Where the two genuinely differ, the caller already guards
  * on the provider (projection, accessToken, aroundCenter).
  */
+// Arabic/Hebrew/Persian labels come out unjoined and reversed without this.
+// MapLibre's signature is (url, lazy) and it resolves a promise — see rtlText.ts.
+registerRtlTextPlugin(() => maplibregl.setRTLTextPlugin(rtlTextPluginUrl, true))
+
 export default maplibregl

--- a/client/src/components/Map/engines/rtlRegistration.test.ts
+++ b/client/src/components/Map/engines/rtlRegistration.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The two lines this fix actually adds. Everything else is a helper: the guard in
+ * rtlText.ts has its own tests, but a guard nobody calls looks exactly like a
+ * working fix from the outside. Deleting either registration, swapping an
+ * argument or dropping the deferred flag left the whole suite green.
+ *
+ * The engines are mocked because importing them for real builds a worker pool
+ * under jsdom, and the plugin URL is mocked so the 133 KB payload never loads.
+ */
+const { mapboxSet, maplibreSet } = vi.hoisted(() => ({
+  mapboxSet: vi.fn(),
+  maplibreSet: vi.fn(),
+}));
+
+vi.mock('mapbox-gl', () => ({ default: { setRTLTextPlugin: mapboxSet } }));
+vi.mock('maplibre-gl', () => ({ default: { setRTLTextPlugin: maplibreSet } }));
+vi.mock('mapbox-gl/dist/mapbox-gl.css', () => ({}));
+vi.mock('maplibre-gl/dist/maplibre-gl.css', () => ({}));
+vi.mock('@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js?url', () => ({ default: '/assets/rtl-plugin.js' }));
+
+beforeEach(() => {
+  vi.resetModules();
+  mapboxSet.mockReset();
+  maplibreSet.mockReset();
+});
+
+describe('the GL engines register the RTL text plugin (#2235)', () => {
+  it('FE-MAP-RTL-001: importing the mapbox engine registers it deferred, with a null callback', async () => {
+    await import('./mapbox');
+
+    expect(mapboxSet).toHaveBeenCalledTimes(1);
+    // Mapbox GL 3 takes (url, callback, deferred). The third argument is what
+    // keeps the payload off the wire until a map paints RTL text; dropping it
+    // would fetch 133 KB for every user on every map.
+    expect(mapboxSet).toHaveBeenCalledWith(expect.stringContaining('rtl'), null, true);
+  });
+
+  it('FE-MAP-RTL-002: importing the maplibre engine registers it lazily', async () => {
+    await import('./maplibre');
+
+    expect(maplibreSet).toHaveBeenCalledTimes(1);
+    // MapLibre 5 takes (url, lazy) and returns a promise, which is the reason
+    // the call stays with each engine instead of going through one wrapper.
+    expect(maplibreSet).toHaveBeenCalledWith(expect.stringContaining('rtl'), true);
+  });
+
+  it('FE-MAP-RTL-003: an engine still loads when its registration throws', async () => {
+    mapboxSet.mockImplementation(() => { throw new Error('already registered'); });
+
+    const engine = await import('./mapbox');
+
+    expect(engine.default).toBeDefined();
+  });
+
+  it('FE-MAP-RTL-004: a rejected registration promise does not surface as an unhandled rejection', async () => {
+    maplibreSet.mockReturnValue(Promise.reject(new Error('already registered')));
+
+    const engine = await import('./maplibre');
+
+    expect(engine.default).toBeDefined();
+    // Give the rejection a tick to go unhandled if nothing caught it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});

--- a/client/src/components/Map/rtlText.test.ts
+++ b/client/src/components/Map/rtlText.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { registerRtlTextPlugin } from './rtlText'
+
+describe('registerRtlTextPlugin', () => {
+  it('runs the engine-supplied registration', () => {
+    const register = vi.fn()
+
+    expect(registerRtlTextPlugin(register)).toBe(true)
+    expect(register).toHaveBeenCalledTimes(1)
+  })
+
+  // Registering twice is how the engines report it: Mapbox throws.
+  it('never lets a refused registration break map creation', () => {
+    const register = vi.fn(() => {
+      throw new Error('setRTLTextPlugin cannot be called multiple times.')
+    })
+
+    expect(() => registerRtlTextPlugin(register)).not.toThrow()
+    expect(registerRtlTextPlugin(register)).toBe(false)
+  })
+
+  // MapLibre reports the same by rejecting, and an unhandled rejection would
+  // reach the console for something the user cannot act on.
+  it('swallows a rejected registration promise', async () => {
+    const onUnhandled = vi.fn()
+    process.on('unhandledRejection', onUnhandled)
+
+    expect(registerRtlTextPlugin(() => Promise.reject(new Error('404')))).toBe(true)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    process.off('unhandledRejection', onUnhandled)
+
+    expect(onUnhandled).not.toHaveBeenCalled()
+  })
+
+  it('leaves a resolved promise alone', async () => {
+    expect(registerRtlTextPlugin(() => Promise.resolve())).toBe(true)
+  })
+})

--- a/client/src/components/Map/rtlText.ts
+++ b/client/src/components/Map/rtlText.ts
@@ -1,0 +1,48 @@
+/**
+ * Arabic, Hebrew, Persian and Urdu labels need two things a GL engine does not do
+ * on its own: the bidirectional algorithm, and Arabic contextual shaping (a letter
+ * is drawn differently depending on its neighbours). Without them the engine lays
+ * the codepoints out one by one, left to right, in isolated forms — so القاهرة
+ * comes out as ة ر ه ا ق ل ا, unjoined and reversed. Raster basemaps never showed
+ * this because their labels are drawn server-side, which is why it only surfaced
+ * once the default basemap became a vector style.
+ *
+ * Both engines expose the fix as an optional plugin and neither loads it by
+ * default. Registering is global to the engine, so it happens once per engine
+ * module rather than at each map's construction site.
+ *
+ * The call itself stays with the caller: this is one of the places the two engines
+ * genuinely differ. MapLibre 5 takes `(url, lazy)` and returns a promise, Mapbox
+ * GL 3 takes `(url, callback, deferred)` and returns nothing — so each engine
+ * module passes its own invocation rather than a shared wrapper guessing an arity.
+ *
+ * Deliberately no getRTLTextPluginStatus() pre-check: reading it makes MapLibre
+ * build its worker pool, which is an eager side effect for a module that is
+ * imported for its default export, and throws outright under jsdom. Registering
+ * twice is reported — by a throw or a rejected promise depending on the engine —
+ * and both are handled below, so the probe bought nothing.
+ */
+
+/**
+ * Runs a GL engine's RTL-plugin registration, swallowing the ways it can fail.
+ *
+ * Callers register lazily, so the payload is only fetched once a map actually
+ * paints RTL text and a user who never leaves Latin script downloads nothing.
+ *
+ * @returns whether the registration call completed without throwing.
+ */
+export function registerRtlTextPlugin(register: () => void | Promise<unknown>): boolean {
+  try {
+    const pending = register()
+    // MapLibre reports a failed or duplicate registration by rejecting; Mapbox
+    // routes the same through its callback. Neither is worth surfacing: a map
+    // with unshaped labels still renders, and an unhandled rejection would not
+    // give the user anything to act on.
+    if (pending instanceof Promise) pending.catch(() => {})
+    return true
+  } catch {
+    // Already registered, or the engine refused outright. Registering the plugin
+    // must never be able to break map creation.
+    return false
+  }
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { visualizer } from 'rollup-plugin-visualizer';
+import { rtlTextAlias } from './rtlTextAlias.js';
 
 // `npm run build:analyze` writes dist/stats.html — a treemap of what actually ended
 // up in each chunk. The plain build only reports chunk sizes, which tells you a chunk
@@ -227,6 +228,7 @@ export default defineConfig(({ mode }) => ({
       },
     }),
   ].filter(Boolean),
+  resolve: { alias: [rtlTextAlias] },
   build: {
     // Pin the output level instead of inheriting whatever the current Vite default
     // is, so a toolchain bump can't silently change which browsers still work.

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -47,8 +47,14 @@ export default defineConfig(({ mode }) => ({
         // Every route chunk is precached alongside the shell, deliberately: for an
         // offline-first travel planner a route the user never opened before losing
         // signal still has to work. The trade is that splitting buys first paint and
-        // not install size — 107 entries / 17,795 KiB before any of it, 220 /
-        // 17,855 KiB now.
+        // not install size: 107 entries / 17,795 KiB before any of it, 463 /
+        // 23,292 KiB now (measured, not estimated).
+        //
+        // Keep this figure honest. #2228 traced PWA boot failures to the browser
+        // evicting this origin's whole bucket, precached shell included, and this
+        // comment is the only record of what the install actually costs. Anything
+        // matching the globs below is fetched at service-worker install by every
+        // user, whether or not they ever reach the code.
         globPatterns: ['**/*.{js,css,html,svg,png,woff,woff2,ttf}'],
         // build:analyze drops a treemap next to the app; it must never end up in a
         // precache manifest if someone ships that build by accident.

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { rtlTextAlias } from './rtlTextAlias.js';
 
 export default defineConfig({
   plugins: [react()],
   test: {
+    alias: [rtlTextAlias],
     root: '.',
     globals: true,
     environment: './tests/environment/jsdom-native-abort.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "name": "@trek/client",
       "version": "4.1.1",
       "dependencies": {
+        "@mapbox/mapbox-gl-rtl-text": "^0.4.0",
         "@fontsource/bebas-neue": "^5.3.0",
         "@fontsource/eb-garamond": "^5.3.0",
         "@fontsource/geist-sans": "^5.2.5",
@@ -4698,6 +4699,12 @@
       "engines": {
         "node": ">= 22"
       }
+    },
+    "node_modules/@mapbox/mapbox-gl-rtl-text": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.4.0.tgz",
+      "integrity": "sha512-WNSgEFxXd2a15Eh2GwZNWBiV7Z8leq8JEGcoHpfrgaBDmFQMW4a1MO5Ol9BNv6APqTbHZ8uq7L8H5q2KCVt1kg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "1.1.0",


### PR DESCRIPTION
## Description

Arabic, Hebrew, Persian and Urdu labels on the vector basemaps render as isolated, unjoined letters in reverse order — `القاهرة` is drawn as `ة ر ه ا ق ل ا`. Neither GL engine loads its optional RTL text plugin by default, and TREK never registered one: `setRTLTextPlugin` appears nowhere in `client/src`. Raster basemaps hid it, because their labels are drawn server-side, so it only became widely visible when 4.1.0 made the default basemap a vector style.

Both engine entry points now register the plugin **lazily**, so a browser tab only fetches the payload once a map actually paints RTL text.

> **Maintainer note.** The lazy flag does not spare a PWA user: the emitted asset matches the `**/*.js` precache glob, so the service worker fetches all 133 KB at install regardless. Verified against a real client build, which no CI workflow performs. The trade is still the right one, since the alternative is a CDN the production CSP refuses and unshaped labels for anyone offline; only the claim that Latin-only users download nothing was wrong. The precache figure in `vite.config.js` is corrected in a follow-up commit.

Two details worth reviewing:

- **The registration call stays with each engine**, because this is one of the places the two genuinely differ: MapLibre takes `(url, lazy)` and returns a promise, Mapbox takes `(url, callback, deferred)` and returns nothing. Only the guard around it is shared, in `rtlText.ts`.
- **No `getRTLTextPluginStatus()` pre-check.** Reading it makes MapLibre build its worker pool as a side effect of importing the engine module, which throws under jsdom and added 86 unhandled errors to an unrelated suite. Registering twice is reported by a throw or a rejected promise depending on the engine, and both are handled, so the probe bought nothing.

**Why the plugin is bundled rather than loaded from the CDN URL the MapLibre docs use:** TREK is offline-first, and the production CSP is `script-src 'self'` — a remote plugin URL is refused by the worker that imports it. Bundling also puts it in the Workbox precache, so shaping keeps working offline. It needs a `resolve` alias because the package publishes only its ESM/WASM entry through `exports` while `setRTLTextPlugin` requires the classic script in `dist/`; the alias is shared by the build and test configs so the two cannot drift.

Note on the version: `0.2.3` — the one most docs cite — is not usable here. It declares `peerDependencies` `mapbox-gl` `">=0.32.1 <2.0.0"` against this repo's mapbox-gl 3.30, which is an ERESOLVE conflict. `0.4.0` dropped that peer range. Licence is BSD-2-Clause.

Happy to switch to the CDN plus a CSP entry instead if you would rather not take the dependency.

## Related Issue or Discussion

Closes #2235

I have not pitched this in `#github-pr` first, which I know the guidelines ask for — please close it if you would rather it went through Discord, and I will take it there.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Test plan

- 4 unit tests for the registration guard (registers once, tolerates a throw, swallows a rejected promise, leaves a resolved one alone).
- Full client build passes; the plugin is emitted as a hashed asset and appears in the Workbox precache manifest, so shaping works offline.
- `npm run check:gl-split` still reports mapbox and maplibre in separate chunks.
- 879 map/journey tests pass with 0 unhandled errors, matching the pre-change baseline exactly.
- `typecheck`, `lint`, `lint:pages` clean.

