### PR TITLE
fix(planner): link the place created for a hotel instead of minting a new one on every save

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -432,7 +432,10 @@ export const daysApi = {
 
 export const placesApi = {
   list: (tripId: number | string, params?: Record<string, unknown>) => apiClient.get(`/trips/${tripId}/places`, { params }).then(r => r.data),
-  create: (tripId: number | string, data: PlaceCreateRequest) => apiClient.post(`/trips/${tripId}/places`, data).then(r => r.data),
+  // Typed: an untyped `r.data` is what let `{ place }` be read as a bare place,
+  // so every hotel booking minted an unlinked duplicate (#2243).
+  create: (tripId: number | string, data: PlaceCreateRequest): Promise<{ place: Place }> =>
+    apiClient.post(`/trips/${tripId}/places`, data).then(r => r.data),
   get: (tripId: number | string, id: number | string) => apiClient.get(`/trips/${tripId}/places/${id}`).then(r => r.data),
   update: (tripId: number | string, id: number | string, data: PlaceUpdateRequest) => apiClient.put(`/trips/${tripId}/places/${id}`, data).then(r => r.data),
   delete: (tripId: number | string, id: number | string) => apiClient.delete(`/trips/${tripId}/places/${id}`).then(r => r.data),

--- a/client/src/pages/tripPlanner/useTripPlanner.test.tsx
+++ b/client/src/pages/tripPlanner/useTripPlanner.test.tsx
@@ -13,7 +13,7 @@ import { resetAllStores, seedStore } from '../../../tests/helpers/store'
 import { buildUser, buildTrip, buildDay, buildPlace, buildAssignment, buildReservation } from '../../../tests/helpers/factories'
 import {
   addonsApi, accommodationsApi, authApi, tripsApi, assignmentsApi,
-  healthApi, airtrailApi, mapsApi, placesApi,
+  healthApi, airtrailApi, mapsApi,
 } from '../../api/client'
 import { accommodationRepo } from '../../repo/accommodationRepo'
 import { offlineDb } from '../../db/offlineDb'
@@ -197,7 +197,6 @@ beforeEach(() => {
   vi.spyOn(airtrailApi, 'sync').mockResolvedValue({ changed: 0 })
   vi.spyOn(mapsApi, 'reverse').mockResolvedValue({ name: '', address: '' } as never)
   vi.spyOn(mapsApi, 'search').mockResolvedValue({ places: [] } as never)
-  vi.spyOn(placesApi, 'create').mockResolvedValue({ id: 321 })
   vi.mocked(accommodationRepo.list).mockResolvedValue({ accommodations: [] })
   vi.mocked(getCached).mockReturnValue(undefined)
 })
@@ -1533,7 +1532,7 @@ describe('useTripPlanner — bookings and transports', () => {
     const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number; venue?: unknown } }
     expect(payload.create_accommodation.place_id).toBe(4)
     expect(payload.create_accommodation.venue).toBeUndefined()
-    expect(placesApi.create).not.toHaveBeenCalled()
+    expect(actions.addPlace).not.toHaveBeenCalled()
   })
 
   it('FE-TP-HOOK-080b: a venue name that only partially matches still links that place', async () => {
@@ -1567,9 +1566,41 @@ describe('useTripPlanner — bookings and transports', () => {
     })
 
     expect(mapsApi.search).toHaveBeenCalledWith('Ryokan Sakura Gion')
-    expect(placesApi.create).toHaveBeenCalledWith(42, { name: 'Ryokan Sakura', lat: 35.1, lng: 135.7, address: 'Gion' })
-    const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number } }
-    expect(payload.create_accommodation.place_id).toBe(321)
+    // Created through the store (addPlace), which unwraps the API's { place }
+    // envelope and pushes the place into `places` — not through placesApi
+    // directly, whose envelope used to be read as the place itself (#2243).
+    expect(actions.addPlace).toHaveBeenCalledWith(42, { name: 'Ryokan Sakura', lat: 35.1, lng: 135.7, address: 'Gion' })
+    const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number; venue?: unknown } }
+    expect(payload.create_accommodation.place_id).toBe(900)
+    expect(payload.create_accommodation.venue).toBeUndefined()
+  })
+
+  it('FE-TP-HOOK-081c: the place created for a new hotel is linked, so the next save of the same hotel reuses it (#2243)', async () => {
+    vi.mocked(mapsApi.search).mockResolvedValue({
+      places: [{ lat: 35.1, lng: 135.7, address: 'Kyoto, JP' }],
+    } as never)
+    // The real addPlace puts the created place into the store; mirror that so
+    // the second save sees it the way the planner does after a create.
+    actions.addPlace.mockImplementation(async (_tripId: unknown, data: { name: string }) => {
+      const created = buildPlace({ id: 901, name: data.name, lat: 35.1, lng: 135.7 })
+      useTripStore.setState(s => ({ places: [created, ...s.places] }))
+      return created
+    })
+    seedTrip()
+
+    const { result } = await renderPlanner()
+    const save = () => result.current.handleSaveReservation({
+      title: 'Ryokan Sakura', type: 'hotel',
+      create_accommodation: { venue: { name: 'Ryokan Sakura' } },
+    } as never)
+    await act(async () => { await save() })
+    await act(async () => { await save() })
+
+    expect(actions.addPlace).toHaveBeenCalledTimes(1)
+    const first = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number } }
+    const second = actions.addReservation.mock.calls[1][1] as { create_accommodation: { place_id?: number } }
+    expect(first.create_accommodation.place_id).toBe(901)
+    expect(second.create_accommodation.place_id).toBe(901)
   })
 
   it('FE-TP-HOOK-081b: a geocoded venue without a reviewed address adopts the hit address', async () => {
@@ -1587,12 +1618,12 @@ describe('useTripPlanner — bookings and transports', () => {
     })
 
     expect(mapsApi.search).toHaveBeenCalledWith('Ryokan Sakura')
-    expect(placesApi.create).toHaveBeenCalledWith(42, { name: 'Ryokan Sakura', lat: 35.1, lng: 135.7, address: 'Kyoto, JP' })
+    expect(actions.addPlace).toHaveBeenCalledWith(42, { name: 'Ryokan Sakura', lat: 35.1, lng: 135.7, address: 'Kyoto, JP' })
   })
 
   it('FE-TP-HOOK-082: a failed geocode still creates the place, a failed create yields no link', async () => {
     vi.mocked(mapsApi.search).mockRejectedValue(new Error('overpass down'))
-    vi.mocked(placesApi.create).mockRejectedValue(new Error('quota'))
+    actions.addPlace.mockRejectedValue(new Error('quota'))
     seedTrip()
 
     const { result } = await renderPlanner()
@@ -1603,7 +1634,7 @@ describe('useTripPlanner — bookings and transports', () => {
       } as never)
     })
 
-    expect(placesApi.create).toHaveBeenCalled()
+    expect(actions.addPlace).toHaveBeenCalled()
     const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number } }
     expect(payload.create_accommodation.place_id).toBeUndefined()
   })

--- a/client/src/pages/tripPlanner/useTripPlanner.test.tsx
+++ b/client/src/pages/tripPlanner/useTripPlanner.test.tsx
@@ -1603,6 +1603,42 @@ describe('useTripPlanner — bookings and transports', () => {
     expect(second.create_accommodation.place_id).toBe(901)
   })
 
+  it('FE-TP-HOOK-081d: offline, no place is minted for a booking that cannot be written', async () => {
+    env.forcedOffline = true
+    seedTrip()
+
+    const { result } = await renderPlanner()
+    await act(async () => {
+      await result.current.handleSaveReservation({
+        title: 'Ryokan Sakura', type: 'hotel',
+        create_accommodation: { venue: { name: 'Ryokan Sakura' } },
+      } as never)
+    })
+
+    // A place created offline gets a negative temp id, and the reservation write
+    // is online-only — linking one is a foreign-key failure on the server.
+    expect(actions.addPlace).not.toHaveBeenCalled()
+    expect(mapsApi.search).not.toHaveBeenCalled()
+    const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number } }
+    expect(payload.create_accommodation.place_id).toBeUndefined()
+  })
+
+  it('FE-TP-HOOK-081e: a place still holding an offline temp id is not linked as the accommodation', async () => {
+    actions.addPlace.mockResolvedValue(buildPlace({ id: 902, name: 'Ryokan Sakura' }))
+    seedTrip({ places: [buildPlace({ id: -1758000000000, name: 'Ryokan Sakura' })] })
+
+    const { result } = await renderPlanner()
+    await act(async () => {
+      await result.current.handleSaveReservation({
+        title: 'Ryokan Sakura', type: 'hotel',
+        create_accommodation: { venue: { name: 'Ryokan Sakura' } },
+      } as never)
+    })
+
+    const payload = actions.addReservation.mock.calls[0][1] as { create_accommodation: { place_id?: number } }
+    expect(payload.create_accommodation.place_id).toBe(902)
+  })
+
   it('FE-TP-HOOK-081b: a geocoded venue without a reviewed address adopts the hit address', async () => {
     vi.mocked(mapsApi.search).mockResolvedValue({
       places: [{ lat: 35.1, lng: 135.7, address: 'Kyoto, JP' }],

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -916,8 +916,18 @@ export function useTripPlanner() {
     if (n) {
       const existing = places.find(p => p.name?.trim().toLowerCase() === n)
         ?? places.find(p => p.name && (p.name.toLowerCase().includes(n) || n.includes(p.name.toLowerCase())))
-      if (existing) return existing.id
+      // Only a server-side id may be linked. A negative id is an offline temp id
+      // (mutationQueue.nextTempId): the reservation write is online-only, the queue
+      // rewrites temp ids in a URL but never inside another entity's body, and
+      // day_accommodations.place_id carries a foreign key — so a temp id here is a
+      // rolled-back insert and a 500 instead of a saved booking.
+      if (existing && existing.id > 0) return existing.id
     }
+    // Offline the booking itself cannot be written (reservations are online-only),
+    // so minting a place here would only leave an orphan behind on the next flush
+    // — and its temp id could never be linked anyway. Link nothing, and skip the
+    // geocode round-trip too; the retry online matches this venue by name.
+    if (isEffectivelyOffline()) return null
     let lat: number | null = null
     let lng: number | null = null
     let address: string | null = venue.address ?? null
@@ -939,8 +949,8 @@ export function useTripPlanner() {
       // learned about the previous one and the name match above could not
       // find it. addPlace unwraps the response and puts the place into
       // `places`, so the next save reuses it.
-      const place = await tripActions.addPlace(tripId, { name: name || address || 'Accommodation', lat, lng, address } as never)
-      return place?.id ?? null
+      const place = await tripActions.addPlace(tripId, { name: name || address || 'Accommodation', lat, lng, address })
+      return place && place.id > 0 ? place.id : null
     } catch { return null }
   }
 

--- a/client/src/pages/tripPlanner/useTripPlanner.ts
+++ b/client/src/pages/tripPlanner/useTripPlanner.ts
@@ -8,7 +8,7 @@ import { useToast } from '../../components/shared/Toast'
 import { Map, Ticket, PackageCheck, Wallet, FolderOpen, Users, Train } from 'lucide-react'
 import { resolvePluginIcon } from '../../components/shared/PluginIcon'
 import { useTranslation, translateApiError } from '../../i18n'
-import { addonsApi, accommodationsApi, authApi, tripsApi, assignmentsApi, healthApi, airtrailApi, mapsApi, placesApi } from '../../api/client'
+import { addonsApi, accommodationsApi, authApi, tripsApi, assignmentsApi, healthApi, airtrailApi, mapsApi } from '../../api/client'
 import { parsedItemToDraft, isTransportItem, isUnplaceableItem, type BookingReviewDraft } from '../../components/Planner/parsedItemToDraft'
 import type { BookingImportPreviewItem } from '@trek/shared'
 import { accommodationRepo } from '../../repo/accommodationRepo'
@@ -933,8 +933,14 @@ export function useTripPlanner() {
       }
     } catch { /* geocode failure is non-fatal — create the place without coords */ }
     try {
-      const place = await placesApi.create(tripId, { name: name || address || 'Accommodation', lat, lng, address } as never)
-      return (place as { id?: number })?.id ?? null
+      // Through the store, not placesApi directly: the API answers { place },
+      // and reading .id off that wrapper linked nothing — every save of the
+      // hotel then minted another orphan place, because the store never
+      // learned about the previous one and the name match above could not
+      // find it. addPlace unwraps the response and puts the place into
+      // `places`, so the next save reuses it.
+      const place = await tripActions.addPlace(tripId, { name: name || address || 'Accommodation', lat, lng, address } as never)
+      return place?.id ?? null
     } catch { return null }
   }
 


### PR DESCRIPTION
## Summary

Closes #2243.

Saving a hotel booking created a new place every time and never linked it to the accommodation. `resolveImportedPlace` (`client/src/pages/tripPlanner/useTripPlanner.ts`) called `placesApi.create` and read `.id` off the response, but `POST /api/trips/:tripId/places` answers `{ place }`, so the id was `undefined`: `create_accommodation.place_id` stayed empty, the place was orphaned, and — since the planner's `places` state never saw it — the existing-place name match failed on the next edit and another copy was created.

The place is now created through the store's `addPlace`, which unwraps the envelope (so the accommodation gets its `place_id`) and pushes the place into `places` (so a later save of the same hotel reuses it). The mobile booking sheet saves through the same `handleSaveReservation`, so it is covered too.

## Test plan

- The hook tests had mocked `placesApi.create` with a bare `{ id }`, which is why they never caught the envelope. They now mock/assert on `actions.addPlace`; `FE-TP-HOOK-081` asserts the linked `place_id` comes from the created place, and a new `FE-TP-HOOK-081c` saves the same new hotel twice and expects exactly one `addPlace` call with both saves linked to it. `081` / `081b` / `081c` fail on `dev` without the fix and pass with it.
- `cd client && npm run test`: full client suite green.
- `npm run typecheck --workspace=client` clean; eslint reports no new warnings on the touched files.
- Observed on a 4.1.1 instance: the duplicates stop as soon as the accommodation carries a `place_id` (the form then sends `place_id` instead of `venue`), which is the state this fix leaves behind after the first save.
