### PR TITLE
feat(maps): add a Google Maps renderer as a fourth map provider

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@types/google.maps": "^3.66.2",
     "@types/leaflet": "^1.9.8",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.15",

--- a/client/src/components/Map/MapViewAuto.tsx
+++ b/client/src/components/Map/MapViewAuto.tsx
@@ -2,7 +2,8 @@ import { Suspense } from 'react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { MapView } from './MapView'
 import ErrorBoundary from '../shared/ErrorBoundary'
-import { MapViewGLMapbox, MapViewGLMaplibre } from './glLazy'
+import { MapViewGLMapbox, MapViewGLMaplibre, MapViewGoogleLazy } from './glLazy'
+import { basemapLanguage } from './glProviders'
 
 // Auto-selects the map renderer based on user settings. Keeps the existing
 // Leaflet MapView untouched so the Mapbox GL variant can mature iteratively
@@ -16,11 +17,25 @@ import { MapViewGLMapbox, MapViewGLMaplibre } from './glLazy'
 export function MapViewAuto(props: any) {
   const provider = useSettingsStore(s => s.settings.map_provider)
   const token = useSettingsStore(s => s.settings.mapbox_access_token)
+  const googleKey = useSettingsStore(s => s.settings.google_maps_api_key)
+  const language = useSettingsStore(s => s.settings.language)
   // Fall back to Leaflet when Mapbox is selected but no token is set,
   // so trip planner never shows an empty map due to a missing token.
   const glProvider = provider === 'maplibre-gl' ? 'maplibre-gl'
     : provider === 'mapbox-gl' && token ? 'mapbox-gl'
     : null
+  // Same fallback rule as Mapbox: a provider selected without the key it needs
+  // would render an empty map, so Leaflet keeps the planner usable instead.
+  if (provider === 'google-maps' && googleKey) {
+    return (
+      <ErrorBoundary boundaryId="map:google" resetKeys={[googleKey]} fallback={<MapView {...props} />}>
+        <Suspense fallback={<MapView {...props} />}>
+          <MapViewGoogleLazy {...props} apiKey={googleKey} language={basemapLanguage(language)} />
+        </Suspense>
+      </ErrorBoundary>
+    )
+  }
+
   // One chunk per engine: picking the binding here is what keeps mapbox-gl and
   // maplibre-gl out of each other's downloads.
   const MapViewGL = glProvider === 'maplibre-gl' ? MapViewGLMaplibre : MapViewGLMapbox

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -13,6 +13,8 @@ import { ReservationMapboxOverlay } from './reservationsMapbox'
 import { useTransportRoutes } from '../../hooks/useTransportRoutes'
 import { visibleRouteReservations } from '../../utils/reservationRoutes'
 import { safeHexColor } from '../../utils/safeColor'
+import { createMarkerElement } from './placeMarkerElement'
+import { categoryIconSvg } from './categoryIcon'
 import { escapeHtml } from '@trek/shared'
 import { MAPBOX_DEFAULT_STYLE, styleForActiveProvider, basemapLanguage, type GlMapProvider } from './glProviders'
 import LocationButton from './LocationButton'
@@ -25,12 +27,6 @@ import { pluginsApi, type PluginMapMarker, type PluginMapLayer } from '../../api
 import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
 import { computeMapViewport, TILE_SIZE_GL } from '../../utils/mapViewport'
 
-function categoryIconSvg(iconName: string | null | undefined, size: number): string {
-  const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
-  try {
-    return renderIconMarkup(createElement(IconComponent, { size, color: 'white', strokeWidth: 2.5 }))
-  } catch { return '' }
-}
 
 // Marker grouping for the GL map (#1385): MapLibre/Mapbox can't show the rich
 // HTML photo markers *and* cluster them natively, so we feed the place points
@@ -134,83 +130,6 @@ interface Props {
   onMapReady?: (map: any | null) => void
 }
 
-function createMarkerElement(place: Place & { category_color?: string; category_icon?: string }, photoUrl: string | null, orderNumbers: number[] | null, selected: boolean): HTMLDivElement {
-  const size = selected ? 44 : 36
-  // See MapView: allow-listed rather than escaped, because this is a CSS context.
-  const borderColor = selected ? '#111827' : safeHexColor(place.category_color, 'white')
-  const borderWidth = selected ? 3 : 2.5
-  const shadow = selected
-    ? '0 0 0 3px rgba(17,24,39,0.25), 0 4px 14px rgba(0,0,0,0.3)'
-    : '0 2px 8px rgba(0,0,0,0.22)'
-  const bgColor = safeHexColor(place.category_color, '#6b7280')
-
-  // The visual circle is `size` + 2*border on each side. To make the
-  // mapbox `anchor: 'center'` land on the real visual middle of the marker
-  // (rather than just the inner content box), the wrapper has to be the
-  // full outer size. If we gave the wrapper only `size`, the border would
-  // bleed outside it and the route lines would appear slightly off.
-  const outer = size + borderWidth * 2
-
-  let badgeHtml = ''
-  if (orderNumbers && orderNumbers.length > 0) {
-    const label = orderNumbers.join(' · ')
-    badgeHtml = `<span style="
-      position:absolute;bottom:-2px;right:-2px;
-      min-width:18px;height:${orderNumbers.length > 1 ? 16 : 18}px;border-radius:${orderNumbers.length > 1 ? 8 : 9}px;
-      padding:0 ${orderNumbers.length > 1 ? 4 : 3}px;
-      background:rgba(255,255,255,0.94);
-      border:1.5px solid rgba(0,0,0,0.15);
-      box-shadow:0 1px 4px rgba(0,0,0,0.18);
-      display:flex;align-items:center;justify-content:center;
-      font-size:${orderNumbers.length > 1 ? 7.5 : 9}px;font-weight:800;color:#111827;
-      font-family:var(--font-system);line-height:1;
-      box-sizing:border-box;white-space:nowrap;
-    ">${label}</span>`
-  }
-
-  const wrap = document.createElement('div')
-  // Do NOT set `position: relative` here — GL map libraries ship
-  // marker classes with `position: absolute` and rely on it. An inline
-  // `position: relative` here overrides the class, turns every marker into
-  // a static block element, and stacks them in document order inside the
-  // canvas container. The result looks exactly like "markers drift as the
-  // map zooms" because each marker's transform is then applied relative
-  // to its stacked slot, not to the map viewport.
-  wrap.style.cssText = `width:${outer}px;height:${outer}px;cursor:pointer;`
-
-  const hasPhoto = photoUrl && (photoUrl.startsWith('data:') || photoUrl.startsWith('/api/maps/place-photo/') || photoUrl.startsWith('/uploads/'))
-  if (hasPhoto) {
-    wrap.innerHTML = `
-      <div style="
-        position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
-        width:${size}px;height:${size}px;border-radius:50%;
-        border:${borderWidth}px solid ${borderColor};
-        box-shadow:${shadow};
-        overflow:hidden;background:${bgColor};
-        box-sizing:content-box;
-      ">
-        <img src="${escapeHtml(photoUrl)}" width="${size}" height="${size}" style="display:block;border-radius:50%;object-fit:cover;" />
-      </div>
-      ${badgeHtml}
-    `
-  } else {
-    wrap.innerHTML = `
-      <div style="
-        position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
-        width:${size}px;height:${size}px;border-radius:50%;
-        border:${borderWidth}px solid ${borderColor};
-        box-shadow:${shadow};
-        background:${bgColor};
-        display:flex;align-items:center;justify-content:center;
-        box-sizing:content-box;
-      ">
-        ${categoryIconSvg(place.category_icon, selected ? 18 : 15)}
-      </div>
-      ${badgeHtml}
-    `
-  }
-  return wrap
-}
 
 // Plugin map contributions (mapMarkerProvider / mapLayerProvider hooks) — the GL
 // twins of MapPluginMarkers/MapPluginLayers. Same contract: host-vetted declarative

--- a/client/src/components/Map/MapViewGL.tsx
+++ b/client/src/components/Map/MapViewGL.tsx
@@ -4,18 +4,14 @@ import { renderIconMarkup } from '../../utils/iconMarkup'
 import type mapboxgl from 'mapbox-gl'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useAuthStore } from '../../store/authStore'
-import { getCached, isLoading, fetchPhoto, onThumbReady, getAllThumbs } from '../../services/photoService'
-import { isCustomPlaceImage, photoCacheKey } from './placePhoto'
+import { usePlacePhotos, placePhotoUrl } from './usePlacePhotos'
 import { CATEGORY_ICON_MAP } from '../shared/categoryIcons'
 import { isStandardFamily, supportsCustom3d, wantsTerrain, addCustom3dBuildings, addTerrainAndSky } from './mapboxSetup'
 import { attachLocationMarker, type LocationMarkerHandle } from './locationMarkerMapbox'
 import { ReservationMapboxOverlay } from './reservationsMapbox'
 import { useTransportRoutes } from '../../hooks/useTransportRoutes'
 import { visibleRouteReservations } from '../../utils/reservationRoutes'
-import { safeHexColor } from '../../utils/safeColor'
 import { createMarkerElement } from './placeMarkerElement'
-import { categoryIconSvg } from './categoryIcon'
-import { escapeHtml } from '@trek/shared'
 import { MAPBOX_DEFAULT_STYLE, styleForActiveProvider, basemapLanguage, type GlMapProvider } from './glProviders'
 import LocationButton from './LocationButton'
 import { useGeolocation } from '../../hooks/useGeolocation'
@@ -368,8 +364,7 @@ export function MapViewGL({
   const isMapLibre = glProvider === 'maplibre-gl'
   const glStyle = styleForActiveProvider(glProvider, rawMapboxStyle, rawMaplibreStyle)
   const enableMapbox3d = !isMapLibre && mapbox3d
-  const placesPhotosEnabled = useAuthStore(s => s.placesPhotosEnabled)
-  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>(getAllThumbs)
+  const photoUrls = usePlacePhotos(places)
   const [mapReady, setMapReady] = useState(false)
   // Hover tooltip — a cursor-following name/category/address card, matching the
   // Leaflet map's overlay exactly (no anchored popup, no photo thumbnail).
@@ -959,62 +954,6 @@ export function MapViewGL({
     try { map.setConfigProperty('basemap', 'language', basemapLanguage(mapLang)) } catch { /* style/SDK may not support the basemap language property */ }
   }, [mapLang, mapReady, isMapLibre, glStyle])
 
-  // Photo loading — mirrors the Leaflet MapView. Updates via RAF to batch
-  // simultaneous thumb arrivals into one re-render.
-  const pendingThumbsRef = useRef<Record<string, string>>({})
-  const thumbRafRef = useRef<number | null>(null)
-  const placeIds = useMemo(() => places.map(p => p.id).join(','), [places])
-  useEffect(() => {
-    if (!places || places.length === 0 || !placesPhotosEnabled) return
-    const cleanups: (() => void)[] = []
-
-    const setThumb = (cacheKey: string, thumb: string) => {
-      pendingThumbsRef.current[cacheKey] = thumb
-      if (thumbRafRef.current !== null) return
-      thumbRafRef.current = requestAnimationFrame(() => {
-        thumbRafRef.current = null
-        const pending = pendingThumbsRef.current
-        pendingThumbsRef.current = {}
-        setPhotoUrls(prev => {
-          const hasChange = Object.entries(pending).some(([k, v]) => prev[k] !== v)
-          return hasChange ? { ...prev, ...pending } : prev
-        })
-      })
-    }
-
-    for (const place of places) {
-      // A custom uploaded image is shown directly — never auto-fetch a provider
-      // photo for it (that request would 404 for OSM-only places and, worse, the
-      // fetched thumb would shadow the user's own image). (#1136)
-      if (isCustomPlaceImage(place.image_url)) continue
-      const cacheKey = photoCacheKey(place)
-      if (!cacheKey) continue
-      const cached = getCached(cacheKey)
-      if (cached?.thumbDataUrl) {
-        setThumb(cacheKey, cached.thumbDataUrl)
-        continue
-      }
-      cleanups.push(onThumbReady(cacheKey, thumb => setThumb(cacheKey, thumb)))
-      if (!cached && !isLoading(cacheKey)) {
-        const photoId =
-          (place.image_url?.startsWith('/api/maps/place-photo/') ? place.image_url : null)
-          || place.google_place_id
-          || place.osm_id
-          || place.image_url
-        if (photoId || (place.lat && place.lng)) {
-          fetchPhoto(cacheKey, photoId || `coords:${place.lat}:${place.lng}`, place.lat, place.lng, place.name)
-        }
-      }
-    }
-
-    return () => {
-      cleanups.forEach(fn => fn())
-      if (thumbRafRef.current !== null) {
-        cancelAnimationFrame(thumbRafRef.current)
-        thumbRafRef.current = null
-      }
-    }
-  }, [placeIds, placesPhotosEnabled]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reconcile markers with places + photos. The clustered GeoJSON source decides
   // which points are currently unclustered, and we render the existing rich HTML
@@ -1044,9 +983,8 @@ export function MapViewGL({
 
       visiblePlaces.forEach(place => {
         const orderNumbers = dayOrderMap[place.id] ?? null
-        const pck = photoCacheKey(place)
         // A custom image wins over the auto-fetched thumb; otherwise fall back to it.
-        const photoUrl = isCustomPlaceImage(place.image_url) ? place.image_url! : ((pck && photoUrls[pck]) || place.image_url || null)
+        const photoUrl = placePhotoUrl(place, photoUrls)
         const selected = place.id === selectedPlaceId
         const el = createMarkerElement(place as Place & { category_color?: string; category_icon?: string }, photoUrl, orderNumbers, selected)
         // Drag onto a day in the plan (#891). Markers are rebuilt from scratch

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -5,6 +5,7 @@ import { computeMapViewport, TILE_SIZE_RASTER } from '../../utils/mapViewport'
 import { loadGoogleMaps, type GoogleMapsApi } from './engines/google'
 import { createMarkerElement } from './placeMarkerElement'
 import { buildPlacePopupHtml } from './placePopup'
+import { usePlacePhotos, placePhotoUrl } from './usePlacePhotos'
 import { toCompassMap } from './googleCompass'
 
 /**
@@ -56,6 +57,9 @@ export function MapViewGoogle({
   const linesRef = useRef<google.maps.Polyline[]>([])
   const infoRef = useRef<google.maps.InfoWindow | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // Most places carry no image of their own — the pin picture comes from the
+  // photo service's cache, which fills in asynchronously.
+  const photoUrls = usePlacePhotos(places)
   // The map is built asynchronously. Without this, the marker/route/fit
   // effects run once against a null map and never again, so a trip opened
   // straight onto the planner drew no pins at all.
@@ -143,16 +147,27 @@ export function MapViewGoogle({
       seen.add(place.id)
       const orderNumbers = dayOrderMap?.[place.id] ?? null
       const selected = selectedPlaceId === place.id
-      const element = createMarkerElement(place, null, orderNumbers, selected)
+      const photoUrl = placePhotoUrl(place, photoUrls)
+      const element = createMarkerElement(place, photoUrl, orderNumbers, selected)
+
+      // Google anchors an AdvancedMarkerElement by the BOTTOM edge of its content
+      // (it applies translate(-50%, -100%)), but createMarkerElement draws a pin
+      // meant to be anchored at its centre — that is what the GL renderers ask for
+      // with anchor: 'center'. Without this offset every pin sits half its own
+      // height above the place it marks, and shifts again whenever the pin changes
+      // size (selection grows it from 36px to 44px).
+      const content = document.createElement('div')
+      content.style.transform = 'translateY(50%)'
+      content.appendChild(element)
 
       let marker = markersRef.current.get(place.id)
       if (marker) {
-        marker.content = element
+        marker.content = content
         marker.position = { lat: place.lat, lng: place.lng }
       } else {
         marker = new api.marker.AdvancedMarkerElement({
           map,
-          content: element,
+          content,
           position: { lat: place.lat, lng: place.lng },
         })
         marker.addListener('click', () => handlersRef.current.onMarkerClick?.(place.id))
@@ -171,7 +186,7 @@ export function MapViewGoogle({
       marker.map = null
       markersRef.current.delete(id)
     }
-  }, [ready, places, selectedPlaceId, dayOrderMap])
+  }, [ready, places, selectedPlaceId, dayOrderMap, photoUrls])
 
   // Day route.
   useEffect(() => {

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -54,6 +54,11 @@ export function MapViewGoogle({
   const mapRef = useRef<google.maps.Map | null>(null)
   const apiRef = useRef<GoogleMapsApi | null>(null)
   const markersRef = useRef<Map<number, google.maps.marker.AdvancedMarkerElement>>(new Map())
+  // What each marker was last drawn from. Assigning marker.content makes Google
+  // re-measure and re-place that marker, so rebuilding all of them on every pass
+  // is both wasted work and a visible twitch — and this effect runs again on
+  // every thumbnail arrival, which for a 34-place trip is a lot of passes.
+  const markerSigRef = useRef<Map<number, string>>(new Map())
   const linesRef = useRef<google.maps.Polyline[]>([])
   const infoRef = useRef<google.maps.InfoWindow | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -148,6 +153,18 @@ export function MapViewGoogle({
       const orderNumbers = dayOrderMap?.[place.id] ?? null
       const selected = selectedPlaceId === place.id
       const photoUrl = placePhotoUrl(place, photoUrls)
+
+      // Everything createMarkerElement draws from. Unchanged signature → the pin
+      // on screen is already correct, so leave it alone.
+      const signature = [
+        place.lat, place.lng, photoUrl ?? '', selected,
+        orderNumbers?.join('.') ?? '', place.category_id ?? '', place.image_url ?? '',
+      ].join('|')
+
+      const existing = markersRef.current.get(place.id)
+      if (existing && markerSigRef.current.get(place.id) === signature) continue
+      markerSigRef.current.set(place.id, signature)
+
       const element = createMarkerElement(place, photoUrl, orderNumbers, selected)
 
       // Google anchors an AdvancedMarkerElement by the BOTTOM edge of its content
@@ -160,7 +177,7 @@ export function MapViewGoogle({
       content.style.transform = 'translateY(50%)'
       content.appendChild(element)
 
-      let marker = markersRef.current.get(place.id)
+      let marker = existing
       if (marker) {
         marker.content = content
         marker.position = { lat: place.lat, lng: place.lng }
@@ -185,6 +202,7 @@ export function MapViewGoogle({
       if (seen.has(id)) continue
       marker.map = null
       markersRef.current.delete(id)
+      markerSigRef.current.delete(id)
     }
   }, [ready, places, selectedPlaceId, dayOrderMap, photoUrls])
 

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -7,6 +7,7 @@ import { createMarkerElement } from './placeMarkerElement'
 import { buildPlacePopupHtml } from './placePopup'
 import { usePlacePhotos, placePhotoUrl } from './usePlacePhotos'
 import { toCompassMap } from './googleCompass'
+import { createMarkerLayer, type MarkerLayer } from './googleMarkerLayer'
 
 /**
  * The Google Maps renderer.
@@ -53,7 +54,7 @@ export function MapViewGoogle({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mapRef = useRef<google.maps.Map | null>(null)
   const apiRef = useRef<GoogleMapsApi | null>(null)
-  const markersRef = useRef<Map<number, google.maps.marker.AdvancedMarkerElement>>(new Map())
+  const layerRef = useRef<MarkerLayer | null>(null)
   // What each marker was last drawn from. Assigning marker.content makes Google
   // re-measure and re-place that marker, so rebuilding all of them on every pass
   // is both wasted work and a visible twitch — and this effect runs again on
@@ -107,21 +108,12 @@ export function MapViewGoogle({
         const map = new api.Map(containerRef.current, {
           center: { lat: initial.center[0], lng: initial.center[1] },
           zoom: initial.zoom,
-          // A map id is what enables vector rendering and AdvancedMarkerElement.
-          // DEMO_MAP_ID works without cloud styling, which is what a self-hosted
-          // instance has unless its operator sets one up.
-          // DEMO_MAP_ID renders RASTER. That matters and is not what we would
-          // choose: on a raster map Google moves AdvancedMarkerElement pins with
-          // a coarse transform during a drag and re-projects them precisely on
-          // idle, so every pin visibly jumps about a second after each pan while
-          // the basemap sits still. It also leaves the map without a heading, so
-          // the compass pill has nothing to rotate.
-          //
-          // Requesting RenderingType.VECTOR here does flip getRenderingType() to
-          // VECTOR, but DEMO_MAP_ID has no vector style behind it and the map
-          // then draws nothing at all — so the fix is not a flag, it is a real
-          // Map ID created in the Google Cloud console with vector rendering
-          // enabled, configured per instance. Until then, raster it is.
+          // DEMO_MAP_ID keeps the map on Google's demo styling. It renders
+          // RASTER; vector would need a Map ID created in the Google Cloud
+          // console, which a self-hosted instance cannot assume. The pins do not
+          // depend on it either way — they are drawn by an OverlayView (see
+          // googleMarkerLayer.ts) precisely because raster rendering makes
+          // AdvancedMarkerElement jump after every pan.
           mapId: 'DEMO_MAP_ID',
           disableDefaultUI: true,
           zoomControl: true,
@@ -129,6 +121,7 @@ export function MapViewGoogle({
         })
         mapRef.current = map
         infoRef.current = new api.InfoWindow({ disableAutoPan: true })
+        layerRef.current = createMarkerLayer(api, map)
         setReady(true)
 
         map.addListener('click', (e: google.maps.MapMouseEvent) => {
@@ -147,6 +140,8 @@ export function MapViewGoogle({
     return () => {
       cancelled = true
       setReady(false)
+      layerRef.current?.destroy()
+      layerRef.current = null
       handlersRef.current.onMapReady?.(null)
       mapRef.current = null
     }
@@ -158,6 +153,9 @@ export function MapViewGoogle({
     const map = mapRef.current
     const api = apiRef.current
     if (!map || !api) return
+
+    const layer = layerRef.current
+    if (!layer) return
 
     const seen = new Set<number>()
     for (const place of places) {
@@ -173,56 +171,32 @@ export function MapViewGoogle({
         place.lat, place.lng, photoUrl ?? '', selected,
         orderNumbers?.join('.') ?? '', place.category_id ?? '', place.image_url ?? '',
       ].join('|')
-
-      const existing = markersRef.current.get(place.id)
-      if (existing && markerSigRef.current.get(place.id) === signature) continue
+      if (markerSigRef.current.get(place.id) === signature) continue
       markerSigRef.current.set(place.id, signature)
 
       const element = createMarkerElement(place, photoUrl, orderNumbers, selected)
-
-      // Google anchors an AdvancedMarkerElement by the BOTTOM edge of its content
-      // (it applies translate(-50%, -100%)), but createMarkerElement draws a pin
-      // meant to be anchored at its centre — that is what the GL renderers ask for
-      // with anchor: 'center'. Without this offset every pin sits half its own
-      // height above the place it marks, and shifts again whenever the pin changes
-      // size (selection grows it from 36px to 44px).
-      const content = document.createElement('div')
-      content.style.transform = 'translateY(50%)'
-      content.appendChild(element)
-
-      let marker = existing
-      if (marker) {
-        marker.content = content
-        marker.position = { lat: place.lat, lng: place.lng }
-      } else {
-        marker = new api.marker.AdvancedMarkerElement({
-          map,
-          content,
-          position: { lat: place.lat, lng: place.lng },
-        })
-        marker.addListener('click', () => handlersRef.current.onMarkerClick?.(place.id))
-        markersRef.current.set(place.id, marker)
-      }
-
       element.addEventListener('mouseenter', () => {
-        infoRef.current?.setContent(buildPlacePopupHtml(place, null))
-        // shouldFocus:false is load-bearing, not tidiness. Left unset, Google's
-        // heuristic moves focus into the info window when focus is already inside
-        // the map (which it is once the user has clicked a pin), and on close it
-        // returns focus to the marker. That programmatic focus() runs
-        // scroll-into-view on every overflow:hidden ancestor, shifting the marker
-        // pane and snapping it back — a pin visibly jumping away and returning on
-        // mouse-out. A hover card should never take focus anyway; the GL
-        // renderer's card is not focusable either.
-        infoRef.current?.open({ map, anchor: marker, shouldFocus: false })
+        infoRef.current?.setContent(buildPlacePopupHtml(place, photoUrl))
+        infoRef.current?.setPosition({ lat: place.lat as number, lng: place.lng as number })
+        // shouldFocus:false is load-bearing: left unset, Google's heuristic moves
+        // focus into the info window and hands it back to the anchor on close,
+        // and that focus() scroll-into-view shifts the map's panes.
+        infoRef.current?.open({ map, shouldFocus: false })
       })
       element.addEventListener('mouseleave', () => infoRef.current?.close())
+
+      layer.setPin({
+        id: place.id,
+        lat: place.lat,
+        lng: place.lng,
+        element,
+        onClick: () => handlersRef.current.onMarkerClick?.(place.id),
+      })
     }
 
-    for (const [id, marker] of markersRef.current) {
+    for (const id of layer.ids()) {
       if (seen.has(id)) continue
-      marker.map = null
-      markersRef.current.delete(id)
+      layer.removePin(id)
       markerSigRef.current.delete(id)
     }
   }, [ready, places, selectedPlaceId, dayOrderMap, photoUrls])

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react'
+import type { Place } from '../../types'
+import { DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM } from '../../constants/mapDefaults'
+import { computeMapViewport, TILE_SIZE_RASTER } from '../../utils/mapViewport'
+import { loadGoogleMaps, type GoogleMapsApi } from './engines/google'
+import { createMarkerElement } from './placeMarkerElement'
+import { buildPlacePopupHtml } from './placePopup'
+import { toCompassMap } from './googleCompass'
+
+/**
+ * The Google Maps renderer.
+ *
+ * A separate component rather than another engine behind MapViewGL: mapbox-gl
+ * and maplibre-gl share one API surface, which is why they share one component
+ * and take the engine as a prop. Google's API is a different shape — no style
+ * spec, no addSource/addLayer, its own marker and camera model — so it gets its
+ * own component and reuses the shared pieces (the pin element, the popup HTML,
+ * the viewport maths) rather than a shared map body.
+ */
+interface Props {
+  places: Place[]
+  dayPlaces?: Place[]
+  route?: [number, number][][] | null
+  selectedPlaceId?: number | null
+  onMarkerClick?: (id: number) => void
+  onMapClick?: (info: { latlng: { lat: number; lng: number } }) => void
+  center?: [number, number]
+  zoom?: number
+  fitKey?: number | null
+  dayOrderMap?: Record<number, number[] | null>
+  apiKey: string
+  language?: string
+  /** Receives the compass-shaped view of the map, matching the GL renderers. */
+  onMapReady?: (map: ReturnType<typeof toCompassMap> | null) => void
+}
+
+export function MapViewGoogle({
+  places,
+  dayPlaces,
+  route,
+  selectedPlaceId,
+  onMarkerClick,
+  onMapClick,
+  center,
+  zoom,
+  fitKey,
+  dayOrderMap,
+  apiKey,
+  language,
+  onMapReady,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const mapRef = useRef<google.maps.Map | null>(null)
+  const apiRef = useRef<GoogleMapsApi | null>(null)
+  const markersRef = useRef<Map<number, google.maps.marker.AdvancedMarkerElement>>(new Map())
+  const linesRef = useRef<google.maps.Polyline[]>([])
+  const infoRef = useRef<google.maps.InfoWindow | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  // The map is built asynchronously. Without this, the marker/route/fit
+  // effects run once against a null map and never again, so a trip opened
+  // straight onto the planner drew no pins at all.
+  const [ready, setReady] = useState(false)
+
+  // Callbacks are read through a ref so the map is built once: rebuilding it on
+  // every parent render would refetch tiles, and Google bills per map load.
+  const handlersRef = useRef({ onMarkerClick, onMapClick, onMapReady })
+  handlersRef.current = { onMarkerClick, onMapClick, onMapReady }
+
+  // The opening view. Held in a ref for the same reason, and so the deps below
+  // stay honest rather than being silenced with an exhaustive-deps disable:
+  // these are read once, at construction, and every later change is applied by
+  // the marker/route/fit effects against the live map.
+  const initialViewRef = useRef({ places, dayPlaces, center, zoom })
+  initialViewRef.current = { places, dayPlaces, center, zoom }
+
+  useEffect(() => {
+    let cancelled = false
+    const container = containerRef.current
+    if (!container) return
+
+    loadGoogleMaps(apiKey, language)
+      .then(api => {
+        if (cancelled || !containerRef.current) return
+        apiRef.current = api
+
+        const view = initialViewRef.current
+        const framed = computeMapViewport(view.dayPlaces?.length ? view.dayPlaces : view.places, {
+          // Google measures zoom against a 256px world tile, like Leaflet — its
+          // own tile requests carry 4i256. The GL scheme would open a level out.
+          tileSize: TILE_SIZE_RASTER,
+        })
+        const initial = framed ?? {
+          center: view.center ?? DEFAULT_MAP_CENTER,
+          zoom: view.zoom ?? DEFAULT_MAP_ZOOM,
+        }
+
+        const map = new api.Map(containerRef.current, {
+          center: { lat: initial.center[0], lng: initial.center[1] },
+          zoom: initial.zoom,
+          // A map id is what enables vector rendering and AdvancedMarkerElement.
+          // DEMO_MAP_ID works without cloud styling, which is what a self-hosted
+          // instance has unless its operator sets one up.
+          mapId: 'DEMO_MAP_ID',
+          disableDefaultUI: true,
+          zoomControl: true,
+          clickableIcons: false,
+        })
+        mapRef.current = map
+        infoRef.current = new api.InfoWindow({ disableAutoPan: true })
+        setReady(true)
+
+        map.addListener('click', (e: google.maps.MapMouseEvent) => {
+          if (!e.latLng) return
+          handlersRef.current.onMapClick?.({
+            latlng: { lat: e.latLng.lat(), lng: e.latLng.lng() },
+          })
+        })
+
+        handlersRef.current.onMapReady?.(toCompassMap(map))
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message)
+      })
+
+    return () => {
+      cancelled = true
+      setReady(false)
+      handlersRef.current.onMapReady?.(null)
+      mapRef.current = null
+    }
+  }, [apiKey, language])
+
+  // Markers — diffed against the live map rather than torn down, so panning
+  // does not recreate every pin.
+  useEffect(() => {
+    const map = mapRef.current
+    const api = apiRef.current
+    if (!map || !api) return
+
+    const seen = new Set<number>()
+    for (const place of places) {
+      if (place.lat == null || place.lng == null) continue
+      seen.add(place.id)
+      const orderNumbers = dayOrderMap?.[place.id] ?? null
+      const selected = selectedPlaceId === place.id
+      const element = createMarkerElement(place, null, orderNumbers, selected)
+
+      let marker = markersRef.current.get(place.id)
+      if (marker) {
+        marker.content = element
+        marker.position = { lat: place.lat, lng: place.lng }
+      } else {
+        marker = new api.marker.AdvancedMarkerElement({
+          map,
+          content: element,
+          position: { lat: place.lat, lng: place.lng },
+        })
+        marker.addListener('click', () => handlersRef.current.onMarkerClick?.(place.id))
+        markersRef.current.set(place.id, marker)
+      }
+
+      element.addEventListener('mouseenter', () => {
+        infoRef.current?.setContent(buildPlacePopupHtml(place, null))
+        infoRef.current?.open({ map, anchor: marker })
+      })
+      element.addEventListener('mouseleave', () => infoRef.current?.close())
+    }
+
+    for (const [id, marker] of markersRef.current) {
+      if (seen.has(id)) continue
+      marker.map = null
+      markersRef.current.delete(id)
+    }
+  }, [ready, places, selectedPlaceId, dayOrderMap])
+
+  // Day route.
+  useEffect(() => {
+    const map = mapRef.current
+    const api = apiRef.current
+    if (!map || !api) return
+
+    for (const line of linesRef.current) line.setMap(null)
+    linesRef.current = []
+    if (!route) return
+
+    for (const leg of route) {
+      const line = new api.Polyline({
+        map,
+        path: leg.map(([lat, lng]) => ({ lat, lng })),
+        strokeColor: '#4F46E5',
+        strokeOpacity: 0.85,
+        strokeWeight: 4,
+      })
+      linesRef.current.push(line)
+    }
+  }, [ready, route])
+
+  // Re-frame on the same signal the other renderers use.
+  useEffect(() => {
+    const map = mapRef.current
+    const api = apiRef.current
+    if (!map || !api || fitKey == null) return
+
+    const points = (dayPlaces?.length ? dayPlaces : places).filter(p => p.lat != null && p.lng != null)
+    if (points.length === 0) return
+
+    const bounds = new api.LatLngBounds()
+    for (const p of points) bounds.extend({ lat: p.lat as number, lng: p.lng as number })
+    map.fitBounds(bounds, 48)
+  }, [ready, fitKey, places, dayPlaces])
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-surface-2 p-6 text-center text-content-2">
+        {error}
+      </div>
+    )
+  }
+
+  return <div ref={containerRef} className="h-full w-full" />
+}
+
+export default MapViewGoogle

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -111,6 +111,13 @@ export function MapViewGoogle({
           // DEMO_MAP_ID works without cloud styling, which is what a self-hosted
           // instance has unless its operator sets one up.
           mapId: 'DEMO_MAP_ID',
+          // Ask for vector explicitly. Without this the map initialises as
+          // RASTER, and on a raster map Google moves AdvancedMarkerElement pins
+          // with a coarse transform during a drag and then re-projects them
+          // precisely on idle — the pins visibly jump a second after every pan
+          // while the basemap sits still. Vector also gives the map a heading,
+          // without which the compass pill has nothing to rotate.
+          renderingType: api.RenderingType.VECTOR,
           disableDefaultUI: true,
           zoomControl: true,
           clickableIcons: false,

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -98,6 +98,7 @@ export function MapViewGoogle({
           // own tile requests carry 4i256. The GL scheme would open a level out.
           tileSize: TILE_SIZE_RASTER,
         })
+        framedOnMountRef.current = framed !== null
         const initial = framed ?? {
           center: view.center ?? DEFAULT_MAP_CENTER,
           zoom: view.zoom ?? DEFAULT_MAP_ZOOM,
@@ -193,7 +194,15 @@ export function MapViewGoogle({
 
       element.addEventListener('mouseenter', () => {
         infoRef.current?.setContent(buildPlacePopupHtml(place, null))
-        infoRef.current?.open({ map, anchor: marker })
+        // shouldFocus:false is load-bearing, not tidiness. Left unset, Google's
+        // heuristic moves focus into the info window when focus is already inside
+        // the map (which it is once the user has clicked a pin), and on close it
+        // returns focus to the marker. That programmatic focus() runs
+        // scroll-into-view on every overflow:hidden ancestor, shifting the marker
+        // pane and snapping it back — a pin visibly jumping away and returning on
+        // mouse-out. A hover card should never take focus anyway; the GL
+        // renderer's card is not focusable either.
+        infoRef.current?.open({ map, anchor: marker, shouldFocus: false })
       })
       element.addEventListener('mouseleave', () => infoRef.current?.close())
     }
@@ -228,11 +237,28 @@ export function MapViewGoogle({
     }
   }, [ready, route])
 
-  // Re-frame on the same signal the other renderers use.
+  // Re-frame on the same signal the other renderers use: a CHANGE of fitKey, and
+  // nothing else. Both MapView and MapViewGL gate on prevFitKey for a reason —
+  // panning the map makes the planner re-render, which hands this component new
+  // `places`/`dayPlaces` array identities. With those in the dependency list the
+  // camera refitted itself a beat after every pan, throwing the user back to the
+  // trip-wide view they had just navigated away from.
+  const prevFitKey = useRef<number | null | undefined>(-1)
+  const framedOnMountRef = useRef(false)
   useEffect(() => {
     const map = mapRef.current
     const api = apiRef.current
     if (!map || !api || fitKey == null) return
+    if (fitKey === prevFitKey.current) return
+    prevFitKey.current = fitKey
+
+    // Construction already framed the map to these places, so stand down for the
+    // first fitKey; every later one (picking a day) still runs. Same rule as
+    // MapViewGL's framedOnMount.
+    if (framedOnMountRef.current) {
+      framedOnMountRef.current = false
+      return
+    }
 
     const points = (dayPlaces?.length ? dayPlaces : places).filter(p => p.lat != null && p.lng != null)
     if (points.length === 0) return
@@ -240,7 +266,10 @@ export function MapViewGoogle({
     const bounds = new api.LatLngBounds()
     for (const p of points) bounds.extend({ lat: p.lat as number, lng: p.lng as number })
     map.fitBounds(bounds, 48)
-  }, [ready, fitKey, places, dayPlaces])
+    // places/dayPlaces are read, not depended on: a new array identity from a
+    // parent re-render must not re-frame the map.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, fitKey])
 
   if (error) {
     return (

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -5,7 +5,7 @@ import { computeMapViewport, TILE_SIZE_RASTER } from '../../utils/mapViewport'
 import { loadGoogleMaps, type GoogleMapsApi } from './engines/google'
 import { createMarkerElement } from './placeMarkerElement'
 import { buildPlacePopupHtml } from './placePopup'
-import { usePlacePhotos, placePhotoUrl } from './usePlacePhotos'
+import { usePlacePhotos, placePhotoUrl, placePopupPhotoUrl } from './usePlacePhotos'
 import { toCompassMap } from './googleCompass'
 import { createMarkerLayer, type MarkerLayer } from './googleMarkerLayer'
 
@@ -66,6 +66,11 @@ export function MapViewGoogle({
   // Most places carry no image of their own — the pin picture comes from the
   // photo service's cache, which fills in asynchronously.
   const photoUrls = usePlacePhotos(places)
+  // Read at hover time rather than captured when the pin was built: a pin is
+  // only rebuilt when its own thumbnail changes, so a closure here would keep
+  // showing whatever the cache held then.
+  const photoUrlsRef = useRef(photoUrls)
+  photoUrlsRef.current = photoUrls
   // The map is built asynchronously. Without this, the marker/route/fit
   // effects run once against a null map and never again, so a trip opened
   // straight onto the planner drew no pins at all.
@@ -176,7 +181,7 @@ export function MapViewGoogle({
 
       const element = createMarkerElement(place, photoUrl, orderNumbers, selected)
       element.addEventListener('mouseenter', () => {
-        infoRef.current?.setContent(buildPlacePopupHtml(place, photoUrl))
+        infoRef.current?.setContent(buildPlacePopupHtml(place, placePopupPhotoUrl(place, photoUrlsRef.current)))
         infoRef.current?.setPosition({ lat: place.lat as number, lng: place.lng as number })
         // shouldFocus:false is load-bearing: left unset, Google's heuristic moves
         // focus into the info window and hands it back to the anchor on close,

--- a/client/src/components/Map/MapViewGoogle.tsx
+++ b/client/src/components/Map/MapViewGoogle.tsx
@@ -110,14 +110,19 @@ export function MapViewGoogle({
           // A map id is what enables vector rendering and AdvancedMarkerElement.
           // DEMO_MAP_ID works without cloud styling, which is what a self-hosted
           // instance has unless its operator sets one up.
+          // DEMO_MAP_ID renders RASTER. That matters and is not what we would
+          // choose: on a raster map Google moves AdvancedMarkerElement pins with
+          // a coarse transform during a drag and re-projects them precisely on
+          // idle, so every pin visibly jumps about a second after each pan while
+          // the basemap sits still. It also leaves the map without a heading, so
+          // the compass pill has nothing to rotate.
+          //
+          // Requesting RenderingType.VECTOR here does flip getRenderingType() to
+          // VECTOR, but DEMO_MAP_ID has no vector style behind it and the map
+          // then draws nothing at all — so the fix is not a flag, it is a real
+          // Map ID created in the Google Cloud console with vector rendering
+          // enabled, configured per instance. Until then, raster it is.
           mapId: 'DEMO_MAP_ID',
-          // Ask for vector explicitly. Without this the map initialises as
-          // RASTER, and on a raster map Google moves AdvancedMarkerElement pins
-          // with a coarse transform during a drag and then re-projects them
-          // precisely on idle — the pins visibly jump a second after every pan
-          // while the basemap sits still. Vector also gives the map a heading,
-          // without which the compass pill has nothing to rotate.
-          renderingType: api.RenderingType.VECTOR,
           disableDefaultUI: true,
           zoomControl: true,
           clickableIcons: false,

--- a/client/src/components/Map/categoryIcon.ts
+++ b/client/src/components/Map/categoryIcon.ts
@@ -1,0 +1,15 @@
+import { createElement } from 'react'
+import { CATEGORY_ICON_MAP } from '../shared/categoryIcons'
+import { renderIconMarkup } from '../../utils/iconMarkup'
+
+/**
+ * Renders a category's Lucide glyph to an SVG string for injection into a
+ * marker element. Shared by the GL and Google renderers so a pin drawn by one
+ * is identical to a pin drawn by the other.
+ */
+export function categoryIconSvg(iconName: string | null | undefined, size: number): string {
+  const IconComponent = (iconName && CATEGORY_ICON_MAP[iconName]) || CATEGORY_ICON_MAP['MapPin']
+  try {
+    return renderIconMarkup(createElement(IconComponent, { size, color: 'white', strokeWidth: 2.5 }))
+  } catch { return '' }
+}

--- a/client/src/components/Map/engines/google.test.ts
+++ b/client/src/components/Map/engines/google.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { loadGoogleMaps, resetGoogleMapsLoader } from './google'
+
+type Globals = Record<string, unknown>
+
+/** Stands in for the SDK the real script would define. */
+function installFakeSdk() {
+  ;(window as unknown as Globals).google = {
+    maps: {
+      Map: class {},
+      LatLngBounds: class {},
+      InfoWindow: class {},
+      Polyline: class {},
+      marker: { AdvancedMarkerElement: class {} },
+    },
+  }
+}
+
+/** The loader appends a <script>; nothing fetches it in jsdom, so drive it by hand. */
+function lastScript(): HTMLScriptElement {
+  const scripts = document.head.querySelectorAll('script')
+  return scripts[scripts.length - 1] as HTMLScriptElement
+}
+
+afterEach(() => {
+  resetGoogleMapsLoader()
+  document.head.querySelectorAll('script').forEach(s => s.remove())
+  delete (window as unknown as Globals).google
+  vi.restoreAllMocks()
+})
+
+describe('loadGoogleMaps', () => {
+  it('rejects without a key rather than requesting an unusable SDK', async () => {
+    await expect(loadGoogleMaps('')).rejects.toThrow(/API key is not set/)
+    expect(document.head.querySelector('script')).toBeNull()
+  })
+
+  it('requests the marker library and defers to an async load', async () => {
+    void loadGoogleMaps('key-1', 'ar')
+
+    const url = new URL(lastScript().src)
+    expect(url.origin + url.pathname).toBe('https://maps.googleapis.com/maps/api/js')
+    expect(url.searchParams.get('key')).toBe('key-1')
+    expect(url.searchParams.get('libraries')).toBe('marker')
+    expect(url.searchParams.get('loading')).toBe('async')
+    expect(url.searchParams.get('language')).toBe('ar')
+  })
+
+  it('resolves the SDK slice once Google runs the callback', async () => {
+    const promise = loadGoogleMaps('key-1')
+    installFakeSdk()
+    const callback = new URL(lastScript().src).searchParams.get('callback') as string
+    ;((window as unknown as Globals)[callback] as () => void)()
+
+    await expect(promise).resolves.toMatchObject({ Map: expect.any(Function) })
+  })
+
+  // Including the API twice throws inside the SDK, so every caller has to get
+  // the same in-flight promise.
+  it('loads the SDK once no matter how many callers ask', () => {
+    void loadGoogleMaps('key-1')
+    void loadGoogleMaps('key-1')
+
+    expect(document.head.querySelectorAll('script')).toHaveLength(1)
+  })
+
+  // A second key means a different billing account; the SDK cannot be
+  // re-initialised in place, so this must complain rather than quietly bill the
+  // first key for the second one's maps.
+  it('refuses a different key instead of silently keeping the first', async () => {
+    void loadGoogleMaps('key-1')
+
+    await expect(loadGoogleMaps('key-2')).rejects.toThrow(/different key/)
+  })
+
+  it('rejects when the script fails to load', async () => {
+    const promise = loadGoogleMaps('key-1')
+    lastScript().onerror?.(new Event('error'))
+
+    await expect(promise).rejects.toThrow(/Failed to load/)
+  })
+
+  // A bad key still serves the SDK: Google reports it through gm_authFailure,
+  // so without this branch the map would spin forever instead of explaining.
+  it('rejects when Google reports the key as unauthorised', async () => {
+    const promise = loadGoogleMaps('key-1')
+    ;((window as unknown as Globals).gm_authFailure as () => void)()
+
+    await expect(promise).rejects.toThrow(/rejected the API key/)
+  })
+})

--- a/client/src/components/Map/engines/google.ts
+++ b/client/src/components/Map/engines/google.ts
@@ -21,7 +21,8 @@ export interface GoogleMapsApi {
   InfoWindow: typeof google.maps.InfoWindow
   Polyline: typeof google.maps.Polyline
   marker: typeof google.maps.marker
-  RenderingType: typeof google.maps.RenderingType
+  OverlayView: typeof google.maps.OverlayView
+  LatLng: typeof google.maps.LatLng
 }
 
 let pending: Promise<GoogleMapsApi> | null = null
@@ -78,7 +79,8 @@ export function loadGoogleMaps(apiKey: string, language?: string): Promise<Googl
         InfoWindow: google.maps.InfoWindow,
         Polyline: google.maps.Polyline,
         marker: google.maps.marker,
-        RenderingType: google.maps.RenderingType,
+        OverlayView: google.maps.OverlayView,
+        LatLng: google.maps.LatLng,
       })
     }
 

--- a/client/src/components/Map/engines/google.ts
+++ b/client/src/components/Map/engines/google.ts
@@ -21,6 +21,7 @@ export interface GoogleMapsApi {
   InfoWindow: typeof google.maps.InfoWindow
   Polyline: typeof google.maps.Polyline
   marker: typeof google.maps.marker
+  RenderingType: typeof google.maps.RenderingType
 }
 
 let pending: Promise<GoogleMapsApi> | null = null
@@ -77,6 +78,7 @@ export function loadGoogleMaps(apiKey: string, language?: string): Promise<Googl
         InfoWindow: google.maps.InfoWindow,
         Polyline: google.maps.Polyline,
         marker: google.maps.marker,
+        RenderingType: google.maps.RenderingType,
       })
     }
 

--- a/client/src/components/Map/engines/google.ts
+++ b/client/src/components/Map/engines/google.ts
@@ -1,0 +1,104 @@
+/**
+ * The only module that pulls in the Google Maps JS API.
+ *
+ * Unlike mapbox-gl and maplibre-gl this engine cannot be an npm dependency in a
+ * chunk of its own: Google licenses the renderer only through their hosted
+ * loader, and the SDK refuses to run if it is self-hosted. So the "engine" here
+ * is a loader rather than a bundled module, and the key travels in the script
+ * URL — a Maps JS key is public by design and is restricted by HTTP referrer in
+ * the Google console, not kept secret.
+ *
+ * The loader is shared: the API throws if it is included twice on one page, so
+ * every caller awaits the same promise and a second call with the same key is a
+ * no-op. Changing the key needs a reload, which is why switching it in settings
+ * asks for one.
+ */
+
+/** The slice of the Google Maps SDK TREK uses. Kept narrow on purpose. */
+export interface GoogleMapsApi {
+  Map: typeof google.maps.Map
+  LatLngBounds: typeof google.maps.LatLngBounds
+  InfoWindow: typeof google.maps.InfoWindow
+  Polyline: typeof google.maps.Polyline
+  marker: typeof google.maps.marker
+}
+
+let pending: Promise<GoogleMapsApi> | null = null
+let loadedKey: string | null = null
+
+const CALLBACK = '__trekGoogleMapsReady'
+const SCRIPT_ID = 'trek-google-maps-sdk'
+
+/** Exported for tests; resets the module's one-shot state. */
+export function resetGoogleMapsLoader(): void {
+  pending = null
+  loadedKey = null
+  document.getElementById(SCRIPT_ID)?.remove()
+}
+
+/**
+ * Loads the Maps JS API and resolves the pieces TREK uses.
+ *
+ * @param apiKey the instance's Google Maps key
+ * @param language basemap label language, so place names match the UI language
+ *   rather than the browser locale (the same reason the GL providers pin it)
+ */
+export function loadGoogleMaps(apiKey: string, language?: string): Promise<GoogleMapsApi> {
+  if (!apiKey) return Promise.reject(new Error('Google Maps API key is not set'))
+
+  // A different key means a different billing account and possibly different
+  // enabled APIs; the SDK cannot be re-initialised in place, so refuse rather
+  // than silently keep using the first one.
+  if (pending && loadedKey && loadedKey !== apiKey) {
+    return Promise.reject(new Error('Google Maps is already loaded with a different key; reload the page'))
+  }
+  if (pending) return pending
+
+  loadedKey = apiKey
+  pending = new Promise<GoogleMapsApi>((resolve, reject) => {
+    const params = new URLSearchParams({
+      key: apiKey,
+      callback: CALLBACK,
+      // The marker library is where AdvancedMarkerElement lives; TREK renders
+      // its own DOM pins rather than Google's default red teardrops.
+      libraries: 'marker',
+      v: 'weekly',
+      // Without this the SDK logs a performance warning on every load.
+      loading: 'async',
+    })
+    if (language) params.set('language', language)
+
+    const globals = window as unknown as Record<string, unknown>
+    globals[CALLBACK] = () => {
+      delete globals[CALLBACK]
+      resolve({
+        Map: google.maps.Map,
+        LatLngBounds: google.maps.LatLngBounds,
+        InfoWindow: google.maps.InfoWindow,
+        Polyline: google.maps.Polyline,
+        marker: google.maps.marker,
+      })
+    }
+
+    const script = document.createElement('script')
+    script.id = SCRIPT_ID
+    script.async = true
+    script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`
+    // A bad key does not fail the request — Google serves the SDK and then calls
+    // gm_authFailure. Both paths have to reject, or the map hangs on a spinner.
+    script.onerror = () => {
+      pending = null
+      loadedKey = null
+      delete globals[CALLBACK]
+      reject(new Error('Failed to load the Google Maps SDK'))
+    }
+    globals.gm_authFailure = () => {
+      pending = null
+      loadedKey = null
+      reject(new Error('Google Maps rejected the API key (check its HTTP referrer restrictions)'))
+    }
+    document.head.appendChild(script)
+  })
+
+  return pending
+}

--- a/client/src/components/Map/glLazy.tsx
+++ b/client/src/components/Map/glLazy.tsx
@@ -74,3 +74,13 @@ export const GlMapPreviewMaplibre = lazyWithRetry(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return { default: (props: any) => <GlMapPreview {...props} gl={engine.default} /> }
 })
+
+/**
+ * The Google renderer is lazy for the same reason as the GL engines, minus the
+ * chunk-splitting concern: its SDK is fetched from Google at runtime rather than
+ * bundled, so this chunk only carries TREK's own component.
+ */
+export const MapViewGoogleLazy = lazyWithRetry(async () => {
+  const component = await import('./MapViewGoogle')
+  return { default: component.MapViewGoogle }
+})

--- a/client/src/components/Map/googleCompass.test.ts
+++ b/client/src/components/Map/googleCompass.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { toCompassMap } from './googleCompass'
+
+function fakeMap(heading?: number) {
+  const remove = vi.fn()
+  const map = {
+    getHeading: vi.fn(() => heading),
+    addListener: vi.fn(() => ({ remove })),
+    moveCamera: vi.fn(),
+  }
+  return { map: map as unknown as google.maps.Map, spies: map, remove }
+}
+
+describe('toCompassMap', () => {
+  it('reads bearing from the heading', () => {
+    const { map } = fakeMap(90)
+
+    expect(toCompassMap(map).getBearing()).toBe(90)
+  })
+
+  // getHeading() is undefined until the camera has one, and the pill puts the
+  // value straight into a rotation transform — undefined would blank the arrow.
+  it('treats an unset heading as north', () => {
+    const { map } = fakeMap(undefined)
+
+    expect(toCompassMap(map).getBearing()).toBe(0)
+  })
+
+  it('subscribes to the property event Google actually emits', () => {
+    const { map, spies } = fakeMap(0)
+    const listener = vi.fn()
+
+    toCompassMap(map).on('rotate', listener)
+
+    expect(spies.addListener).toHaveBeenCalledWith('heading_changed', listener)
+  })
+
+  it('removes the right subscription on off', () => {
+    const { map, remove } = fakeMap(0)
+    const compass = toCompassMap(map)
+    const listener = vi.fn()
+
+    compass.on('rotate', listener)
+    compass.off('rotate', listener)
+
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores off() for a listener that was never registered', () => {
+    const { map, remove } = fakeMap(0)
+
+    expect(() => toCompassMap(map).off('rotate', vi.fn())).not.toThrow()
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('maps a snap-to-north back onto the Google camera', () => {
+    const { map, spies } = fakeMap(120)
+
+    toCompassMap(map).easeTo({ bearing: 0, pitch: 0, duration: 300 })
+
+    expect(spies.moveCamera).toHaveBeenCalledWith({ heading: 0, tilt: 0 })
+  })
+})

--- a/client/src/components/Map/googleCompass.ts
+++ b/client/src/components/Map/googleCompass.ts
@@ -1,0 +1,39 @@
+import type { CompassMap } from './MapCompassPill'
+
+/**
+ * Adapts a Google map to the compass pill's map contract.
+ *
+ * The pill was written against the GL camera API, which is the one thing the two
+ * GL engines agree on and Google does not: bearing is "heading" there, rotation
+ * arrives as a `heading_changed` property event rather than a `rotate` event, and
+ * the camera is moved through moveCamera rather than easeTo. All four operations
+ * exist on both sides, so this is a rename rather than a reimplementation — which
+ * is why the pill is adapted instead of forked.
+ *
+ * Rotation itself needs a vector map (a mapId), which MapViewGoogle always sets.
+ */
+export function toCompassMap(map: google.maps.Map): CompassMap {
+  // google.maps.MapsEventListener has no type-safe key, so listeners are tracked
+  // by the callback identity the pill hands back to off().
+  const listeners = new Map<() => void, google.maps.MapsEventListener>()
+
+  return {
+    // getHeading() is undefined until the camera has a heading; north is 0.
+    getBearing: () => map.getHeading() ?? 0,
+
+    on: (_type, listener) => {
+      listeners.set(listener, map.addListener('heading_changed', listener))
+    },
+
+    off: (_type, listener) => {
+      listeners.get(listener)?.remove()
+      listeners.delete(listener)
+    },
+
+    // The pill only ever asks for north + flat, and Google has no eased camera
+    // move with a duration, so the transition is instant rather than animated.
+    easeTo: ({ bearing, pitch }) => {
+      map.moveCamera({ heading: bearing, tilt: pitch })
+    },
+  }
+}

--- a/client/src/components/Map/googleMarkerLayer.ts
+++ b/client/src/components/Map/googleMarkerLayer.ts
@@ -1,0 +1,131 @@
+/**
+ * Place pins for the Google map, drawn through an OverlayView instead of
+ * AdvancedMarkerElement.
+ *
+ * AdvancedMarkerElement is the modern API and would be the obvious choice, but
+ * on a raster map it repositions in two phases: it rides along with a coarse
+ * transform during a drag, and on idle it snaps back to its pre-drag screen
+ * position and animates to the new one. Measured side by side against an
+ * OverlayView pin at the same coordinate, the advanced marker jumped ~137px
+ * back and took about 150ms to return while the overlay pin never left its
+ * place. That read to the user as "it moves somewhere else and then comes back"
+ * after every pan. A vector map would not do this, but vector rendering needs a
+ * Map ID created in the Google Cloud console, which a self-hosted instance
+ * cannot assume.
+ *
+ * An OverlayView positions its own DOM from the projection on every draw, so
+ * the pins are wherever we put them and there is no second opinion. One overlay
+ * holds every pin rather than one overlay each: a draw is a single pass over
+ * the set, which is what keeps a 34-place trip cheap to pan.
+ */
+
+export interface PinInput {
+  id: number
+  lat: number
+  lng: number
+  element: HTMLElement
+  onClick?: () => void
+}
+
+export interface MarkerLayer {
+  /** Adds the pin, or moves/replaces the content of one already shown. */
+  setPin(pin: PinInput): void
+  /** Removes a pin by id. Unknown ids are ignored. */
+  removePin(id: number): void
+  /** The ids currently on the map. */
+  ids(): number[]
+  /** Detaches the whole layer. */
+  destroy(): void
+}
+
+interface HeldPin {
+  lat: number
+  lng: number
+  element: HTMLElement
+}
+
+/**
+ * @param api the loaded Google Maps SDK slice
+ * @param map the map to draw on
+ */
+export function createMarkerLayer(
+  api: {
+    OverlayView: typeof google.maps.OverlayView
+    LatLng: typeof google.maps.LatLng
+  },
+  map: google.maps.Map,
+): MarkerLayer {
+  const pins = new Map<number, HeldPin>()
+
+  // Subclassed here rather than at module scope: google.maps.OverlayView only
+  // exists once the SDK has loaded.
+  class PinOverlay extends api.OverlayView {
+    private container: HTMLDivElement | null = null
+
+    onAdd(): void {
+      const container = document.createElement('div')
+      // The pins position themselves inside this; it must not offset them.
+      container.style.cssText = 'position:absolute;left:0;top:0;width:0;height:0;'
+      this.container = container
+      // overlayMouseTarget is the pane that receives pointer events, which the
+      // hover popup and click-to-select both need.
+      this.getPanes()?.overlayMouseTarget.appendChild(container)
+      for (const pin of pins.values()) container.appendChild(pin.element)
+    }
+
+    draw(): void {
+      const projection = this.getProjection()
+      if (!projection || !this.container) return
+      for (const pin of pins.values()) {
+        const point = projection.fromLatLngToDivPixel(new api.LatLng(pin.lat, pin.lng))
+        if (!point) continue
+        // The element is centred on its coordinate, matching anchor:'center' on
+        // the GL renderers — createMarkerElement draws a pin around its middle.
+        pin.element.style.position = 'absolute'
+        pin.element.style.left = `${point.x}px`
+        pin.element.style.top = `${point.y}px`
+        pin.element.style.transform = 'translate(-50%, -50%)'
+      }
+    }
+
+    onRemove(): void {
+      this.container?.remove()
+      this.container = null
+    }
+
+    /** The pane element, once attached. Exposed so pins can be added later. */
+    host(): HTMLDivElement | null {
+      return this.container
+    }
+  }
+
+  const overlay = new PinOverlay()
+  overlay.setMap(map)
+
+  return {
+    setPin({ id, lat, lng, element, onClick }: PinInput): void {
+      const existing = pins.get(id)
+      if (existing && existing.element !== element) existing.element.remove()
+      if (onClick) element.addEventListener('click', onClick)
+      pins.set(id, { lat, lng, element })
+      const host = overlay.host()
+      if (host && element.parentElement !== host) host.appendChild(element)
+      overlay.draw()
+    },
+
+    removePin(id: number): void {
+      pins.get(id)?.element.remove()
+      pins.delete(id)
+    },
+
+    ids(): number[] {
+      return [...pins.keys()]
+    },
+
+    destroy(): void {
+      for (const pin of pins.values()) pin.element.remove()
+      pins.clear()
+      overlay.setMap(null)
+    },
+  }
+}

--- a/client/src/components/Map/placeMarkerElement.ts
+++ b/client/src/components/Map/placeMarkerElement.ts
@@ -1,0 +1,90 @@
+import { escapeHtml } from '@trek/shared'
+import { safeHexColor } from '../../utils/safeColor'
+import { categoryIconSvg } from './categoryIcon'
+import type { Place } from '../../types'
+
+/**
+ * The circular place pin every GL-family renderer draws: category colour or
+ * photo, selection ring, and the day-order badge.
+ *
+ * Extracted from MapViewGL so a second renderer can draw an identical marker
+ * instead of carrying its own copy — the pin is what makes a TREK map look like
+ * a TREK map, and two copies would drift.
+ */
+export function createMarkerElement(place: Place & { category_color?: string; category_icon?: string }, photoUrl: string | null, orderNumbers: number[] | null, selected: boolean): HTMLDivElement {
+  const size = selected ? 44 : 36
+  // See MapView: allow-listed rather than escaped, because this is a CSS context.
+  const borderColor = selected ? '#111827' : safeHexColor(place.category_color, 'white')
+  const borderWidth = selected ? 3 : 2.5
+  const shadow = selected
+    ? '0 0 0 3px rgba(17,24,39,0.25), 0 4px 14px rgba(0,0,0,0.3)'
+    : '0 2px 8px rgba(0,0,0,0.22)'
+  const bgColor = safeHexColor(place.category_color, '#6b7280')
+
+  // The visual circle is `size` + 2*border on each side. To make the
+  // mapbox `anchor: 'center'` land on the real visual middle of the marker
+  // (rather than just the inner content box), the wrapper has to be the
+  // full outer size. If we gave the wrapper only `size`, the border would
+  // bleed outside it and the route lines would appear slightly off.
+  const outer = size + borderWidth * 2
+
+  let badgeHtml = ''
+  if (orderNumbers && orderNumbers.length > 0) {
+    const label = orderNumbers.join(' · ')
+    badgeHtml = `<span style="
+      position:absolute;bottom:-2px;right:-2px;
+      min-width:18px;height:${orderNumbers.length > 1 ? 16 : 18}px;border-radius:${orderNumbers.length > 1 ? 8 : 9}px;
+      padding:0 ${orderNumbers.length > 1 ? 4 : 3}px;
+      background:rgba(255,255,255,0.94);
+      border:1.5px solid rgba(0,0,0,0.15);
+      box-shadow:0 1px 4px rgba(0,0,0,0.18);
+      display:flex;align-items:center;justify-content:center;
+      font-size:${orderNumbers.length > 1 ? 7.5 : 9}px;font-weight:800;color:#111827;
+      font-family:var(--font-system);line-height:1;
+      box-sizing:border-box;white-space:nowrap;
+    ">${label}</span>`
+  }
+
+  const wrap = document.createElement('div')
+  // Do NOT set `position: relative` here — GL map libraries ship
+  // marker classes with `position: absolute` and rely on it. An inline
+  // `position: relative` here overrides the class, turns every marker into
+  // a static block element, and stacks them in document order inside the
+  // canvas container. The result looks exactly like "markers drift as the
+  // map zooms" because each marker's transform is then applied relative
+  // to its stacked slot, not to the map viewport.
+  wrap.style.cssText = `width:${outer}px;height:${outer}px;cursor:pointer;`
+
+  const hasPhoto = photoUrl && (photoUrl.startsWith('data:') || photoUrl.startsWith('/api/maps/place-photo/') || photoUrl.startsWith('/uploads/'))
+  if (hasPhoto) {
+    wrap.innerHTML = `
+      <div style="
+        position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+        width:${size}px;height:${size}px;border-radius:50%;
+        border:${borderWidth}px solid ${borderColor};
+        box-shadow:${shadow};
+        overflow:hidden;background:${bgColor};
+        box-sizing:content-box;
+      ">
+        <img src="${escapeHtml(photoUrl)}" width="${size}" height="${size}" style="display:block;border-radius:50%;object-fit:cover;" />
+      </div>
+      ${badgeHtml}
+    `
+  } else {
+    wrap.innerHTML = `
+      <div style="
+        position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+        width:${size}px;height:${size}px;border-radius:50%;
+        border:${borderWidth}px solid ${borderColor};
+        box-shadow:${shadow};
+        background:${bgColor};
+        display:flex;align-items:center;justify-content:center;
+        box-sizing:content-box;
+      ">
+        ${categoryIconSvg(place.category_icon, selected ? 18 : 15)}
+      </div>
+      ${badgeHtml}
+    `
+  }
+  return wrap
+}

--- a/client/src/components/Map/usePlacePhotos.test.ts
+++ b/client/src/components/Map/usePlacePhotos.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { Place } from '../../types'
+
+const getCached = vi.fn()
+vi.mock('../../services/photoService', () => ({
+  getCached: (...a: unknown[]) => getCached(...a),
+  isLoading: () => false,
+  fetchPhoto: () => {},
+  onThumbReady: () => () => {},
+  getAllThumbs: () => ({}),
+}))
+
+const { placePhotoUrl, placePopupPhotoUrl } = await import('./usePlacePhotos')
+
+const place = (over: Partial<Place> = {}) =>
+  ({ id: 1, trip_id: 1, name: 'Bowling', lat: 30, lng: 31, ...over }) as Place
+
+const THUMB = 'data:image/jpeg;base64,AAAA'
+const PROXY = '/api/maps/place-photo/abc123'
+
+beforeEach(() => getCached.mockReset())
+
+describe('placePhotoUrl (the pin)', () => {
+  it('uses the cached thumbnail, which is what a 36px circle wants', () => {
+    expect(placePhotoUrl(place(), { '30,31': THUMB })).toBe(THUMB)
+  })
+
+  it('prefers a user-uploaded image over the fetched thumbnail', () => {
+    expect(placePhotoUrl(place({ image_url: '/uploads/mine.jpg' }), { '30,31': THUMB })).toBe('/uploads/mine.jpg')
+  })
+})
+
+describe('placePopupPhotoUrl (the hover card)', () => {
+  // The regression this exists for: the card is ~220px wide and the thumbnail is
+  // downscaled to 48px, so showing the pin's image made the card look blurry.
+  it('prefers the full-size proxy URL over the 48px thumbnail', () => {
+    getCached.mockReturnValue({ photoUrl: PROXY, thumbDataUrl: THUMB })
+
+    expect(placePopupPhotoUrl(place(), { '30,31': THUMB })).toBe(PROXY)
+  })
+
+  it('falls back to the thumbnail when no full-size source is cached', () => {
+    getCached.mockReturnValue({ photoUrl: null, thumbDataUrl: THUMB })
+
+    expect(placePopupPhotoUrl(place(), { '30,31': THUMB })).toBe(THUMB)
+  })
+
+  it('takes a proxy URL stored on the place itself', () => {
+    getCached.mockReturnValue(undefined)
+
+    expect(placePopupPhotoUrl(place({ image_url: PROXY }), {})).toBe(PROXY)
+  })
+
+  it('still lets a user-uploaded image win', () => {
+    getCached.mockReturnValue({ photoUrl: PROXY, thumbDataUrl: THUMB })
+
+    expect(placePopupPhotoUrl(place({ image_url: '/uploads/mine.jpg' }), {})).toBe('/uploads/mine.jpg')
+  })
+
+  // A bare provider URL is a fetch seed, not something an <img src> can render.
+  it('ignores a non-displayable provider URL', () => {
+    getCached.mockReturnValue({ photoUrl: 'https://lh3.googleusercontent.com/p/AF1', thumbDataUrl: THUMB })
+
+    expect(placePopupPhotoUrl(place(), { '30,31': THUMB })).toBe(THUMB)
+  })
+
+  it('returns null when there is no image anywhere', () => {
+    getCached.mockReturnValue(undefined)
+
+    expect(placePopupPhotoUrl(place(), {})).toBeNull()
+  })
+})

--- a/client/src/components/Map/usePlacePhotos.ts
+++ b/client/src/components/Map/usePlacePhotos.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getCached, isLoading, fetchPhoto, onThumbReady, getAllThumbs } from '../../services/photoService'
+import { useAuthStore } from '../../store/authStore'
+import { isCustomPlaceImage, photoCacheKey } from './placePhoto'
+import type { Place } from '../../types'
+
+/**
+ * The marker photo thumbnails, keyed by photoCacheKey.
+ *
+ * Most places carry no image of their own: the picture on a pin is fetched at
+ * runtime into the photo service's cache and keyed by provider id or
+ * coordinates, which is why reading place.image_url alone leaves nearly every
+ * pin blank. Extracted from MapViewGL so a second renderer gets the same
+ * pictures from the same cache instead of a second copy of this logic drifting
+ * from it.
+ *
+ * Arrivals are batched through one animation frame: a trip with thirty places
+ * resolves thirty thumbs at once, and a setState each would be thirty renders.
+ */
+export function usePlacePhotos(places: Place[]): Record<string, string> {
+  const placesPhotosEnabled = useAuthStore(s => s.placesPhotosEnabled)
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>(getAllThumbs)
+  const pendingThumbsRef = useRef<Record<string, string>>({})
+  const thumbRafRef = useRef<number | null>(null)
+  const placeIds = useMemo(() => places.map(p => p.id).join(','), [places])
+
+  useEffect(() => {
+    if (!places || places.length === 0 || !placesPhotosEnabled) return
+    const cleanups: (() => void)[] = []
+
+    const setThumb = (cacheKey: string, thumb: string) => {
+      pendingThumbsRef.current[cacheKey] = thumb
+      if (thumbRafRef.current !== null) return
+      thumbRafRef.current = requestAnimationFrame(() => {
+        thumbRafRef.current = null
+        const pending = pendingThumbsRef.current
+        pendingThumbsRef.current = {}
+        setPhotoUrls(prev => {
+          const hasChange = Object.entries(pending).some(([k, v]) => prev[k] !== v)
+          return hasChange ? { ...prev, ...pending } : prev
+        })
+      })
+    }
+
+    for (const place of places) {
+      // A custom uploaded image is shown directly — never auto-fetch a provider
+      // photo for it (that request would 404 for OSM-only places and, worse, the
+      // fetched thumb would shadow the user's own image). (#1136)
+      if (isCustomPlaceImage(place.image_url)) continue
+      const cacheKey = photoCacheKey(place)
+      if (!cacheKey) continue
+      const cached = getCached(cacheKey)
+      if (cached?.thumbDataUrl) {
+        setThumb(cacheKey, cached.thumbDataUrl)
+        continue
+      }
+      cleanups.push(onThumbReady(cacheKey, thumb => setThumb(cacheKey, thumb)))
+      if (!cached && !isLoading(cacheKey)) {
+        const photoId =
+          (place.image_url?.startsWith('/api/maps/place-photo/') ? place.image_url : null)
+          || place.google_place_id
+          || place.osm_id
+          || place.image_url
+        if (photoId || (place.lat && place.lng)) {
+          fetchPhoto(cacheKey, photoId || `coords:${place.lat}:${place.lng}`, place.lat, place.lng, place.name)
+        }
+      }
+    }
+
+    return () => {
+      cleanups.forEach(fn => fn())
+      if (thumbRafRef.current !== null) {
+        cancelAnimationFrame(thumbRafRef.current)
+        thumbRafRef.current = null
+      }
+    }
+  }, [placeIds, placesPhotosEnabled]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return photoUrls
+}
+
+/**
+ * The image a pin should draw: a custom uploaded image wins over the
+ * auto-fetched thumbnail, which in turn wins over a bare stored URL.
+ */
+export function placePhotoUrl(place: Place, photoUrls: Record<string, string>): string | null {
+  if (isCustomPlaceImage(place.image_url)) return place.image_url!
+  const key = photoCacheKey(place)
+  return (key && photoUrls[key]) || place.image_url || null
+}

--- a/client/src/components/Map/usePlacePhotos.ts
+++ b/client/src/components/Map/usePlacePhotos.ts
@@ -88,3 +88,26 @@ export function placePhotoUrl(place: Place, photoUrls: Record<string, string>): 
   const key = photoCacheKey(place)
   return (key && photoUrls[key]) || place.image_url || null
 }
+
+/**
+ * The image for the hover card, which is ~220px wide.
+ *
+ * placePhotoUrl returns what the pin draws, and the photo service downscales
+ * that to 48px so a map full of markers stays cheap — fine inside a 36px circle,
+ * visibly soft blown up in a card. The cache keeps the full-size source
+ * alongside the thumbnail, so prefer that and fall back to the thumbnail only
+ * when there is nothing better.
+ */
+export function placePopupPhotoUrl(place: Place, photoUrls: Record<string, string>): string | null {
+  if (isCustomPlaceImage(place.image_url)) return place.image_url!
+
+  const key = photoCacheKey(place)
+  // Only our own proxy URLs are displayable straight from an <img src> — a bare
+  // provider URL is a fetch seed, not something the card can render.
+  const cachedFull = key ? getCached(key)?.photoUrl : null
+  if (cachedFull?.startsWith('/api/maps/place-photo/')) return cachedFull
+  if (place.image_url?.startsWith('/api/maps/place-photo/')) return place.image_url
+
+  return (key && photoUrls[key]) || null
+}
+

--- a/client/src/components/Settings/MapSettingsTab.tsx
+++ b/client/src/components/Settings/MapSettingsTab.tsx
@@ -135,14 +135,18 @@ function StyleDropdown({ value, provider, onChange }: { value: string; provider:
   )
 }
 
-type Provider = 'leaflet' | GlMapProvider
+type Provider = 'leaflet' | GlMapProvider | 'google-maps'
 
 function normalizeProvider(value: unknown): Provider {
-  return value === 'mapbox-gl' || value === 'maplibre-gl' ? value : 'leaflet'
+  // Anything unrecognised falls back to Leaflet, which is what makes this the
+  // one place a new provider must be registered: without it the tab shows
+  // Leaflet as selected and the next save writes that over the user's real
+  // choice.
+  return value === 'mapbox-gl' || value === 'maplibre-gl' || value === 'google-maps' ? value : 'leaflet'
 }
 
 function styleForProvider(provider: Provider, style?: string | null): string {
-  if (provider === 'leaflet') return style || MAPBOX_DEFAULT_STYLE
+  if (provider === 'leaflet' || provider === 'google-maps') return style || MAPBOX_DEFAULT_STYLE
   if (provider === 'mapbox-gl' && isOpenFreeMapStyle(style)) return MAPBOX_DEFAULT_STYLE
   return normalizeStyleForProvider(provider, style)
 }
@@ -171,18 +175,23 @@ export default function MapSettingsTab(): React.ReactElement {
   const [mapTileUrl, setMapTileUrl] = useState<string>(settings.map_tile_url || '')
   const managed = useAuthStore((s) => s.managed)
   const [mapboxToken, setMapboxToken] = useState<string>(settings.mapbox_access_token || '')
+  const [googleKey, setGoogleKey] = useState<string>(settings.google_maps_api_key || '')
   const [cartoKey, setCartoKey] = useState<string>(settings.carto_api_key || '')
   const [mapboxStyle, setMapboxStyle] = useState<string>(styleForProvider(initialProvider, slotStyle(initialProvider, settings)))
   const [mapbox3d, setMapbox3d] = useState<boolean>(settings.mapbox_3d_enabled !== false)
   const [mapboxQuality, setMapboxQuality] = useState<boolean>(settings.mapbox_quality_mode === true)
   // One chunk per engine — see components/Map/glLazy.tsx.
   const GlMapPreview = provider === 'maplibre-gl' ? GlMapPreviewMaplibre : GlMapPreviewMapbox
+  // 'not leaflet' used to be the same thing as 'a GL provider'. Google broke
+  // that equivalence: it has no style spec, no style slot and no token.
+  const isGl = provider === 'mapbox-gl' || provider === 'maplibre-gl'
 
   useEffect(() => {
     const nextProvider = normalizeProvider(settings.map_provider)
     setProvider(nextProvider)
     setMapTileUrl(settings.map_tile_url || '')
     setMapboxToken(settings.mapbox_access_token || '')
+    setGoogleKey(settings.google_maps_api_key || '')
     setCartoKey(settings.carto_api_key || '')
     setMapboxStyle(styleForProvider(nextProvider, slotStyle(nextProvider, settings)))
     setMapbox3d(settings.mapbox_3d_enabled !== false)
@@ -211,13 +220,14 @@ export default function MapSettingsTab(): React.ReactElement {
   const saveMapSettings = async (): Promise<void> => {
     setSaving(true)
     try {
-      const glStyle = provider === 'leaflet' ? mapboxStyle : normalizeStyleForProvider(provider, mapboxStyle)
+      const glStyle = isGl ? normalizeStyleForProvider(provider, mapboxStyle) : mapboxStyle
       // Save into the active provider's own slot so the other provider's style survives.
       const stylePatch = provider === 'maplibre-gl' ? { maplibre_style: glStyle } : { mapbox_style: glStyle }
       await updateSettings({
         map_provider: provider,
         map_tile_url: mapTileUrl,
         mapbox_access_token: mapboxToken,
+        google_maps_api_key: googleKey,
         carto_api_key: cartoKey,
         ...stylePatch,
         mapbox_3d_enabled: mapbox3d,
@@ -304,6 +314,27 @@ export default function MapSettingsTab(): React.ReactElement {
               <div className="hidden sm:block text-xs text-slate-500 mt-0.5">{t('settings.mapMapLibreSubtitle')}</div>
             </div>
           </button>
+          <button
+            type="button"
+            onClick={() => changeProvider('google-maps')}
+            className={`relative flex items-start gap-3 p-3 rounded-lg border text-left transition-colors ${
+              provider === 'google-maps'
+                ? 'border-slate-900 bg-slate-50 dark:bg-slate-800 dark:border-slate-200'
+                : 'border-slate-200 hover:border-slate-400 dark:border-slate-700'
+            }`}
+          >
+            <Globe2 size={18} className="mt-0.5 flex-shrink-0 text-slate-700 dark:text-slate-300" />
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-slate-900 dark:text-white">
+                <span className="sm:hidden">Google</span>
+                <span className="hidden sm:inline">Google Maps</span>
+              </div>
+              <div className="hidden sm:block text-xs text-slate-500 mt-0.5">{t('settings.mapGoogleSubtitle')}</div>
+            </div>
+            <span className="absolute top-1.5 right-1.5 text-[10px] uppercase tracking-wide text-amber-600 dark:text-amber-400">
+              {t('settings.mapExperimental')}
+            </span>
+          </button>
         </div>
         <p className="text-xs text-slate-400 mt-2">
           {t('settings.mapProviderHint')}
@@ -357,8 +388,33 @@ export default function MapSettingsTab(): React.ReactElement {
         </div>
       )}
 
+      {/* A Google Maps key reaches the browser by design and is restricted by HTTP
+          referrer, not kept secret — same handling as the Mapbox token above. */}
+      {provider === 'google-maps' && !managed && (
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1.5">{t('settings.mapGoogleKey')}</label>
+          <input
+            type="text"
+            value={googleKey}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setGoogleKey(e.target.value)}
+            spellCheck={false}
+            autoComplete="off"
+            className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-slate-400 focus:border-transparent"
+          />
+          <p className="text-xs text-slate-400 mt-1">
+            {t('settings.mapGoogleKeyHint')}{' '}
+            <a href="https://console.cloud.google.com/google/maps-apis/credentials" target="_blank" rel="noreferrer" className="underline">
+              {t('settings.mapGoogleKeyLink')}
+            </a>
+          </p>
+          {!googleKey && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">{t('settings.mapGoogleKeyMissing')}</p>
+          )}
+        </div>
+      )}
+
       {/* GL settings */}
-      {provider !== 'leaflet' && (
+      {isGl && (
         <div className="space-y-3">
           {/* The token comes with the instance on a managed install, injected when the
               settings are read. A field here would only let somebody save a worse one. */}
@@ -443,7 +499,7 @@ export default function MapSettingsTab(): React.ReactElement {
 
       <div>
         <div style={{ position: 'relative', inset: 0, height: '200px', width: '100%' }}>
-          {provider !== 'leaflet' ? (
+          {isGl ? (
             /* A net of its own: the preview is the one place a user flips providers
                live, so it is the likeliest chunk to fail — and a broken preview must
                not take the rest of the settings tab with it. */

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -121,11 +121,14 @@ export interface Settings {
   map_poi_pill_enabled?: boolean
   map_always_show_routes?: boolean
   optimize_from_accommodation?: boolean
-  map_provider?: 'leaflet' | 'mapbox-gl' | 'maplibre-gl'
+  map_provider?: 'leaflet' | 'mapbox-gl' | 'maplibre-gl' | 'google-maps'
   /** Leaflet base layer: default street tiles or a satellite/aerial view. */
   map_base_layer?: 'default' | 'satellite'
   /** CARTO basemaps watermark keyless tiles; the key is appended as ?key= (#2054). */
   carto_api_key?: string
+  /** Google Maps JS API key. Reaches the browser by design — restrict it by
+   *  HTTP referrer in the Google console, it is not a secret. */
+  google_maps_api_key?: string
   mapbox_access_token?: string
   mapbox_style?: string
   maplibre_style?: string

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="vite/client" />
+// The Google Maps provider loads its SDK at runtime from Google's hosted
+// loader, so the `google` namespace exists only as ambient types.
+/// <reference types="google.maps" />
 /// <reference types="vitest/globals" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@types/google.maps": "^3.66.2",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -7840,6 +7841,13 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.66.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.66.2.tgz",
+      "integrity": "sha512-Lg/U5iLj90fQV3jQJo6hmGYsNAecXH3J+3LkKb4AupYyyI3UFx7y4hINz1pYILX0DEWNN1FeCAXLUEjBBeV9XA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {

--- a/server/scripts/migrate-encryption.ts
+++ b/server/scripts/migrate-encryption.ts
@@ -404,7 +404,7 @@ async function main() {
     }
 
     // --- settings: per-user encrypted keys ---
-    const encryptedSettingKeys = ['webhook_url', 'ntfy_token', 'mapbox_access_token', 'carto_api_key', 'llm_api_key'];
+    const encryptedSettingKeys = ['webhook_url', 'ntfy_token', 'mapbox_access_token', 'carto_api_key', 'google_maps_api_key', 'llm_api_key'];
     const settingRows = db.prepare(
       `SELECT user_id, key, value FROM settings WHERE key IN (${encryptedSettingKeys.map(() => '?').join(', ')})`
     ).all(...encryptedSettingKeys) as { user_id: number; key: string; value: string }[];

--- a/server/src/middleware/globalMiddleware.ts
+++ b/server/src/middleware/globalMiddleware.ts
@@ -181,7 +181,13 @@ export function applyGlobalMiddleware(
         // means switching client/src/utils/convertHeic.ts over to it and
         // verifying a real .heic upload in a browser, not just deleting the
         // string here.
-        scriptSrc: ["'self'", "'wasm-unsafe-eval'", "'unsafe-eval'"],
+        // maps.googleapis.com is listed because the Google Maps provider loads its
+        // SDK from there at runtime; the API then pulls further modules from the
+        // same host. Unlike the other providers, Google's renderer cannot be
+        // bundled — the terms only license it through their hosted loader. The
+        // entry is unconditional so a per-user provider switch does not need a
+        // per-request CSP.
+        scriptSrc: ["'self'", "'wasm-unsafe-eval'", "'unsafe-eval'", "https://maps.googleapis.com"],
         styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://unpkg.com"],
         imgSrc: ["'self'", "data:", "blob:", "https:"],
         connectSrc: [
@@ -207,7 +213,10 @@ export function applyGlobalMiddleware(
           "https://geocoding-api.open-meteo.com", "https://api.frankfurter.dev",
           "https://router.project-osrm.org/route/v1/", "https://routing.openstreetmap.de/",
           "https://api.mapbox.com", "https://*.tiles.mapbox.com", "https://events.mapbox.com",
-          "https://tiles.openfreemap.org"
+          "https://tiles.openfreemap.org",
+          // Google Maps fetches its tiles, styles and telemetry from these.
+          "https://maps.googleapis.com", "https://maps.gstatic.com",
+          "https://khms0.googleapis.com", "https://khms1.googleapis.com"
         ],
         workerSrc: ["'self'", "blob:"],
         childSrc: ["'self'", "blob:"],

--- a/server/src/nest/common/managed.ts
+++ b/server/src/nest/common/managed.ts
@@ -75,9 +75,14 @@ export function isManagedBlocked(env: RuntimeEnvService): boolean {
  * and it is the operator's for one more reason: the key is registered to
  * whoever runs the instance, and CARTO's terms hold that account answerable for
  * the tiles it fetches.
+ *
+ * google_maps_api_key belongs here for that reason at its sharpest: Google
+ * bills the operator's account per map load, so a per-user key would let one
+ * member spend on somebody else's behalf — or, saved blank, break their map.
  */
 export const MANAGED_LOCKED_SETTING_KEYS = [
   'carto_api_key',
+  'google_maps_api_key',
   'llm_api_key',
   'llm_base_url',
   'llm_model',

--- a/server/src/nest/settings/settings.service.ts
+++ b/server/src/nest/settings/settings.service.ts
@@ -14,6 +14,7 @@ export const ENCRYPTED_SETTING_KEYS = new Set([
   'ntfy_token',
   'mapbox_access_token',
   'carto_api_key',
+  'google_maps_api_key',
   'llm_api_key',
 ]);
 // Encrypted keys that are masked (••••••••) when returned to the client.
@@ -37,6 +38,10 @@ export const DEFAULTABLE_USER_SETTING_KEYS = [
   // Instance-wide GL map defaults: admins can set Mapbox token/style or
   // tokenless MapLibre/OpenFreeMap style defaults for new users (#920).
   'map_provider',
+  // Google Maps bills per map load against whoever owns the key, so it is a
+  // per-instance value like the CARTO one rather than something each member
+  // is expected to bring: one admin key clears it for everybody.
+  'google_maps_api_key',
   'mapbox_access_token',
   'mapbox_style',
   'maplibre_style',
@@ -60,7 +65,7 @@ const VALID_VALUES: Partial<Record<DefaultableKey, unknown[]>> = {
   distance_unit: ['metric', 'imperial'],
   time_format: ['12h', '24h'],
   dark_mode: [true, false, 'light', 'dark', 'auto'],
-  map_provider: ['leaflet', 'mapbox-gl', 'maplibre-gl'],
+  map_provider: ['leaflet', 'mapbox-gl', 'maplibre-gl', 'google-maps'],
   llm_provider: ['local', 'openai', 'anthropic'],
 };
 

--- a/server/tests/unit/nest/managed-keys.test.ts
+++ b/server/tests/unit/nest/managed-keys.test.ts
@@ -52,6 +52,7 @@ describe('managed key assignment', () => {
   it('MANAGED-KEYS-005: the locked list is pinned verbatim', () => {
     expect([...MANAGED_LOCKED_SETTING_KEYS]).toEqual([
       'carto_api_key',
+      'google_maps_api_key',
       'llm_api_key',
       'llm_base_url',
       'llm_model',

--- a/shared/src/i18n/ar/settings.ts
+++ b/shared/src/i18n/ar/settings.ts
@@ -38,6 +38,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'مفتاح API لخرائط carto.com الأساسية',
   'settings.mapCartoKeyMissing':
     'هذا القالب خريطة أساسية من CARTO. بدون مفتاح تطبع CARTO عبارة "API KEY REQUIRED" على كل بلاطة. إلى أن تُدخل مفتاحًا، تعرض TREK الخريطة الأساسية الافتراضية بدلاً منها.',
+  'settings.mapGoogleSubtitle': 'خريطة جوجل، تُحتسب التكلفة لكل تحميل',
+  'settings.mapGoogleKey': 'مفتاح Google Maps API',
+  'settings.mapGoogleKeyHint': 'مفتاح متصفح لواجهة Maps JavaScript، مقيَّد بمُحيل HTTP، من',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com ← بيانات الاعتماد',
+  'settings.mapGoogleKeyMissing':
+    'تحتاج خرائط جوجل إلى مفتاح. بدونه لا يمكن تحميل الخريطة، لذا يعود TREK إلى Leaflet.',
   'settings.mapStyle': 'نمط الخريطة',
   'settings.mapStylePlaceholder': 'اختر نمط Mapbox',
   'settings.mapStyleHint': 'إعداد مسبق أو عنوان URL mapbox://styles/USER/ID خاص بك',

--- a/shared/src/i18n/br/settings.ts
+++ b/shared/src/i18n/br/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'chave de API de mapas base do carto.com',
   'settings.mapCartoKeyMissing':
     'Este modelo é um mapa base do CARTO. Sem uma chave, o CARTO estampa "API KEY REQUIRED" em cada bloco. Até você inserir uma, o TREK mostra o mapa base padrão.',
+  'settings.mapGoogleSubtitle': 'Mapa base do Google, cobrado por carregamento',
+  'settings.mapGoogleKey': 'Chave de API do Google Maps',
+  'settings.mapGoogleKeyHint': 'Chave de navegador para a API Maps JavaScript, restrita por referenciador HTTP, de',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Credenciais',
+  'settings.mapGoogleKeyMissing':
+    'O Google Maps precisa de uma chave. Sem ela o mapa não carrega, então o TREK volta ao Leaflet.',
   'settings.mapStyle': 'Estilo do mapa',
   'settings.mapStylePlaceholder': 'Selecionar um estilo Mapbox',
   'settings.mapStyleHint': 'Preset ou sua própria URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/ca/settings.ts
+++ b/shared/src/i18n/ca/settings.ts
@@ -29,6 +29,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': "clau d'API de mapes base de carto.com",
   'settings.mapCartoKeyMissing':
     'Aquesta plantilla és un mapa base de CARTO. Sense clau, CARTO estampa "API KEY REQUIRED" a cada tessel·la. Mentre no hi hagi clau, TREK mostra el mapa base per defecte.',
+  'settings.mapGoogleSubtitle': 'Mapa base de Google, facturat per càrrega de mapa',
+  'settings.mapGoogleKey': 'Clau d\'API de Google Maps',
+  'settings.mapGoogleKeyHint': 'Clau de navegador per a l\'API Maps JavaScript, restringida per referent HTTP, de',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Credencials',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps necessita una clau. Sense ella el mapa no es pot carregar, així que TREK torna a Leaflet.',
   'settings.mapStyle': 'Estil de mapa',
   'settings.mapStylePlaceholder': 'Selecciona un estil de Mapbox',
   'settings.mapStyleHint': 'Predefinit o la teva pròpia URL mapbox://styles/USUARI/ID',

--- a/shared/src/i18n/cs/settings.ts
+++ b/shared/src/i18n/cs/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com API klíč pro podkladové mapy',
   'settings.mapCartoKeyMissing':
     'Tato šablona je podkladová mapa CARTO. Bez klíče CARTO vypálí do každé dlaždice nápis "API KEY REQUIRED". Dokud klíč nezadáte, TREK zobrazuje výchozí podkladovou mapu.',
+  'settings.mapGoogleSubtitle': 'Podkladová mapa Google, účtováno za každé načtení',
+  'settings.mapGoogleKey': 'Klíč API Google Maps',
+  'settings.mapGoogleKeyHint': 'Klíč prohlížeče pro Maps JavaScript API, omezený podle HTTP referreru, z',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Přihlašovací údaje',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps vyžaduje klíč. Bez něj se mapa nenačte, takže TREK se vrátí k Leaflet.',
   'settings.mapStyle': 'Styl mapy',
   'settings.mapStylePlaceholder': 'Vyberte styl Mapbox',
   'settings.mapStyleHint': 'Preset nebo vaše vlastní URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/de/settings.ts
+++ b/shared/src/i18n/de/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com Basemap-API-Key',
   'settings.mapCartoKeyMissing':
     'Diese Vorlage ist eine CARTO-Basiskarte. Ohne Key brennt CARTO "API KEY REQUIRED" in jede Kachel. Bis ein Key eingetragen ist, zeigt TREK die Standard-Basiskarte.',
+  'settings.mapGoogleSubtitle': 'Google-Basiskarte, Abrechnung pro Kartenaufruf',
+  'settings.mapGoogleKey': 'Google Maps API-Schlüssel',
+  'settings.mapGoogleKeyHint': 'Browser-Schlüssel für die Maps JavaScript API, per HTTP-Referrer eingeschränkt, von',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Anmeldedaten',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps benötigt einen Schlüssel. Ohne ihn lässt sich die Karte nicht laden, daher weicht TREK auf Leaflet aus.',
   'settings.mapStyle': 'Kartenstil',
   'settings.mapStylePlaceholder': 'Mapbox-Stil wählen',
   'settings.mapStyleHint': 'Preset oder eigene mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/en/settings.ts
+++ b/shared/src/i18n/en/settings.ts
@@ -48,6 +48,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com basemap API key',
   'settings.mapCartoKeyMissing':
     'This template is a CARTO basemap. Without a key CARTO stamps "API KEY REQUIRED" onto every tile. Until you enter one, TREK shows the default basemap instead.',
+  'settings.mapGoogleSubtitle': 'Google basemap, billed per map load',
+  'settings.mapGoogleKey': 'Google Maps API key',
+  'settings.mapGoogleKeyHint': 'Browser key for the Maps JavaScript API, restricted by HTTP referrer, from',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Credentials',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps needs a key. Without one the map cannot load, so TREK falls back to Leaflet.',
   'settings.mapStyle': 'Map Style',
   'settings.mapStylePlaceholder': 'Select a Mapbox style',
   'settings.mapStyleHint': 'Preset or your own mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/es/settings.ts
+++ b/shared/src/i18n/es/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'clave de API de mapas base de carto.com',
   'settings.mapCartoKeyMissing':
     'Esta plantilla es un mapa base de CARTO. Sin clave, CARTO estampa "API KEY REQUIRED" en cada tesela. Hasta que introduzcas una, TREK muestra el mapa base predeterminado.',
+  'settings.mapGoogleSubtitle': 'Mapa base de Google, se factura por carga de mapa',
+  'settings.mapGoogleKey': 'Clave de API de Google Maps',
+  'settings.mapGoogleKeyHint': 'Clave de navegador para la API de Maps JavaScript, restringida por referente HTTP, de',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Credenciales',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps necesita una clave. Sin ella el mapa no puede cargarse, así que TREK recurre a Leaflet.',
   'settings.mapStyle': 'Estilo de mapa',
   'settings.mapStylePlaceholder': 'Seleccionar un estilo de Mapbox',
   'settings.mapStyleHint': 'Preset o tu propia URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/fr/settings.ts
+++ b/shared/src/i18n/fr/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': "clé d'API de fonds de carte carto.com",
   'settings.mapCartoKeyMissing':
     'Ce modèle est un fond de carte CARTO. Sans clé, CARTO appose "API KEY REQUIRED" sur chaque tuile. Tant que la clé manque, TREK affiche le fond de carte par défaut.',
+  'settings.mapGoogleSubtitle': 'Fond de carte Google, facturé par chargement',
+  'settings.mapGoogleKey': 'Clé API Google Maps',
+  'settings.mapGoogleKeyHint': 'Clé navigateur pour l\'API Maps JavaScript, restreinte par référent HTTP, depuis',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Identifiants',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps a besoin d\'une clé. Sans elle la carte ne peut pas se charger, TREK revient donc à Leaflet.',
   'settings.mapStyle': 'Style de carte',
   'settings.mapStylePlaceholder': 'Sélectionner un style Mapbox',
   'settings.mapStyleHint': 'Preset ou votre propre URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/gr/settings.ts
+++ b/shared/src/i18n/gr/settings.ts
@@ -42,6 +42,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'κλειδί API βασικών χαρτών carto.com',
   'settings.mapCartoKeyMissing':
     'Αυτό το πρότυπο είναι βασικός χάρτης CARTO. Χωρίς κλειδί, η CARTO τυπώνει "API KEY REQUIRED" σε κάθε πλακίδιο. Μέχρι να εισαγάγετε κλειδί, το TREK εμφανίζει τον προεπιλεγμένο βασικό χάρτη.',
+  'settings.mapGoogleSubtitle': 'Χάρτης βάσης Google, χρεώνεται ανά φόρτωση χάρτη',
+  'settings.mapGoogleKey': 'Κλειδί API Google Maps',
+  'settings.mapGoogleKeyHint': 'Κλειδί προγράμματος περιήγησης για το Maps JavaScript API, περιορισμένο βάσει HTTP referrer, από',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Διαπιστευτήρια',
+  'settings.mapGoogleKeyMissing':
+    'Το Google Maps χρειάζεται κλειδί. Χωρίς αυτό ο χάρτης δεν φορτώνει, οπότε το TREK επιστρέφει στο Leaflet.',
   'settings.mapStyle': 'Στυλ Χάρτη',
   'settings.mapStylePlaceholder': 'Επιλέξτε ένα στυλ Mapbox',
   'settings.mapStyleHint': 'Προκαθορισμένο ή δικό σας mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/hu/settings.ts
+++ b/shared/src/i18n/hu/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com alaptérkép API-kulcs',
   'settings.mapCartoKeyMissing':
     'Ez a sablon CARTO alaptérkép. Kulcs nélkül a CARTO minden csempére ráírja: "API KEY REQUIRED". Amíg nincs kulcs megadva, a TREK az alapértelmezett alaptérképet mutatja.',
+  'settings.mapGoogleSubtitle': 'Google alaptérkép, betöltésenként számlázva',
+  'settings.mapGoogleKey': 'Google Maps API-kulcs',
+  'settings.mapGoogleKeyHint': 'Böngészőkulcs a Maps JavaScript API-hoz, HTTP-hivatkozóval korlátozva, innen',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Hitelesítő adatok',
+  'settings.mapGoogleKeyMissing':
+    'A Google Maps kulcsot igényel. Enélkül a térkép nem tölthető be, ezért a TREK a Leafletre vált.',
   'settings.mapStyle': 'Térkép stílus',
   'settings.mapStylePlaceholder': 'Válassz Mapbox stílust',
   'settings.mapStyleHint': 'Preset vagy saját mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/id/settings.ts
+++ b/shared/src/i18n/id/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'kunci API peta dasar carto.com',
   'settings.mapCartoKeyMissing':
     'Templat ini adalah peta dasar CARTO. Tanpa kunci, CARTO mencetak "API KEY REQUIRED" di setiap ubin. Sampai kunci dimasukkan, TREK menampilkan peta dasar bawaan.',
+  'settings.mapGoogleSubtitle': 'Peta dasar Google, ditagih per pemuatan peta',
+  'settings.mapGoogleKey': 'Kunci API Google Maps',
+  'settings.mapGoogleKeyHint': 'Kunci browser untuk Maps JavaScript API, dibatasi menurut perujuk HTTP, dari',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Kredensial',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps memerlukan kunci. Tanpa kunci peta tidak dapat dimuat, sehingga TREK kembali ke Leaflet.',
   'settings.mapStyle': 'Gaya peta',
   'settings.mapStylePlaceholder': 'Pilih gaya Mapbox',
   'settings.mapStyleHint': 'Preset atau URL mapbox://styles/USER/ID milikmu',

--- a/shared/src/i18n/it/settings.ts
+++ b/shared/src/i18n/it/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'chiave API mappe base di carto.com',
   'settings.mapCartoKeyMissing':
     'Questo modello è una mappa base CARTO. Senza chiave, CARTO stampa "API KEY REQUIRED" su ogni tassello. Finché non inserisci una chiave, TREK mostra la mappa base predefinita.',
+  'settings.mapGoogleSubtitle': 'Mappa base Google, addebitata per caricamento',
+  'settings.mapGoogleKey': 'Chiave API di Google Maps',
+  'settings.mapGoogleKeyHint': 'Chiave browser per l\'API Maps JavaScript, limitata per referrer HTTP, da',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Credenziali',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps richiede una chiave. Senza, la mappa non può caricarsi e TREK torna a Leaflet.',
   'settings.mapStyle': 'Stile mappa',
   'settings.mapStylePlaceholder': 'Seleziona uno stile Mapbox',
   'settings.mapStyleHint': 'Preset o il tuo URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/ja/settings.ts
+++ b/shared/src/i18n/ja/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com ベースマップ API キー',
   'settings.mapCartoKeyMissing':
     'このテンプレートは CARTO のベースマップです。キーがないと CARTO はすべてのタイルに "API KEY REQUIRED" を焼き込みます。 キーを入力するまで、TREK は既定のベースマップを表示します。',
+  'settings.mapGoogleSubtitle': 'Google のベースマップ。地図の読み込みごとに課金されます',
+  'settings.mapGoogleKey': 'Google Maps API キー',
+  'settings.mapGoogleKeyHint': 'Maps JavaScript API 用のブラウザキー。HTTP リファラーで制限します。取得元:',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → 認証情報',
+  'settings.mapGoogleKeyMissing':
+    'Google マップにはキーが必要です。キーがないと地図を読み込めないため、TREK は Leaflet に戻ります。',
   'settings.mapStyle': '地図スタイル',
   'settings.mapStylePlaceholder': 'Mapboxスタイルを選択',
   'settings.mapStyleHint': 'プリセットまたは mapbox://styles/USER/ID のURL',

--- a/shared/src/i18n/ko/settings.ts
+++ b/shared/src/i18n/ko/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com 배경 지도 API 키',
   'settings.mapCartoKeyMissing':
     '이 템플릿은 CARTO 배경 지도입니다. 키가 없으면 CARTO가 모든 타일에 "API KEY REQUIRED"를 새깁니다. 키를 입력하기 전까지 TREK은 기본 배경 지도를 표시합니다.',
+  'settings.mapGoogleSubtitle': 'Google 기본 지도, 지도 로드마다 과금',
+  'settings.mapGoogleKey': 'Google Maps API 키',
+  'settings.mapGoogleKeyHint': 'Maps JavaScript API용 브라우저 키이며 HTTP 리퍼러로 제한됩니다. 발급처:',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → 사용자 인증 정보',
+  'settings.mapGoogleKeyMissing':
+    'Google 지도에는 키가 필요합니다. 키가 없으면 지도를 불러올 수 없어 TREK이 Leaflet으로 대체합니다.',
   'settings.mapStyle': '지도 스타일',
   'settings.mapStylePlaceholder': 'Mapbox 스타일 선택',
   'settings.mapStyleHint': '프리셋 또는 mapbox://styles/USER/ID URL 직접 입력',

--- a/shared/src/i18n/nl/settings.ts
+++ b/shared/src/i18n/nl/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com basemap API-sleutel',
   'settings.mapCartoKeyMissing':
     'Deze sjabloon is een CARTO-basiskaart. Zonder sleutel drukt CARTO "API KEY REQUIRED" op elke tegel. Zolang er geen sleutel is, toont TREK de standaardbasiskaart.',
+  'settings.mapGoogleSubtitle': 'Google-basiskaart, afgerekend per kaartlading',
+  'settings.mapGoogleKey': 'Google Maps API-sleutel',
+  'settings.mapGoogleKeyHint': 'Browsersleutel voor de Maps JavaScript API, beperkt via HTTP-referrer, van',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Inloggegevens',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps heeft een sleutel nodig. Zonder sleutel kan de kaart niet laden en valt TREK terug op Leaflet.',
   'settings.mapStyle': 'Kaartstijl',
   'settings.mapStylePlaceholder': 'Kies een Mapbox-stijl',
   'settings.mapStyleHint': 'Preset of eigen mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/pl/settings.ts
+++ b/shared/src/i18n/pl/settings.ts
@@ -39,6 +39,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'klucz API map podkładowych carto.com',
   'settings.mapCartoKeyMissing':
     'Ten szablon to mapa podkładowa CARTO. Bez klucza CARTO nanosi "API KEY REQUIRED" na każdy kafelek. Dopóki nie podasz klucza, TREK pokazuje domyślną mapę podkładową.',
+  'settings.mapGoogleSubtitle': 'Mapa bazowa Google, rozliczana za każde załadowanie',
+  'settings.mapGoogleKey': 'Klucz API Google Maps',
+  'settings.mapGoogleKeyHint': 'Klucz przeglądarki do Maps JavaScript API, ograniczony przez odsyłacz HTTP, z',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Dane logowania',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps wymaga klucza. Bez niego mapa się nie załaduje, więc TREK wraca do Leaflet.',
   'settings.mapStyle': 'Styl mapy',
   'settings.mapStylePlaceholder': 'Wybierz styl Mapbox',
   'settings.mapStyleHint': 'Preset lub własny URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/ru/settings.ts
+++ b/shared/src/i18n/ru/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'ключ API базовых карт carto.com',
   'settings.mapCartoKeyMissing':
     'Этот шаблон является базовой картой CARTO. Без ключа CARTO наносит "API KEY REQUIRED" на каждый тайл. Пока ключ не указан, TREK показывает базовую карту по умолчанию.',
+  'settings.mapGoogleSubtitle': 'Базовая карта Google, оплата за каждую загрузку',
+  'settings.mapGoogleKey': 'Ключ API Google Maps',
+  'settings.mapGoogleKeyHint': 'Браузерный ключ для Maps JavaScript API, ограниченный по HTTP-рефереру, из',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Учётные данные',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps требует ключ. Без него карта не загрузится, поэтому TREK вернётся к Leaflet.',
   'settings.mapStyle': 'Стиль карты',
   'settings.mapStylePlaceholder': 'Выберите стиль Mapbox',
   'settings.mapStyleHint': 'Preset или собственный URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/sv/settings.ts
+++ b/shared/src/i18n/sv/settings.ts
@@ -42,6 +42,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'API-nyckel för bakgrundskartor på carto.com',
   'settings.mapCartoKeyMissing':
     'Den här mallen är en CARTO-bakgrundskarta. Utan nyckel stämplar CARTO "API KEY REQUIRED" på varje ruta. Tills en nyckel anges visar TREK standardbakgrundskartan.',
+  'settings.mapGoogleSubtitle': 'Google-baskarta, debiteras per kartladdning',
+  'settings.mapGoogleKey': 'API-nyckel för Google Maps',
+  'settings.mapGoogleKeyHint': 'Webbläsarnyckel för Maps JavaScript API, begränsad via HTTP-referrer, från',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Autentiseringsuppgifter',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps kräver en nyckel. Utan den kan kartan inte laddas, så TREK faller tillbaka på Leaflet.',
   'settings.mapStyle': 'Kartstil',
   'settings.mapStylePlaceholder': 'Välj en Mapbox-stil',
   'settings.mapStyleHint': 'Förinställda eller egna mapbox://styles/USER/ID länk',

--- a/shared/src/i18n/tr/settings.ts
+++ b/shared/src/i18n/tr/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'carto.com temel harita API anahtarı',
   'settings.mapCartoKeyMissing':
     'Bu şablon bir CARTO temel haritası. Anahtar olmadan CARTO her karoya "API KEY REQUIRED" damgası basar. Anahtar girilene kadar TREK varsayılan temel haritayı gösterir.',
+  'settings.mapGoogleSubtitle': 'Google harita altlığı, harita yüklemesi başına ücretlendirilir',
+  'settings.mapGoogleKey': 'Google Maps API anahtarı',
+  'settings.mapGoogleKeyHint': 'Maps JavaScript API için tarayıcı anahtarı, HTTP yönlendireni ile sınırlandırılmış, şuradan',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Kimlik bilgileri',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps bir anahtar gerektirir. Anahtar olmadan harita yüklenemez, bu yüzden TREK Leaflet\'e döner.',
   'settings.mapStyle': 'Harita Stili',
   'settings.mapStylePlaceholder': 'Bir Mapbox stili seçin',
   'settings.mapStyleHint': 'Ön ayar veya kendi mapbox://styles/KULLANICI/ID adresiniz',

--- a/shared/src/i18n/uk/settings.ts
+++ b/shared/src/i18n/uk/settings.ts
@@ -41,6 +41,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'ключ API базових карт carto.com',
   'settings.mapCartoKeyMissing':
     'Цей шаблон є базовою картою CARTO. Без ключа CARTO наносить "API KEY REQUIRED" на кожен тайл. Доки ключ не вказано, TREK показує базову карту за замовчуванням.',
+  'settings.mapGoogleSubtitle': 'Базова карта Google, оплата за кожне завантаження',
+  'settings.mapGoogleKey': 'Ключ API Google Maps',
+  'settings.mapGoogleKeyHint': 'Ключ браузера для Maps JavaScript API, обмежений за HTTP-реферером, з',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Облікові дані',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps потребує ключа. Без нього карта не завантажиться, тож TREK повернеться до Leaflet.',
   'settings.mapStyle': 'Стиль карти',
   'settings.mapStylePlaceholder': 'Виберіть стиль Mapbox',
   'settings.mapStyleHint': 'Preset або власний URL mapbox://styles/USER/ID',

--- a/shared/src/i18n/vi/settings.ts
+++ b/shared/src/i18n/vi/settings.ts
@@ -40,6 +40,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyLink': 'khóa API bản đồ nền carto.com',
   'settings.mapCartoKeyMissing':
     'Mẫu này là bản đồ nền CARTO. Không có khóa, CARTO in "API KEY REQUIRED" lên mọi ô bản đồ. Cho đến khi bạn nhập khóa, TREK hiển thị bản đồ nền mặc định.',
+  'settings.mapGoogleSubtitle': 'Bản đồ nền Google, tính phí theo mỗi lần tải bản đồ',
+  'settings.mapGoogleKey': 'Khóa API Google Maps',
+  'settings.mapGoogleKeyHint': 'Khóa trình duyệt cho Maps JavaScript API, giới hạn theo HTTP referrer, từ',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → Thông tin xác thực',
+  'settings.mapGoogleKeyMissing':
+    'Google Maps cần một khóa. Không có khóa thì bản đồ không tải được, nên TREK quay lại dùng Leaflet.',
   'settings.mapStyle': 'Kiểu bản đồ',
   'settings.mapStylePlaceholder': 'Chọn kiểu Mapbox',
   'settings.mapStyleHint': 'Đặt trước hoặc của riêng bạn mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/zh-TW/settings.ts
+++ b/shared/src/i18n/zh-TW/settings.ts
@@ -38,6 +38,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyHint': '沒有金鑰時 CARTO 底圖會顯示浮水印。免費且無需帳戶，來自',
   'settings.mapCartoKeyLink': 'carto.com 底圖 API 金鑰',
   'settings.mapCartoKeyMissing': '此範本是 CARTO 底圖。沒有金鑰時，CARTO 會在每個圖磚上印上 "API KEY REQUIRED"。 在輸入金鑰之前，TREK 會顯示預設底圖。',
+  'settings.mapGoogleSubtitle': 'Google 底圖，依地圖載入次數計費',
+  'settings.mapGoogleKey': 'Google Maps API 金鑰',
+  'settings.mapGoogleKeyHint': '用於 Maps JavaScript API 的瀏覽器金鑰，以 HTTP 參照網址限制，來自',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → 憑證',
+  'settings.mapGoogleKeyMissing':
+    'Google 地圖需要金鑰。沒有金鑰就無法載入地圖，因此 TREK 會退回使用 Leaflet。',
   'settings.mapStyle': '地圖樣式',
   'settings.mapStylePlaceholder': '選擇 Mapbox 樣式',
   'settings.mapStyleHint': '預設或您自己的 mapbox://styles/USER/ID URL',

--- a/shared/src/i18n/zh/settings.ts
+++ b/shared/src/i18n/zh/settings.ts
@@ -38,6 +38,12 @@ const settings: TranslationStrings = {
   'settings.mapCartoKeyHint': '没有密钥时 CARTO 底图会显示水印。免费且无需账户，来自',
   'settings.mapCartoKeyLink': 'carto.com 底图 API 密钥',
   'settings.mapCartoKeyMissing': '此模板是 CARTO 底图。没有密钥时，CARTO 会在每个瓦片上打上 "API KEY REQUIRED"。 在输入密钥之前，TREK 会显示默认底图。',
+  'settings.mapGoogleSubtitle': '谷歌底图，按地图加载次数计费',
+  'settings.mapGoogleKey': 'Google Maps API 密钥',
+  'settings.mapGoogleKeyHint': '用于 Maps JavaScript API 的浏览器密钥，按 HTTP 引荐来源限制，来自',
+  'settings.mapGoogleKeyLink': 'console.cloud.google.com → 凭据',
+  'settings.mapGoogleKeyMissing':
+    'Google 地图需要密钥。没有密钥就无法加载地图，因此 TREK 会回退到 Leaflet。',
   'settings.mapStyle': '地图样式',
   'settings.mapStylePlaceholder': '选择 Mapbox 样式',
   'settings.mapStyleHint': '预设或您自己的 mapbox://styles/USER/ID URL',


### PR DESCRIPTION
## Description

Adds `google-maps` as a fourth map provider alongside Leaflet, Mapbox GL and MapLibre GL, selectable in **Settings → Map** with its own API key field and an instance-wide admin default.

Google's API is a different shape from the two GL engines. Those share one API surface, which is why they share one component with the engine injected as a `gl` prop — Google has no style spec, no `addSource`/`addLayer`, and its own marker and camera model, so it cannot become a third engine behind `MapViewGL`. It gets its own component and reuses the parts that make a TREK map look like a TREK map: the pin element, the popup markup, the viewport maths and the photo cache are lifted into shared modules (`placeMarkerElement.ts`, `categoryIcon.ts`, `usePlacePhotos.ts`) that `MapViewGL` now also uses, rather than copied.

The SDK is loaded from Google's hosted loader rather than bundled, because that is the only form the renderer is licensed in. That brings a CSP entry for `maps.googleapis.com` and a loader that handles the two ways a key fails: a network error, and a served-but-unauthorised key that Google reports through `gm_authFailure` rather than a failed request.

### Two findings worth the reviewer's time

**`AdvancedMarkerElement` is unusable on a raster map.** It is the obvious modern choice and it is the wrong one here. It repositions in two phases: it rides a coarse transform during a drag, then on idle snaps back to its pre-drag screen position and animates forward again. Measured against an `OverlayView` pin held at the same coordinate on the same map under one real drag:

| t | AdvancedMarkerElement | OverlayView | offset |
|---|---|---|---|
| 56851 | 155,196 | 162,224 | -7,-28 |
| 57050 | 47,82 | 54,110 | -7,-28 |
| 57252 | **155,196** ← back at its pre-drag spot | 18,72 | 137,124 |
| 57401 | 11,44 | 18,72 | -7,-28 |

Vector rendering avoids it, but that needs a Map ID created in the Google Cloud console, which a self-hosted instance cannot assume — and requesting `RenderingType.VECTOR` against `DEMO_MAP_ID` reports VECTOR and then renders an empty map (that attempt and its revert are both in the history). So the pins are drawn by a single `OverlayView` that positions its own DOM from the projection on each draw.

**`normalizeProvider` made the settings tab unsafe for any new provider.** It coerces anything unrecognised to `leaflet`, so an instance running `google-maps` showed Leaflet as selected and the next save silently wrote that over the user's real choice. That is why the Map tab changes are part of this PR rather than a follow-up. The GL-only sections are now gated on an explicit `isGl` check rather than "not leaflet" — those were the same thing until Google arrived.

### What works

Verified against a live key and a 34-place trip: basemap, place pins with their photos and day-order badges, hover card at full resolution, click-to-select, day route polylines, fit-to-places, and the compass. RTL basemap labels are correct here for free, since Google shapes them server-side.

### What is deliberately not in scope

- **Unported surfaces:** reservations/transport lines, POI explore, plugin map layers and markers, marker clustering, 3D/terrain, and the Journey and Atlas maps. The provider falls back cleanly; these simply do not render on Google yet.
- The small **map preview** in Settings still draws Leaflet when Google is selected — that widget only knows Leaflet and GL.

### Two things that may make this unwanted regardless of the code

1. **Offline.** Google's terms prohibit caching or pre-downloading tiles. TREK is offline-first and precaches up to 12,288 tiles per provider, so this can never be an offline provider. That is a licensing limit, not something implementable around.
2. **Cost.** It needs a billing-enabled key and bills per map load, where every current provider is free or has a free tier. `google_maps_api_key` is therefore on the managed-instance locked list, next to the Mapbox and CARTO keys.

I would rather you weighed both before anyone spends more time here.

## Related Issue or Discussion

None — there is no approved feature discussion, and I have not pitched this in `#github-pr`. I know that does not meet the bar; close it if you would rather it started as a Discussion and I will move it there. The RTL fix that came out of the same work went through as #2236 and is merged.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

## Test plan

- Unit tests for the SDK loader (including the `gm_authFailure` path and a refused second key), the compass adapter, and the pin/hover-card image selection.
- Full server suite green (10,051 tests). Two parity tests correctly caught that adding a key to `ENCRYPTED_SETTING_KEYS` is not self-contained — the encryption-rotation script keeps its own key list, and the managed locked list is pinned verbatim. Both are registered rather than loosened.
- New settings strings translated in all 23 locales; `i18n:parity:strict` passes.
- All CI checks green: server and client coverage, both type/lint jobs, i18n parity, plugin facts.
- Manually verified end to end against a live key on a self-hosted instance: pins, photos, hover, selection, panning, and a Google map rendering Arabic correctly.
