### PR TITLE
fix(maps): let the imagery through the CSP, so the GL switch does something

### DIFF
--- a/server/src/middleware/globalMiddleware.ts
+++ b/server/src/middleware/globalMiddleware.ts
@@ -235,6 +235,13 @@ export function applyGlobalMiddleware(
           // document and never reaches the Service Worker that would cache it
           // (#2180). routing.openstreetmap.de below is a different host.
           "https://tile.openstreetmap.de", "https://tiles.stadiamaps.com",
+          // The imagery host, for the same reason and one more. Leaflet fetches a tile
+          // as an <img>, which img-src's blanket `https:` waves through, so the satellite
+          // view worked on Leaflet with this host missing. A GL map reads the raster
+          // through fetch to hand it to WebGL, and the prefetch does too, so both were
+          // refused here while nothing in the app could see it: the switch flipped, the
+          // layer went on, and no tile ever arrived (#2307).
+          "https://server.arcgisonline.com",
           "https://unpkg.com", "https://open-meteo.com", "https://api.open-meteo.com",
           "https://geocoding-api.open-meteo.com", "https://api.frankfurter.dev",
           "https://router.project-osrm.org/route/v1/", "https://routing.openstreetmap.de/",

--- a/server/tests/unit/middleware/globalMiddleware.csp.test.ts
+++ b/server/tests/unit/middleware/globalMiddleware.csp.test.ts
@@ -52,6 +52,25 @@ describe('global CSP: the other shipped raster presets (#2180)', () => {
   });
 });
 
+describe('global CSP: the imagery host (#2307)', () => {
+  it('allows server.arcgisonline.com, which a GL map reaches through fetch', async () => {
+    // The gap hid behind Leaflet for as long as Leaflet was the only renderer to
+    // show the imagery: it loads a tile as an <img>, and img-src allows `https:`
+    // outright. A GL map reads the raster through fetch to hand it to WebGL, so
+    // it lands on connect-src instead and was refused with nothing to see for it.
+    expect(await connectSrcSources()).toContain('https://server.arcgisonline.com');
+  });
+
+  it('names the apex host, because img-src is what used to carry it', async () => {
+    // img-src keeps its blanket `https:`, which is why Leaflet never noticed. The
+    // fix belongs on connect-src alone; widening img-src further would buy nothing
+    // and widening connect-src to a wildcard would not match the apex anyway.
+    const sources = await connectSrcSources();
+    expect(sources).not.toContain('https://*.arcgisonline.com');
+    expect(await directiveSources('img-src')).toContain('https:');
+  });
+});
+
 describe('global CSP: script-src', () => {
   it("allows 'wasm-unsafe-eval' so the WASM decoders keep running", async () => {
     expect(await directiveSources('script-src')).toContain("'wasm-unsafe-eval'");


### PR DESCRIPTION
The satellite toggle works on Leaflet and does nothing at all on a GL map, which is the
default renderer since the vector basemap landed. Not for want of the layer that #2307
added: `connect-src` never named `server.arcgisonline.com`.

Leaflet asks for a tile as an `<img>`, and `img-src` waves every `https:` host through, so
the gap could sit there unnoticed for as long as Leaflet was the only renderer that showed
the imagery. A GL map reads the raster through `fetch` to hand it to WebGL, and that lands
on `connect-src` instead, where the host is missing.

Measured against dev1, on the page as it ships:

```
fetch  server.arcgisonline.com   refused by CSP
fetch  tile.openstreetmap.org    ok        (it is on the list)
<img>  server.arcgisonline.com   ok 256x256 (img-src allows https:)
```

> Connecting to 'https://server.arcgisonline.com/…' violates the following Content Security
> Policy directive: "connect-src 'self' ws: wss: …". The action has been blocked.

That is the worst shape a failure can take here: the switch flips, the layer goes on, the
source is there, and no tile ever arrives. Nothing in the app can see it either, because a
CSP refusal is not an error the fetch can catch.

The prefetcher asks for the same tiles the same way, with `mode: 'no-cors'`, which relaxes
CORS and not CSP, so the imagery was never cached for offline use either.

Same shape as #2180, which added the other two raster presets for exactly this reason and
did not reach this host.