### PR TITLE
fix(notices): let the 4.0.0 release modal cover the whole 4.x line

### DIFF
--- a/server/src/systemNotices/registry.ts
+++ b/server/src/systemNotices/registry.ts
@@ -36,10 +36,13 @@ export const RETIRED_NOTICE_IDS = [
 export const SYSTEM_NOTICES: SystemNotice[] = [
   // ── 4.0.0 release — what shipped, and a note from the maintainer ────────────
   // Carries `release`, so it renders as the two-column release modal rather than
-  // the generic notice body. Shown once, not per-version: the copy is about this
-  // release. The next one gets its own entry with its own id.
+  // the generic notice body. 4.0.0 was big enough that the whole 4.x line should
+  // carry it, so `recurring: 'per-version'` brings it back on each upgrade inside
+  // the window rather than the default one-time dismissal, which retired it for
+  // everyone who closed it once on 4.0.0. A 5.x release gets its own entry.
   {
     id: 'release-4-0-0',
+    recurring: 'per-version',
     display: 'modal',
     severity: 'info',
     titleKey: 'system_notice.release_400.headline',

--- a/server/tests/unit/systemNotices/registry.test.ts
+++ b/server/tests/unit/systemNotices/registry.test.ts
@@ -82,6 +82,14 @@ describe('registry integrity', () => {
     expect(isNoticeVersionActive(release!, '5.0.0')).toBe(false);
   });
 
+  it('the 4.0.0 release notice comes back on each upgrade inside that line', () => {
+    const release = SYSTEM_NOTICES.find(n => n.id === 'release-4-0-0')!;
+    // The version window above is only half of "covers the whole 4.x line". Without
+    // this, the default one-time dismissal retired the notice for everyone who
+    // closed it on 4.0.0, so none of them saw it again on 4.1, 4.2 or later.
+    expect(release.recurring).toBe('per-version');
+  });
+
   it('the thank-you notice hands over to the release modal at 4.0.0', () => {
     const thankYou = SYSTEM_NOTICES.find(n => n.id === 'thank-you-support');
     expect(thankYou).toBeDefined();


### PR DESCRIPTION
## Description

The 4.0.0 release modal stopped appearing after 4.0.0, which is why the 4.2.1 update showed nothing.

The version window was never the problem: it says `minVersion: 4.0.0` / `maxVersion: 5.0.0`, and the unit test above it is called *"the 4.0.0 release notice covers the whole 4.x line"*. But that test only checks `isNoticeVersionActive`, and the window is only half of what "covers the line" needs. Without `recurring: 'per-version'` a notice falls back to the default one-time dismissal, so every user who closed the modal once on 4.0.0 had it retired permanently. It did not come back on 4.1.0, 4.2.0 or 4.2.1, which is the opposite of what the window advertises.

4.0.0 was a big enough release that the whole 4.x line should carry it, so the fix is to say so.

## What changes

`recurring: 'per-version'` on the `release-4-0-0` entry. The mechanism already exists and is already in use one entry below, on `thank-you-support`, and `dismissNotice` already records the app version each dismissal happened at. So the modal re-surfaces on the next upgrade and stays down within the same version.

Users who dismissed it before that column was recorded read as `0.0.0` and simply get it once more. Nobody on 3.x sees it, and 5.0.0 still falls outside the window and gets its own entry.

The existing test kept passing through all of this, so it gained a sibling that pins the half it was missing.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My branch is up to date with `dev`
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective
- [ ] I have updated documentation if needed
