### PR TITLE
feat(admin): an instance-wide switch for whether the model reads images

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -613,6 +613,13 @@ export const adminApi = {
   // Local LLM (Ollama) management for the AI-parsing addon.
   llmLocalModels: (baseUrl: string): Promise<{ models: { name: string; size: number }[] }> =>
     apiClient.get('/admin/llm/local/models', { params: { baseUrl } }).then(r => r.data),
+  /**
+   * What the local server says a model can do. `capabilities: null` means the
+   * server could not answer (unreachable, unknown model, or an Ollama too old to
+   * report it) — the caller falls back to guessing from the id.
+   */
+  llmLocalCapabilities: (baseUrl: string, model: string): Promise<{ capabilities: string[] | null }> =>
+    apiClient.get('/admin/llm/local/capabilities', { params: { baseUrl, model } }).then(r => r.data),
   /** Pull a model, streaming Ollama's NDJSON progress to `onProgress`. */
   llmLocalPull: async (
     baseUrl: string,

--- a/client/src/components/Admin/AddonManager.test.tsx
+++ b/client/src/components/Admin/AddonManager.test.tsx
@@ -72,7 +72,9 @@ beforeEach(() => {
   seedStore(useSettingsStore, { settings: { dark_mode: false } });
   vi.spyOn(useAddonStore.getState(), 'loadAddons').mockResolvedValue(undefined);
   server.use(
-    http.get('/api/admin/addons', () => HttpResponse.json({ addons: [] }))
+    http.get('/api/admin/addons', () => HttpResponse.json({ addons: [] })),
+    // What Ollama says about a model: nothing, unless a test says otherwise.
+    http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: null })),
   );
 });
 
@@ -693,5 +695,66 @@ describe('AddonManager', () => {
 
     await waitFor(() => expect(screen.getByDisplayValue('https://proxy.local/v1')).toBeInTheDocument());
     expect(urls).toHaveLength(0);
+  });
+
+  it('FE-ADMIN-ADDON-033: a local model the server calls text-only starts off, and turning it on warns', async () => {
+    const user = userEvent.setup();
+    server.use(
+      addonsRoute([llmAddon({ provider: 'local', model: 'qwen3:8b', baseUrl: '', apiKey: '' })]),
+      modelsRoute(['qwen3:8b']),
+      http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: ['completion', 'tools', 'thinking'] })),
+    );
+    render(<AddonManager />);
+
+    await screen.findByText('The server reports that qwen3:8b does not read images.');
+    const toggle = screen.getByRole('checkbox', { name: 'This model reads images' });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    expect(toggle).toBeChecked();
+    expect(screen.getByText(/against what the server reports/)).toBeInTheDocument();
+  });
+
+  it('FE-ADMIN-ADDON-034: a local model the server says reads images turns the switch on, and it is saved', async () => {
+    const user = userEvent.setup();
+    const bodies: unknown[] = [];
+    server.use(
+      addonsRoute([llmAddon({ provider: 'local', model: 'some-vision-model', baseUrl: '', apiKey: '', multimodal: false })]),
+      modelsRoute(['some-vision-model']),
+      http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: ['completion', 'vision'] })),
+      http.put('/api/admin/addons/llm_parsing', async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    render(<><ToastContainer /><AddonManager /></>);
+
+    await screen.findByText('The server reports that some-vision-model reads images.');
+    expect(screen.getByRole('checkbox', { name: 'This model reads images' })).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Saved');
+    expect(bodies[0]).toEqual({
+      config: { provider: 'local', model: 'some-vision-model', baseUrl: '', apiKey: '', multimodal: true },
+    });
+  });
+
+  it('FE-ADMIN-ADDON-035: a cloud model has only its id to go on, and an unknown one turned on warns', async () => {
+    const user = userEvent.setup();
+    let asked = 0;
+    server.use(
+      addonsRoute([llmAddon({ provider: 'openai', model: 'mistral-large', baseUrl: '', apiKey: '' })]),
+      http.get('/api/admin/llm/local/capabilities', () => { asked += 1; return HttpResponse.json({ capabilities: ['vision'] }); }),
+    );
+    render(<AddonManager />);
+
+    const toggle = await screen.findByRole('checkbox', { name: 'This model reads images' });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    expect(screen.getByText('mistral-large is not known to read images — if the provider refuses the document, this is why.')).toBeInTheDocument();
+    expect(asked).toBe(0);
   });
 });

--- a/client/src/components/Admin/AddonManager.tsx
+++ b/client/src/components/Admin/AddonManager.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ComponentType } from 'react'
 import { adminApi } from '../../api/client'
+import { useModelVision } from './useModelVision'
 import { useTranslation } from '../../i18n'
 import { useAddonStore } from '../../store/addonStore'
 import { useIsDark } from '../../hooks/useIsDark'
@@ -335,6 +336,7 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
   const [pullStatus, setPullStatus] = useState('')
 
   const effectiveUrl = baseUrl.trim() || DEFAULT_OLLAMA_URL
+  const vision = useModelVision({ provider, model, baseUrl: effectiveUrl, stored: cfg })
   const isInstalled = (id: string) => installed.some(n => n === id || n.startsWith(id + ':') || n.startsWith(id))
 
   const loadModels = async () => {
@@ -385,7 +387,7 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
     setSaving(true)
     try {
       // Send the masked sentinel unchanged so the server keeps the stored key.
-      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: provider === 'anthropic' ? '' : baseUrl.trim(), apiKey, multimodal: cfg.multimodal === true } })
+      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: provider === 'anthropic' ? '' : baseUrl.trim(), apiKey, multimodal: vision.multimodal } })
       toast.success('Saved')
     } catch {
       toast.error('Failed to save')
@@ -432,6 +434,19 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
         <span className={labelCls}>Model</span>
         <input autoComplete="off" className={fieldCls} value={model} onChange={e => setModel(e.target.value)} placeholder={provider === 'anthropic' ? 'claude-opus-4-8' : provider === 'openai' ? 'gpt-4o' : 'select or pull below'} />
       </label>
+
+      <div className="rounded-lg border border-edge-secondary px-2.5 py-2">
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={vision.multimodal} onChange={e => vision.setMultimodal(e.target.checked)} />
+          <span className="text-caption font-medium text-content">This model reads images</span>
+        </label>
+        <p className="mt-1 text-caption text-content-faint">
+          A vision model is handed the document itself — a scanned page, a photo — instead of text pulled out of it.
+          Leave this off for a text-only model: the provider refuses an image rather than doing its best with it.
+        </p>
+        {vision.serverNote && <p className="mt-1.5 text-caption text-content-muted">{vision.serverNote}</p>}
+        {vision.warning && <p className="mt-1.5 text-caption text-warning">{vision.warning}</p>}
+      </div>
 
       {/* Local model management (Ollama) */}
       {provider === 'local' && (

--- a/client/src/components/Admin/useModelVision.test.ts
+++ b/client/src/components/Admin/useModelVision.test.ts
@@ -1,0 +1,117 @@
+// FE-ADMIN-VISION-001 to -010 — the shared "this model reads images" hook.
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { adminApi } from '../../api/client'
+import { useModelVision } from './useModelVision'
+
+const URL = 'http://ollama.lan:11434/v1'
+
+type Props = Parameters<typeof useModelVision>[0]
+
+function mount(props: Partial<Props> = {}) {
+  const initial: Props = { provider: 'local', model: '', baseUrl: URL, stored: {}, ...props }
+  return renderHook((p: Props) => useModelVision(p), { initialProps: initial })
+}
+
+/** A promise this test controls the settling of, to pin down state mid-flight. */
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>(r => { resolve = r })
+  return { promise, resolve }
+}
+
+let capabilities: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  capabilities = vi.spyOn(adminApi, 'llmLocalCapabilities').mockResolvedValue({ capabilities: null })
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('useModelVision', () => {
+  it('FE-ADMIN-VISION-001: starts from the stored flag when there is one', () => {
+    const { result } = mount({ provider: 'openai', model: 'mistral:7b', stored: { model: 'mistral:7b', multimodal: true } })
+    expect(result.current.multimodal).toBe(true)
+  })
+
+  it('FE-ADMIN-VISION-002: without a stored flag, a model from a vision family starts on', () => {
+    // An instance configured before the switch existed must not be told its model is blind.
+    const { result } = mount({ provider: 'openai', model: 'qwen3.5:4b', stored: { model: 'qwen3.5:4b' } })
+    expect(result.current.multimodal).toBe(true)
+    expect(result.current.warning).toBeNull()
+  })
+
+  it('FE-ADMIN-VISION-003: a local model is looked up on the server, and its answer replaces the guess', async () => {
+    capabilities.mockResolvedValue({ capabilities: ['completion', 'vision', 'tools', 'thinking'] })
+    const { result } = mount({ model: 'some-local-thing', stored: { model: 'some-local-thing' } })
+
+    await waitFor(() => expect(result.current.multimodal).toBe(true))
+    expect(capabilities).toHaveBeenCalledWith(URL, 'some-local-thing')
+    expect(result.current.serverNote).toBe('The server reports that some-local-thing reads images.')
+    expect(result.current.warning).toBeNull()
+  })
+
+  it('FE-ADMIN-VISION-004: a local model the server calls blind is turned off, id notwithstanding', async () => {
+    capabilities.mockResolvedValue({ capabilities: ['completion', 'tools'] })
+    const { result } = mount({ model: 'qwen3.5:4b', stored: { model: 'qwen3.5:4b' } })
+
+    await waitFor(() => expect(result.current.multimodal).toBe(false))
+    expect(result.current.serverNote).toBe('The server reports that qwen3.5:4b does not read images.')
+  })
+
+  it('FE-ADMIN-VISION-005: turning it on against the server warns, and does not undo the choice', async () => {
+    capabilities.mockResolvedValue({ capabilities: ['completion'] })
+    const { result } = mount({ model: 'qwen3:8b' })
+    await waitFor(() => expect(result.current.serverNote).not.toBeNull())
+
+    act(() => result.current.setMultimodal(true))
+
+    expect(result.current.multimodal).toBe(true)
+    expect(result.current.warning).toMatch(/against what the server reports/)
+  })
+
+  it('FE-ADMIN-VISION-006: with no server answer, an unknown model turned on warns where the refusal will come from', async () => {
+    const { result } = mount({ model: 'mistral:7b' })
+    await waitFor(() => expect(capabilities).toHaveBeenCalled())
+
+    act(() => result.current.setMultimodal(true))
+
+    expect(result.current.serverNote).toBeNull()
+    expect(result.current.warning).toBe('mistral:7b is not known to read images — if the provider refuses the document, this is why.')
+  })
+
+  it('FE-ADMIN-VISION-007: an unreachable server is no answer, not an error', async () => {
+    capabilities.mockRejectedValue(new Error('Network Error'))
+    const { result } = mount({ model: 'qwen3.5:4b', stored: { model: 'qwen3.5:4b' } })
+    await waitFor(() => expect(capabilities).toHaveBeenCalled())
+
+    expect(result.current.serverNote).toBeNull()
+    expect(result.current.multimodal).toBe(true)
+  })
+
+  it('FE-ADMIN-VISION-008: a cloud provider, or no model yet, asks nothing', () => {
+    mount({ provider: 'openai', model: 'gpt-4o' })
+    mount({ provider: 'local', model: '   ' })
+    expect(capabilities).not.toHaveBeenCalled()
+  })
+
+  it('FE-ADMIN-VISION-009: a late answer about the previous model is not shown as one about the current model', async () => {
+    const first = deferred<{ capabilities: string[] | null }>()
+    capabilities.mockReturnValueOnce(first.promise).mockResolvedValueOnce({ capabilities: null })
+    const { result, rerender } = mount({ model: 'qwen3.5:4b' })
+
+    rerender({ provider: 'local', model: 'mistral:7b', baseUrl: URL, stored: {} })
+    await act(async () => { first.resolve({ capabilities: ['vision'] }) })
+
+    expect(result.current.serverNote).toBeNull()
+    expect(result.current.multimodal).toBe(false)
+  })
+
+  it('FE-ADMIN-VISION-010: leaving the local provider drops what the server said', async () => {
+    capabilities.mockResolvedValue({ capabilities: ['vision'] })
+    const { result, rerender } = mount({ model: 'qwen3.5:4b' })
+    await waitFor(() => expect(result.current.serverNote).not.toBeNull())
+
+    rerender({ provider: 'openai', model: 'qwen3.5:4b', baseUrl: URL, stored: {} })
+
+    expect(result.current.serverNote).toBeNull()
+  })
+})

--- a/client/src/components/Admin/useModelVision.ts
+++ b/client/src/components/Admin/useModelVision.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { modelReadsPhotos } from '@trek/shared'
+import { adminApi } from '../../api/client'
+
+export interface ModelVision {
+  /** Whether the model may be handed the document itself — the switch, and what is saved. */
+  multimodal: boolean
+  setMultimodal: (next: boolean) => void
+  /** What the local server reported about the model, as a sentence; null when it said nothing. */
+  serverNote: string | null
+  /** Why the provider is likely to refuse the document as set; null when nothing is off. */
+  warning: string | null
+}
+
+/**
+ * The instance-wide "this model reads images" switch — the ONE logic path behind
+ * both admin shells, which render their own markup over it.
+ *
+ * It starts from the stored flag, or from the id when there is none, so a setup
+ * that predates the switch is not told its vision model is blind. With the local
+ * provider the server is asked instead: Ollama's `/api/show` reports what a model
+ * can do, and that answer replaces the guess. The switch stays an override either
+ * way — going against what is known warns, it does not block.
+ */
+export function useModelVision({ provider, model, baseUrl, stored }: {
+  provider: string
+  model: string
+  /** The Ollama address to ask, already defaulted by the caller. */
+  baseUrl: string
+  /** The addon config as loaded. */
+  stored: { model?: unknown; multimodal?: unknown }
+}): ModelVision {
+  const [multimodal, setMultimodal] = useState<boolean>(
+    stored.multimodal === true || modelReadsPhotos(typeof stored.model === 'string' ? stored.model : ''),
+  )
+  // The server's answer, keyed by what was asked: a reply about the previous
+  // model or address must not be read as one about the current one.
+  const [answer, setAnswer] = useState<{ key: string; sees: boolean | null } | null>(null)
+
+  const id = model.trim()
+  const key = `${baseUrl}\n${id}`
+
+  useEffect(() => {
+    if (provider !== 'local' || !id) return
+    let cancelled = false
+    adminApi.llmLocalCapabilities(baseUrl, id)
+      .then(r => {
+        if (cancelled) return
+        const sees = r.capabilities ? r.capabilities.includes('vision') : null
+        setAnswer({ key, sees })
+        if (sees !== null) setMultimodal(sees)
+      })
+      .catch(() => { if (!cancelled) setAnswer({ key, sees: null }) })
+    return () => { cancelled = true }
+  }, [provider, id, baseUrl, key])
+
+  // null = no answer: not local, no model, unreachable, unknown to the server, or too old to say.
+  const serverVision = provider === 'local' && answer?.key === key ? answer.sees : null
+
+  let serverNote: string | null = null
+  if (serverVision !== null) {
+    serverNote = serverVision
+      ? `The server reports that ${id} reads images.`
+      : `The server reports that ${id} does not read images.`
+  }
+
+  let warning: string | null = null
+  if (multimodal && serverVision === false) {
+    warning = 'You have turned this on against what the server reports — the provider will refuse the document.'
+  } else if (multimodal && serverVision === null && id !== '' && !modelReadsPhotos(id)) {
+    warning = `${id} is not known to read images — if the provider refuses the document, this is why.`
+  }
+
+  return { multimodal, setMultimodal, serverNote, warning }
+}

--- a/client/src/mobile/screens/admin/MAdminAddonManager.tsx
+++ b/client/src/mobile/screens/admin/MAdminAddonManager.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../../../i18n'
 import { useSettingsStore } from '../../../store/settingsStore'
 import { useAddonStore } from '../../../store/addonStore'
 import { useToast } from '../../../components/shared/Toast'
+import { useModelVision } from '../../../components/Admin/useModelVision'
 import {
   Puzzle, ListChecks, Wallet, FileText, CalendarDays, Globe, Briefcase, Image, Terminal, Link2, Compass, BookOpen,
   MessageCircle, StickyNote, BarChart3, Sparkles, Luggage, Plane, Server, Cloud, Bookmark, Check, Loader2,
@@ -380,6 +381,7 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
   const [pullStatus, setPullStatus] = useState('')
 
   const effectiveUrl = baseUrl.trim() || DEFAULT_OLLAMA_URL
+  const vision = useModelVision({ provider, model, baseUrl: effectiveUrl, stored: cfg })
   const isInstalled = (id: string) => installed.some(n => n === id || n.startsWith(id + ':') || n.startsWith(id))
 
   const loadModels = async () => {
@@ -430,7 +432,7 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
     setSaving(true)
     try {
       // Send the masked sentinel unchanged so the server keeps the stored key.
-      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: baseUrl.trim(), apiKey, multimodal: cfg.multimodal === true } })
+      await adminApi.updateAddon(addon.id, { config: { provider, model: model.trim(), baseUrl: baseUrl.trim(), apiKey, multimodal: vision.multimodal } })
       toast.success('Saved')
     } catch {
       toast.error('Failed to save')
@@ -517,6 +519,19 @@ function LlmParsingConfig({ addon }: { addon: Addon }) {
           onChange={e => setModel(e.target.value)}
           placeholder={provider === 'anthropic' ? 'claude-opus-4-8' : provider === 'openai' ? 'gpt-4o' : 'select or pull below'}
         />
+
+        <div className="rounded-xl border border-[color:var(--m-rowbr)] px-3 py-[10px]">
+          <div className="flex items-center gap-[10px]">
+            <span className="flex-1 text-[0.8125rem] font-semibold text-m-ink">This model reads images</span>
+            <MToggle checked={vision.multimodal} onChange={vision.setMultimodal} ariaLabel="This model reads images" />
+          </div>
+          <p className="mt-1 font-geist text-[0.6875rem] text-m-faint">
+            A vision model is handed the document itself — a scanned page, a photo — instead of text pulled out of it.
+            Leave this off for a text-only model: the provider refuses an image rather than doing its best with it.
+          </p>
+          {vision.serverNote && <p className="mt-2 font-geist text-[0.6875rem] text-m-muted">{vision.serverNote}</p>}
+          {vision.warning && <p className="mt-2 font-geist text-[0.6875rem] text-warning">{vision.warning}</p>}
+        </div>
 
         {/* Local model management (Ollama) */}
         {provider === 'local' && (

--- a/client/tests/unit/mobile/admin/MAdminAddonManager.test.tsx
+++ b/client/tests/unit/mobile/admin/MAdminAddonManager.test.tsx
@@ -1,4 +1,4 @@
-// FE-MOB-AADD-001 to FE-MOB-AADD-025
+// FE-MOB-AADD-001 to FE-MOB-AADD-029
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { delay, http, HttpResponse } from 'msw';
@@ -62,7 +62,11 @@ beforeEach(() => {
   resetAllStores();
   seedStore(useSettingsStore, { settings: buildSettings({ dark_mode: false }) });
   loadAddonsSpy = vi.spyOn(useAddonStore.getState(), 'loadAddons').mockResolvedValue(undefined);
-  server.use(addonsRoute([]));
+  server.use(
+    addonsRoute([]),
+    // What Ollama says about a model: nothing, unless a test says otherwise.
+    http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: null })),
+  );
 });
 
 afterEach(() => {
@@ -555,5 +559,48 @@ describe('MAdminAddonManager', () => {
 
     await user.type(screen.getByDisplayValue('sk-secret'), '-rotated');
     expect(screen.getByDisplayValue('sk-secret-rotated')).toBeInTheDocument();
+  });
+
+  it('FE-MOB-AADD-028: a local model the server says reads images turns the switch on, and it is saved', async () => {
+    const user = userEvent.setup();
+    const bodies: unknown[] = [];
+    server.use(
+      addonsRoute([llmAddon({ provider: 'local', model: 'some-vision-model', baseUrl: '', apiKey: '', multimodal: false })]),
+      modelsRoute(['some-vision-model']),
+      http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: ['completion', 'vision'] })),
+      http.put('/api/admin/addons/llm_parsing', async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    render(<><ToastContainer /><MAdminAddonManager /></>);
+
+    await screen.findByText('The server reports that some-vision-model reads images.');
+    expect(screen.getByRole('switch', { name: 'This model reads images' })).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Saved');
+    expect(bodies[0]).toEqual({
+      config: { provider: 'local', model: 'some-vision-model', baseUrl: '', apiKey: '', multimodal: true },
+    });
+  });
+
+  it('FE-MOB-AADD-029: turning the switch on against what the server reports warns rather than blocks', async () => {
+    const user = userEvent.setup();
+    server.use(
+      addonsRoute([llmAddon({ provider: 'local', model: 'qwen3:8b', baseUrl: '', apiKey: '' })]),
+      modelsRoute(['qwen3:8b']),
+      http.get('/api/admin/llm/local/capabilities', () => HttpResponse.json({ capabilities: ['completion', 'tools'] })),
+    );
+    render(<MAdminAddonManager />);
+
+    await screen.findByText('The server reports that qwen3:8b does not read images.');
+    const toggle = screen.getByRole('switch', { name: 'This model reads images' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText(/against what the server reports/)).toBeInTheDocument();
   });
 });

--- a/server/src/nest/common/validate-managed-routes.ts
+++ b/server/src/nest/common/validate-managed-routes.ts
@@ -73,6 +73,7 @@ export const MANAGED_ROUTE_ALLOW_LIST: string[] = [
   'BackupController.restore',
   'BackupController.updateAutoSettings',
   'BackupController.uploadRestore',
+  'LlmLocalController.capabilities',
   'LlmLocalController.models',
   'LlmLocalController.pull',
   'NotificationsController.testSmtp',

--- a/server/src/nest/llm-parse/llm-capabilities.controller.ts
+++ b/server/src/nest/llm-parse/llm-capabilities.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { LlmParseService } from './llm-parse.service';
+import type { User } from '../../types';
+
+/**
+ * What the caller's own AI configuration can do.
+ *
+ * /api/health/features answers for the instance and is public, so it cannot see
+ * whose model is configured or what it reads. This can: it is the difference
+ * between offering to photograph a receipt and offering a five-minute wait that
+ * ends in a provider refusal.
+ */
+@Controller('api/llm')
+@UseGuards(JwtAuthGuard)
+export class LlmCapabilitiesController {
+  constructor(private readonly llmParse: LlmParseService) {}
+
+  @Get('capabilities')
+  async capabilities(@CurrentUser() user: User) {
+    return {
+      /** A provider and model are set — for this user or by the operator. */
+      configured: this.llmParse.isAvailable(user.id),
+      /** That model can be handed a photograph. */
+      photos: await this.llmParse.readsPhotos(user.id),
+    };
+  }
+}

--- a/server/src/nest/llm-parse/llm-local.controller.ts
+++ b/server/src/nest/llm-parse/llm-local.controller.ts
@@ -22,6 +22,18 @@ export class LlmLocalController {
   }
 
   /**
+   * What the local server says a model can do — `vision`, `thinking`, `tools`.
+   * Lets the addon screen fill the "reads images" switch from the truth instead
+   * of guessing from the model id. `null` when the server cannot answer or is
+   * too old to report it, and the screen falls back to the id heuristic.
+   */
+  @ManagedForbidden('the model list belongs to the operator runtime, not to one instance')
+  @Get('capabilities')
+  async capabilities(@Query('model') model?: string, @Query('baseUrl') baseUrl?: string) {
+    return { capabilities: model ? await this.local.capabilities(baseUrl, model) : null };
+  }
+
+  /**
    * Stream a model pull. Proxies Ollama's NDJSON progress lines
    * ({ status, total?, completed? }) straight to the client, which reads the
    * response body to render a progress bar. Uses @Res() to stream manually.

--- a/server/src/nest/llm-parse/llm-local.service.ts
+++ b/server/src/nest/llm-parse/llm-local.service.ts
@@ -46,6 +46,38 @@ export class LlmLocalService {
   }
 
   /**
+   * What Ollama says a model can do.
+   *
+   * `/api/show` reports a `capabilities` list — `vision`, `thinking`, `tools` —
+   * which is the authoritative answer to a question TREK otherwise guesses at
+   * from the model id. Verified against Ollama 0.32.15:
+   *
+   *   qwen3.5:4b -> ['completion', 'vision', 'tools', 'thinking']
+   *   qwen3:8b   -> ['completion', 'tools', 'thinking']
+   *
+   * Returns null rather than throwing when the server cannot answer or predates
+   * the field: the caller falls back to the id heuristic, and a model that works
+   * must not be hidden because an older Ollama has nothing to say about it.
+   */
+  async capabilities(baseUrl: string | undefined, model: string): Promise<string[] | null> {
+    const root = this.ollamaRoot(baseUrl);
+    try {
+      const res = await safeFetchLlm(`${root}/api/show`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { capabilities?: unknown };
+      if (!Array.isArray(data.capabilities)) return null;
+      return data.capabilities.filter((c): c is string => typeof c === 'string');
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Start a streamed pull. Returns the upstream NDJSON body so the controller can
    * pipe Ollama's progress lines straight to the client.
    */

--- a/server/src/nest/llm-parse/llm-parse.module.ts
+++ b/server/src/nest/llm-parse/llm-parse.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { LlmParseService } from './llm-parse.service';
 import { LlmLocalService } from './llm-local.service';
 import { LlmLocalController } from './llm-local.controller';
+import { LlmCapabilitiesController } from './llm-capabilities.controller';
 import { LlmConfigResolver } from './llm-config.resolver';
 import { SettingsModule } from '../settings/settings.module';
 import { AddonsModule } from '../addons/addons.module';
@@ -13,7 +14,7 @@ import { AppConfigModule } from '../app-config/app-config.module';
  */
 @Module({
   imports: [AppConfigModule, SettingsModule, AddonsModule],
-  controllers: [LlmLocalController],
+  controllers: [LlmLocalController, LlmCapabilitiesController],
   providers: [LlmParseService, LlmLocalService, LlmConfigResolver],
   exports: [LlmParseService, LlmConfigResolver],
 })

--- a/server/src/nest/llm-parse/llm-parse.service.ts
+++ b/server/src/nest/llm-parse/llm-parse.service.ts
@@ -1,12 +1,13 @@
 import type { KiReservation } from '../booking-import/kitinerary.types';
 import { createLlmClient } from './llm-client.factory';
 import { LlmConfigResolver } from './llm-config.resolver';
+import { LlmLocalService } from './llm-local.service';
 import { buildSystemPrompt, KI_RESERVATION_JSON_SCHEMA } from './llm-prompt';
 import type { LlmExtractionInput } from './llm-provider.interface';
 import { isPdf, extractText } from './text-extract';
 import { routeExtraction, detectFlightNumbers } from './router/extraction-router';
 import { Injectable } from '@nestjs/common';
-import { kiReservationSchema } from '@trek/shared';
+import { kiReservationSchema, modelReadsPhotos } from '@trek/shared';
 import { RuntimeEnvService } from '../app-config/runtime-env.service';
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -29,12 +30,39 @@ export interface LlmParseResult {
 export class LlmParseService {
   constructor(
     private readonly llmConfig: LlmConfigResolver,
+    private readonly llmLocal: LlmLocalService,
     private readonly env: RuntimeEnvService,
   ) {}
 
   /** True when the addon is enabled AND a usable config resolves for this user. */
   isAvailable(userId: number): boolean {
     return this.llmConfig.resolve(userId) !== null;
+  }
+
+  /**
+   * Whether this user's model can be handed an image at all.
+   *
+   * A text-only model does not do its best with one, the provider rejects it —
+   * after the minutes a read takes. So the answer decides whether the affordance
+   * is offered in the first place. The operator's switch is taken at its word;
+   * without it a local server is asked, and the id is guessed from only when
+   * nothing better answers, which keeps a working setup working without anyone
+   * having to go and confirm it.
+   */
+  async readsPhotos(userId: number): Promise<boolean> {
+    const config = this.llmConfig.resolve(userId);
+    if (!config) return false;
+    // The operator's switch is an explicit override and wins outright.
+    if (config.multimodal) return true;
+    // On a self-hosted server the answer is not a matter of opinion: Ollama
+    // reports it. `null` means an older server with nothing to say, and the
+    // guess below takes over rather than hiding a model that works.
+    if (config.provider === 'local') {
+      const caps = await this.llmLocal.capabilities(config.baseUrl, config.model);
+      if (caps) return caps.includes('vision');
+    }
+    // Cloud providers have no equivalent endpoint — the id is all there is.
+    return modelReadsPhotos(config.model);
   }
 
   async parse(file: { buffer: Buffer; originalName: string }, userId: number): Promise<LlmParseResult> {

--- a/server/tests/unit/nest/llm-parse/llm-capabilities.controller.test.ts
+++ b/server/tests/unit/nest/llm-parse/llm-capabilities.controller.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LlmCapabilitiesController } from '../../../../src/nest/llm-parse/llm-capabilities.controller';
+import type { User } from '../../../../src/types';
+
+const user = { id: 7 } as User;
+
+function make(overrides: { configured?: boolean; photos?: boolean } = {}) {
+  const llmParse = {
+    isAvailable: vi.fn(() => overrides.configured ?? true),
+    readsPhotos: vi.fn(async () => overrides.photos ?? true),
+  };
+  return { ctrl: new LlmCapabilitiesController(llmParse as never), llmParse };
+}
+
+describe('LlmCapabilitiesController', () => {
+  it('answers for the caller, not for the instance', async () => {
+    const { ctrl, llmParse } = make();
+
+    expect(await ctrl.capabilities(user)).toEqual({ configured: true, photos: true });
+    expect(llmParse.isAvailable).toHaveBeenCalledWith(7);
+    expect(llmParse.readsPhotos).toHaveBeenCalledWith(7);
+  });
+
+  it('separates "a model is set" from "that model can see"', async () => {
+    // The text-only case: booking imports and PDF invoices still work, so the
+    // scanner stays — it is the camera that has nothing to offer.
+    const { ctrl } = make({ configured: true, photos: false });
+    expect(await ctrl.capabilities(user)).toEqual({ configured: true, photos: false });
+  });
+
+  it('says no to both when nothing is configured', async () => {
+    const { ctrl } = make({ configured: false, photos: false });
+    expect(await ctrl.capabilities(user)).toEqual({ configured: false, photos: false });
+  });
+});

--- a/server/tests/unit/nest/llm-parse/llm-local.service.test.ts
+++ b/server/tests/unit/nest/llm-parse/llm-local.service.test.ts
@@ -68,3 +68,50 @@ describe('LlmLocalService.pull', () => {
     expect(JSON.parse(init.body)).toEqual({ model: 'nuextract', stream: true });
   });
 });
+
+describe('LlmLocalService.capabilities', () => {
+  const ok = (body: unknown) => ({ ok: true, json: async () => body });
+
+  it('reports what the server says the model can do', async () => {
+    // Verified against Ollama 0.32.15: qwen3.5:4b answers with vision, qwen3:8b
+    // does not. This is the answer the id heuristic exists to guess at.
+    mockFetch(async () => ok({ capabilities: ['completion', 'vision', 'tools', 'thinking'] }));
+    await expect(svc().capabilities('http://localhost:11434/v1', 'qwen3.5:4b')).resolves.toEqual([
+      'completion',
+      'vision',
+      'tools',
+      'thinking',
+    ]);
+  });
+
+  it('asks the native API at the root, not the /v1 path, and names the model', async () => {
+    const fetchMock = mockFetch(async () => ok({ capabilities: [] }));
+    await svc().capabilities('http://ollama.lan:11434/v1', 'qwen3:8b');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://ollama.lan:11434/api/show');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ model: 'qwen3:8b' });
+  });
+
+  it('answers null when the server refuses, so the caller falls back to the id', async () => {
+    mockFetch(async () => ({ ok: false, status: 404, json: async () => ({}) }));
+    await expect(svc().capabilities(undefined, 'nope')).resolves.toBeNull();
+  });
+
+  it('answers null when the server is too old to report capabilities', async () => {
+    // A model that works must not be hidden because Ollama predates the field.
+    mockFetch(async () => ok({ details: { family: 'qwen3' } }));
+    await expect(svc().capabilities(undefined, 'qwen3.5:4b')).resolves.toBeNull();
+  });
+
+  it('answers null rather than throwing when the server cannot be reached', async () => {
+    // Reject only the one call, as above: a persistent rejection surfaces as an
+    // unhandled rejection on vitest's own probe of the mock.
+    safeFetchLlmMock.mockImplementationOnce(() => Promise.reject(new Error('ECONNREFUSED')));
+    await expect(svc().capabilities(undefined, 'qwen3.5:4b')).resolves.toBeNull();
+  });
+
+  it('drops anything in the list that is not a string', async () => {
+    mockFetch(async () => ok({ capabilities: ['vision', 7, null] }));
+    await expect(svc().capabilities(undefined, 'm')).resolves.toEqual(['vision']);
+  });
+});

--- a/server/tests/unit/nest/llm-parse/llm-parse.service.test.ts
+++ b/server/tests/unit/nest/llm-parse/llm-parse.service.test.ts
@@ -24,11 +24,19 @@ vi.mock('../../../../src/nest/llm-parse/router/extraction-router', () => ({ rout
 
 import { LlmParseService } from '../../../../src/nest/llm-parse/llm-parse.service';
 import type { LlmConfigResolver } from '../../../../src/nest/llm-parse/llm-config.resolver';
+import type { LlmLocalService } from '../../../../src/nest/llm-parse/llm-local.service';
 import type { RuntimeEnvService } from '../../../../src/nest/app-config/runtime-env.service';
 
 const cfg = (over: Record<string, unknown> = {}) => ({ provider: 'openai', model: 'm', multimodal: false, ...over });
 const llmConfigStub = { resolve: resolveLlmConfig } as unknown as LlmConfigResolver;
-const svc = () => new LlmParseService(llmConfigStub, { isManaged: () => false } as unknown as RuntimeEnvService);
+/** Ollama's own answer about a model. `null` = an older server with nothing to say. */
+const localCapabilities = vi.fn<(baseUrl: string | undefined, model: string) => Promise<string[] | null>>(
+  async () => null,
+);
+const llmLocalStub = { capabilities: localCapabilities } as unknown as LlmLocalService;
+
+const svc = () =>
+  new LlmParseService(llmConfigStub, llmLocalStub, { isManaged: () => false } as unknown as RuntimeEnvService);
 const file = (name: string, body = 'Flight AB123') => ({ buffer: Buffer.from(body), originalName: name });
 
 beforeEach(() => {
@@ -186,5 +194,53 @@ describe('LlmParseService', () => {
     expect(res.kiItems).toEqual([]);
     expect(res.warnings[0]).toMatch(/could not read file/i);
     expect(res.warnings[0]).toContain('corrupt pdf');
+  });
+});
+
+describe('LlmParseService.readsPhotos', () => {
+  beforeEach(() => localCapabilities.mockResolvedValue(null));
+
+  it('takes the operator at their word when the switch is on', async () => {
+    resolveLlmConfig.mockReturnValue(cfg({ model: 'some-local-thing', multimodal: true }));
+    await expect(svc().readsPhotos(1)).resolves.toBe(true);
+  });
+
+  it('asks the local server, which knows, instead of guessing from the id', async () => {
+    // Verified against Ollama 0.32.15: qwen3.5:4b reports vision, qwen3:8b does not.
+    resolveLlmConfig.mockReturnValue(cfg({ provider: 'local', model: 'anything-at-all' }));
+    localCapabilities.mockResolvedValue(['completion', 'vision', 'tools', 'thinking']);
+    await expect(svc().readsPhotos(1)).resolves.toBe(true);
+    expect(localCapabilities).toHaveBeenCalledWith(undefined, 'anything-at-all');
+  });
+
+  it('believes the local server when it says the model is blind, id notwithstanding', async () => {
+    resolveLlmConfig.mockReturnValue(cfg({ provider: 'local', model: 'qwen3.5:4b' }));
+    localCapabilities.mockResolvedValue(['completion', 'tools']);
+    await expect(svc().readsPhotos(1)).resolves.toBe(false);
+  });
+
+  it('falls back to the id when the server is too old to answer', async () => {
+    // A model that works must not be hidden because Ollama predates the field.
+    resolveLlmConfig.mockReturnValue(cfg({ provider: 'local', model: 'qwen3.5:4b' }));
+    localCapabilities.mockResolvedValue(null);
+    await expect(svc().readsPhotos(1)).resolves.toBe(true);
+  });
+
+  it('never asks the local server about a cloud model', async () => {
+    resolveLlmConfig.mockReturnValue(cfg({ provider: 'openai', model: 'gpt-4o' }));
+    await expect(svc().readsPhotos(1)).resolves.toBe(true);
+    expect(localCapabilities).not.toHaveBeenCalled();
+  });
+
+  it('says no to a text-only model when the switch is off', async () => {
+    // Not a lesser choice for a photograph — the wrong one: the provider rejects
+    // the image rather than doing its best with it.
+    resolveLlmConfig.mockReturnValue(cfg({ model: 'qwen3:8b', multimodal: false }));
+    await expect(svc().readsPhotos(1)).resolves.toBe(false);
+  });
+
+  it('says no when nothing is configured at all', async () => {
+    resolveLlmConfig.mockReturnValue(null);
+    await expect(svc().readsPhotos(1)).resolves.toBe(false);
   });
 });

--- a/shared/src/admin/admin.schema.spec.ts
+++ b/shared/src/admin/admin.schema.spec.ts
@@ -1,4 +1,5 @@
 import {
+  modelReadsPhotos,
   adminUserCreateRequestSchema,
   adminUserUpdateRequestSchema,
   adminPermissionsRequestSchema,
@@ -152,5 +153,29 @@ describe('adminTestNotificationRequestSchema', () => {
       }).success,
     ).toBe(true);
     expect(adminTestNotificationRequestSchema.safeParse({ targetId: 'one' }).success).toBe(false);
+  });
+});
+
+describe('modelReadsPhotos', () => {
+  it('recognises the model the addon offers to pull', () => {
+    expect(modelReadsPhotos('qwen3.5:4b')).toBe(true);
+  });
+
+  it('ignores the whitespace an operator leaves around a pasted id', () => {
+    expect(modelReadsPhotos('  qwen3.5:4b  ')).toBe(true);
+  });
+
+  it('assumes a hand-typed id from a family that advertises vision can see', () => {
+    expect(modelReadsPhotos('llava:13b')).toBe(true);
+    expect(modelReadsPhotos('qwen2.5-vl:7b')).toBe(true);
+    expect(modelReadsPhotos('gpt-4o-mini')).toBe(true);
+    expect(modelReadsPhotos('minicpm-v:8b')).toBe(true);
+  });
+
+  it('says nothing about an id it cannot place, which the admin switch is there to settle', () => {
+    // Text-only: booking imports and PDF invoices, never a photographed receipt.
+    expect(modelReadsPhotos('qwen3:8b')).toBe(false);
+    expect(modelReadsPhotos('mistral:7b')).toBe(false);
+    expect(modelReadsPhotos('')).toBe(false);
   });
 });

--- a/shared/src/admin/admin.schema.ts
+++ b/shared/src/admin/admin.schema.ts
@@ -136,3 +136,16 @@ export const API_KEY_SOURCES = ['operator-env', 'instance', 'user-row'] as const
 export type ApiKeySource = (typeof API_KEY_SOURCES)[number];
 /** The nullable form the admin transit-provider response carries. */
 export type TransitKeySource = ApiKeySource | null;
+
+/**
+ * Whether a model id belongs to a family that advertises reading images.
+ *
+ * A guess from the name, for the cases with nothing better to go on: a cloud
+ * provider has no endpoint that reports a model's capabilities, and a local
+ * server may be unreachable or too old to say. It errs toward letting a model
+ * try — a guess that hides a working model is worse than one that lets it fail
+ * loudly — which is why the admin switch overrides it.
+ */
+export function modelReadsPhotos(id: string): boolean {
+  return /qwen3\.5|-vl\b|vl:|llava|minicpm-v|vision|gpt-4o|gpt-5|claude|gemini/i.test(id.trim());
+}

--- a/wiki/AI-Booking-Import.md
+++ b/wiki/AI-Booking-Import.md
@@ -50,6 +50,16 @@ With the **Local** provider selected, the panel manages your Ollama server direc
 
 You can also select any other model already installed on the server, or type a model id by hand.
 
+### This model reads images
+
+A **This model reads images** switch sits under the model field. It records whether the model *can* be handed a document as an image rather than as text pulled out of it. Nothing sends one that way yet — extraction still gives every provider but Anthropic the extracted text, as above — so what reads the switch today is `GET /api/llm/capabilities`: it lets a feature ask whether offering a photo would make sense before offering one. `/api/health/features` cannot answer that: it is public, so it does not know whose model is configured.
+
+With the **Local** provider TREK does not guess: it asks the server. Ollama's `/api/show` reports what a model can do, so selecting `qwen3.5:4b` turns the switch on and the panel says *The server reports that qwen3.5:4b reads images*; a text-only model turns it off and says so. Turning it on against that answer shows a warning rather than blocking it — the switch stays an override.
+
+For a cloud provider there is no such endpoint, so the id is all there is: one from a family that advertises vision (`qwen3.5`, `llava`, `minicpm-v`, anything `-vl`, GPT-4o, GPT-5, Claude, Gemini) is assumed to see, and anything else starts off. The same guess is the fallback when the local server is unreachable or too old to report capabilities.
+
+This is the instance-wide form of the per-user **Send documents as images** toggle below.
+
 ## Per-user configuration
 
 If an admin leaves the instance config blank, each user can configure their own model under **Settings → Integrations → AI parsing** (the section only appears when the addon is enabled):
@@ -58,7 +68,7 @@ If an admin leaves the instance config blank, each user can configure their own 
 
 The fields are a **Provider** (only **OpenAI** or **Anthropic** here), a **Model** id, and an **API key** that is *stored encrypted* (leave blank to keep the current key). There is no personal Base URL: the address this server calls is instance configuration, so a local (Ollama) model can only be set up by an admin on the addon, and the server answers 403 to anyone, admins included, who tries to store a personal base URL or a personal `local` provider.
 
-There is also a **Send documents as images** toggle. It is stored per user, but extraction currently ignores it: only Anthropic is sent the raw PDF, every other provider always gets the extracted text.
+There is also a **Send documents as images** toggle — the per-user form of the admin switch above. Booking extraction ignores it: only Anthropic is sent the raw PDF, every other provider always gets the extracted text.
 
 > **Precedence:** an admin instance model always wins. Personal settings only take effect when no instance-wide model is configured.
 


### PR DESCRIPTION
## Description

`multimodal` has been on the AI Parsing addon config for a while: stored, passed straight back on save, **settable by nobody**. Each user has the toggle in their own settings, but the instance config — which wins over them — did not. So on any instance where an admin configured the model, nothing could say it reads images.

**The switch**, under the model field in both admin screens, for every provider:

- **Local provider — TREK asks, it does not guess.** Ollama's `/api/show` reports what a model can do, and that answer sets the switch and says so. Verified against Ollama 0.32.15:
  ```
  qwen3.5:4b → ['completion', 'vision', 'tools', 'thinking']
  qwen3:8b   → ['completion', 'tools', 'thinking']          ← no vision
  ```
- **Cloud provider, or a local server that cannot answer** — a guess from the model family (`qwen3.5`, `llava`, `minicpm-v`, `-vl`, GPT-4o/5, Claude, Gemini), erring toward letting a model try.
- **It stays an override.** Going against what the server reports, or turning it on for an unknown model, warns — it never blocks Save.

**Server side**, the same answer in one place: `LlmParseService.readsPhotos()` (switch, then the local server, then the id), `GET /api/llm/capabilities` for the signed-in caller — which the public `/api/health/features` cannot give, since it has no idea whose model is configured — and the admin-only `GET /api/admin/llm/local/capabilities` the screens use, forbidden in managed mode like its `models`/`pull` siblings.

The two admin shells render their own markup over one hook (`useModelVision`), so the logic is written and tested once.

**Deliberately not here:** nothing that reads a document as an image. Extraction still sends every provider but Anthropic the extracted text, exactly as #2331 now documents — this PR makes the capability known and askable, so a feature can stop offering a photo that would only come back refused. Nothing consumes `/api/llm/capabilities` yet.

## Related Issue or Discussion
Addresses discussion https://discord.com/channels/1488298068427411591/1542235727033540728

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## How to test

1. **Admin → Addons → AI Parsing**, provider **Local**, model `qwen3.5:4b`: the switch comes up **on** and the panel says *The server reports that qwen3.5:4b reads images.*
2. Select `qwen3:8b`: **off**, and the panel says it does not. Turn it on → a warning that this goes against the server; **Save still works**.
3. Provider **OpenAI**, model `mistral-large`: **off**, no request to the local server. Turn it on → *mistral-large is not known to read images…*
4. Local provider with a dead base URL: no note, no error toast, the id guess applies.
5. Save, reload: the state persists (it rides in the addon config as `multimodal`).
6. `curl -b <session> localhost:3001/api/llm/capabilities` → `{"configured":true,"photos":true}` for a vision model, `photos:false` for a text-only one; unauthenticated → 401.
7. Same in the mobile admin screen (an `MToggle`, `role="switch"`).

```bash
npm run build --workspace=shared
npm run test --workspace=shared -- --run src/admin/admin.schema.spec.ts
cd server && npx vitest run tests/unit/nest/llm-parse tests/unit/nest/validate-managed-routes.test.ts tests/unit/nest/route-inventory.test.ts
cd client && npx vitest run src/components/Admin/useModelVision.test.ts src/components/Admin/AddonManager.test.tsx tests/unit/mobile/admin/MAdminAddonManager.test.tsx
```

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/liketrek/TREK/wiki/Contributing)
- [ ] My branch is [up to date with `dev`](https://github.com/liketrek/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date) *(stacked on #2331; rebased onto `dev` when it lands)*
- [ ] This PR targets the `dev` branch, not `main` *(targets #2331's branch until it lands)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
