### PR TITLE
Follow the new default dock through the mobile nav suites, and stop one storage test racing itself

### DIFF
--- a/client/tests/unit/mobile/MBottomNav.test.tsx
+++ b/client/tests/unit/mobile/MBottomNav.test.tsx
@@ -89,14 +89,30 @@ describe('MBottomNav', () => {
     expect(screen.getByRole('button', { name: 'Manual Booking' })).toBeInTheDocument();
   });
 
-  it('FE-MOB-NAV-006: journey and collections live in the More popover, not the dock', () => {
+  it('FE-MOB-NAV-006: atlas and collections live in the More popover, not the dock', () => {
     seedAddons(['vacay', 'atlas', 'journey', 'collections']);
     render(<MBottomNav />, { initialEntries: ['/dashboard'] });
 
-    expect(screen.queryByRole('button', { name: 'Journey' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Atlas' })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { expanded: false }));
-    expect(screen.getByRole('button', { name: /Journey/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Atlas/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Collections/ })).toBeInTheDocument();
+  });
+
+  it('FE-MOB-NAV-006b: the dock keeps Journey next to Vacay when both are enabled', () => {
+    seedAddons(['vacay', 'atlas', 'journey', 'collections']);
+    render(<MBottomNav />, { initialEntries: ['/dashboard'] });
+
+    expect(screen.getByRole('button', { name: 'Journey' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Vacay' })).toBeInTheDocument();
+  });
+
+  it('FE-MOB-NAV-006c: an instance without the journey addon keeps the Vacay/Atlas dock', () => {
+    seedAddons(['vacay', 'atlas', 'collections']);
+    render(<MBottomNav />, { initialEntries: ['/dashboard'] });
+
+    expect(screen.getByRole('button', { name: 'Vacay' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Atlas' })).toBeInTheDocument();
   });
 
   it('FE-MOB-NAV-007: no More slot without popover entries', () => {
@@ -126,7 +142,7 @@ describe('MBottomNav', () => {
     render(<MBottomNav />, { initialEntries: ['/dashboard'] });
 
     fireEvent.click(screen.getByRole('button', { name: 'More' }));
-    fireEvent.click(screen.getByRole('button', { name: /Journey/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Atlas/ }));
 
     const more = screen.getByRole('button', { name: 'More' });
     expect(more).toHaveAttribute('aria-expanded', 'false');

--- a/client/tests/unit/mobile/admin/MAdminStoragePanel.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminStoragePanel.test.tsx
@@ -271,7 +271,12 @@ describe('MAdminStoragePanel', () => {
     await screen.findByText('Storage configuration saved');
     // files is default-sourced (uploads-local) in baseState() — stripping restores "no override".
     expect((putBody as StorageConfig).categories.files).toBeUndefined();
-    expect(migrationBody).toEqual({ category: 'files', to: 'off-box' });
+    // Waited for, not read straight after the toast. The toast comes from the
+    // PUT, while the migration POST is fired by the queue effect one commit
+    // later, so the two are not the same tick. Reading it immediately only held
+    // while that effect happened to flush first, which under CI load it does
+    // not. Same fix as FE-ADMIN-STOR-030 on the desktop twin.
+    await waitFor(() => expect(migrationBody).toEqual({ category: 'files', to: 'off-box' }));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 

--- a/client/tests/unit/mobile/settings/MMobileNavCustomizer.test.tsx
+++ b/client/tests/unit/mobile/settings/MMobileNavCustomizer.test.tsx
@@ -36,8 +36,8 @@ describe('MMobileNavCustomizer', () => {
   it('FE-MOB-SETNAVC-001: an uncustomised value falls back to the built-in dock split', () => {
     render(<MMobileNavCustomizer value={{ bar: [], more: [] }} onChange={vi.fn()} />);
 
-    expect(rowLabels('In the bar')).toEqual(['Vacay', 'Atlas']);
-    expect(rowLabels('Under “More”')).toEqual(['Journey', 'Collections']);
+    expect(rowLabels('In the bar')).toEqual(['Vacay', 'Journey']);
+    expect(rowLabels('Under “More”')).toEqual(['Atlas', 'Collections']);
   });
 
   it('FE-MOB-SETNAVC-002: Dashboard is listed pinned and has no reorder buttons', () => {


### PR DESCRIPTION
Follow-up to #2286, which landed before the client coverage job finished. Three expectations in the mobile suites still describe the Vacay/Atlas dock and are red on `dev` right now:

* `FE-MOB-NAV-006` asserted Journey is *not* in the dock
* `FE-MOB-NAV-011` picked Journey out of the More popover, where it no longer is
* `FE-MOB-SETNAVC-001` expected `['Vacay', 'Atlas']` in the customiser preview

Two of those were pinning the arrangement itself rather than catching a regression, so they are rewritten around Atlas, which is the one that moved under More. Two new cases cover what the change is actually about: Journey sits in the dock when the addon is enabled, and an instance without it still gets Vacay and Atlas.

The first run of this branch stayed red on a fourth, unrelated test. `FE-MOB-MSTOR-013` read `migrationBody` straight after the save toast, but that toast comes from the PUT while the migration POST is fired by the queue effect one commit later. It only ever passed while that effect happened to flush first, which on a loaded runner it does not. The desktop twin `FE-ADMIN-STOR-030` has waited here since 8069b8805; the mobile file was simply left behind, so it now waits too.

Tests only, no source change.