### PR TITLE
Stop the journey load-more observer rebuilding itself on every render

### DIFF
--- a/client/src/components/Journey/JourneyDetailPageScrollTrigger.test.tsx
+++ b/client/src/components/Journey/JourneyDetailPageScrollTrigger.test.tsx
@@ -1,4 +1,4 @@
-// FE-COMP-JSCROLLTRIG-001 to FE-COMP-JSCROLLTRIG-006
+// FE-COMP-JSCROLLTRIG-001 to FE-COMP-JSCROLLTRIG-009
 
 import { render } from '../../../tests/helpers/render'
 import { resetAllStores } from '../../../tests/helpers/store'
@@ -85,6 +85,46 @@ describe('ScrollTrigger', () => {
   it('FE-COMP-JSCROLLTRIG-006: unmounting disconnects the observer', () => {
     const { unmount } = render(<ScrollTrigger onVisible={vi.fn()} loading={false} />)
     unmount()
+    expect(observers[0].disconnect).toHaveBeenCalled()
+  })
+
+  it('FE-COMP-JSCROLLTRIG-007: a fresh callback identity alone does not rebuild the observer', () => {
+    // Both callers hand in a new arrow every render; rebuilding for that churn
+    // replays the initial callback and pulls pages nobody asked for.
+    const { rerender } = render(<ScrollTrigger onVisible={vi.fn()} loading={false} />)
+    expect(observers).toHaveLength(1)
+
+    rerender(<ScrollTrigger onVisible={vi.fn()} loading={false} />)
+    rerender(<ScrollTrigger onVisible={vi.fn()} loading={false} />)
+
+    expect(observers).toHaveLength(1)
+    expect(observers[0].disconnect).not.toHaveBeenCalled()
+  })
+
+  it('FE-COMP-JSCROLLTRIG-008: the surviving observer calls the newest callback, not the one it was built with', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = render(<ScrollTrigger onVisible={first} loading={false} />)
+    rerender(<ScrollTrigger onVisible={second} loading={false} />)
+
+    intersect(observers[0], true)
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('FE-COMP-JSCROLLTRIG-009: a settled page really re-observes the sentinel', () => {
+    // A browser observer only fires on a threshold crossing plus once per
+    // observe(). A sentinel that never leaves the 200px margin therefore only
+    // gets another callback because the loading flip rebuilds the observer, so
+    // loading must stay a dependency rather than moving into a ref as well.
+    const onVisible = vi.fn()
+    const { rerender } = render(<ScrollTrigger onVisible={onVisible} loading />)
+    expect(observers).toHaveLength(1)
+
+    rerender(<ScrollTrigger onVisible={onVisible} loading={false} />)
+
+    expect(observers).toHaveLength(2)
     expect(observers[0].disconnect).toHaveBeenCalled()
   })
 })

--- a/client/src/components/Journey/JourneyDetailPageScrollTrigger.tsx
+++ b/client/src/components/Journey/JourneyDetailPageScrollTrigger.tsx
@@ -2,13 +2,24 @@ import { useEffect, useRef } from 'react'
 
 export function ScrollTrigger({ onVisible, loading }: { onVisible: () => void; loading: boolean }) {
   const ref = useRef<HTMLDivElement>(null)
+  // Both callers hand in a fresh arrow on every render — the picker its
+  // loadMorePhotos, the gallery its setVisibleCount step. With onVisible in the
+  // effect deps, every unrelated re-render tore the observer down and observed
+  // again, and each observe() replays the initial callback. The ref keeps the
+  // observer out of that churn.
+  //
+  // loading stays a dependency on purpose: re-observing after a page has landed
+  // is the only thing that still produces a callback when the sentinel never
+  // left the 200px margin.
+  const onVisibleRef = useRef(onVisible)
+  onVisibleRef.current = onVisible
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    const obs = new IntersectionObserver(([entry]) => { if (entry.isIntersecting && !loading) onVisible() }, { rootMargin: '200px' })
+    const obs = new IntersectionObserver(([entry]) => { if (entry.isIntersecting && !loading) onVisibleRef.current() }, { rootMargin: '200px' })
     obs.observe(el)
     return () => obs.disconnect()
-  }, [onVisible, loading])
+  }, [loading])
   return (
     <div ref={ref} className="flex justify-center py-4 mt-2">
       <div className="w-5 h-5 border-2 border-zinc-300 border-t-zinc-900 dark:border-zinc-600 dark:border-t-white rounded-full animate-spin" />


### PR DESCRIPTION
`ScrollTrigger` kept `onVisible` in its effect dependencies. Both callers hand in a fresh arrow on every render, the picker its `loadMorePhotos` and the gallery its `setVisibleCount` step, so every unrelated re-render tore the `IntersectionObserver` down and observed again. Ticking a photo in the picker is enough to do it, and each `observe()` replays the initial callback.

The callback moves into a ref, which is the house pattern in this folder already (`JourneyMap.tsx`, `JourneyMapGL.tsx`).

## What deliberately did not change

`loading` stays a dependency. A browser observer fires on threshold crossings plus once per `observe()`, so a sentinel that never leaves the 200px margin only gets another callback because the loading flip rebuilds the observer. Folding `loading` into a ref as well and emptying the deps looks tidier and leaves paging dead after the first page. `FE-COMP-JSCROLLTRIG-009` pins that so the tidier version cannot land by accident.

Markup, classes and the signature are byte-identical, so nothing shifts visually. That includes the gallery's permanently spinning sentinel at `loading={false}`, which is a separate question and is left alone here.

## Tests

Three new cases. `007` (a fresh callback identity alone does not rebuild the observer) and `008` (the surviving observer calls the newest callback) are **red on the old component** and green on the new one. `009` is green either way and exists to block the over-correction described above.