### PR TITLE
feat(share): enrich public trip details

### DIFF
--- a/client/src/pages/SharedTripPage.test.tsx
+++ b/client/src/pages/SharedTripPage.test.tsx
@@ -1352,4 +1352,86 @@ describe('SharedTripPage', () => {
       await waitFor(() => expect(screen.getByText(/Airport Parking/)).toBeInTheDocument());
     });
   });
+
+  describe('FE-PAGE-SHARED-042: richer public place and booking details', () => {
+    const day = { id: 7, trip_id: 1, day_number: 1, date: '2026-07-02', title: 'Day One' };
+    const place = {
+      id: 201,
+      name: 'Colosseum',
+      lat: 41.8902,
+      lng: 12.4922,
+      address: 'Piazza del Colosseo, Rome',
+      description: 'Ancient amphitheatre',
+      notes: 'Use the east entrance',
+      duration_minutes: 90,
+      place_time: '09:00',
+      end_time: '10:30',
+      website: 'https://colosseo.it/',
+      phone: '+39 06 3996 7700',
+      category_id: null,
+      image_url: null,
+    };
+
+    it('renders separate place context, assignment notes, duration and safe contact links', async () => {
+      await open('rich-place-token', payload({
+        days: [day],
+        places: [place],
+        assignments: {
+          '7': [{ id: 301, day_id: 7, place_id: 201, order_index: 0, notes: 'Arrive before opening', place }],
+        },
+      }));
+
+      fireEvent.click(screen.getByText('Day One'));
+
+      await waitFor(() => expect(screen.getByText('Piazza del Colosseo, Rome')).toBeInTheDocument());
+      expect(screen.getByText('Ancient amphitheatre')).toBeInTheDocument();
+      expect(screen.getByText('Arrive before opening')).toBeInTheDocument();
+      expect(screen.getByText('Use the east entrance')).toBeInTheDocument();
+      expect(screen.getByText(/1 hr.*30 min/)).toBeInTheDocument();
+      expect(screen.getByText(/09:00 – 10:30/)).toBeInTheDocument();
+
+      const maps = screen.getByRole('link', { name: /google maps/i });
+      expect(maps).toHaveAttribute('href', expect.stringContaining('google.com/maps/search'));
+      expect(maps).toHaveAttribute('target', '_blank');
+      expect(maps).toHaveAttribute('rel', 'noopener noreferrer');
+
+      const website = screen.getByRole('link', { name: /website/i });
+      expect(website).toHaveAttribute('href', 'https://colosseo.it/');
+      expect(website).toHaveAttribute('target', '_blank');
+      expect(website).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByRole('link', { name: '+39 06 3996 7700' })).toHaveAttribute('href', 'tel:+390639967700');
+    });
+
+    it('renders reservation notes and only links an HTTP(S) booking URL', async () => {
+      await open('rich-booking-token', payload({
+        permissions: { share_bookings: true, share_packing: false, share_budget: false, share_collab: false },
+        reservations: [
+          { id: 1, title: 'Museum entry', type: 'ticket', status: 'confirmed', notes: 'Use gate B', url: 'https://tickets.example.com/booking/123' },
+          { id: 2, title: 'Unsafe booking', type: 'ticket', status: 'pending', notes: 'Text only', url: 'javascript:alert(1)' },
+        ],
+      }));
+
+      fireEvent.click(screen.getByRole('button', { name: /bookings/i }));
+      await waitFor(() => expect(screen.getByText('Use gate B')).toBeInTheDocument());
+      expect(screen.getByText('Text only')).toBeInTheDocument();
+      const booking = document.querySelector('a[href="https://tickets.example.com/booking/123"]');
+      expect(booking).toBeInTheDocument();
+      expect(booking).toHaveAttribute('target', '_blank');
+      expect(booking).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(document.querySelector('a[href^="javascript:"]')).toBeNull();
+    });
+
+    it('does not link a non-HTTP(S) place website', async () => {
+      const unsafePlace = { ...place, website: 'data:text/html,unsafe' };
+      await open('unsafe-place-token', payload({
+        days: [day],
+        places: [unsafePlace],
+        assignments: { '7': [{ id: 301, day_id: 7, place_id: 201, order_index: 0, place: unsafePlace }] },
+      }));
+
+      fireEvent.click(screen.getByText('Day One'));
+      await waitFor(() => expect(screen.getByText('Ancient amphitheatre')).toBeInTheDocument());
+      expect(document.querySelector('a[href^="data:"]')).toBeNull();
+    });
+  });
 });

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -3,12 +3,15 @@ import {
   Bus,
   Car,
   Clock,
+  ExternalLink,
   FileText,
+  Globe,
   Hotel,
   Luggage,
   Map,
   MapPin,
   MessageCircle,
+  Phone,
   Plane,
   Ship,
   Ticket,
@@ -18,6 +21,7 @@ import {
 import { createElement, useEffect, useRef } from 'react';
 import { renderIconMarkup } from '../utils/iconMarkup';
 import { MapContainer, Marker, Polyline, TileLayer, Tooltip, useMap } from 'react-leaflet';
+import { getGoogleMapsUrlForPlace } from '../components/Planner/placeGoogleMaps';
 import { getCategoryIcon } from '../components/shared/categoryIcons';
 import PublicLanguagePicker from '../components/shared/PublicLanguagePicker';
 import { OFM_POSITRON, DEFAULT_MAP_CENTER, DEFAULT_MAP_ZOOM, MAP_MAX_ZOOM, attributionForTile } from '../constants/mapDefaults';
@@ -31,9 +35,32 @@ import { getFlightLegs, getTrainLegs } from '../utils/flightLegs';
 import { splitReservationDateTime } from '../utils/formatters';
 import { computeMapViewport, TILE_SIZE_RASTER } from '../utils/mapViewport';
 import { resolveBasemap } from '../utils/tileUrl';
+import { safeHttpUrl } from '../utils/safeUrl';
 import { useSharedTrip } from './sharedTrip/useSharedTrip';
 
 const TRANSPORT_ICONS = { flight: Plane, train: Train, bus: Bus, car: Car, cruise: Ship };
+
+function formatDuration(minutes: unknown, locale: string): string | null {
+  const total = Math.floor(Number(minutes));
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const hours = Math.floor(total / 60);
+  const mins = total % 60;
+  const formatUnit = (value: number, unit: 'hour' | 'minute') => new Intl.NumberFormat(locale, {
+    style: 'unit', unit, unitDisplay: 'short',
+  }).format(value);
+  if (hours && mins) return `${formatUnit(hours, 'hour')} ${formatUnit(mins, 'minute')}`;
+  if (hours) return formatUnit(hours, 'hour');
+  return formatUnit(mins, 'minute');
+}
+
+function visiblePlaceNotes(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .split('\n')
+    .filter(line => !line.trim().startsWith('Google Maps:'))
+    .join('\n')
+    .trim();
+}
 
 // Injected into Leaflet's marker HTML, where CSS variables cannot reach - the same
 // reason MapView.tsx is exempt from theme:lint outright.
@@ -733,14 +760,21 @@ export default function SharedTripPage() {
                           const place = item.data.place;
                           if (!place) return null;
                           const cat = categories?.find((c: any) => c.id === place.category_id);
+                          const mapsUrl = getGoogleMapsUrlForPlace(place);
+                          const websiteUrl = safeHttpUrl(place.website);
+                          const phoneNumber = typeof place.phone === 'string' ? place.phone.trim() : '';
+                          const phoneTarget = phoneNumber.replace(/[^+\d]/g, '');
+                          const phoneHref = /\d/.test(phoneTarget) ? `tel:${phoneTarget}` : null;
+                          const duration = formatDuration(place.duration_minutes, locale);
+                          const placeNotes = visiblePlaceNotes(place.notes);
                           return (
                             <div
                               key={`p-${item.data.id}`}
                               style={{
                                 display: 'flex',
-                                alignItems: 'center',
+                                alignItems: 'flex-start',
                                 gap: 10,
-                                padding: '6px 8px',
+                                padding: '9px 8px',
                                 borderRadius: 6,
                               }}
                             >
@@ -767,42 +801,60 @@ export default function SharedTripPage() {
                                 )}
                               </div>
                               <div style={{ flex: 1, minWidth: 0 }}>
-                                <div
-                                  className="text-[#111827]"
-                                  style={{ fontSize: 'calc(12.5px * var(--fs-scale-body, 1))', fontWeight: 500 }}
-                                >
+                                <div className="text-body font-semibold text-content">
                                   {place.name}
                                 </div>
-                                {(place.address || place.description) && (
-                                  <div
-                                    className="text-[#9ca3af]"
-                                    style={{
-                                      fontSize: 'calc(10px * var(--fs-scale-caption, 1))',
-                                      overflow: 'hidden',
-                                      textOverflow: 'ellipsis',
-                                      whiteSpace: 'nowrap',
-                                    }}
-                                  >
-                                    {place.address || place.description}
+                                {place.address && (
+                                  <div className="mt-0.5 text-caption text-content-muted">
+                                    {place.address}
+                                  </div>
+                                )}
+                                {place.description && (
+                                  <div className="mt-1 whitespace-pre-wrap text-caption text-content-muted">
+                                    {place.description}
+                                  </div>
+                                )}
+                                {item.data.notes && (
+                                  <div className="mt-1.5 whitespace-pre-wrap text-caption text-content-muted">
+                                    {item.data.notes}
+                                  </div>
+                                )}
+                                {placeNotes && (
+                                  <div className="mt-1 whitespace-pre-wrap text-caption text-content-muted">
+                                    {placeNotes}
+                                  </div>
+                                )}
+                                {(place.place_time || duration) && (
+                                  <div className="mt-1.5 flex flex-wrap items-center gap-2 text-caption text-content-muted">
+                                    {place.place_time && (
+                                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                                        <Clock size={9} />
+                                        {place.place_time}{place.end_time ? ` – ${place.end_time}` : ''}
+                                      </span>
+                                    )}
+                                    {duration && <span>{duration}</span>}
+                                  </div>
+                                )}
+                                {(mapsUrl || websiteUrl || phoneHref) && (
+                                  <div className="mt-2 flex flex-wrap gap-2.5 text-caption">
+                                    {mapsUrl && (
+                                      <a href={mapsUrl} target="_blank" rel="noopener noreferrer" className="text-accent" style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                                        <ExternalLink size={10} /> {t('inspector.google')}
+                                      </a>
+                                    )}
+                                    {websiteUrl && (
+                                      <a href={websiteUrl} target="_blank" rel="noopener noreferrer" className="text-accent" style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                                        <Globe size={10} /> {t('inspector.website')}
+                                      </a>
+                                    )}
+                                    {phoneHref && (
+                                      <a href={phoneHref} className="text-accent" style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                                        <Phone size={10} /> {phoneNumber}
+                                      </a>
+                                    )}
                                   </div>
                                 )}
                               </div>
-                              {place.place_time && (
-                                <span
-                                  className="text-[#6b7280]"
-                                  style={{
-                                    fontSize: 'calc(10px * var(--fs-scale-caption, 1))',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 3,
-                                    flexShrink: 0,
-                                  }}
-                                >
-                                  <Clock size={9} />
-                                  {place.place_time}
-                                  {place.end_time ? ` – ${place.end_time}` : ''}
-                                </span>
-                              )}
                             </div>
                           );
                         })}
@@ -830,6 +882,7 @@ export default function SharedTripPage() {
                     timeZone: 'UTC',
                   })
                 : '';
+              const bookingUrl = safeHttpUrl(r.url);
               return (
                 <div
                   key={r.id}
@@ -900,6 +953,16 @@ export default function SharedTripPage() {
                               </span>
                             )}
                     </div>
+                    {r.notes && (
+                      <div className="mt-1.5 whitespace-pre-wrap text-caption text-content-muted">
+                        {r.notes}
+                      </div>
+                    )}
+                    {bookingUrl && (
+                      <a href={bookingUrl} target="_blank" rel="noopener noreferrer" className="mt-1.5 inline-flex items-center gap-1 text-caption text-accent">
+                        <ExternalLink size={10} /> {t('reservations.urlLabel')}
+                      </a>
+                    )}
                   </div>
                   <span
                     className={

--- a/server/src/nest/share/share.service.ts
+++ b/server/src/nest/share/share.service.ts
@@ -13,6 +13,61 @@ type Trip = TripAccess;
 
 const PLACE_PHOTO_PROXY_PREFIX = '/api/maps/place-photo/';
 
+const PUBLIC_RESERVATION_METADATA_KEYS = new Set([
+  'airline',
+  'arrival_airport',
+  'departure_airport',
+  'flight_number',
+  'platform',
+  'seat',
+  'train_number',
+]);
+const PUBLIC_RESERVATION_LEG_KEYS = new Set([
+  'airline',
+  'arr_day_id',
+  'arr_time',
+  'dep_day_id',
+  'dep_time',
+  'flight_number',
+  'from',
+  'platform',
+  'seat',
+  'to',
+  'train_number',
+]);
+
+function sanitizePublicReservationMetadata(raw: unknown): unknown {
+  const wasString = typeof raw === 'string';
+  let parsed: unknown = raw;
+  if (wasString) {
+    try {
+      parsed = JSON.parse(raw);
+      if (typeof parsed === 'string') parsed = JSON.parse(parsed);
+    } catch {
+      return '{}';
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return wasString ? '{}' : {};
+
+  const source = parsed as Record<string, unknown>;
+  const sanitized: Record<string, unknown> = {};
+  for (const key of PUBLIC_RESERVATION_METADATA_KEYS) {
+    const value = source[key];
+    if (value == null || ['string', 'number', 'boolean'].includes(typeof value)) sanitized[key] = value;
+  }
+  if (Array.isArray(source.legs)) {
+    sanitized.legs = source.legs
+      .filter((leg): leg is Record<string, unknown> => Boolean(leg) && typeof leg === 'object' && !Array.isArray(leg))
+      .map((leg) => Object.fromEntries(
+        Object.entries(leg).filter(([key, value]) =>
+          PUBLIC_RESERVATION_LEG_KEYS.has(key)
+          && (value == null || ['string', 'number', 'boolean'].includes(typeof value)),
+        ),
+      ));
+  }
+  return wasString ? JSON.stringify(sanitized) : sanitized;
+}
+
 /**
  * Place photo proxy URLs (`/api/maps/place-photo/<id>/bytes`) are served by the
  * JWT-guarded MapsController, so they 401 for an unauthenticated shared-trip
@@ -181,6 +236,7 @@ export class ShareService {
             COALESCE(da.assignment_time, p.place_time) as place_time,
             COALESCE(da.assignment_end_time, p.end_time) as end_time,
             p.duration_minutes, p.notes as place_notes, p.image_url, p.transport_mode,
+            p.website, p.phone,
             c.name as category_name, c.color as category_color, c.icon as category_icon
           FROM day_assignments da
           JOIN places p ON da.place_id = p.id
@@ -201,6 +257,8 @@ export class ShareService {
               id: a.place_id, name: a.place_name, description: a.place_description,
               lat: a.lat, lng: a.lng, address: a.address, category_id: a.category_id,
               price: a.price, place_time: a.place_time, end_time: a.end_time,
+              duration_minutes: a.duration_minutes, notes: a.place_notes,
+              website: a.website, phone: a.phone,
               image_url: rewritePlacePhotoUrl(a.image_url, token), transport_mode: a.transport_mode,
               category: a.category_id ? { id: a.category_id, name: a.category_name, color: a.category_color, icon: a.category_icon } : null,
               tags: tagsByPlace[a.place_id] ?? [],
@@ -245,13 +303,23 @@ export class ShareService {
       // The alias is not cosmetic: the visibility predicate qualifies its column,
       // and this query had no alias to qualify against.
       reservations = this.dbs.all<any>(
-        `SELECT r.* FROM reservations r
+        `SELECT r.id, r.trip_id, r.day_id, r.end_day_id, r.place_id, r.assignment_id,
+                r.title, r.accommodation_id, r.reservation_time, r.reservation_end_time,
+                r.location, r.notes, r.status, r.type, r.metadata, r.needs_review,
+                r.url, r.created_at
+         FROM reservations r
          WHERE r.trip_id = ? AND ${publicReservationSql('r')}
          ORDER BY r.reservation_time ASC`, tripId)
-        .map((r) => ({ ...r, day_positions: posMap.get(r.id) ?? null }));
+        .map((reservation) => ({
+          ...reservation,
+          metadata: sanitizePublicReservationMetadata(reservation.metadata),
+          day_positions: posMap.get(reservation.id) ?? null,
+        }));
 
       accommodations = this.dbs.all(`
-        SELECT a.*, p.name as place_name, p.address as place_address, p.lat as place_lat, p.lng as place_lng
+        SELECT a.id, a.trip_id, a.place_id, a.start_day_id, a.end_day_id,
+               a.check_in, a.check_in_end, a.check_out, a.notes, a.created_at,
+               p.name as place_name, p.address as place_address, p.lat as place_lat, p.lng as place_lng
         FROM day_accommodations a JOIN places p ON a.place_id = p.id
         WHERE a.trip_id = ? AND ${publicStaySql('a')}
       `, tripId);

--- a/server/tests/integration/share.test.ts
+++ b/server/tests/integration/share.test.ts
@@ -219,6 +219,33 @@ describe('Shared trip access', () => {
     expect(res.body.budget).toHaveLength(0);
   });
 
+  it('SHARE-031 — withholds all reservation details when share_bookings=false', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id);
+    const place = createPlace(testDb, trip.id);
+    testDb.prepare(`
+      INSERT INTO reservations (trip_id, day_id, title, notes, url, confirmation_number, status, type)
+      VALUES (?, ?, 'Private booking', 'Private reservation note', 'https://private.example.com', 'PRIVATE-CODE', 'confirmed', 'other')
+    `).run(trip.id, day.id);
+    testDb.prepare(`
+      INSERT INTO day_accommodations (trip_id, place_id, start_day_id, end_day_id, confirmation, notes)
+      VALUES (?, ?, ?, ?, 'PRIVATE-STAY-CODE', 'Private stay note')
+    `).run(trip.id, place.id, day.id, day.id);
+
+    const create = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_bookings: false });
+    const res = await request(app).get(`/api/shared/${create.body.token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.reservations).toEqual([]);
+    expect(res.body.accommodations).toEqual([]);
+    expect(JSON.stringify(res.body)).not.toContain('Private reservation note');
+    expect(JSON.stringify(res.body)).not.toContain('Private stay note');
+  });
+
   // Regression: a co-member's private packing item (#858) must never reach a public share.
   it('SHARE-026 — hides private packing items from the public payload', async () => {
     const { user } = createUser(testDb);
@@ -244,6 +271,11 @@ describe('Shared trip access', () => {
     const trip = createTrip(testDb, user.id, { title: 'Secret Route' });
     const day = createDay(testDb, trip.id, { date: '2025-06-01' });
     const place = createPlace(testDb, trip.id, { name: 'Safehouse', lat: 12.3456, lng: 65.4321 });
+    testDb.prepare(`
+      UPDATE places SET duration_minutes = 75, notes = 'Private place note',
+        website = 'https://private.example.com', phone = '+1 212 555 0199'
+      WHERE id = ?
+    `).run(place.id);
     createDayAssignment(testDb, day.id, place.id);
     createDayNote(testDb, day.id, trip.id, { text: 'Do not share' });
 
@@ -264,6 +296,8 @@ describe('Shared trip access', () => {
     // …and the coordinates never appear anywhere in the response.
     expect(JSON.stringify(res.body)).not.toContain('12.3456');
     expect(JSON.stringify(res.body)).not.toContain('65.4321');
+    expect(JSON.stringify(res.body)).not.toContain('Private place note');
+    expect(JSON.stringify(res.body)).not.toContain('https://private.example.com');
   });
 
   it('SHARE-008 — GET /shared/:invalid-token returns 404', async () => {
@@ -378,6 +412,73 @@ describe('Shared trip — day assignments and notes', () => {
     expect(Array.isArray(dayNotes)).toBe(true);
     expect(dayNotes).toHaveLength(1);
     expect(dayNotes[0].text).toBe('Meet at the station');
+  });
+
+  it('SHARE-030 — exposes richer itinerary place details but no confirmation numbers', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Detailed Rome Trip' });
+    const day = createDay(testDb, trip.id, { date: '2025-07-01' });
+    const place = createPlace(testDb, trip.id, { name: 'Colosseum', description: 'Ancient amphitheatre' });
+    testDb.prepare(`
+      UPDATE places
+      SET address = ?, duration_minutes = ?, notes = ?, website = ?, phone = ?
+      WHERE id = ?
+    `).run('Piazza del Colosseo, Rome', 90, 'Use the east entrance', 'https://colosseo.it/', '+39 06 3996 7700', place.id);
+    const assignment = createDayAssignment(testDb, day.id, place.id, { notes: 'Arrive before opening' });
+    testDb.prepare(`
+      INSERT INTO reservations
+        (trip_id, day_id, assignment_id, title, notes, url, metadata, confirmation_number, status, type)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'confirmed', 'ticket')
+    `).run(
+      trip.id,
+      day.id,
+      assignment.id,
+      'Colosseum entry',
+      'Use gate B',
+      'https://tickets.example.com/booking/123',
+      JSON.stringify({
+        airline: 'Public Air',
+        passenger_name: 'Private Traveler',
+        pnr: 'PRIVATE-PNR',
+        legs: [{ from: 'FCO', to: 'JFK', flight_number: 'PA123', confirmation_number: 'PRIVATE-LEG-CODE' }],
+      }),
+      'PRIVATE-CODE-123',
+    );
+    testDb.prepare(`
+      INSERT INTO day_accommodations
+        (trip_id, place_id, start_day_id, end_day_id, confirmation, notes)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(trip.id, place.id, day.id, day.id, 'PRIVATE-STAY-CODE', 'Check in after 15:00');
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_map: true, share_bookings: true });
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    const sharedAssignment = res.body.assignments[day.id][0];
+    expect(sharedAssignment.notes).toBe('Arrive before opening');
+    expect(sharedAssignment.place).toMatchObject({
+      address: 'Piazza del Colosseo, Rome',
+      description: 'Ancient amphitheatre',
+      duration_minutes: 90,
+      notes: 'Use the east entrance',
+      website: 'https://colosseo.it/',
+      phone: '+39 06 3996 7700',
+    });
+    expect(res.body.reservations[0]).toMatchObject({
+      title: 'Colosseum entry',
+      notes: 'Use gate B',
+      url: 'https://tickets.example.com/booking/123',
+    });
+    expect(res.body.reservations[0]).not.toHaveProperty('confirmation_number');
+    expect(JSON.parse(res.body.reservations[0].metadata)).toEqual({
+      airline: 'Public Air',
+      legs: [{ from: 'FCO', to: 'JFK', flight_number: 'PA123' }],
+    });
+    expect(res.body.accommodations[0]).toMatchObject({ notes: 'Check in after 15:00' });
+    expect(res.body.accommodations[0]).not.toHaveProperty('confirmation');
   });
 
   it('SHARE-012 — share_collab=true includes collab messages in response', async () => {


### PR DESCRIPTION
## Description

Improves the unauthenticated, read-only shared-trip experience with richer context that trip owners have already chosen to share:

- separates place address and description
- shows assignment notes, place notes, schedules, and localized duration
- adds Google Maps, validated website, and telephone links
- shows reservation notes and validated booking URLs
- explicitly projects public reservation/accommodation fields instead of returning wildcard rows
- removes top-level and nested confirmation/record-locator/passenger metadata from the public payload through a narrow display-metadata allowlist

Permission boundaries remain server-enforced: itinerary/place data is returned only with `share_map`, and booking/accommodation data only with `share_bookings`. The page remains unauthenticated and exposes no edit controls or authenticated routes.

## Related Issue or Discussion

Closes #2320

Approved feature discussion: https://discord.com/channels/1488298068427411591/1545484889179168819

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Verification

- Server shared-trip integration tests: 33/33 passing
- Client `SharedTripPage` tests: 60/60 passing
- Server production typecheck: passing
- Server test typecheck: passing
- Client typecheck: passing
- Client page-pattern gate: passing
- Exact staged-diff credential scan: 0 findings
- `git diff --check`: passing
- Independent Claude Opus review: `APPROVE_WITH_CHANGES`; verified security and permission findings were applied and retested. Two unsupported findings were rejected after direct source/schema inspection.

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed *(no documentation change required for this UI/API response enhancement)*
