### PR TITLE
test(login): stub the world animation so the takeoff assertions stop flaking

### DIFF
--- a/client/src/pages/LoginPage.test.tsx
+++ b/client/src/pages/LoginPage.test.tsx
@@ -6,6 +6,13 @@ import { server } from '../../tests/helpers/msw/server';
 import { resetAllStores } from '../../tests/helpers/store';
 import LoginPage from './LoginPage';
 
+// The takeoff overlay renders the animated dot world, which starts three
+// requestAnimationFrame loops the moment it mounts. Nothing here asserts on the
+// animation (LoginWorld has its own tests), but under the load of the full suite
+// those loops pushed the overlay assertions past waitFor's default timeout and
+// made FE-PAGE-LOGIN-014 fail intermittently in CI while passing in isolation.
+vi.mock('./login/LoginWorld', () => ({ default: () => null }));
+
 // LoginPage uses inline styles for labels (no htmlFor/id pairing).
 // We find inputs by placeholder text.
 const EMAIL_PLACEHOLDER = 'your@email.com';


### PR DESCRIPTION
## Description

`FE-PAGE-LOGIN-014` has been failing intermittently in CI while passing in isolation. It cost a full Client Coverage run twice today on unrelated PRs, and once failed on one of two runs of the identical commit, which is what identified it as a flake rather than a regression.

The takeoff overlay renders `LoginWorld`, which starts three `requestAnimationFrame` loops the moment it mounts. Under the load of the full suite that was enough to push the overlay assertion past `waitFor`'s default timeout. Nothing in this file asserts on the animation and `LoginWorld` has its own tests, so the file stubs it.

## Related Issue or Discussion

No issue; found while shipping the 4.2.1 fixes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed