### PR TITLE
fix(app): stop mounting authed-only widgets on public visitor routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -402,13 +402,18 @@ export default function App() {
     || location.pathname.startsWith('/register')
     || location.pathname.startsWith('/forgot-password')
     || location.pathname.startsWith('/reset-password')
+  // Anonymous visitor routes: no session, so authenticated-only widgets (system
+  // notices, background tasks, save-to-collection) have nothing to do here and
+  // would otherwise fire a doomed authenticated request on mount.
+  const isPublicVisitorPage = isSharedPage || location.pathname.startsWith('/public/journey/')
+  const hideAuthedWidgets = isAuthPage || isPublicVisitorPage
 
   return (
     <TranslationProvider>
-      {!isAuthPage && <ErrorBoundary boundaryId="widget:system-notice" fallback={null}><SystemNoticeHost /></ErrorBoundary>}
+      {!hideAuthedWidgets && <ErrorBoundary boundaryId="widget:system-notice" fallback={null}><SystemNoticeHost /></ErrorBoundary>}
       <ErrorBoundary boundaryId="widget:toast" fallback={null}><ToastContainer /></ErrorBoundary>
-      {!isAuthPage && <ErrorBoundary boundaryId="widget:background-tasks" fallback={null}><BackgroundTasksWidget /></ErrorBoundary>}
-      {!isAuthPage && (isPhone ? <MSaveToCollectionSheet /> : <SaveToCollectionModal />)}
+      {!hideAuthedWidgets && <ErrorBoundary boundaryId="widget:background-tasks" fallback={null}><BackgroundTasksWidget /></ErrorBoundary>}
+      {!hideAuthedWidgets && (isPhone ? <MSaveToCollectionSheet /> : <SaveToCollectionModal />)}
       <ErrorBoundary boundaryId="widget:offline-banner" fallback={null}><OfflineBanner /></ErrorBoundary>
       {/* One boundary for all route chunks, above <Routes> so it stays mounted
           across navigations. react-router runs location updates inside a transition,


### PR DESCRIPTION
## Description
stop mounting authed-only widgets on public visitor routes. SystemNoticeHost, BackgroundTasksWidget, and save-to-collection were gated only on login/register/password routes, so anonymous visitors to /shared/:token and /public/journey/:token still mounted them and hit system-notices/active with no session, logging a 401 on every visit.

## Related Issue or Discussion
None, its related to https://github.com/liketrek/TREK/pull/2255 (https://github.com/liketrek/TREK/issues/2254) but as in the Contributing Guideliness bundling things is not wanted. Its not discussed whatsoever given I'm on vacation so this is an extra you can have :) 

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
